### PR TITLE
enhance: Set S3Options address as-is

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/s3_fs.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_fs.h
@@ -52,7 +52,7 @@ class S3FileSystemProducer : public FileSystemProducer {
   void InitS3();
 
   private:
-  const ArrowFileSystemConfig& config_;
+  const ArrowFileSystemConfig config_;
 };
 
 static const char* GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG = "GoogleHttpClientFactory";

--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -2514,6 +2514,9 @@ struct AwsInstance {
 };
 
 AwsInstance* GetAwsInstance() {
+  // make sure ClientFinializer is initialized before the AwsInstance
+  // so that the static object destructor is called later
+  GetClientFinalizer();
   static auto instance = std::make_unique<AwsInstance>();
   return instance.get();
 }

--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -106,14 +106,7 @@ Result<arrow::fs::S3Options> S3FileSystemProducer::CreateS3Options() {
     RETURN_ARROW_NOT_OK(arrow::fs::Initialize(fs_global_options));
   }
 
-  auto uri = options.scheme + "://" + config_.bucket_name + "." + config_.address;
-  auto status = uri_parser.Parse(uri);
-  if (!status.ok()) {
-    throw std::invalid_argument("Cannot parse endpoint URI with Arrow file system config: bucket_name=" +
-                                config_.bucket_name + ", address=" + config_.address);
-  }
-
-  options.endpoint_override = uri_parser.ToString();
+  options.endpoint_override = config_.address;
 
   options.force_virtual_addressing = config_.useVirtualHost;
 

--- a/cpp/test/filesystem/s3_fs_test.cpp
+++ b/cpp/test/filesystem/s3_fs_test.cpp
@@ -38,10 +38,11 @@ class S3FileSystemProducerTest : public ::testing::Test {
 };
 
 TEST_F(S3FileSystemProducerTest, TestCreateS3Options_NotUseSSL) {
+  // config.useVirtualHost = true;
   auto producer = std::make_shared<S3FileSystemProducer>(config);
   auto options = producer->CreateS3Options().value();
   EXPECT_EQ(options.scheme, "http");
-  EXPECT_EQ(options.endpoint_override, "http://test-bucket.s3.amazonaws.com");
+  EXPECT_EQ(options.endpoint_override, "s3.amazonaws.com");
   EXPECT_EQ(options.region, config.region);
   EXPECT_EQ(options.force_virtual_addressing, false);
   EXPECT_EQ(options.request_timeout, 3);
@@ -54,7 +55,7 @@ TEST_F(S3FileSystemProducerTest, TestCreateS3Options_UseSSL) {
   auto producer = std::make_shared<S3FileSystemProducer>(config);
   auto options = producer->CreateS3Options().value();
   EXPECT_EQ(options.scheme, "https");
-  EXPECT_EQ(options.endpoint_override, "https://test-bucket.s3.amazonaws.com");
+  EXPECT_EQ(options.endpoint_override, "s3.amazonaws.com");
   EXPECT_EQ(options.region, config.region);
   EXPECT_EQ(options.force_virtual_addressing, true);
   EXPECT_EQ(options.request_timeout, DEFAULT_ARROW_FILESYSTEM_S3_REQUEST_TIMEOUT_SEC);


### PR DESCRIPTION
Endpoint shall be processed via virtual host logic so we shall put s3address as-is to fit minio access.