### PR TITLE
Add missing virtual destructors

### DIFF
--- a/cpp/include/milvus-storage/format/reader.h
+++ b/cpp/include/milvus-storage/format/reader.h
@@ -23,5 +23,7 @@ class Reader {
   virtual void Close() = 0;
 
   virtual Result<std::shared_ptr<arrow::Table>> ReadByOffsets(std::vector<int64_t>& offsets) = 0;
+
+  virtual ~Reader() = default;
 };
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/writer.h
+++ b/cpp/include/milvus-storage/format/writer.h
@@ -26,5 +26,7 @@ class FileWriter {
   virtual int64_t count() = 0;
 
   virtual Status Close() = 0;
+
+  virtual ~FileWriter() = default;
 };
 }  // namespace milvus_storage


### PR DESCRIPTION
Add missing virtual destructors, as mentioned in the clang-tidy log during one of the milvus tests

issue #120 