### PR TITLE
enhance: remove glog to avoid large TLS

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ option(ARROW_WITH_JEMALLOC "Build with jemalloc." OFF)
 
 include(GNUInstallDirs)
 
-add_compile_definitions(GLOG_USE_GLOG_EXPORT) # fix glog build error
+# add_compile_definitions(GLOG_USE_GLOG_EXPORT) # fix glog build error
 
 if (WITH_OPENDAL)
   add_compile_definitions(MILVUS_OPENDAL)
@@ -42,7 +42,7 @@ find_package(Arrow REQUIRED)
 include_directories(${Arrow_INCLUDE_DIRS})
 
 find_package(Protobuf REQUIRED)
-find_package(glog REQUIRED)
+# find_package(glog REQUIRED)
 find_package(google-cloud-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
@@ -79,7 +79,7 @@ if (WITH_OPENDAL)
   list(APPEND LINK_LIBS opendal)
 endif()
 
-list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management glog::glog google-cloud-cpp::storage nlohmann_json::nlohmann_json)
+list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management google-cloud-cpp::storage nlohmann_json::nlohmann_json)
 list(APPEND INLCUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 target_link_libraries(milvus-storage PUBLIC ${LINK_LIBS})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -23,8 +23,6 @@ option(ARROW_WITH_JEMALLOC "Build with jemalloc." OFF)
 
 include(GNUInstallDirs)
 
-# add_compile_definitions(GLOG_USE_GLOG_EXPORT) # fix glog build error
-
 if (WITH_OPENDAL)
   add_compile_definitions(MILVUS_OPENDAL)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -42,7 +40,6 @@ find_package(Arrow REQUIRED)
 include_directories(${Arrow_INCLUDE_DIRS})
 
 find_package(Protobuf REQUIRED)
-# find_package(glog REQUIRED)
 find_package(google-cloud-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -95,7 +95,6 @@ class StorageConan(ConanFile):
         self.requires("arrow/17.0.0@milvus/dev-2.6#7af258a853e20887f9969f713110aac8")
         self.requires("openssl/3.1.2#02594c4c0a6e2b4feb3cd15119993597")
         self.requires("protobuf/3.21.4#fd372371d994b8585742ca42c12337f9")
-        # self.requires("glog/0.6.0#d22ebf9111fed68de86b0fa6bf6f9c3f")
         self.requires("zlib/1.2.13#df233e6bed99052f285331b9f54d9070")
         self.requires("libcurl/7.86.0#bbc887fae3341b3cb776c601f814df05")
         self.requires("nlohmann_json/3.11.2#ffb9e9236619f1c883e36662f944345d")

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -95,7 +95,7 @@ class StorageConan(ConanFile):
         self.requires("arrow/17.0.0@milvus/dev-2.6#7af258a853e20887f9969f713110aac8")
         self.requires("openssl/3.1.2#02594c4c0a6e2b4feb3cd15119993597")
         self.requires("protobuf/3.21.4#fd372371d994b8585742ca42c12337f9")
-        self.requires("glog/0.6.0#d22ebf9111fed68de86b0fa6bf6f9c3f")
+        # self.requires("glog/0.6.0#d22ebf9111fed68de86b0fa6bf6f9c3f")
         self.requires("zlib/1.2.13#df233e6bed99052f285331b9f54d9070")
         self.requires("libcurl/7.86.0#bbc887fae3341b3cb776c601f814df05")
         self.requires("nlohmann_json/3.11.2#ffb9e9236619f1c883e36662f944345d")

--- a/cpp/include/milvus-storage/common/log.h
+++ b/cpp/include/milvus-storage/common/log.h
@@ -33,7 +33,6 @@
 #include <string>
 #include <sys/types.h>
 #include <unistd.h>
-#include <iostream>
 
 // namespace milvus {
 

--- a/cpp/include/milvus-storage/common/log.h
+++ b/cpp/include/milvus-storage/common/log.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <sys/types.h>
 #include <unistd.h>
-#include "glog/logging.h"
+#include <iostream>
 
 // namespace milvus {
 
@@ -59,13 +59,6 @@
 #define STORAGE_MODULE_CLASS_FUNCTION \
   LogOut("[%s][%s::%s][%s] ", STORAGE_MODULE_NAME, (typeid(*this).name()), __FUNCTION__, GetThreadName().c_str())
 #define STORAGE_MODULE_FUNCTION LogOut("[%s][%s][%s] ", STORAGE_MODULE_NAME, __FUNCTION__, GetThreadName().c_str())
-
-#define LOG_STORAGE_TRACE_ DLOG(INFO) << STORAGE_MODULE_FUNCTION
-#define LOG_STORAGE_DEBUG_ DLOG(INFO) << STORAGE_MODULE_FUNCTION
-#define LOG_STORAGE_INFO_ LOG(INFO) << STORAGE_MODULE_FUNCTION
-#define LOG_STORAGE_WARNING_ LOG(WARNING) << STORAGE_MODULE_FUNCTION
-#define LOG_STORAGE_ERROR_ LOG(ERROR) << STORAGE_MODULE_FUNCTION
-#define LOG_STORAGE_FATAL_ LOG(FATAL) << STORAGE_MODULE_FUNCTION
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/cpp/include/milvus-storage/filesystem/io/io_util.h
+++ b/cpp/include/milvus-storage/filesystem/io/io_util.h
@@ -2,7 +2,7 @@
 #include <arrow/status.h>
 #include <arrow/util/thread_pool.h>
 #include <stdexcept>
-#include "milvus-storage/common/log.h"
+#include "arrow/util/logging.h"
 
 namespace milvus_storage {
 
@@ -20,7 +20,7 @@ inline void CloseFromDestructor(arrow::io::FileInterface* file) {
     auto file_type = typeid(*file).name();
     std::stringstream ss;
     ss << "When destroying file of type " << file_type << ": " << st.message();
-    LOG_STORAGE_ERROR_ << st.WithMessage(ss.str());
+    ARROW_LOG(ERROR) << st.WithMessage(ss.str());
     throw std::runtime_error(ss.str());
   }
 }

--- a/cpp/include/milvus-storage/filesystem/s3/s3_fs.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_fs.h
@@ -26,7 +26,6 @@
 #include <google/cloud/storage/oauth2/google_credentials.h>
 #include <google/cloud/status_or.h>
 #include <cstdlib>
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"

--- a/cpp/src/common/log.cpp
+++ b/cpp/src/common/log.cpp
@@ -44,6 +44,7 @@
 #include <chrono>
 #include <cstdarg>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/cpp/src/filesystem/azure/azure_fs.cpp
+++ b/cpp/src/filesystem/azure/azure_fs.cpp
@@ -16,7 +16,6 @@
 
 #include "arrow/filesystem/azurefs.h"
 #include <cstdlib>
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/azure/azure_fs.h"

--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -34,7 +34,6 @@
 #include "milvus-storage/filesystem/s3/TencentCloudSTSClient.h"
 #include "milvus-storage/filesystem/s3/AliyunCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/TencentCloudCredentialsProvider.h"
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/s3/s3_fs.h"
 #include "milvus-storage/filesystem/fs.h"

--- a/cpp/src/format/parquet/chunk_reader.cpp
+++ b/cpp/src/format/parquet/chunk_reader.cpp
@@ -32,7 +32,6 @@
 #include "milvus-storage/format/parquet/reader.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/arrow_util.h"
 
 namespace milvus_storage::parquet {

--- a/cpp/src/format/parquet/file_reader.cpp
+++ b/cpp/src/format/parquet/file_reader.cpp
@@ -24,6 +24,7 @@
 #include <arrow/type.h>
 #include <arrow/type_fwd.h>
 #include <arrow/util/key_value_metadata.h>
+#include <arrow/util/logging.h>
 
 #include <parquet/arrow/schema.h>
 #include <parquet/type_fwd.h>
@@ -31,7 +32,6 @@
 #include "milvus-storage/format/parquet/file_reader.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/status.h"
 #include "milvus-storage/packed/chunk_manager.h"
@@ -44,7 +44,7 @@ FileRowGroupReader::FileRowGroupReader(std::shared_ptr<arrow::fs::FileSystem> fs
                                        parquet::ReaderProperties reader_props) {
   auto status = init(fs, path, buffer_size, nullptr, reader_props);
   if (!status.ok()) {
-    LOG_STORAGE_ERROR_ << "Error initializing file reader: " << status.ToString();
+    ARROW_LOG(ERROR) << "Error initializing file reader: " << status.ToString();
     throw std::runtime_error(status.ToString());
   }
 }
@@ -56,7 +56,7 @@ FileRowGroupReader::FileRowGroupReader(std::shared_ptr<arrow::fs::FileSystem> fs
                                        parquet::ReaderProperties reader_props) {
   auto status = init(fs, path, buffer_size, schema, reader_props);
   if (!status.ok()) {
-    LOG_STORAGE_ERROR_ << "Error initializing file reader: " << status.ToString();
+    ARROW_LOG(ERROR) << "Error initializing file reader: " << status.ToString();
     throw std::runtime_error(status.ToString());
   }
 }
@@ -182,7 +182,7 @@ arrow::Status FileRowGroupReader::SliceRowGroupFromTable(std::shared_ptr<arrow::
 
 arrow::Status FileRowGroupReader::ReadNextRowGroup(std::shared_ptr<arrow::Table>* out) {
   if (current_rg_ > rg_end_ || rg_start_ == -1) {
-    LOG_STORAGE_WARNING_ << "Please set row group offset and count before reading next.";
+    ARROW_LOG(WARNING) << "Please set row group offset and count before reading next.";
     current_rg_ = -1;
     rg_start_ = -1;
     rg_end_ = -1;
@@ -218,7 +218,7 @@ arrow::Status FileRowGroupReader::ReadNextRowGroup(std::shared_ptr<arrow::Table>
     // No more row groups to read
     if (buffer_table_ != nullptr) {
       std::string error_msg = "No more row groups to read, but buffer table is not empty";
-      LOG_STORAGE_ERROR_ << error_msg;
+      ARROW_LOG(ERROR) << error_msg;
       return arrow::Status::IOError(error_msg);
     }
     rg_start_ = -1;

--- a/cpp/src/packed/chunk_manager.cpp
+++ b/cpp/src/packed/chunk_manager.cpp
@@ -16,7 +16,6 @@
 #include <arrow/status.h>
 #include <arrow/table.h>
 #include <parquet/properties.h>
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/packed/chunk_manager.h"
 #include <set>

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -23,11 +23,11 @@
 #include <arrow/result.h>
 #include <arrow/status.h>
 #include <arrow/table.h>
+#include <arrow/util/logging.h>
 
 #include <parquet/properties.h>
 
 #include "milvus-storage/common/arrow_util.h"
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/packed/chunk_manager.h"
@@ -47,7 +47,7 @@ PackedRecordBatchReader::PackedRecordBatchReader(std::shared_ptr<arrow::fs::File
       read_count_(0) {
   auto status = init(fs, paths, schema, reader_props);
   if (!status.ok()) {
-    LOG_STORAGE_ERROR_ << "Error initializing PackedRecordBatchReader: " << status.ToString();
+    ARROW_LOG(ERROR) << "Error initializing PackedRecordBatchReader: " << status.ToString();
     throw std::runtime_error(status.ToString());
   }
 }
@@ -269,9 +269,9 @@ arrow::Status PackedRecordBatchReader::ReadNext(std::shared_ptr<arrow::RecordBat
 }
 
 arrow::Status PackedRecordBatchReader::Close() {
-  LOG_STORAGE_DEBUG_ << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
+  ARROW_LOG(DEBUG) << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
   for (size_t i = 0; i < column_group_states_.size(); ++i) {
-    LOG_STORAGE_DEBUG_ << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
+    ARROW_LOG(DEBUG) << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
   }
 
   // Clean up remaining data in all tables

--- a/cpp/src/packed/splitter/size_based_splitter.cpp
+++ b/cpp/src/packed/splitter/size_based_splitter.cpp
@@ -14,7 +14,6 @@
 
 #include "milvus-storage/packed/splitter/size_based_splitter.h"
 #include "milvus-storage/common/arrow_util.h"
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/packed/column_group.h"
 #include <stdexcept>

--- a/cpp/src/storage/schema.cpp
+++ b/cpp/src/storage/schema.cpp
@@ -17,7 +17,8 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/utils.h"
-#include "milvus-storage/common/log.h"
+#include "arrow/util/logging.h"
+
 namespace milvus_storage {
 
 Schema::Schema(std::shared_ptr<arrow::Schema> schema, SchemaOptions& options)
@@ -28,7 +29,7 @@ Status Schema::Validate() {
   RETURN_NOT_OK(BuildScalarSchema());
   RETURN_NOT_OK(BuildVectorSchema());
   RETURN_NOT_OK(BuildDeleteSchema());
-  LOG_STORAGE_DEBUG_ << "Schema validate success";
+  ARROW_LOG(DEBUG) << "Schema validate success";
   return Status::OK();
 }
 

--- a/cpp/test/space_test.cpp
+++ b/cpp/test/space_test.cpp
@@ -1,5 +1,4 @@
 #include "milvus-storage/storage/space.h"
-#include "milvus-storage/common/log.h"
 #include "milvus-storage/filter/constant_filter.h"
 
 #include <memory>


### PR DESCRIPTION
libmilvus-storage.so had a 40KB TLS segment (79.6% from glog's google::thread_msg_data), exceeding the static TLS allocation limit for dynamically loaded libraries.

 Removed glog dependency and TLS reduced from 40KB to 10KB (~73% reduction)