### PR TITLE
Enhance: Cleanup c/cpp code

### DIFF
--- a/cpp/include/milvus-storage/common/macro.h
+++ b/cpp/include/milvus-storage/common/macro.h
@@ -25,26 +25,16 @@ namespace milvus_storage {
 #undef RETURN_NOT_OK
 #define RETURN_NOT_OK(status) \
   do {                        \
-    auto _s = (status);       \
-    if (!_s.ok()) {           \
-      return _s;              \
+    if (!(status).ok()) {     \
+      return (status);        \
     }                         \
   } while (false)
 
-#define RETURN_ARROW_NOT_OK(status)               \
-  do {                                            \
-    auto _s = (status);                           \
-    if (!_s.ok()) {                               \
-      return Status::ArrowError((_s).ToString()); \
-    }                                             \
-  } while (false)
-
-#define RETURN_ARROW_NOT_OK_WITH_PREFIX(msg, staus)              \
-  do {                                                           \
-    auto status_name = (status);                                 \
-    if (!status_name.ok()) {                                     \
-      return Status::ArrowError((msg) + status_name.ToString()); \
-    }                                                            \
+#define RETURN_ARROW_NOT_OK(status)                   \
+  do {                                                \
+    if (!(status).ok()) {                             \
+      return Status::ArrowError((status).ToString()); \
+    }                                                 \
   } while (false)
 
 #define ASSIGN_OR_RETURN_ARROW_NOT_OK_IMPL(status_name, lhs, rexpr) \

--- a/cpp/include/milvus-storage/common/status.h
+++ b/cpp/include/milvus-storage/common/status.h
@@ -21,7 +21,7 @@ namespace milvus_storage {
 
 class Status {
   public:
-  Status(const Status& s);
+  Status(const Status& s) = default;
 
   Status& operator=(const Status& s);
 

--- a/cpp/include/milvus-storage/file/delete_fragment.h
+++ b/cpp/include/milvus-storage/file/delete_fragment.h
@@ -30,8 +30,6 @@ using pk_type = std::variant<std::string_view, std::int64_t>;
 // DeleteFragment is a set of deleted records
 class DeleteFragment {
   public:
-  DeleteFragment() = default;
-
   DeleteFragment(arrow::fs::FileSystem& fs, std::shared_ptr<Schema> schema, int64_t id = 0);
 
   bool id() const { return id_; }
@@ -53,7 +51,7 @@ class DeleteFragment {
   private:
   int64_t id_;
   std::shared_ptr<Schema> schema_;
-  arrow::fs::FileSystem& fs_;
+  [[maybe_unused]] arrow::fs::FileSystem& fs_;
   // the deleted data parsed from the files of fragment_
   std::unordered_map<pk_type, std::vector<int64_t>> data_;  // pk to versions(if exists)
 };
@@ -80,7 +78,6 @@ class DeleteFragmentVisitor : public arrow::ArrayVisitor {
         continue;
       }
       if (delete_set_.count(value) != 0) {
-        auto v = version_col_->Value(i);
         delete_set_.at(value).push_back(version_col_->Value(i));
       } else {
         delete_set_.emplace(value, std::vector<int64_t>{version_col_->Value(i)});

--- a/cpp/include/milvus-storage/format/parquet/file_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/file_reader.h
@@ -103,7 +103,7 @@ class FileRowGroupReader {
   int rg_end_ = -1;
   int current_rg_ = -1;
 
-  int64_t buffer_size_limit_;
+  int64_t buffer_size_limit_ = 0;
   int64_t buffer_size_ = 0;
   std::shared_ptr<PackedFileMetadata> file_metadata_;
   std::shared_ptr<arrow::Table> buffer_table_ = nullptr;

--- a/cpp/include/milvus-storage/packed/chunk_manager.h
+++ b/cpp/include/milvus-storage/packed/chunk_manager.h
@@ -33,13 +33,14 @@ struct ColumnOffset {
 
   ColumnOffset(int path_index, int col_index) : path_index(path_index), col_index(col_index) {}
 
-  std::string ToString() {
+  std::string ToString() const {
     return "path_index: " + std::to_string(path_index) + ", col_index: " + std::to_string(col_index);
   }
 };
 
 // record which chunk is in use and its offset in the file
 struct ChunkState {
+  public:
   int chunk;
   int64_t offset;
 

--- a/cpp/include/milvus-storage/packed/column_group.h
+++ b/cpp/include/milvus-storage/packed/column_group.h
@@ -33,11 +33,13 @@ class ColumnGroup {
               const std::vector<int>& origin_column_indices,
               const std::shared_ptr<arrow::RecordBatch>& batch);
 
-  ~ColumnGroup();
+  ~ColumnGroup() = default;
 
-  size_t size() const;
+  inline size_t size() const { return batches_.size(); }
 
-  GroupId group_id() const;
+  inline bool Empty() const { return batches_.empty(); }
+
+  inline GroupId GrpId() const { return group_id_; }
 
   Status AddRecordBatch(const std::shared_ptr<arrow::RecordBatch>& batch);
 

--- a/cpp/include/milvus-storage/packed/reader.h
+++ b/cpp/include/milvus-storage/packed/reader.h
@@ -84,7 +84,6 @@ class PackedRecordBatchReader : public arrow::RecordBatchReader {
   Status init(std::shared_ptr<arrow::fs::FileSystem> fs,
               std::vector<std::string>& paths,
               std::shared_ptr<arrow::Schema> origin_schema,
-              int64_t buffer_size,
               parquet::ReaderProperties& reader_props);
 
   Status schemaMatching(std::shared_ptr<arrow::fs::FileSystem> fs,

--- a/cpp/include/milvus-storage/packed/splitter/indices_based_splitter.h
+++ b/cpp/include/milvus-storage/packed/splitter/indices_based_splitter.h
@@ -23,8 +23,6 @@ class IndicesBasedSplitter : public SplitterPlugin {
   public:
   explicit IndicesBasedSplitter(const std::vector<std::vector<int>>& column_indices);
 
-  void Init() override;
-
   std::vector<ColumnGroup> Split(const std::shared_ptr<arrow::RecordBatch>& record) override;
 
   private:

--- a/cpp/include/milvus-storage/packed/splitter/size_based_splitter.h
+++ b/cpp/include/milvus-storage/packed/splitter/size_based_splitter.h
@@ -26,12 +26,12 @@ class SizeBasedSplitter : public SplitterPlugin {
    */
   explicit SizeBasedSplitter(size_t max_group_size);
 
-  void Init() override;
-
-  std::vector<ColumnGroup> SplitRecordBatches(const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches);
-
   std::vector<ColumnGroup> Split(const std::shared_ptr<arrow::RecordBatch>& record) override;
 
+  private:
+  std::vector<ColumnGroup> SplitRecordBatches(const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches);
+
+  private:
   size_t max_group_size_;
   static constexpr size_t SPLIT_THRESHOLD = 1024;  // 1K
 };

--- a/cpp/include/milvus-storage/packed/splitter/splitter_plugin.h
+++ b/cpp/include/milvus-storage/packed/splitter/splitter_plugin.h
@@ -25,8 +25,6 @@ class SplitterPlugin {
   public:
   virtual ~SplitterPlugin() = default;
 
-  virtual void Init() = 0;
-
   // Split the input record batch into multiple groups of columns
   virtual std::vector<ColumnGroup> Split(const std::shared_ptr<arrow::RecordBatch>& record) = 0;
 };

--- a/cpp/include/milvus-storage/packed/writer.h
+++ b/cpp/include/milvus-storage/packed/writer.h
@@ -22,16 +22,17 @@
 
 namespace milvus_storage {
 
-struct MemoryComparator {
-  bool operator()(const std::pair<GroupId, size_t>& a, const std::pair<GroupId, size_t>& b) const {
-    return a.second < b.second;
-  }
-};
-
-using MemoryMaxHeap =
-    std::priority_queue<std::pair<GroupId, size_t>, std::vector<std::pair<GroupId, size_t>>, MemoryComparator>;
-
 class PackedRecordBatchWriter {
+  private:
+  struct MemoryComparator final {
+    bool operator()(const std::pair<GroupId, size_t>& a, const std::pair<GroupId, size_t>& b) const {
+      return a.second < b.second;
+    }
+  };
+
+  using MemoryMaxHeap =
+      std::priority_queue<std::pair<GroupId, size_t>, std::vector<std::pair<GroupId, size_t>>, MemoryComparator>;
+
   public:
   /**
    * @brief Open a packed writer to write needed columns into the specified paths.

--- a/cpp/include/milvus-storage/reader/multi_files_sequential_reader.h
+++ b/cpp/include/milvus-storage/reader/multi_files_sequential_reader.h
@@ -43,8 +43,8 @@ class MultiFilesSequentialReader : public arrow::RecordBatchReader {
   std::unique_ptr<arrow::RecordBatchReader> curr_reader_;
   std::unique_ptr<parquet::arrow::FileReader>
       holding_file_reader_;  // file reader have to outlive than record batch reader, so we hold here.
-  const ReadOptions options_;
   const SchemaOptions schema_options_;
+  const ReadOptions options_;
 
   friend FilterQueryRecordReader;
 };

--- a/cpp/include/milvus-storage/writer.h
+++ b/cpp/include/milvus-storage/writer.h
@@ -49,10 +49,10 @@ enum class CompressionType {
  */
 struct WriteProperties {
   /// Maximum number of rows per row group (affects memory usage and query granularity)
-  int64_t max_row_group_size = 64 * 1024;
+  uint64_t max_row_group_size = 64 * 1024;
 
   /// Write buffer size for each column group writer
-  int64_t buffer_size = 64 * 1024 * 1024;  // 64MB
+  uint64_t buffer_size = 64 * 1024 * 1024;  // 64MB
 
   /// Compression algorithm to use for data storage
   CompressionType compression = CompressionType::ZSTD;

--- a/cpp/src/common/log.cpp
+++ b/cpp/src/common/log.cpp
@@ -86,14 +86,14 @@ std::string GetThreadName() {
   return thread_name;
 }
 
-int64_t get_now_timestamp() {
+int64_t GetNowTimestamp() {
   auto now = std::chrono::system_clock::now().time_since_epoch();
   return std::chrono::duration_cast<std::chrono::seconds>(now).count();
 }
 
 #ifndef WIN32
 
-int64_t get_system_boottime() {
+int64_t GetSystemBoottime() {
   FILE* uptime = fopen("/proc/uptime", "r");
   float since_sys_boot, _;
   auto ret = fscanf(uptime, "%f %f", &since_sys_boot, &_);
@@ -104,7 +104,7 @@ int64_t get_system_boottime() {
   return static_cast<int64_t>(since_sys_boot);
 }
 
-int64_t get_thread_starttime() {
+int64_t GetThreadStarttime() {
 #ifdef __APPLE__
   uint64_t tid;
   pthread_threadid_np(nullptr, &tid);
@@ -140,7 +140,7 @@ int64_t get_thread_starttime() {
 
 int64_t get_thread_start_timestamp() {
   try {
-    return get_now_timestamp() - get_system_boottime() + get_thread_starttime();
+    return GetNowTimestamp() - GetSystemBoottime() + GetThreadStarttime();
   } catch (...) {
     return 0;
   }
@@ -158,7 +158,7 @@ int64_t get_thread_start_timestamp() {
   if (GetThreadTimes(GetCurrentThread(), &ret, &dummy, &dummy, &dummy)) {
     auto ticks = Int64ShllMod32(ret.dwHighDateTime, 32) | ret.dwLowDateTime;
     auto thread_started = ticks / WINDOWS_TICK - SEC_TO_UNIX_EPOCH;
-    return get_now_timestamp() - thread_started;
+    return GetNowTimestamp() - thread_started;
   }
   return 0;
 }

--- a/cpp/src/common/metadata.cpp
+++ b/cpp/src/common/metadata.cpp
@@ -295,9 +295,9 @@ Result<std::shared_ptr<PackedFileMetadata>> PackedFileMetadata::Make(std::shared
   }
   auto group_fields = GroupFieldIDList::Deserialize(group_field_id_list_meta.ValueOrDie());
   std::map<FieldID, ColumnOffset> field_id_mapping;
-  for (int path = 0; path < group_fields.num_groups(); path++) {
+  for (size_t path = 0; path < group_fields.num_groups(); path++) {
     auto field_ids = group_fields.GetFieldIDList(path);
-    for (int col = 0; col < field_ids.size(); col++) {
+    for (size_t col = 0; col < field_ids.size(); col++) {
       FieldID field_id = field_ids.Get(col);
       field_id_mapping[field_id] = ColumnOffset(path, col);
     }

--- a/cpp/src/common/status.cpp
+++ b/cpp/src/common/status.cpp
@@ -16,7 +16,6 @@
 #include <cstdio>
 #include <string>
 namespace milvus_storage {
-Status::Status(const Status& s) : code_(s.code_), msg_(s.msg_) {}
 
 Status& Status::operator=(const Status& s) {
   code_ = s.code_;

--- a/cpp/src/file/delete_fragment.cpp
+++ b/cpp/src/file/delete_fragment.cpp
@@ -27,7 +27,7 @@ arrow::Status DeleteFragmentVisitor::Visit(const arrow::Int64Array& array) { ret
 arrow::Status DeleteFragmentVisitor::Visit(const arrow::StringArray& array) { return Visit<arrow::StringArray>(array); }
 
 DeleteFragment::DeleteFragment(arrow::fs::FileSystem& fs, std::shared_ptr<Schema> schema, int64_t id)
-    : fs_(fs), schema_(schema), id_(id) {}
+    : id_(id), schema_(schema), fs_(fs) {}
 
 Status DeleteFragment::Add(std::shared_ptr<arrow::RecordBatch> batch) {
   auto schema_options = schema_->options();

--- a/cpp/src/format/parquet/file_writer.cpp
+++ b/cpp/src/format/parquet/file_writer.cpp
@@ -32,27 +32,28 @@ ParquetFileWriter::ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
                                      const std::string& file_path,
                                      const StorageConfig& storage_config,
                                      std::shared_ptr<parquet::WriterProperties> writer_props)
-    : schema_(std::move(schema)),
-      fs_(std::move(fs)),
+    : fs_(std::move(fs)),
+      schema_(std::move(schema)),
       file_path_(file_path),
       storage_config_(storage_config),
-      writer_props_(std::move(writer_props)),
       count_(0),
+      writer_props_(std::move(writer_props)),
       cached_size_(0) {}
 
 Status ParquetFileWriter::Init() {
   if (!fs_) {
     return Status::InvalidArgument("Invalid file system for parquet file writer");
   }
+  bool is_local_fs = fs_->type_name() == "local";
   // create parent dir if not exist only for local file system
-  if (fs_->type_name() == "local") {
+  if (is_local_fs) {
     boost::filesystem::path dir_path(file_path_);
     RETURN_ARROW_NOT_OK(fs_->CreateDir(dir_path.parent_path().string()));
   }
 
-  auto s3fs = std::dynamic_pointer_cast<MultiPartUploadS3FS>(fs_);
   std::shared_ptr<arrow::io::OutputStream> sink;
-  if (storage_config_.part_size > 0 && s3fs) {
+  if (storage_config_.part_size > 0 && !is_local_fs) {  // should be s3 fs
+    auto s3fs = std::dynamic_pointer_cast<MultiPartUploadS3FS>(fs_);
     // azure does not support custom part upload size output stream
     ASSIGN_OR_RETURN_ARROW_NOT_OK(sink, s3fs->OpenOutputStreamWithUploadSize(file_path_, storage_config_.part_size));
   } else {
@@ -85,7 +86,7 @@ Status ParquetFileWriter::WriteRecordBatches(const std::vector<std::shared_ptr<a
   size_t rg_size = cached_size_;
 
   for (size_t i = 0; i < batches.size(); ++i) {
-    auto batch = batches[i];
+    const auto& batch = batches[i];
     size_t batch_size = batch_memory_sizes[i];
     int64_t total_rows = batch->num_rows();
     double avg_row_size = static_cast<double>(batch_size) / total_rows;
@@ -104,14 +105,14 @@ Status ParquetFileWriter::WriteRecordBatches(const std::vector<std::shared_ptr<a
         remain_size = DEFAULT_MAX_ROW_GROUP_SIZE - rg_size;
       }
 
-      int64_t max_rows = static_cast<int64_t>(remain_size / avg_row_size);
+      auto max_rows = static_cast<int64_t>(remain_size / avg_row_size);
       if (max_rows <= 0) {
         max_rows = 1;
       }
       int64_t slice_len = std::min(max_rows, total_rows - offset);
       auto slice = batch->Slice(offset, slice_len);
       size_t slice_size = avg_row_size * slice_len;
-      current_batches.push_back(slice);
+      current_batches.emplace_back(slice);
       rg_size += slice_size;
       offset += slice_len;
     }
@@ -123,13 +124,11 @@ Status ParquetFileWriter::WriteRecordBatches(const std::vector<std::shared_ptr<a
 
 Status ParquetFileWriter::WriteRowGroup(const std::vector<std::shared_ptr<arrow::RecordBatch>>& batch,
                                         size_t row_group_size) {
-  int64_t row_offset = count_;
-
   ASSIGN_OR_RETURN_ARROW_NOT_OK(auto table, arrow::Table::FromRecordBatches(batch));
   RETURN_ARROW_NOT_OK(writer_->WriteTable(*table));
 
   // Add row group metadata after writing
-  row_group_metadata_.Add(RowGroupMetadata(row_group_size, table->num_rows(), row_offset));
+  row_group_metadata_.Add(std::move(RowGroupMetadata(row_group_size, table->num_rows(), count_)));
   count_ += table->num_rows();
   return Status::OK();
 }

--- a/cpp/src/packed/chunk_manager.cpp
+++ b/cpp/src/packed/chunk_manager.cpp
@@ -39,7 +39,7 @@ std::vector<std::shared_ptr<arrow::ArrayData>> ChunkManager::SliceChunksByMaxCon
   std::set<int> table_to_pop;
 
   // Identify the chunk for each column and adjust chunk size
-  for (int i = 0; i < column_offsets_.size(); ++i) {
+  for (size_t i = 0; i < column_offsets_.size(); ++i) {
     auto offset = column_offsets_[i];
     auto& table_queue = tables[offset.path_index];
 
@@ -68,7 +68,7 @@ std::vector<std::shared_ptr<arrow::ArrayData>> ChunkManager::SliceChunksByMaxCon
 
   // Slice chunks and advance chunk index as appropriate
   std::vector<std::shared_ptr<arrow::ArrayData>> batch_data(column_offsets_.size());
-  for (int i = 0; i < column_offsets_.size(); ++i) {
+  for (size_t i = 0; i < column_offsets_.size(); ++i) {
     auto& chunk_state = chunk_states_[i];
     const auto& chunk = chunks[i];
     int64_t offset = chunk_state.offset;
@@ -105,7 +105,7 @@ std::vector<std::shared_ptr<arrow::ArrayData>> ChunkManager::SliceChunksByMaxCon
 
 // resets the chunk states for columns in a specific file.
 void ChunkManager::ResetChunkState(int path_index) {
-  for (int j = 0; j < column_offsets_.size(); ++j) {
+  for (size_t j = 0; j < column_offsets_.size(); ++j) {
     if (column_offsets_[j].path_index == path_index) {
       chunk_states_[j].reset();
     }

--- a/cpp/src/packed/splitter/indices_based_splitter.cpp
+++ b/cpp/src/packed/splitter/indices_based_splitter.cpp
@@ -20,8 +20,6 @@ namespace milvus_storage {
 IndicesBasedSplitter::IndicesBasedSplitter(const std::vector<std::vector<int>>& column_indices)
     : column_indices_(column_indices) {}
 
-void IndicesBasedSplitter::Init() {}
-
 std::vector<ColumnGroup> IndicesBasedSplitter::Split(const std::shared_ptr<arrow::RecordBatch>& record) {
   std::vector<ColumnGroup> column_groups;
 

--- a/cpp/src/reader/merge_record_reader.cpp
+++ b/cpp/src/reader/merge_record_reader.cpp
@@ -35,7 +35,7 @@ MergeRecordReader::MergeRecordReader(const ReadOptions& options,
                                      const DeleteFragmentVector& delete_fragments,
                                      arrow::fs::FileSystem& fs,
                                      std::shared_ptr<Schema> schema)
-    : schema_(schema), fs_(fs), options_(options), delete_fragments_(delete_fragments) {
+    : fs_(fs), schema_(schema), options_(options), delete_fragments_(delete_fragments) {
   scalar_reader_ = std::make_unique<MultiFilesSequentialReader>(fs, scalar_fragments, schema->scalar_schema(),
                                                                 schema->options(), options);
   vector_reader_ = std::make_unique<MultiFilesSequentialReader>(fs, vector_fragments, schema->vector_schema(),

--- a/cpp/src/reader/record_reader.cpp
+++ b/cpp/src/reader/record_reader.cpp
@@ -36,7 +36,7 @@ DeleteFragmentVector FilterDeleteFragments(FragmentVector& data_fragments, Delet
   DeleteFragmentVector res;
   for (const auto& fragment : delete_fragments) {
     if (fragment.id() >= minid) {
-      res.push_back(fragment);
+      res.emplace_back(fragment);
     }
   }
   return res;
@@ -104,7 +104,7 @@ bool filters_only_contain_pk_and_version(std::shared_ptr<Schema> schema, const F
 
 std::unique_ptr<arrow::RecordBatchReader> MakeScanDataReader(std::shared_ptr<Manifest> manifest,
                                                              arrow::fs::FileSystem& fs,
-                                                             const ReadOptions& options) {
+                                                             const ReadOptions& /*options*/) {
   auto scalar_reader = std::make_unique<MultiFilesSequentialReader>(fs, manifest->scalar_fragments(),
                                                                     manifest->schema()->scalar_schema(),
                                                                     manifest->schema()->options(), ReadOptions());

--- a/cpp/test/format/parquet/file_reader_test.cpp
+++ b/cpp/test/format/parquet/file_reader_test.cpp
@@ -39,7 +39,7 @@ TEST_F(FileReaderTest, ReadAllColumnsWithEnoughMemory) {
   // Read and validate row counts
   int64_t total_rows = 0;
   std::shared_ptr<arrow::Table> table;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     ASSERT_STATUS_OK(fr.ReadNextRowGroup(&table));
     ASSERT_EQ(table->num_rows(), row_group_sizes.Get(i).row_num());
     total_rows += table->num_rows();
@@ -51,7 +51,7 @@ TEST_F(FileReaderTest, ReadAllColumnsWithEnoughMemory) {
 
   // Verify row group counts
   int64_t expected_rows = 0;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     expected_rows += row_group_sizes.Get(i).row_num();
   }
   ASSERT_EQ(total_rows, expected_rows);
@@ -71,7 +71,7 @@ TEST_F(FileReaderTest, ReadAllColumnsWithFewerMemory) {
   // Read and validate row counts
   int64_t total_rows = 0;
   std::shared_ptr<arrow::Table> table;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     ASSERT_STATUS_OK(fr.ReadNextRowGroup(&table));
     ASSERT_EQ(table->num_rows(), row_group_sizes.Get(i).row_num());
     total_rows += table->num_rows();
@@ -83,7 +83,7 @@ TEST_F(FileReaderTest, ReadAllColumnsWithFewerMemory) {
 
   // Verify row group counts
   int64_t expected_rows = 0;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     expected_rows += row_group_sizes.Get(i).row_num();
   }
   ASSERT_EQ(total_rows, expected_rows);
@@ -222,7 +222,7 @@ TEST_F(FileReaderTest, ReadWithoutSchema) {
 
   int64_t total_rows = 0;
   std::shared_ptr<arrow::Table> table;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     ASSERT_STATUS_OK(fr.ReadNextRowGroup(&table));
     ASSERT_EQ(table->num_rows(), row_group_sizes.Get(i).row_num());
     total_rows += table->num_rows();
@@ -344,7 +344,7 @@ TEST_F(FileReaderTest, ReadAfterAllRowGroups) {
 
   // Read all row groups
   std::shared_ptr<arrow::Table> table;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     ASSERT_STATUS_OK(fr.ReadNextRowGroup(&table));
     ASSERT_NE(table, nullptr);
   }
@@ -391,7 +391,7 @@ TEST_F(FileReaderTest, MemoryPressureWithLargeRowGroups) {
   // Should still be able to read all row groups
   int64_t total_rows = 0;
   std::shared_ptr<arrow::Table> table;
-  for (int i = 0; i < row_group_sizes.size(); ++i) {
+  for (size_t i = 0; i < row_group_sizes.size(); ++i) {
     ASSERT_STATUS_OK(fr.ReadNextRowGroup(&table));
     ASSERT_NE(table, nullptr);
     total_rows += table->num_rows();

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -94,9 +94,6 @@ TEST_F(ParquetFileWriterTest, LargeRecordBatchSplitting) {
   // Create record batch
   auto record_batch = arrow::RecordBatch::Make(schema_, num_rows, {id_array, text_array, vector_array});
 
-  // Calculate memory size
-  size_t batch_memory_size = GetRecordBatchMemorySize(record_batch);
-
   // Create temporary file path
   std::string temp_file = "/tmp/test_large_batch.parquet";
 
@@ -122,7 +119,6 @@ TEST_F(ParquetFileWriterTest, LargeRecordBatchSplitting) {
   for (int i = 0; i < num_row_groups; ++i) {
     const auto& metadata = row_group_metadata.Get(i);
     int64_t row_group_size = metadata.memory_size();
-    int64_t num_rows_in_group = metadata.row_num();
 
     // Verify that row group size is reasonable (should be around 1MB)
     EXPECT_LE(row_group_size, DEFAULT_MAX_ROW_GROUP_SIZE * 1.1);  // Allow some tolerance

--- a/cpp/test/packed/packed_test_base.h
+++ b/cpp/test/packed/packed_test_base.h
@@ -109,8 +109,6 @@ class PackedTestBase : public ::testing::Test {
   }
 
   void ValidateTableData(const std::shared_ptr<arrow::Table>& table) {
-    int64_t total_rows = table->num_rows();
-
     auto chunks = table->GetColumnByName("str");
     int64_t count = 0;
     for (int i = 0; i < chunks->num_chunks(); ++i) {


### PR DESCRIPTION
Currently, the code style of miluvs-storage is not entirely consistent. The current changes aim to unify the code style as much as possible and modify some code that does not follow common C++ practices, including:

- Using get() on shared_ptr/unique_ptr to obtain a raw pointer for method calls. Which is unnecessary and dangerous.
- Removed class-private unused variables and local unused variables.
- Implicit type conversions, ex `for (int i = 0; i < size_t)`, which can be dangerous.
- Unnecessary `std::move`, such as using `std::move` in cases where Return Value Optimization (RVO) already applies.
- Missing `std::move` (resulting in extra memory copies), such as when a local variableis assigned and then passed to `push_back` or `emplace_back`.
- Replacing most `push_back` calls with `emplace_back`, as `push_back` always incurs an additional memory copy.
- Renaming some methods that used underscore naming to camelCase.

This commit does not yet cover all code comprehensively—only parts that were encountered during code review have been modified.