### PR TITLE
fix: missing return value in tencent credentials provider

### DIFF
--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -145,6 +145,7 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateA
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateTencentCredentialsProvider() {
   static auto provider = Aws::MakeShared<Aws::Auth::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
       "TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider");
+  return provider;
 }
 
 Result<ArrowFileSystemPtr> S3FileSystemProducer::Make() {


### PR DESCRIPTION
It seems that there has been a problem since the creation of this method.

I didn't test it on Tencent Cloud, just saw this problem and fixed it.