### PR TITLE
enhance: Introduce error code in storage reader FFI

### DIFF
--- a/cpp/include/milvus-storage/result_c.h
+++ b/cpp/include/milvus-storage/result_c.h
@@ -1,0 +1,57 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef RESULT_C
+#define RESULT_C
+
+#define LOON_SUCCESS 0
+#define LOON_INVALID_ARGS 1
+#define LOON_MEMORY_ERROR 2
+#define LOON_ARROW_ERROR 3
+#define LOON_LOGICAL_ERROR 4
+#define LOON_GOT_EXCEPTION 5
+#define LOON_UNREACHABLE_ERROR 6
+#define LOON_ERRORCODE_MAX 7
+
+// usage example(caller must free the message string):
+//
+// FFIResult result = SomeFFIFunction(...);
+// if (!IsSuccess(&result)) {
+//    printf("Error: %s\n", GetErrorMessage(&result));
+//    ... // handle error, e.g. log result.message
+//    FreeFFIResult(&result); // free the message string
+// }
+typedef struct ffi_result {
+  int err_code;
+  char* message;
+} FFIResult;
+
+// check result is success
+int IsSuccess(FFIResult* result);
+
+// get the error message, return NULL if success
+const char* GetErrorMessage(FFIResult* result);
+
+// free the message string inside FFIResult
+void FreeFFIResult(FFIResult* result);
+
+#endif  // RESULT_C
+
+#ifdef __cplusplus
+}
+#endif

--- a/cpp/include/milvus-storage/result_internal.h
+++ b/cpp/include/milvus-storage/result_internal.h
@@ -1,0 +1,58 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "milvus-storage/result_c.h"
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sstream>
+#include <cassert>
+#include <iostream>
+
+#define RETURN_SUCCESS()                     \
+  do {                                       \
+    return FFIResult{LOON_SUCCESS, nullptr}; \
+  } while (0)
+
+#define RETURN_ERROR(code, ...)                    \
+  do {                                             \
+    return CreateFFIResult((code), ##__VA_ARGS__); \
+  } while (0)
+
+#define RETURN_UNREACHABLE() RETURN_ERROR(LOON_UNREACHABLE_ERROR);
+
+std::string error_to_string(int code);
+
+template <typename... Args>
+FFIResult CreateFFIResult(int code, Args&&... args) {
+  FFIResult result;
+  std::ostringstream ss;
+  assert(code != LOON_SUCCESS);
+
+  ss << "ERROR: " << error_to_string(code) << "(code " << code << ") details: ";
+  if constexpr (sizeof...(Args) > 0) {
+    (ss << ... << std::forward<Args>(args));
+  } else {
+    ss << "<no details>";
+  }
+
+  result.err_code = code;
+  result.message = strdup(ss.str().c_str());
+
+  return result;
+}

--- a/cpp/src/result_c.cpp
+++ b/cpp/src/result_c.cpp
@@ -1,0 +1,54 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/result_c.h"
+#include "milvus-storage/result_internal.h"
+
+#include <string.h>
+#include <cassert>
+
+std::string error_to_string(int code) {
+  static std::string error_strings[] = {"Success",                   // NOLINT
+                                        "Invalid args",              //
+                                        "Memory allocation failed",  //
+                                        "Internal error",            //
+                                        "Logical error",             //
+                                        "Got exception",             //
+                                        "Unreachable code"};
+  static_assert(sizeof(error_strings) / sizeof((error_strings)[0]) == LOON_ERRORCODE_MAX);
+
+  if (code < LOON_SUCCESS || code >= LOON_ERRORCODE_MAX) {
+    return "Unknown error(undefined)";
+  }
+
+  return error_strings[code];
+}
+
+int IsSuccess(FFIResult* result) {
+  assert(result);
+  return result->err_code == LOON_SUCCESS;
+}
+
+const char* GetErrorMessage(FFIResult* result) {
+  assert(result);
+  if (IsSuccess(result)) {
+    return NULL;
+  }
+  return result->message;
+}
+
+void FreeFFIResult(FFIResult* result) {
+  assert(result);
+  free(result->message);
+}


### PR DESCRIPTION
This commit changes the return values of all FFI functions
(which may failed) to int. The caller can use the `errno_c.h`
as header to obtain specific error types. Before returning
an error in FFI, detailed error information will be printed
to stderr.