### PR TITLE
fix: s3fs client finalizer should be a singleton

### DIFF
--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -599,7 +599,7 @@ void S3ClientHolder::Finalize() {
 }
 
 std::shared_ptr<S3ClientFinalizer> GetClientFinalizer() {
-  auto finalizer = std::make_shared<S3ClientFinalizer>();
+  static auto finalizer = std::make_shared<S3ClientFinalizer>();
   return finalizer;
 }
 


### PR DESCRIPTION
This PR fixes error `S3 subsystem is finalized` reported by `PackedWriter` initialization.

s3fs client finalizer is designed to be a singleton that collects all clients. The current implementation missed the `static` keyword, making `GetClientFinalizer` returns an empty instance every time.