### PR TITLE
enhance: Make MultipartUploadS3FS handle bucket logic

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
+++ b/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -35,6 +36,8 @@ namespace milvus_storage {
 
 struct ExtendedS3Options : public arrow::fs::S3Options {
   ExtendedS3Options();
+
+  std::string bucket_name;
 };
 
 class S3ClientMetrics {
@@ -139,8 +142,11 @@ class MultiPartUploadS3FS : public arrow::fs::S3FileSystem {
   protected:
   explicit MultiPartUploadS3FS(const ExtendedS3Options& options, const arrow::io::IOContext& io_context);
 
+  std::string MakePathWithBucketName(const std::string& path) const;
+
   class Impl;
   std::shared_ptr<Impl> impl_;
+  std::filesystem::path bucket_name_;
 };
 
 struct ExtendS3GlobalOptions : public arrow::fs::S3GlobalOptions {

--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -2363,10 +2363,14 @@ Result<std::string> MultiPartUploadS3FS::PathFromUri(const std::string& uri_stri
                                                 arrow::fs::internal::AuthorityHandlingBehavior::kPrepend);
 }
 
+std::string MultiPartUploadS3FS::MakePathWithBucketName(const std::string& path) const {
+  return (bucket_name_ / path).string();
+}
+
 Result<FileInfo> MultiPartUploadS3FS::GetFileInfo(const std::string& s) {
   ARROW_ASSIGN_OR_RAISE(auto client_lock, impl_->holder_->Lock());
 
-  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(MakePathWithBucketName(s)));
   FileInfo info;
   info.set_path(s);
 
@@ -2440,7 +2444,7 @@ FileInfoGenerator MultiPartUploadS3FS::GetFileInfoGenerator(const FileSelector& 
 }
 
 arrow::Status MultiPartUploadS3FS::CreateDir(const std::string& s, bool recursive) {
-  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(MakePathWithBucketName(s)));
 
   if (path.key.empty()) {
     // Create bucket
@@ -2512,7 +2516,7 @@ arrow::Status MultiPartUploadS3FS::CreateDir(const std::string& s, bool recursiv
 }
 
 arrow::Status MultiPartUploadS3FS::DeleteDir(const std::string& s) {
-  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(MakePathWithBucketName(s)));
   if (path.empty()) {
     return Status::NotImplemented("Cannot delete all S3 buckets");
   }
@@ -2540,7 +2544,7 @@ arrow::Status MultiPartUploadS3FS::DeleteDirContents(const std::string& s, bool 
 }
 
 arrow::Future<> MultiPartUploadS3FS::DeleteDirContentsAsync(const std::string& s, bool missing_dir_ok) {
-  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(MakePathWithBucketName(s)));
 
   if (path.empty()) {
     return Status::NotImplemented("Cannot delete all S3 buckets");
@@ -2567,7 +2571,7 @@ arrow::Status MultiPartUploadS3FS::DeleteRootDirContents() {
 arrow::Status MultiPartUploadS3FS::DeleteFile(const std::string& s) {
   ARROW_ASSIGN_OR_RAISE(auto client_lock, impl_->holder_->Lock());
 
-  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(MakePathWithBucketName(s)));
   RETURN_NOT_OK(ValidateFilePath(path));
 
   // Check the object exists
@@ -2630,7 +2634,7 @@ arrow::Result<std::shared_ptr<arrow::io::OutputStream>> MultiPartUploadS3FS::Ope
 arrow::Result<std::shared_ptr<arrow::io::OutputStream>> MultiPartUploadS3FS::OpenOutputStreamWithUploadSize(
     const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t upload_size) {
   ARROW_RETURN_NOT_OK(arrow::fs::internal::AssertNoTrailingSlash(s));
-  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(MakePathWithBucketName(s)));
   RETURN_NOT_OK(ValidateFilePath(path));
 
   RETURN_NOT_OK(CheckS3Initialized());
@@ -2644,10 +2648,11 @@ arrow::Result<std::shared_ptr<arrow::io::OutputStream>> MultiPartUploadS3FS::Ope
 MultiPartUploadS3FS::MultiPartUploadS3FS(const ExtendedS3Options& options, const arrow::io::IOContext& io_context)
     : arrow::fs::S3FileSystem(options, io_context), impl_(std::make_shared<Impl>(options, io_context)) {
   default_async_is_sync_ = false;
+  bucket_name_ = options.bucket_name;
 }
 
 arrow::Result<std::shared_ptr<arrow::io::InputStream>> MultiPartUploadS3FS::OpenInputStream(const std::string& s) {
-  return impl_->OpenInputFile(s, this);
+  return impl_->OpenInputFile(MakePathWithBucketName(s), this);
 }
 
 arrow::Result<std::shared_ptr<arrow::io::InputStream>> MultiPartUploadS3FS::OpenInputStream(const FileInfo& info) {
@@ -2655,7 +2660,7 @@ arrow::Result<std::shared_ptr<arrow::io::InputStream>> MultiPartUploadS3FS::Open
 }
 
 arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> MultiPartUploadS3FS::OpenInputFile(const std::string& s) {
-  return impl_->OpenInputFile(s, this);
+  return impl_->OpenInputFile(MakePathWithBucketName(s), this);
 }
 
 arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> MultiPartUploadS3FS::OpenInputFile(const FileInfo& info) {

--- a/cpp/test/s3_client_metrics_test.cpp
+++ b/cpp/test/s3_client_metrics_test.cpp
@@ -151,7 +151,7 @@ TEST_F(S3ClientMetricsTest, TestMetricsAfterFileOperations) {
   EXPECT_EQ(metrics->GetDownloadCount(), 0);
 
   // Generate a unique test file path
-  std::string test_file_path = BUCKET_NAME + "/" + GenerateTestFilePath();
+  std::string test_file_path = GenerateTestFilePath();
   TrackTestFile(test_file_path);
 
   // Create some test data (large enough to trigger multipart upload)


### PR DESCRIPTION
When using S3 filesystem API, the bucket name shall be the first part of file path input, while local fs don't. This PR make this logic be part of s3fs and transparent to users.

Related to milvus-io/milvus#39173