### PR TITLE
fix: ChunkReader can't pass the error when reader init failed

### DIFF
--- a/cpp/include/milvus-storage/format/format.h
+++ b/cpp/include/milvus-storage/format/format.h
@@ -26,6 +26,7 @@ namespace internal::api {
 class ColumnGroupReader {
   public:
   virtual ~ColumnGroupReader() = default;
+  virtual arrow::Status open() = 0;
   virtual arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) = 0;
 
   virtual arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) = 0;

--- a/cpp/include/milvus-storage/format/parquet/reader.h
+++ b/cpp/include/milvus-storage/format/parquet/reader.h
@@ -55,6 +55,8 @@ class ParquetChunkReader : public internal::api::ColumnGroupReader {
         reader_props_(std::move(reader_props)),
         needed_columns_(std::move(needed_columns)) {}
 
+  arrow::Status open() override;
+
   [[nodiscard]] arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) override;
 
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) override;
@@ -70,8 +72,6 @@ class ParquetChunkReader : public internal::api::ColumnGroupReader {
   [[nodiscard]] arrow::Result<int64_t> get_chunk_rows(int64_t chunk_index) override;
 
   protected:
-  arrow::Status init();
-
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::shared_ptr<arrow::Schema> schema_;
   std::vector<std::string> paths_;

--- a/cpp/src/ffi/reader_c.cpp
+++ b/cpp/src/ffi/reader_c.cpp
@@ -237,8 +237,8 @@ FFIResult get_record_batch_reader(ReaderHandle reader,
     }
 
     RETURN_SUCCESS();
-  } catch (...) {  // TODO: make sure which exception will be throw
-    RETURN_ERROR(LOON_GOT_EXCEPTION);
+  } catch (std::exception& e) {  // TODO: make sure which exception will be throw
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
   }
 
   RETURN_UNREACHABLE();
@@ -259,8 +259,8 @@ FFIResult get_chunk_reader(ReaderHandle reader, int64_t column_group_id, ChunkRe
 
     *out_handle = reinterpret_cast<ChunkReaderHandle>(chunk_reader);
     RETURN_SUCCESS();
-  } catch (...) {
-    RETURN_ERROR(LOON_GOT_EXCEPTION);
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
   }
 
   RETURN_UNREACHABLE();
@@ -286,8 +286,8 @@ FFIResult take(
       RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
     }
     RETURN_SUCCESS();
-  } catch (...) {
-    RETURN_ERROR(LOON_GOT_EXCEPTION);
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
   }
 
   RETURN_UNREACHABLE();

--- a/cpp/src/ffi/writer_c.cpp
+++ b/cpp/src/ffi/writer_c.cpp
@@ -92,8 +92,8 @@ FFIResult writer_write(WriterHandle handle, struct ArrowArray* array) {
     }
 
     RETURN_SUCCESS();
-  } catch (...) {
-    RETURN_ERROR(LOON_GOT_EXCEPTION);
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
   }
 
   RETURN_UNREACHABLE();
@@ -111,8 +111,8 @@ FFIResult writer_flush(WriterHandle handle) {
     }
 
     RETURN_SUCCESS();
-  } catch (...) {
-    RETURN_ERROR(LOON_GOT_EXCEPTION);
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
   }
 
   RETURN_UNREACHABLE();
@@ -138,8 +138,8 @@ FFIResult writer_close(WriterHandle handle, char** out_manifest, size_t* out_man
     *out_manifest_size = manifest_raw.size();
 
     RETURN_SUCCESS();
-  } catch (...) {
-    RETURN_ERROR(LOON_GOT_EXCEPTION);
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
   }
 
   RETURN_UNREACHABLE();

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -736,7 +736,7 @@ class ReaderImpl : public Reader {
 
     // Collect file paths from needed column groups only
     // This provides the PackedRecordBatchReader with only necessary data files
-    auto paths = std::vector<std::string>(needed_column_groups_.size());
+    auto paths = std::vector<std::string>();
 
     for (const auto& column_group : needed_column_groups_) {
       if (column_group->paths.empty()) {

--- a/cpp/test/ffi/ffi_writer_test.c
+++ b/cpp/test/ffi/ffi_writer_test.c
@@ -7,7 +7,7 @@
 #include <arrow/c/abi.h>
 #include <time.h>
 
-#define TEST_BASE_PATH "./writer_test_dir"
+#define TEST_BASE_PATH "writer-test-dir"
 
 void field_schema_release(struct ArrowSchema* schema);
 void struct_schema_release(struct ArrowSchema* schema);
@@ -31,6 +31,32 @@ struct ArrowArray* create_struct_array(struct ArrowArray** children, int64_t n_c
 FFIResult create_test_writer_pp(Properties* rp) {
   FFIResult rc;
   size_t test_count;
+
+#if 0
+  // minio config
+  const char* test_key[] = {
+      "writer.policy",
+      "fs.storage_type",
+      "fs.access_key_id",
+      "fs.access_key_value",
+      "fs.bucket_name",
+      "fs.use_ssl",
+      "fs.address",
+      "fs.region"
+  };
+
+  const char* test_val[] = {
+      "single",
+      "remote",
+      "minioadmin",
+      "minioadmin",
+      "testbucket",
+      "false",
+      "localhost:9000",
+      "us-west-2"
+  };
+#else
+  // local config
   const char* test_key[] = {
       "writer.policy",
       "fs.storage_type",
@@ -42,6 +68,7 @@ FFIResult create_test_writer_pp(Properties* rp) {
       "local",
       "/tmp/",
   };
+#endif
 
   test_count = sizeof(test_key) / sizeof(test_key[0]);
   assert(test_count == sizeof(test_val) / sizeof(test_val[0]));


### PR DESCRIPTION
reproduce case:

1. create a reader(top-level) with a wrong manifest(invalid paths)
2. call `reader->get_record_batch_reader` will got a empty `ArrowArrayStream`

This issue occurs in PackedRecordBatchReader::advanceBuffer. Due to the lazy loading of the chunk reader, when methods of the chunk reader are called in advanceBuffer, it mistakenly considers the current chunk reader to be empty (which is allowed).

The lazy loading of the chunk reader causes the caller to be unable to distinguish whether the current chunk reader is inherently empty or if it is due to some other error. Therefore, the current change makes the chunk reader no longer lazy-loaded and instead switches to using the open method.