### PR TITLE
[DNM] Introduce vortex(demo stage) into storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ compile_commands.json
 CMakeUserPresets.json
 .vscode/*
 go/internal/core/output/*
+cpp/vortex-src/*
+cpp/vortex-src

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,6 +9,31 @@ option(WITH_ASAN "Build with address sanitizer." OFF)
 option(WITH_OPENDAL "Build with opendal." OFF)
 option(WITH_BENCHMARK "Build with micro benchmark." OFF)
 option(WITH_AZURE_FS "Build with azure file system." ON)
+option(WITH_VORTEX "Build with vortex" OFF)
+
+if(WITH_VORTEX)
+  include(ExternalProject)
+  include(FetchContent)
+
+  set(VORTEX_BUILD_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/build-vortex.sh")
+  set(VORTEX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vortex-src)
+
+  FetchContent_Declare(nanoarrow
+    URL "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/apache-arrow-nanoarrow-0.7.0/apache-arrow-nanoarrow-0.7.0.tar.gz")
+  FetchContent_MakeAvailable(nanoarrow)
+
+  ExternalProject_Add(
+    vortex_storage
+    GIT_REPOSITORY "https://github.com/jiaqizho/vortex.git"
+    GIT_TAG "develop"
+    SOURCE_DIR ${VORTEX_SOURCE_DIR}
+    GIT_SHALLOW 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${VORTEX_BUILD_SCRIPT} "${VORTEX_SOURCE_DIR}"
+    BUILD_IN_SOURCE 0
+    INSTALL_COMMAND ""
+  )
+endif()
 
 # Disable Azure FS on macOS since the Arrow library is built without Azure support
 if(APPLE)
@@ -55,8 +80,25 @@ if (WITH_OPENDAL)
   list(APPEND LINK_LIBS opendal)
 endif()
 
+list(APPEND INLCUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+list(APPEND INLCUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+if (WITH_VORTEX) 
+  message(${VORTEX_SOURCE_DIR})
+  add_dependencies(milvus-storage vortex_storage)
+  set(VORTEX_CXX_BUILD_PATH "${VORTEX_SOURCE_DIR}/vortex-cxx/build")
+
+  list(APPEND LINK_LIBS "${VORTEX_CXX_BUILD_PATH}/libvortex.a" "${VORTEX_CXX_BUILD_PATH}/libvortex_cxx_bridge.a" "${VORTEX_CXX_BUILD_PATH}/libvortex_cxx.a")
+  # for vortex header, vortex already link the nanoarrow_static, maybe direct include nanoarrow header?
+  list(APPEND LINK_LIBS "nanoarrow_static")
+  
+  list(APPEND INLCUDE_PATHS ${VORTEX_SOURCE_DIR}/vortex-cxx/cpp/include)
+  # only for debug...
+  list(APPEND INLCUDE_PATHS ${VORTEX_CXX_BUILD_PATH}/corrosion_generated/cxxbridge/vortex_cxx_bridge/include/)
+endif()
+
 target_link_libraries(milvus-storage PUBLIC ${LINK_LIBS})
-target_include_directories(milvus-storage PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(milvus-storage PUBLIC ${INLCUDE_PATHS})
 
 if (WITH_UT)
   add_subdirectory(test)

--- a/cpp/include/milvus-storage/vortex/VortexReader.h
+++ b/cpp/include/milvus-storage/vortex/VortexReader.h
@@ -1,0 +1,25 @@
+#include <string>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <arrow/result.h>
+#include <parquet/properties.h>
+
+namespace milvus_storage {
+class VortexReader {
+  public:
+  VortexReader(std::shared_ptr<arrow::fs::FileSystem> fs, std::string path);
+
+  arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> TakeToRecordBatchs(const uint64_t* indices,
+                                                                                     std::size_t size);
+
+  arrow::Result<std::shared_ptr<arrow::Table>> TakeToTable(const uint64_t* indices, std::size_t size);
+
+  void close();
+
+  private:
+  std::string path_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/vortex/VortexWriter.h
+++ b/cpp/include/milvus-storage/vortex/VortexWriter.h
@@ -1,0 +1,35 @@
+
+#include <string>
+#include "milvus-storage/writer.h"
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <arrow/result.h>
+#include <parquet/properties.h>
+
+namespace milvus_storage {
+using namespace milvus_storage::api;
+class VortexWriter {
+  public:
+  VortexWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
+               std::string base_path,
+               std::shared_ptr<arrow::Schema> schema,
+               WriteProperties properties = default_write_properties);
+
+  ~VortexWriter() = default;
+
+  arrow::Status write(const std::shared_ptr<arrow::RecordBatch>& batch);
+
+  arrow::Status flush();
+
+  void close();
+
+  private:
+  std::string path_;
+  std::shared_ptr<arrow::Schema> schema_;
+  WriteProperties properties_;
+
+  // ::vortex::VortexFile vortex_file_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/scripts/build-vortex.sh
+++ b/cpp/scripts/build-vortex.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+VORTEX_SOURCE_DIR=$1
+VORTEX_BUILD_DIR="${VORTEX_SOURCE_DIR}/vortex-cxx/build"
+LIB_FILE="${VORTEX_BUILD_DIR}/libvortex.a" # main static lib
+
+if [ -f "$LIB_FILE" ]; then
+    echo "libvortex.a exists, running make only."
+    cd "${VORTEX_BUILD_DIR}" && make -j24
+else
+    echo "libvortex.a does not exist, running full build process."
+    cd "${VORTEX_SOURCE_DIR}/vortex-cxx" && \
+    mkdir -p build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Debug && \
+    make -j24
+fi

--- a/cpp/src/vortex/VortexReader.cpp
+++ b/cpp/src/vortex/VortexReader.cpp
@@ -1,0 +1,38 @@
+
+#include "milvus-storage/vortex/VortexReader.h"
+#include "vortex.hpp"
+#include <arrow/c/bridge.h>
+#include <arrow/chunked_array.h>
+#include <arrow/array.h>
+
+namespace milvus_storage {
+
+VortexReader::VortexReader(std::shared_ptr<arrow::fs::FileSystem> /*fs*/, std::string path) : path_(std::move(path)) {}
+
+arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> VortexReader::TakeToRecordBatchs(
+    const uint64_t* indices, std::size_t size) {
+  auto file = vortex::VortexFile::Open(path_);
+  auto scan_builder = file.CreateScanBuilder().WithIncludeByIndex(indices, size).IntoStream();
+
+  auto rb_reader = *arrow::ImportRecordBatchReader(&scan_builder);
+  auto rbs = rb_reader->ToRecordBatches();
+  rb_reader->Close();
+  return rbs;
+}
+
+// There still remain lots of interface have not export in C++ implments
+arrow::Result<std::shared_ptr<arrow::Table>> VortexReader::TakeToTable(const uint64_t* indices, std::size_t size) {
+  auto file = vortex::VortexFile::Open(path_);
+  auto scan_builder = file.CreateScanBuilder().WithIncludeByIndex(indices, size).IntoStream();
+
+  auto rb_reader = *arrow::ImportRecordBatchReader(&scan_builder);
+  auto tb = rb_reader->ToTable();
+  rb_reader->Close();
+  return tb;
+}
+
+void VortexReader::close() {
+  // nothing todo
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/vortex/VortexWriter.cpp
+++ b/cpp/src/vortex/VortexWriter.cpp
@@ -1,0 +1,51 @@
+#include "milvus-storage/vortex/VortexWriter.h"
+#include "vortex.hpp"
+#include <arrow/c/bridge.h>
+#include <arrow/chunked_array.h>
+#include <arrow/array.h>
+
+namespace milvus_storage {
+
+VortexWriter::VortexWriter(std::shared_ptr<arrow::fs::FileSystem> /*fs*/,
+                           std::string base_path,
+                           std::shared_ptr<arrow::Schema> schema,
+                           WriteProperties properties)
+    : path_(std::move(base_path)), schema_(std::move(schema)), properties_(std::move(properties)) {}
+
+arrow::Status VortexWriter::write(const std::shared_ptr<arrow::RecordBatch>& batch) {
+  ArrowArrayStream stream_reader{};
+
+  const int ncolumns = static_cast<int>(schema_->num_fields());
+  if (!batch->schema()->Equals(*schema_, false)) {
+    return arrow::Status::Invalid("Schema", " was different: \n", schema_->ToString(), "\nvs\n",
+                                  batch->schema()->ToString());
+  }
+
+  ::vortex::VortexWriteOptions write_options;
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> columns(ncolumns);
+  // must be struct, limit by arrow-ffi(for rust)
+  assert(ncolumns == 1);
+  for (int i = 0; i < ncolumns; ++i) {
+    std::vector<std::shared_ptr<arrow::Array>> column_arrays(1);
+    column_arrays[0] = batch->column(i);
+    columns[i] = std::make_shared<arrow::ChunkedArray>(column_arrays, schema_->field(i)->type());
+
+    // columns[i] = std::make_shared<arrow::ChunkedArray>(batch->column(i));
+    ARROW_RETURN_NOT_OK(ExportChunkedArray(columns[i], &stream_reader));
+    std::string copy_path = path_;
+    write_options.WriteArrayStream(stream_reader, copy_path);
+  }
+
+  return arrow::Status::OK();
+}
+
+arrow::Status VortexWriter::flush() {
+  // NO implements
+  return arrow::Status::OK();
+}
+
+void VortexWriter::close() {
+  // NO implements
+}
+
+}  // namespace milvus_storage

--- a/cpp/test/packed/packed_test_base.h
+++ b/cpp/test/packed/packed_test_base.h
@@ -24,7 +24,7 @@
 #include <arrow/builder.h>
 #include <arrow/type.h>
 #include <arrow/util/key_value_metadata.h>
-#include "arrow/table.h"
+#include <arrow/table.h>
 
 #include "test_util.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -37,7 +37,7 @@
 #include <parquet/properties.h>
 #include <vector>
 #include <string>
-#include "boost/filesystem/path.hpp"
+#include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
 namespace milvus_storage {

--- a/cpp/test/vortex/basic_test.cpp
+++ b/cpp/test/vortex/basic_test.cpp
@@ -1,0 +1,131 @@
+#include <memory>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/filesystem/s3fs.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/api.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/type_fwd.h>
+#include <arrow/array.h>
+#include <arrow/record_batch.h>
+#include <arrow/builder.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+#include <arrow/table.h>
+
+#include "test_util.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/common/constants.h"
+#include <gtest/gtest.h>
+#include "milvus-storage/vortex/VortexWriter.h"
+#include "milvus-storage/vortex/VortexReader.h"
+
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
+
+namespace milvus_storage {
+
+class VortexBasicTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    path_ = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    auto conf = ArrowFileSystemConfig();
+    conf.storage_type = "local";
+    conf.root_path = path_.string();
+
+    ArrowFileSystemSingleton::GetInstance().Init(conf);
+    fs_ = ArrowFileSystemSingleton::GetInstance().GetArrowFileSystem();
+
+    record_batch_ = randomRecordBatch();
+    table_ = arrow::Table::FromRecordBatches({record_batch_}).ValueOrDie();
+    schema_ = table_->schema();
+  }
+
+  private:
+  std::shared_ptr<arrow::RecordBatch> randomRecordBatch() {
+    auto fields = {
+        arrow::field("int32", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+        arrow::field("int64", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
+        arrow::field("str", arrow::utf8(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"300"}))};
+    // limit by arrow-ffi
+    auto struct_field = ::arrow::field("struct", arrow::struct_(fields));
+    auto schema = arrow::schema({struct_field});
+    std::shared_ptr<arrow::Array> struct_array;
+
+    auto int_builder = std::make_shared<arrow::Int32Builder>();
+    auto int64_builder = std::make_shared<arrow::Int64Builder>();
+    auto str_builder = std::make_shared<arrow::StringBuilder>();
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>> builders = {int_builder, int64_builder, str_builder};
+    arrow::StructBuilder struct_builder(arrow::struct_(fields), arrow::default_memory_pool(), builders);
+
+    int32_values = {1, 2, 3};
+    int64_values = {11, 12, 13};
+    str_values = {random_string(10000), random_string(10000), random_string(10000)};
+
+    int_builder->AppendValues(int32_values).ok();
+    int64_builder->AppendValues(int64_values).ok();
+    str_builder->AppendValues(str_values).ok();
+    struct_builder.Append(true).ok();
+
+    struct_builder.Finish(&struct_array).ok();
+
+    return arrow::RecordBatch::Make(schema, 1, {struct_array});
+  }
+
+  std::string random_string(size_t length) {
+    auto randchar = []() -> char {
+      const char charset[] =
+          "0123456789"
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+          "abcdefghijklmnopqrstuvwxyz";
+      const size_t max_index = (sizeof(charset) - 1);
+      return charset[rand() % max_index];
+    };
+    std::string str(length, 0);
+    std::generate_n(str.begin(), length, randchar);
+    return str;
+  }
+
+  protected:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  boost::filesystem::path path_;
+
+  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<arrow::RecordBatch> record_batch_;
+  std::shared_ptr<arrow::Table> table_;
+
+  std::vector<int32_t> int32_values;
+  std::vector<int64_t> int64_values;
+  std::vector<std::basic_string<char>> str_values;
+};
+
+TEST_F(VortexBasicTest, TestBasicWriteRead) {
+  auto vw = VortexWriter(fs_, path_.string() + "/test.vortex", schema_);
+  vw.write(record_batch_);
+  vw.flush();
+  vw.close();
+
+  auto vr = VortexReader(fs_, path_.string() + "/test.vortex");
+  uint64_t idx = 0;
+  auto rbs = vr.TakeToRecordBatchs(&idx, 1);
+  ASSERT_TRUE(rbs.ok());
+  ASSERT_EQ((*rbs).size(), 1);
+  ASSERT_EQ((*rbs)[0]->num_rows(), 1);
+
+  // take the row1
+  auto tb = vr.TakeToTable(&idx, 1);
+  ASSERT_TRUE(tb.ok());
+  ASSERT_EQ((*tb)->fields().size(), 3);
+  auto f1 = (*tb)->field(0);
+
+  auto chunks = (*tb)->GetColumnByName("int32");
+  ASSERT_EQ(chunks->num_chunks(), 1);
+  auto int32_array = std::dynamic_pointer_cast<arrow::Int32Array>(chunks->chunk(0));
+  ASSERT_EQ(int32_array->length(), 1);
+  ASSERT_EQ(int32_array->Value(0), 1);  // row1
+
+  vr.close();
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
DON'T MERGE THIS PR. The current PR is just a demo, and it may be implemented in the future (or not).

In the current version of `vortex`, the `vortex-cxx` interface lacks of filesystem interface support.

There are currently two possible solutions to this problem.
1. Extend the vortex-cxx interface, perhaps using make_object_store, which uses the vortex implementation.
2. Find a way to add the S3 interface implemented in storage to vortex.


