### PR TITLE
enhance: implement the get_chunks interface in the FFI

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -221,6 +221,14 @@ FFIResult get_chunks(ChunkReaderHandle reader,
                      size_t* num_arrays);
 
 /**
+ * @brief Frees an array of ArrowArray allocated by get_chunks
+ *
+ * @param arrays Array of ArrowArray to free
+ * @param num_arrays Number of arrays in the array
+ */
+void free_chunk_arrays(struct ArrowArray* arrays, size_t num_arrays);
+
+/**
  * @brief Destroys a ChunkReader
  *
  * @param reader ChunkReader handle to destroy

--- a/cpp/test/ffi/arrow_c_wrapper.c
+++ b/cpp/test/ffi/arrow_c_wrapper.c
@@ -123,8 +123,7 @@ void struct_schema_release(struct ArrowSchema* schema) {
   schema->release = NULL;
 }
 
-static int field_offset = 0;
-struct ArrowSchema* create_test_field_schema(const char* format, const char* name, int nullable) {
+struct ArrowSchema* create_test_field_schema(const char* format, const char* name, int nullable, int field_offset) {
   struct ArrowSchema* schema = malloc(sizeof(struct ArrowSchema));
   if (schema == NULL) {
     return NULL;
@@ -138,9 +137,9 @@ struct ArrowSchema* create_test_field_schema(const char* format, const char* nam
   schema->children = NULL;
   schema->dictionary = NULL;
   // work around to make sure each field has a milvus:field_id
-  char fid = '1' + field_offset++;
+  assert(field_offset < 9);
+  char fid = '1' + field_offset;
   char fid_str[2] = {fid, '\0'};
-  assert(field_offset < 10);
   schema->metadata = create_arrow_schema_meta(1, "PARQUET:field_id", fid_str);
 
   schema->release = field_schema_release;
@@ -163,13 +162,13 @@ struct ArrowSchema* create_test_struct_schema() {
   table_schema->children = malloc(sizeof(struct ArrowSchema*) * 3);
 
   // first field: int64
-  table_schema->children[0] = create_test_field_schema("l", FIELD_INT64_NAME, 0);
+  table_schema->children[0] = create_test_field_schema("l", FIELD_INT64_NAME, 0, 0);
 
   // second field: int32
-  table_schema->children[1] = create_test_field_schema("i", FIELD_INT32_NAME, 1);
+  table_schema->children[1] = create_test_field_schema("i", FIELD_INT32_NAME, 1, 1);
 
   // third field: utf8 string
-  table_schema->children[2] = create_test_field_schema("u", FIELD_STRING_NAME, 1);
+  table_schema->children[2] = create_test_field_schema("u", FIELD_STRING_NAME, 1, 2);
 
   table_schema->dictionary = NULL;
   table_schema->metadata = NULL;

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -17,7 +17,7 @@ int main(void) {
   int failed;
   SRunner* sr;
 
-  setenv("CK_FORK", "0", 1);
+  setenv("CK_FORK", "NO", 1);
   setenv("CK_DEFAULT_TIMEOUT", "0", 1);
   setenv("CK_VERBOSITY", "verbose", 1);
 
@@ -25,6 +25,7 @@ int main(void) {
   srunner_add_suite(sr, make_properties_suite());
   srunner_add_suite(sr, make_writer_suite());
   srunner_add_suite(sr, make_reader_suite());
+  srunner_set_fork_status(sr, CK_NOFORK);
 
   srunner_run_all(sr, CK_NORMAL);
   failed = srunner_ntests_failed(sr);


### PR DESCRIPTION
`get_chunks` used for reading multiple row groups (in the case of Parquet) data.

In the top-level reader API, this method was not tested. The current commit modifies the following issues:

- If the provided rowid exceeds the current file list (in the manifest), an error will be returned.
- If the provided parallelism is 0, no data will be returned.