### PR TITLE
feat: schema evolution for packed reader and file reader

### DIFF
--- a/cpp/include/milvus-storage/common/metadata.h
+++ b/cpp/include/milvus-storage/common/metadata.h
@@ -111,7 +111,8 @@ class PackedFileMetadata {
 
   explicit PackedFileMetadata(const std::shared_ptr<parquet::FileMetaData>& metadata,
                               const RowGroupSizeVector& row_group_sizes,
-                              const std::map<FieldID, ColumnOffset>& field_id_mapping);
+                              const std::map<FieldID, ColumnOffset>& field_id_mapping,
+                              const GroupFieldIDList& group_field_id_list);
 
   static Result<std::shared_ptr<PackedFileMetadata>> Make(std::shared_ptr<parquet::FileMetaData> metadata);
 
@@ -120,6 +121,8 @@ class PackedFileMetadata {
   size_t GetRowGroupSize(int index) const;
 
   const std::map<FieldID, ColumnOffset>& GetFieldIDMapping();
+
+  const GroupFieldIDList GetGroupFieldIDList();
 
   const std::shared_ptr<parquet::FileMetaData>& GetParquetMetadata();
 
@@ -131,6 +134,7 @@ class PackedFileMetadata {
   std::shared_ptr<parquet::FileMetaData> parquet_metadata_;
   RowGroupSizeVector row_group_sizes_;
   std::map<FieldID, ColumnOffset> field_id_mapping_;
+  GroupFieldIDList group_field_id_list_;
 };
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/common/type_fwd.h
+++ b/cpp/include/milvus-storage/common/type_fwd.h
@@ -26,6 +26,8 @@ class RowGroupSizeVector;
 class FieldIDList;
 class GroupFieldIDList;
 
+struct ColumnOffset;
+
 using FieldID = int64_t;
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/parquet/file_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/file_reader.h
@@ -32,6 +32,7 @@ class FileRecordBatchReader : public arrow::RecordBatchReader {
    */
   FileRecordBatchReader(std::shared_ptr<arrow::fs::FileSystem> fs,
                         const std::string& path,
+                        const std::shared_ptr<arrow::Schema> schema,
                         const int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE);
 
   Status SetRowGroupOffsetAndCount(int row_group_offset, int row_group_num);
@@ -58,11 +59,16 @@ class FileRecordBatchReader : public arrow::RecordBatchReader {
   arrow::Status Close();
 
   private:
-  Status init(std::shared_ptr<arrow::fs::FileSystem> fs, const std::string& path, const int64_t buffer_size);
+  Status init(std::shared_ptr<arrow::fs::FileSystem> fs,
+              const std::string& path,
+              const std::shared_ptr<arrow::Schema> schema,
+              const int64_t buffer_size);
 
   std::vector<int> needed_columns_;
+  std::shared_ptr<arrow::Schema> schema_;
   std::unique_ptr<parquet::arrow::FileReader> file_reader_;
   std::shared_ptr<parquet::FileMetaData> metadata_;
+  FieldIDList field_id_list_;
   int rg_start_ = -1;
   int rg_end_ = -1;
   size_t read_count_ = 0;

--- a/cpp/src/common/metadata.cpp
+++ b/cpp/src/common/metadata.cpp
@@ -203,10 +203,12 @@ GroupFieldIDList GroupFieldIDList::Deserialize(const std::string& input) {
 
 PackedFileMetadata::PackedFileMetadata(const std::shared_ptr<parquet::FileMetaData>& metadata,
                                        const RowGroupSizeVector& row_group_sizes,
-                                       const std::map<FieldID, ColumnOffset>& field_id_mapping)
+                                       const std::map<FieldID, ColumnOffset>& field_id_mapping,
+                                       const GroupFieldIDList& group_field_id_list)
     : parquet_metadata_(std::move(metadata)),
       row_group_sizes_(std::move(row_group_sizes)),
-      field_id_mapping_(std::move(field_id_mapping)) {}
+      field_id_mapping_(std::move(field_id_mapping)),
+      group_field_id_list_(std::move(group_field_id_list)) {}
 
 Result<std::shared_ptr<PackedFileMetadata>> PackedFileMetadata::Make(std::shared_ptr<parquet::FileMetaData> metadata) {
   // deserialize row group size metadata
@@ -231,7 +233,7 @@ Result<std::shared_ptr<PackedFileMetadata>> PackedFileMetadata::Make(std::shared
       field_id_mapping[field_id] = ColumnOffset(path, col);
     }
   }
-  return std::make_shared<PackedFileMetadata>(metadata, row_group_sizes, field_id_mapping);
+  return std::make_shared<PackedFileMetadata>(metadata, row_group_sizes, field_id_mapping, group_fields);
 }
 
 const RowGroupSizeVector PackedFileMetadata::GetRowGroupSizeVector() { return row_group_sizes_; }
@@ -239,6 +241,8 @@ const RowGroupSizeVector PackedFileMetadata::GetRowGroupSizeVector() { return ro
 size_t PackedFileMetadata::GetRowGroupSize(int index) const { return row_group_sizes_.Get(index); }
 
 const std::map<FieldID, ColumnOffset>& PackedFileMetadata::GetFieldIDMapping() { return field_id_mapping_; }
+
+const GroupFieldIDList PackedFileMetadata::GetGroupFieldIDList() { return group_field_id_list_; }
 
 const std::shared_ptr<parquet::FileMetaData>& PackedFileMetadata::GetParquetMetadata() { return parquet_metadata_; }
 

--- a/cpp/test/packed/packed_integration_test.cpp
+++ b/cpp/test/packed/packed_integration_test.cpp
@@ -29,9 +29,7 @@ TEST_F(PackedIntegrationTest, TestOneFile) {
   }
   EXPECT_TRUE(writer.Close().ok());
 
-  std::set<int> needed_columns = {0, 1, 2};
-
-  PackedRecordBatchReader pr(fs_, paths, schema_, needed_columns, reader_memory_);
+  PackedRecordBatchReader pr(fs_, paths, schema_, reader_memory_);
   ASSERT_AND_ARROW_ASSIGN(auto table, pr.ToTable());
   ASSERT_STATUS_OK(pr.Close());
 
@@ -49,16 +47,14 @@ TEST_F(PackedIntegrationTest, TestSplitColumnGroup) {
   }
   EXPECT_TRUE(writer.Close().ok());
 
-  std::set<int> needed_columns = {0, 1, 2};
-
-  PackedRecordBatchReader pr(fs_, paths, schema_, needed_columns, reader_memory_);
+  PackedRecordBatchReader pr(fs_, paths, schema_, reader_memory_);
   ASSERT_AND_ARROW_ASSIGN(auto table, pr.ToTable());
   ASSERT_STATUS_OK(pr.Close());
 
   ValidateTableData(table);
 }
 
-TEST_F(PackedIntegrationTest, TestPartialField) {
+TEST_F(PackedIntegrationTest, SchemaEvolutionFewerColumns) {
   int batch_size = 1000;
 
   auto paths = std::vector<std::string>{path_.string() + "/10000.parquet", path_.string() + "/10001.parquet"};
@@ -69,12 +65,52 @@ TEST_F(PackedIntegrationTest, TestPartialField) {
   }
   EXPECT_TRUE(writer.Close().ok());
 
-  std::set<int> needed_columns = {0, 2};
-  PackedRecordBatchReader pr(fs_, paths, schema_, needed_columns, reader_memory_);
+  std::shared_ptr<arrow::Schema> partial_schema = arrow::schema({schema_->field(0)->Copy(), schema_->field(2)->Copy()});
+
+  PackedRecordBatchReader pr(fs_, paths, partial_schema, reader_memory_);
   ASSERT_AND_ARROW_ASSIGN(auto table, pr.ToTable());
-  ASSERT_EQ(table->fields()[0], schema_->field(0));
-  ASSERT_EQ(table->fields()[1], schema_->field(2));
+  ASSERT_EQ(table->fields()[0]->name(), schema_->field(0)->name());
+  ASSERT_EQ(table->fields()[1]->name(), schema_->field(2)->name());
   ASSERT_EQ(table->schema(), pr.schema());
+}
+
+TEST_F(PackedIntegrationTest, SchemaEvolutionMoreColumns) {
+  int batch_size = 1000;
+
+  auto paths = std::vector<std::string>{path_.string() + "/10000.parquet", path_.string() + "/10001.parquet"};
+  auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
+  PackedRecordBatchWriter writer(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+  for (int i = 0; i < batch_size; ++i) {
+    EXPECT_TRUE(writer.Write(record_batch_).ok());
+  }
+  EXPECT_TRUE(writer.Close().ok());
+
+  std::shared_ptr<arrow::Schema> added_field_schema = arrow::schema(
+      {schema_->field(1)->Copy(), schema_->field(0)->Copy(),
+       arrow::field("float", arrow::float32(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"400"})),
+       schema_->field(2)->Copy()});
+
+  PackedRecordBatchReader pr(fs_, paths, added_field_schema, reader_memory_);
+
+  std::shared_ptr<RecordBatch> batch;
+  int total_size = 0;
+  while (true) {
+    ASSERT_STATUS_OK(pr.ReadNext(&batch));
+    if (batch == nullptr) {
+      break;
+    }
+    total_size += batch->num_rows();
+    ASSERT_EQ(batch->num_columns(), 4);
+    ASSERT_EQ(batch->schema()->field(0)->name(), "int64");
+    ASSERT_EQ(batch->schema()->field(1)->name(), "int32");
+    ASSERT_EQ(batch->schema()->field(2)->name(), "float");
+    ASSERT_EQ(batch->schema()->field(3)->name(), "str");
+    ASSERT_EQ(batch->column(0)->null_count(), 0);
+    ASSERT_EQ(batch->column(1)->null_count(), 0);
+    ASSERT_EQ(batch->column(2)->null_count(), batch->num_rows());
+    ASSERT_EQ(batch->column(3)->null_count(), 0);
+  }
+  ASSERT_EQ(total_size, batch_size * 3);
 }
 
 }  // namespace milvus_storage


### PR DESCRIPTION
Schema Evolution Support for PackedReader and FileReader

1. Partial Field Reading: Allow reading only a subset of fields if the reader schema contains fewer fields than the file schema.
2. Field Order Alignment: Ensure that the reading order follows the sequence defined in the reader schema, regardless of the field order in the file schema.
3. Null Value Filling: If the reader schema includes additional fields that are not present in the file schema, fill these fields with null values.

related: #180 
