### PR TITLE
enhance: Throw error when packed rw init fail

### DIFF
--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -44,7 +44,11 @@ PackedRecordBatchReader::PackedRecordBatchReader(std::shared_ptr<arrow::fs::File
       row_limit_(0),
       absolute_row_position_(0),
       read_count_(0) {
-  init(fs, paths, schema, buffer_size, reader_props);
+  auto status = init(fs, paths, schema, buffer_size, reader_props);
+  if (!status.ok()) {
+    LOG_STORAGE_ERROR_ << "Error initializing PackedRecordBatchReader: " << status.ToString();
+    throw std::runtime_error(status.ToString());
+  }
 }
 
 Status PackedRecordBatchReader::init(std::shared_ptr<arrow::fs::FileSystem> fs,

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -16,6 +16,7 @@
 #include <arrow/type.h>
 #include <cstddef>
 #include <cstdint>
+#include <stdexcept>
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
@@ -39,12 +40,12 @@ PackedRecordBatchWriter::PackedRecordBatchWriter(std::shared_ptr<arrow::fs::File
   if (paths.size() != group_indices_.size()) {
     LOG_STORAGE_ERROR_ << "Mismatch between paths number and column groups number: " << paths.size() << " vs "
                        << group_indices_.size();
-    return;
+    throw runtime_error("Mismatch between paths number and column groups number");
   }
   auto field_id_list = FieldIDList::Make(schema);
   if (!field_id_list.ok()) {
     LOG_STORAGE_ERROR_ << "Failed to get field id from schema: " << schema->ToString();
-    return;
+    throw runtime_error("Failed to get field id from schema: " + schema->ToString());
   }
   group_field_id_list_ = GroupFieldIDList::Make(column_groups, field_id_list.value());
 
@@ -58,6 +59,7 @@ PackedRecordBatchWriter::PackedRecordBatchWriter(std::shared_ptr<arrow::fs::File
       group_writers_.emplace_back(std::move(writer));
     } else {
       LOG_STORAGE_ERROR_ << "Failed to initialize writer for column group " << i << ": " << status.ToString();
+      throw runtime_error("Failed to initialize writer for column group: " + status.ToString());
     }
   }
 }


### PR DESCRIPTION
Make constructor throw error instead of silent failure when reader/writer initialization returns error