### PR TITLE
fix: refactor and fix PackedRecordBatchReader in src/reader.cpp

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -274,8 +274,6 @@ void reader_set_keyretriever(ReaderHandle reader, const char* (*key_retriever)(c
  */
 FFIResult get_record_batch_reader(ReaderHandle reader,
                                   const char* predicate,
-                                  int64_t batch_size,
-                                  int64_t buffer_size,
                                   struct ArrowArrayStream* out_array_stream);
 
 /**

--- a/cpp/include/milvus-storage/ffi_jni.h
+++ b/cpp/include/milvus-storage/ffi_jni.h
@@ -183,8 +183,10 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(
  * @param buffer_size Buffer size
  * @return Arrow array stream pointer as long
  */
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getRecordBatchReader(
-    JNIEnv* env, jobject obj, jlong reader_handle, jstring predicate, jlong batch_size, jlong buffer_size);
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getRecordBatchReader(JNIEnv* env,
+                                                                                        jobject obj,
+                                                                                        jlong reader_handle,
+                                                                                        jstring predicate);
 
 /**
  * @brief Get chunk reader

--- a/cpp/include/milvus-storage/format/format.h
+++ b/cpp/include/milvus-storage/format/format.h
@@ -27,6 +27,8 @@ class ColumnGroupReader {
   public:
   virtual ~ColumnGroupReader() = default;
   virtual arrow::Status open() = 0;
+  virtual size_t total_number_of_chunks() const = 0;
+  virtual size_t total_rows() const = 0;
   virtual arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) = 0;
 
   virtual arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) = 0;

--- a/cpp/include/milvus-storage/format/parquet/reader.h
+++ b/cpp/include/milvus-storage/format/parquet/reader.h
@@ -45,17 +45,20 @@ class ParquetChunkReader : public internal::api::ColumnGroupReader {
    * @param needed_columns Subset of columns to read (empty = all columns)
    */
   ParquetChunkReader(std::shared_ptr<arrow::fs::FileSystem> fs,
-                     std::shared_ptr<arrow::Schema> schema,
                      std::vector<std::string> paths,
                      ::parquet::ReaderProperties reader_props,
                      std::vector<std::string> needed_columns)
       : fs_(std::move(fs)),
-        schema_(std::move(schema)),
+        schema_(nullptr),
         paths_(std::move(paths)),
         reader_props_(std::move(reader_props)),
         needed_columns_(std::move(needed_columns)) {}
 
-  arrow::Status open() override;
+  [[nodiscard]] arrow::Status open() override;
+
+  [[nodiscard]] size_t total_number_of_chunks() const override;
+
+  [[nodiscard]] size_t total_rows() const override;
 
   [[nodiscard]] arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) override;
 
@@ -77,6 +80,7 @@ class ParquetChunkReader : public internal::api::ColumnGroupReader {
   std::vector<std::string> paths_;
   ::parquet::ReaderProperties reader_props_;
   std::vector<std::string> needed_columns_;
+  size_t total_rows_;
 
   std::vector<int> needed_column_indices_;
   std::vector<std::shared_ptr<::parquet::arrow::FileReader>> file_readers_;

--- a/cpp/include/milvus-storage/format/vortex/vortex_chunk_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_chunk_reader.h
@@ -36,6 +36,10 @@ class VortexChunkReader final : public internal::api::ColumnGroupReader {
   ~VortexChunkReader();
   [[nodiscard]] arrow::Status open() override;
 
+  [[nodiscard]] size_t total_number_of_chunks() const override;
+
+  [[nodiscard]] size_t total_rows() const override;
+
   [[nodiscard]] arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) override;
 
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) override;

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -95,11 +95,14 @@ struct PropertyInfo {
 #define PROPERTY_WRITER_COMPRESSION "writer.compression"
 #define PROPERTY_WRITER_COMPRESSION_LEVEL "writer.compression_level"
 #define PROPERTY_WRITER_ENABLE_DICTIONARY "writer.enable_dictionary"
-
 #define PROPERTY_WRITER_ENC_ENABLE "writer.enc.enable"
 #define PROPERTY_WRITER_ENC_KEY "writer.enc.key"
 #define PROPERTY_WRITER_ENC_META "writer.enc.meta"
 #define PROPERTY_WRITER_ENC_ALGORITHM "writer.enc.algorithm"
+
+// --- Define Reader property keys ---
+#define PROPERTY_READER_RECORD_BATCH_MAX_ROWS "reader.record_batch_max_rows"
+#define PROPERTY_READER_RECORD_BATCH_MAX_SIZE "reader.record_batch_max_size"
 
 /**
  * Get the value of a property by key, returning an error if the key does

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -140,26 +140,10 @@ class Reader {
   virtual ~Reader() = default;
 
   /**
-   * @brief Convenience method for get_record_batch_reader with default parameters
+   * @brief Convenience method for get_record_batch_reader with no predicate
    */
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> get_record_batch_reader() const {
-    return get_record_batch_reader("", 1024, 32 * 1024 * 1024);
-  }
-
-  /**
-   * @brief Convenience method for get_record_batch_reader with predicate only
-   */
-  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> get_record_batch_reader(
-      const std::string& predicate) const {
-    return get_record_batch_reader(predicate, 1024, 32 * 1024 * 1024);
-  }
-
-  /**
-   * @brief Convenience method for get_record_batch_reader with predicate and batch_size
-   */
-  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> get_record_batch_reader(
-      const std::string& predicate, int64_t batch_size) const {
-    return get_record_batch_reader(predicate, batch_size, 32 * 1024 * 1024);
+    return get_record_batch_reader("");
   }
 
   /**
@@ -186,7 +170,7 @@ class Reader {
    *       Additional client-side filtering may be required for complete accuracy.
    */
   [[nodiscard]] virtual arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> get_record_batch_reader(
-      const std::string& predicate, int64_t batch_size, int64_t buffer_size) const = 0;
+      const std::string& predicate) const = 0;
 
   /**
    * @brief Get a chunk reader for a specific column group

--- a/cpp/src/ffi/reader_c.cpp
+++ b/cpp/src/ffi/reader_c.cpp
@@ -230,11 +230,7 @@ void reader_set_keyretriever(ReaderHandle reader, const char* (*key_retriever)(c
   });
 }
 
-FFIResult get_record_batch_reader(ReaderHandle reader,
-                                  const char* predicate,
-                                  int64_t batch_size,
-                                  int64_t buffer_size,
-                                  ArrowArrayStream* out_array_stream) {
+FFIResult get_record_batch_reader(ReaderHandle reader, const char* predicate, ArrowArrayStream* out_array_stream) {
   if (!reader || !out_array_stream)
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: reader and out_array_stream must not be null");
 
@@ -242,7 +238,7 @@ FFIResult get_record_batch_reader(ReaderHandle reader,
     auto* cpp_reader = reinterpret_cast<Reader*>(reader);
     std::string predicate_str = predicate ? predicate : "";
 
-    auto result = cpp_reader->get_record_batch_reader(predicate_str, batch_size, buffer_size);
+    auto result = cpp_reader->get_record_batch_reader(predicate_str);
     if (!result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
     }

--- a/cpp/src/ffi/reader_writer_jni.cpp
+++ b/cpp/src/ffi/reader_writer_jni.cpp
@@ -326,15 +326,16 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(
   }
 }
 
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getRecordBatchReader(
-    JNIEnv* env, jobject obj, jlong reader_handle, jstring predicate, jlong batch_size, jlong buffer_size) {
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getRecordBatchReader(JNIEnv* env,
+                                                                                        jobject obj,
+                                                                                        jlong reader_handle,
+                                                                                        jstring predicate) {
   try {
     ReaderHandle handle = static_cast<ReaderHandle>(reader_handle);
     const char* predicate_cstr = predicate ? env->GetStringUTFChars(predicate, nullptr) : nullptr;
 
     ArrowArrayStream* stream = static_cast<ArrowArrayStream*>(malloc(sizeof(ArrowArrayStream)));
-    FFIResult result = get_record_batch_reader(handle, predicate_cstr, static_cast<int64_t>(batch_size),
-                                               static_cast<int64_t>(buffer_size), stream);
+    FFIResult result = get_record_batch_reader(handle, predicate_cstr, stream);
 
     if (predicate_cstr) {
       env->ReleaseStringUTFChars(predicate, predicate_cstr);

--- a/cpp/src/format/format.cpp
+++ b/cpp/src/format/format.cpp
@@ -80,8 +80,8 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> GroupReaderFactory::create(
     }
 
     ARROW_ASSIGN_OR_RAISE(auto file_system, create_parquet_file_system(fs_config));
-    reader = std::make_unique<ParquetChunkReader>(file_system, schema, column_group->paths, reader_properties,
-                                                  filtered_columns);
+    reader =
+        std::make_unique<ParquetChunkReader>(file_system, column_group->paths, reader_properties, filtered_columns);
   }
 #ifdef BUILD_VORTEX_BRIDGE
   else if (column_group->format == LOON_FORMAT_VORTEX) {
@@ -95,7 +95,7 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> GroupReaderFactory::create(
   }
 
   ARROW_RETURN_NOT_OK(reader->open());
-  return reader;
+  return std::move(reader);
 }
 
 // ==================== ChunkWriterFactory Implementation ====================

--- a/cpp/src/format/vortex/vortex_chunk_reader.cpp
+++ b/cpp/src/format/vortex/vortex_chunk_reader.cpp
@@ -40,6 +40,13 @@ VortexChunkReader::VortexChunkReader(std::shared_ptr<ObjectStoreWrapper> fs,
   assert(paths_.empty() == false);
 }
 
+size_t VortexChunkReader::total_number_of_chunks() const { return number_of_chunks_; }
+
+size_t VortexChunkReader::total_rows() const {
+  assert(!idx_offsets_.empty());
+  return idx_offsets_.back();
+}
+
 VortexChunkReader::~VortexChunkReader() {
   // make sure raw reference is released before obsw_ is destructed
   for (auto& vxfile : vxfiles_) {
@@ -113,8 +120,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> VortexChunkReade
     const std::vector<int64_t>& chunk_indices) {
   std::vector<std::shared_ptr<arrow::RecordBatch>> rbs(chunk_indices.size());
   for (int i = 0; i < chunk_indices.size(); i++) {
-    ARROW_ASSIGN_OR_RAISE(auto rb, get_chunk(chunk_indices[i]));
-    rbs.emplace_back(rb);
+    ARROW_ASSIGN_OR_RAISE(rbs[i], get_chunk(chunk_indices[i]));
   }
 
   return rbs;

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -417,6 +417,17 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       ENCRYPTION_ALGORITHM_AES_GCM_V1,
                       ValidatePropertyType() + ValidatePropertyEnum<std::string>(ENCRYPTION_ALGORITHM_AES_GCM_V1,
                                                                                  ENCRYPTION_ALGORITHM_AES_GCM_CTR_V1)),
+    // --- reader properties define ---
+    REGISTER_PROPERTY(PROPERTY_READER_RECORD_BATCH_MAX_ROWS,
+                      PropertyType::INT64,
+                      "The maximum number of rows per record batch when reading.",
+                      int64_t(1024),  // 1024 rows
+                      ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_READER_RECORD_BATCH_MAX_SIZE,
+                      PropertyType::INT64,
+                      "The maximum size in bytes per record batch when reading.",
+                      int64_t(32 * 1024 * 1024),  // 32 MB
+                      ValidatePropertyType()),
 };
 
 template <typename T>

--- a/cpp/test/ffi/ffi_reader_test.c
+++ b/cpp/test/ffi/ffi_reader_test.c
@@ -88,8 +88,7 @@ START_TEST(test_basic) {
 
   // test create arrowarraysteam
   {
-    rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, 1024 /*batch_size*/,
-                                 8 * 1024 * 1024 /*buffer_size*/, &arraystream);
+    rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, &arraystream);
     ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
     arraystream.release(&arraystream);
   }
@@ -143,8 +142,7 @@ START_TEST(test_empty_projection) {
   rc = reader_new(out_manifest, schema, NULL, 0, &rp, &reader_handle);
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
 
-  rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, 1024 /*batch_size*/, 8 * 1024 * 1024 /*buffer_size*/,
-                               &arraystream);
+  rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, &arraystream);
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
   // verify arraystream number of columns and number of rows
   {
@@ -256,8 +254,7 @@ START_TEST(test_reader_with_invalid_manifest) {
     ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
 
     // test create arrowarraysteam
-    rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, 1024 /*batch_size*/,
-                                 8 * 1024 * 1024 /*buffer_size*/, &arraystream);
+    rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, &arraystream);
     ck_assert(!IsSuccess(&rc));
     printf("Expected error: %s\n", GetErrorMessage(&rc));
     FreeFFIResult(&rc);
@@ -296,8 +293,7 @@ START_TEST(test_record_batch_reader_verify_schema) {
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
 
   // test create arrowarraysteam
-  rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, 1024 /*batch_size*/, 8 * 1024 * 1024 /*buffer_size*/,
-                               &arraystream);
+  rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, &arraystream);
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
 
   ck_assert(arraystream.get_schema != NULL);
@@ -414,8 +410,7 @@ START_TEST(test_record_batch_reader_verify_arrowarray) {
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
 
   // test create arrowarraysteam
-  rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, 1024 /*batch_size*/, 8 * 1024 * 1024 /*buffer_size*/,
-                               &arraystream);
+  rc = get_record_batch_reader(reader_handle, NULL /*predicate*/, &arraystream);
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
 
   ck_assert(arraystream.get_schema != NULL);

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageReader.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageReader.scala
@@ -37,14 +37,12 @@ class MilvusStorageReader {
   /**
    * Get record batch reader
    * @param predicate Filter predicate (can be null)
-   * @param batchSize Batch size for reading
-   * @param bufferSize Buffer size
    * @return Pointer to Arrow stream
    */
-  def getRecordBatchReaderScala(predicate: String, batchSize: Long, bufferSize: Long): Long = {
+  def getRecordBatchReaderScala(predicate: String): Long = {
     if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
     if (readerHandle == 0) throw new IllegalStateException("Reader not initialized")
-    getRecordBatchReader(readerHandle, predicate, batchSize, bufferSize)
+    getRecordBatchReader(readerHandle, predicate)
   }
 
   /**
@@ -52,7 +50,7 @@ class MilvusStorageReader {
    * @return Pointer to Arrow stream
    */
   def getRecordBatchReaderScala(): Long = {
-    getRecordBatchReaderScala(null, 1024, 4096)
+    getRecordBatchReaderScala(null)
   }
 
   /**
@@ -115,7 +113,7 @@ class MilvusStorageReader {
   def isValid: Boolean = !isDestroyed && readerHandle != 0
 
   @native private def readerNew(manifest: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Long
-  @native private def getRecordBatchReader(readerHandle: Long, predicate: String, batchSize: Long, bufferSize: Long): Long
+  @native private def getRecordBatchReader(readerHandle: Long, predicate: String): Long
   @native private def getChunkReader(readerHandle: Long, columnGroupId: Long): Long
   @native private def take(readerHandle: Long, rowIndices: Array[Long], parallelism: Long): Long
   @native private def readerDestroy(readerHandle: Long): Unit

--- a/java/src/test/scala/io/milvus/storage/MilvusStorageIntegrationTest.scala
+++ b/java/src/test/scala/io/milvus/storage/MilvusStorageIntegrationTest.scala
@@ -95,7 +95,7 @@ class MilvusStorageIntegrationTest extends AnyFlatSpec with Matchers with Before
     val neededColumns = Array("int64_field", "int32_field", "string_field")
     val readerSchema = ArrowTestUtils.createTestStructSchema()
     reader.create(manifest, readerSchema, neededColumns, readerProperties)
-    val recordBatchReader = reader.getRecordBatchReaderScala(null, 1024, 8 * 1024 * 1024)
+    val recordBatchReader = reader.getRecordBatchReaderScala(null)
     val arrowArray = ArrowUtils.readNextBatch(recordBatchReader)
 
     // validate data

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -120,9 +120,7 @@ impl Reader {
         let result = unsafe {
             get_record_batch_reader(
                 self.handle, 
-                predicate_ptr, 
-                batch_size, 
-                buffer_size, 
+                predicate_ptr,
                 &mut raw_stream as *mut ArrowArrayStream
             )
         };


### PR DESCRIPTION
notice that: current commit fixed the PackedRecordBatchReader which is under dir `src/reader.cpp` not the `packed/reader.cpp`.

The `PackedRecordBatchReader` before the refactoring had the following issues:

1. Invalid `chunk_index++` may cause some chunks to be skipped
2. Invalid `queue->pop` after `queue->push` in same `arrow::RecordBatch` which call the `Slice`. It will cause row alignment with wrong column.
3. `ReadNext` always do the projection and and  recalculate the output schema.
4. The code is too unreadable, The member variables in the class passed into the lambda, also too many unnecessary foreach or check.

In fact, PackedRecordBatchReader is mainly responsible for these things:

- Add the recordbatch from the chunk reader to the memory
- Do the projection
- Do row alignment

So the logical in refactored `PackedRecordBatchReader` more simple.

1. Initialize resources and calculate column projection in `open`.
2. Do the read and row align in the `ReadNext` 2.1 call `load_internal` to load record batchs from chunk readers 2.2 do the row align after `load_internal` with `out_field_map_`, the `out_field_map_` map the `needed_columns_` to the location of the column data(arrow::array)