### PR TITLE
fix: non apple cmake condition check

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -120,7 +120,7 @@ if (WITH_JNI)
     ${LINK_LIBS}
   )
 
-if(not APPLE)
+if(NOT APPLE)
   target_link_options(milvus-storage-jni PRIVATE
     -Wl,--no-as-needed
     -Wl,-z,lazy


### PR DESCRIPTION
when build milvus storage jni, cmake breaks for non apple systems due to wrong condition check