### PR TITLE
Fix fs path mismatch in go and cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ cpp/build/*
 cpp/.vscode/*
 cpp/.cache/*
 cpp/.idea/*
+cpp/conan.lock
+cpp/conaninfo.txt
+cpp/conanbuildinfo.txt
+cpp/graph_info.json
 go/.vscode/*
 go/.idea/*
 compile_commands.json

--- a/go/io/fs/minio_fs_test.go
+++ b/go/io/fs/minio_fs_test.go
@@ -22,34 +22,36 @@ func (suite *MinioFsTestSuite) SetupSuite() {
 }
 
 func (suite *MinioFsTestSuite) TestMinioOpenFile() {
-	file, err := suite.fs.OpenFile("a")
+	file, err := suite.fs.OpenFile("default/a")
 	suite.NoError(err)
 	n, err := file.Write([]byte{1})
 	suite.NoError(err)
 	suite.Equal(1, n)
 	suite.NoError(file.Close())
 
-	file, err = suite.fs.OpenFile("a")
+	file, err = suite.fs.OpenFile("default/a")
 	suite.NoError(err)
 	buf := make([]byte, 10)
 	n, err = file.Read(buf)
 	suite.Equal(io.EOF, err)
 	suite.Equal(1, n)
 	suite.ElementsMatch(buf[:n], []byte{1})
+
+	suite.NoError(suite.fs.DeleteFile("default/a"))
 }
 
 func (suite *MinioFsTestSuite) TestMinioRename() {
-	file, err := suite.fs.OpenFile("a")
+	file, err := suite.fs.OpenFile("default/a")
 	suite.NoError(err)
 	n, err := file.Write([]byte{1})
 	suite.NoError(err)
 	suite.Equal(1, n)
 	suite.NoError(file.Close())
 
-	err = suite.fs.Rename("a", "b")
+	err = suite.fs.Rename("default/a", "default/b")
 	suite.NoError(err)
 
-	file, err = suite.fs.OpenFile("b")
+	file, err = suite.fs.OpenFile("default/b")
 	suite.NoError(err)
 	buf := make([]byte, 10)
 	n, err = file.Read(buf)
@@ -59,61 +61,66 @@ func (suite *MinioFsTestSuite) TestMinioRename() {
 }
 
 func (suite *MinioFsTestSuite) TestMinioFsDeleteFile() {
-	file, err := suite.fs.OpenFile("a")
+	file, err := suite.fs.OpenFile("default/a")
 	suite.NoError(err)
 	n, err := file.Write([]byte{1})
 	suite.NoError(err)
 	suite.Equal(1, n)
 	suite.NoError(file.Close())
 
-	err = suite.fs.DeleteFile("a")
+	err = suite.fs.DeleteFile("default/a")
 	suite.NoError(err)
 
-	exist, err := suite.fs.Exist("a")
+	exist, err := suite.fs.Exist("default/a")
 	suite.NoError(err)
 	suite.False(exist)
+
 }
 
 func (suite *MinioFsTestSuite) TestMinioFsList() {
-	file, err := suite.fs.OpenFile("a/b/c")
+	file, err := suite.fs.OpenFile("default/a/b/c")
 	suite.NoError(err)
 	_, err = file.Write([]byte{1})
 	suite.NoError(err)
 	suite.NoError(file.Close())
 
-	entries, err := suite.fs.List("a/")
+	entries, err := suite.fs.List("default/a/")
 	suite.NoError(err)
-	suite.EqualValues([]fs.FileEntry{{Path: "a/b/c"}}, entries)
+	suite.EqualValues([]fs.FileEntry{{Path: "default/a/b/c"}}, entries)
+
+	suite.NoError(suite.fs.DeleteFile("default/a/b/c"))
 }
 
 func (suite *MinioFsTestSuite) TestMinioFsReadFile() {
-	file, err := suite.fs.OpenFile("a")
+	file, err := suite.fs.OpenFile("default/a")
 	suite.NoError(err)
 	n, err := file.Write([]byte{1})
 	suite.NoError(err)
 	suite.Equal(1, n)
 	suite.NoError(file.Close())
 
-	content, err := suite.fs.ReadFile("a")
+	content, err := suite.fs.ReadFile("default/a")
 	suite.NoError(err)
 	suite.EqualValues([]byte{1}, content)
 }
 
 func (suite *MinioFsTestSuite) TestMinioFsExist() {
-	exist, err := suite.fs.Exist("nonexist")
+	exist, err := suite.fs.Exist("default/nonexist")
 	suite.NoError(err)
 	suite.False(exist)
 
-	file, err := suite.fs.OpenFile("exist")
+	file, err := suite.fs.OpenFile("default/exist")
 	suite.NoError(err)
 	n, err := file.Write([]byte{1})
 	suite.NoError(err)
 	suite.Equal(1, n)
 	suite.NoError(file.Close())
 
-	exist, err = suite.fs.Exist("exist")
+	exist, err = suite.fs.Exist("default/exist")
 	suite.NoError(err)
 	suite.True(exist)
+
+	suite.NoError(suite.fs.DeleteFile("default/exist"))
 }
 
 func TestMinioFsSuite(t *testing.T) {


### PR DESCRIPTION
The semantics of "path" are different in the fs interfaces of Go and C++. In C++, the path needs to include the bucket, while in Go version it is not required. This leads to issues with reading and writing.