### PR TITLE
Fix: empty needed columns will got empty projections

### DIFF
--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -696,7 +696,7 @@ class ReaderImpl : public Reader {
     }
 
     // Initialize the list of columns to read from the dataset
-    if (needed_columns != nullptr) {
+    if (needed_columns != nullptr && !needed_columns->empty()) {
       needed_columns_ = *needed_columns;
 
       // Validate that all requested columns exist in the schema


### PR DESCRIPTION
In the top-level FFI API(C interface), if the caller passes a nullptr need_columns, the FFI always creates an empty but non-nullptr projection object (type is std::shared_ptr<std::vectorstd::string>). And in the top-level reader interface, it only checks whether the projection is empty to decide whether to do a full projection.

In current commit, reader allowed empty or nullptr projection as the full projection, also make FFI API create the nullptr projection pass to the top-level reader which is more sensetive.