### PR TITLE
Fix: core dump caused by writing to the allnulls column in gtest

### DIFF
--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -36,10 +36,13 @@ class ParquetFileWriterTest : public ::testing::Test {
   protected:
   void SetUp() override {
     // Create schema with mixed data types
-    auto id_field = arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"0"}));
-    auto text_field =
-        arrow::field("text", arrow::utf8(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}));
-    auto vector_field = arrow::field("vector", arrow::fixed_size_binary(128), false,
+    // Current test case exist some nullable columns
+    // should set all field `nullable` to true.
+    auto id_field =
+        arrow::field("id", arrow::int64(), true /*nullable*/, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"0"}));
+    auto text_field = arrow::field("text", arrow::utf8(), true /*nullable*/,
+                                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}));
+    auto vector_field = arrow::field("vector", arrow::fixed_size_binary(128), true /*nullable*/,
                                      arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"}));
 
     schema_ = arrow::schema({id_field, text_field, vector_field});


### PR DESCRIPTION
In the gtest setup test, the schema defines three fields that do not allow null values. When arrow actually writing data to these three columns, `arrow::MakeArrayOfNull` is used to construct the column data.

For the types `arrow::int64` and `arrow::utf8`, this does not cause a core dump. However, for the type `arrow::fixed_size_binary`, this approach causes arrow to produce a core dump.

The relevant arrow logic is located in `column_writer.cc:L1782(WriteArrowSerialize)`:

```
Status WriteArrowSerialize(...)
{
	...
	bool no_nulls = // <---------- `no_nulls` always be true
      writer->descr()->schema_node()->is_required() || (array.null_count() == 0);

    if (!maybe_parent_nulls && no_nulls) {
      PARQUET_CATCH_NOT_OK(writer->WriteBatch(num_levels, def_levels, rep_levels, buffer));
  	} else {
      PARQUET_CATCH_NOT_OK(writer->WriteBatchSpaced(num_levels, def_levels, rep_levels,
                                                  array.null_bitmap_data(),
                                                  array.offset(), buffer));
	}
}
```