### PR TITLE
fix: Use `GetContentLength()` preventing seek to end

### DIFF
--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -500,7 +500,7 @@ class S3Client : public Aws::S3::S3Client {
     if (!outcome.IsSuccess()) {
       metrics_->IncrementFailedCount();
     } else {
-      metrics_->IncrementUploadBytes(request.GetBody()->rdbuf()->pubseekoff(0, std::ios::end, std::ios::in));
+      metrics_->IncrementUploadBytes(request.GetContentLength());
     }
     return outcome;
   }
@@ -511,8 +511,7 @@ class S3Client : public Aws::S3::S3Client {
     if (!outcome.IsSuccess()) {
       metrics_->IncrementFailedCount();
     } else {
-      metrics_->IncrementDownloadBytes(
-          outcome.GetResult().GetBody().rdbuf()->pubseekoff(0, std::ios::end, std::ios::in));
+      metrics_->IncrementDownloadBytes(outcome.GetResult().GetContentLength());
     }
     return outcome;
   }


### PR DESCRIPTION
Related to milvus-io/milvus#43871