### PR TITLE
enhance: Introducing LRUCache to cache the filesystem

### DIFF
--- a/cpp/include/milvus-storage/common/lrucache.h
+++ b/cpp/include/milvus-storage/common/lrucache.h
@@ -1,0 +1,117 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <mutex>
+#include <map>
+#include <shared_mutex>
+#include <functional>
+#include <list>
+
+#include <arrow/status.h>
+#include <arrow/result.h>
+
+namespace milvus_storage {
+
+template <typename K, typename V>
+class LRUCache {
+  public:
+  static LRUCache& getInstance() {
+    static LRUCache instance;
+    return instance;
+  }
+
+  // Set the capacity of cache
+  void set_capacity(size_t capacity) {
+    std::unique_lock lock(mutex_);
+    capacity_ = capacity;
+    // evict if current size exceeds new capacity
+    while (cache_.size() > capacity_) {
+      auto last_key = lru_list_.back();
+      cache_.erase(last_key);
+      lru_list_.pop_back();
+    }
+  }
+
+  // Get the value associated with the key
+  [[nodiscard]] arrow::Result<V> get(const K& key, std::function<arrow::Result<V>(const K&)> CreateFunc) {
+    std::unique_lock write_lock(mutex_);
+    // check if key exists
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+      // need to move to front in LRU list; upgrade to unique lock
+      // re-find the entry after upgrading lock
+      auto it2 = cache_.find(key);
+      if (it2 != cache_.end()) {
+        lru_list_.splice(lru_list_.begin(), lru_list_, it2->second.second);
+        return it2->second.first;
+      }
+      // if disappeared, fallthrough to create
+    }
+
+    // not exist, create new instance
+    ARROW_ASSIGN_OR_RAISE(auto instance, CreateFunc(key));
+    // insert into LRU front and map
+    lru_list_.push_front(key);
+    cache_[key] = std::make_pair(instance, lru_list_.begin());
+
+    // evict if exceed capacity
+    while (cache_.size() > capacity_) {
+      auto last_key = lru_list_.back();
+      cache_.erase(last_key);
+      lru_list_.pop_back();
+    }
+
+    return instance;
+  }
+
+  // Get the size of cached entries
+  [[nodiscard]] size_t size() const {
+    std::shared_lock lock(mutex_);
+    return cache_.size();
+  }
+
+  // Remove the cache entry by key
+  void remove(const K& key) {
+    std::unique_lock lock(mutex_);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+      lru_list_.erase(it->second.second);
+      cache_.erase(it);
+    }
+  }
+
+  // Clean all cache entries
+  void clean() {
+    std::unique_lock lock(mutex_);
+    cache_.clear();
+    lru_list_.clear();
+  }
+
+  private:
+  LRUCache(size_t capacity = 16) : capacity_(capacity) {}
+  ~LRUCache() = default;
+
+  mutable std::shared_mutex mutex_;
+  // LRU list holds keys with most-recent at front
+  std::list<K> lru_list_;
+  // map key -> (value, iterator to list)
+  // don't use unordered_map, because hash function may slow down the performance
+  std::map<K, std::pair<V, typename std::list<K>::iterator>> cache_;
+  size_t capacity_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/format.h
+++ b/cpp/include/milvus-storage/format/format.h
@@ -68,17 +68,16 @@ class GroupReaderFactory {
    *
    * @param schema Schema of the dataset
    * @param column_group Column group containing format, path, and metadata
-   * @param fs Filesystem interface
    * @param needed_columns Vector of column names to read (empty = all columns)
    * @param properties Read properties
    * @return Unique pointer to the created chunk reader
    */
-  static std::unique_ptr<ColumnGroupReader> create(std::shared_ptr<arrow::Schema> schema,
-                                                   std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
-                                                   std::shared_ptr<arrow::fs::FileSystem> fs,
-                                                   const std::vector<std::string>& needed_columns,
-                                                   const milvus_storage::api::Properties& properties,
-                                                   const std::function<std::string(const std::string&)>& key_retriever);
+  static arrow::Result<std::unique_ptr<ColumnGroupReader>> create(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
+      const std::vector<std::string>& needed_columns,
+      const milvus_storage::api::Properties& properties,
+      const std::function<std::string(const std::string&)>& key_retriever);
 
   private:
   GroupReaderFactory() = default;
@@ -101,10 +100,10 @@ class GroupWriterFactory {
    * @param properties Write properties
    * @return Unique pointer to the created chunk writer
    */
-  static std::unique_ptr<ColumnGroupWriter> create(std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
-                                                   std::shared_ptr<arrow::Schema> schema,
-                                                   std::shared_ptr<arrow::fs::FileSystem> fs,
-                                                   const milvus_storage::api::Properties& properties);
+  [[nodiscard]] static arrow::Result<std::unique_ptr<ColumnGroupWriter>> create(
+      std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
+      std::shared_ptr<arrow::Schema> schema,
+      const milvus_storage::api::Properties& properties);
 
   private:
   GroupWriterFactory() = default;

--- a/cpp/include/milvus-storage/format/vortex/vortex_chunk_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_chunk_reader.h
@@ -27,7 +27,8 @@ namespace milvus_storage::vortex {
 
 class VortexChunkReader final : public internal::api::ColumnGroupReader {
   public:
-  VortexChunkReader(std::shared_ptr<arrow::Schema> schema,
+  VortexChunkReader(std::shared_ptr<ObjectStoreWrapper> fs,
+                    std::shared_ptr<arrow::Schema> schema,
                     const std::vector<std::string>& paths,
                     const std::vector<std::string>& needed_columns,
                     const api::Properties& properties);
@@ -53,7 +54,7 @@ class VortexChunkReader final : public internal::api::ColumnGroupReader {
   arrow::Result<std::vector<std::vector<int64_t>>> calc_ridxs_in_chunks(const std::vector<int64_t>& row_indices);
 
   private:
-  std::unique_ptr<ObjectStoreWrapper> obsw_;
+  std::shared_ptr<ObjectStoreWrapper> obsw_;
   const size_t number_of_chunks_;
 
   std::shared_ptr<arrow::Schema> schema_;

--- a/cpp/include/milvus-storage/format/vortex/vortex_writer.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_writer.h
@@ -27,6 +27,7 @@ namespace milvus_storage::vortex {
 class VortexFileWriter : public internal::api::ColumnGroupWriter {
   public:
   VortexFileWriter(std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
+                   std::shared_ptr<ObjectStoreWrapper> fs,
                    std::shared_ptr<arrow::Schema> schema,
                    const api::Properties& properties);
 
@@ -45,7 +46,7 @@ class VortexFileWriter : public internal::api::ColumnGroupWriter {
 
   private:
   bool closed_;
-  ObjectStoreWrapper obsw_;
+  std::shared_ptr<ObjectStoreWrapper> obsw_;
   VortexWriter vx_writer_;
   std::shared_ptr<arrow::Schema> schema_;
   api::Properties properties_;

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -101,7 +101,6 @@ class Reader {
    * milvus storage datasets. This function provides a clean interface for creating
    * readers without exposing the concrete implementation details.
    *
-   * @param fs Shared pointer to the filesystem interface for data access
    * @param manifest Dataset manifest containing metadata and column group information
    * @param schema Arrow schema defining the logical structure of the data
    * @param needed_columns Optional vector of column names to read (nullptr reads all columns)
@@ -118,7 +117,7 @@ class Reader {
    * props["cipher_type"] = "AES256";
    * props["buffer_size"] = "65536";
    *
-   * auto reader = Reader::create(fs, manifest, schema, nullptr, props);
+   * auto reader = Reader::create(manifest, schema, nullptr, props);
    * auto batch_reader = reader->get_record_batch_reader().ValueOrDie();
    *
    * std::shared_ptr<arrow::RecordBatch> batch;
@@ -127,8 +126,7 @@ class Reader {
    * }
    * @endcode
    */
-  static std::unique_ptr<Reader> create(std::shared_ptr<arrow::fs::FileSystem> fs,
-                                        std::shared_ptr<Manifest> manifest,
+  static std::unique_ptr<Reader> create(std::shared_ptr<Manifest> manifest,
                                         std::shared_ptr<arrow::Schema> schema,
                                         const std::shared_ptr<std::vector<std::string>>& needed_columns = nullptr,
                                         const Properties& properties = {});

--- a/cpp/include/milvus-storage/writer.h
+++ b/cpp/include/milvus-storage/writer.h
@@ -181,7 +181,6 @@ class Writer {
    * milvus storage datasets. This function provides a clean interface for creating
    * writers without exposing the concrete implementation details.
    *
-   * @param fs Shared pointer to the filesystem interface for data access
    * @param base_path Base directory path where column group files will be written
    * @param schema Arrow schema defining the logical structure of the data
    * @param column_group_policy Policy for organizing columns into groups
@@ -190,7 +189,6 @@ class Writer {
    *
    * @example
    * @code
-   * auto fs = arrow::fs::LocalFileSystem::Make().ValueOrDie();
    * auto schema = arrow::schema({
    *   arrow::field("id", arrow::int64()),
    *   arrow::field("name", arrow::utf8()),
@@ -203,15 +201,14 @@ class Writer {
    *                     .build();
    *
    * auto policy = std::make_unique<SingleColumnGroupPolicy>(schema);
-   * auto writer = Writer::create(fs, "/path/to/dataset", schema, std::move(policy), properties);
+   * auto writer = Writer::create("/path/to/dataset", schema, std::move(policy), properties);
    *
    * // Use the writer
    * writer->write(batch);
    * auto manifest = writer->close().ValueOrDie();
    * @endcode
    */
-  static std::unique_ptr<Writer> create(std::shared_ptr<arrow::fs::FileSystem> fs,
-                                        std::string base_path,
+  static std::unique_ptr<Writer> create(std::string base_path,
                                         std::shared_ptr<arrow::Schema> schema,
                                         std::unique_ptr<ColumnGroupPolicy> column_group_policy,
                                         const Properties& properties = {});

--- a/cpp/src/ffi/writer_c.cpp
+++ b/cpp/src/ffi/writer_c.cpp
@@ -39,18 +39,6 @@ FFIResult writer_new(const char* base_path,
     RETURN_ERROR(LOON_INVALID_PROPERTIES, "Failed to parse properties [", opt->c_str(), "]");
   }
 
-  ArrowFileSystemConfig fs_config;
-  auto fs_status = ArrowFileSystemConfig::create_file_system_config(properties_map, fs_config);
-  if (!fs_status.ok()) {
-    RETURN_ERROR(LOON_ARROW_ERROR, fs_status.ToString());
-  }
-
-  auto fs_result = CreateArrowFileSystem(fs_config);
-  if (!fs_result.ok()) {
-    RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
-  }
-
-  auto cpp_fs = std::shared_ptr<arrow::fs::FileSystem>(fs_result.ValueOrDie());
   auto schema_result = arrow::ImportSchema(schema_raw);
   if (!schema_result.ok()) {
     RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
@@ -63,8 +51,8 @@ FFIResult writer_new(const char* base_path,
     RETURN_ERROR(LOON_ARROW_ERROR, policy_status.ToString());
   }
 
-  auto cpp_writer = Writer::create(std::move(cpp_fs), std::move(std::string(base_path)), schema, std::move(policy),
-                                   std::move(properties_map));
+  auto cpp_writer =
+      Writer::create(std::move(std::string(base_path)), schema, std::move(policy), std::move(properties_map));
 
   auto raw_cpp_writer = reinterpret_cast<WriterHandle>(cpp_writer.release());
   assert(raw_cpp_writer);

--- a/cpp/src/format/format.cpp
+++ b/cpp/src/format/format.cpp
@@ -13,27 +13,51 @@
 // limitations under the License.
 
 #include "milvus-storage/format/format.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/format/parquet/file_writer.h"
 #include "milvus-storage/format/parquet/reader.h"
 #include "milvus-storage/format/parquet/key_retriever.h"
-#include "milvus-storage/properties.h"
 #include "milvus-storage/format/vortex/vortex_writer.h"
 #include "milvus-storage/format/vortex/vortex_chunk_reader.h"
+#include "milvus-storage/properties.h"
 
 namespace internal::api {
 
+using namespace milvus_storage::parquet;
+static inline arrow::Result<milvus_storage::ArrowFileSystemPtr> create_parquet_file_system(
+    const milvus_storage::ArrowFileSystemConfig& fs_config) {
+  auto& fs_cache = milvus_storage::LRUCache<milvus_storage::ArrowFileSystemConfig,
+                                            milvus_storage::ArrowFileSystemPtr>::getInstance();
+  return fs_cache.get(fs_config, milvus_storage::CreateArrowFileSystem);
+}
+
+#ifdef BUILD_VORTEX_BRIDGE
+using namespace milvus_storage::vortex;
+static inline arrow::Result<std::shared_ptr<ObjectStoreWrapper>> create_vortex_object_store(
+    const milvus_storage::ArrowFileSystemConfig& fs_config) {
+  auto& fs_cache = milvus_storage::LRUCache<milvus_storage::ArrowFileSystemConfig,
+                                            std::shared_ptr<ObjectStoreWrapper>>::getInstance();
+  auto create_func = [](const milvus_storage::ArrowFileSystemConfig& config) {
+    return std::make_shared<ObjectStoreWrapper>(
+        ObjectStoreWrapper::OpenObjectStore(config.storage_type, config.address, config.access_key_id,
+                                            config.access_key_value, config.region, config.bucket_name));
+  };
+  return fs_cache.get(fs_config, create_func);
+}
+#endif  // BUILD_VORTEX_BRIDGE
+
 // ==================== ColumnGroupReaderFactory Implementation ====================
 
-std::unique_ptr<ColumnGroupReader> GroupReaderFactory::create(
+arrow::Result<std::unique_ptr<ColumnGroupReader>> GroupReaderFactory::create(
     std::shared_ptr<arrow::Schema> schema,
     std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
-    std::shared_ptr<arrow::fs::FileSystem> fs,
     const std::vector<std::string>& needed_columns,
     const milvus_storage::api::Properties& properties,
     const std::function<std::string(const std::string&)>& key_retriever) {
   std::unique_ptr<ColumnGroupReader> reader = nullptr;
   if (!column_group) {
-    throw std::runtime_error("Column group cannot be null");
+    return arrow::Status::Invalid("Column group cannot be null");
   }
 
   std::vector<std::string> filtered_columns;
@@ -44,42 +68,41 @@ std::unique_ptr<ColumnGroupReader> GroupReaderFactory::create(
     }
   }
 
+  milvus_storage::ArrowFileSystemConfig fs_config;
+  ARROW_RETURN_NOT_OK(milvus_storage::ArrowFileSystemConfig::create_file_system_config(properties, fs_config));
   if (column_group->format == LOON_FORMAT_PARQUET) {
     ::parquet::ReaderProperties reader_properties = ::parquet::default_reader_properties();
     if (key_retriever) {
-      reader_properties.file_decryption_properties(
-          ::parquet::FileDecryptionProperties::Builder()
-              .key_retriever(std::make_shared<milvus_storage::parquet::KeyRetriever>(key_retriever))
-              ->plaintext_files_allowed()
-              ->build());
+      reader_properties.file_decryption_properties(::parquet::FileDecryptionProperties::Builder()
+                                                       .key_retriever(std::make_shared<KeyRetriever>(key_retriever))
+                                                       ->plaintext_files_allowed()
+                                                       ->build());
     }
-    reader = std::make_unique<milvus_storage::parquet::ParquetChunkReader>(fs, schema, column_group->paths,
-                                                                           reader_properties, filtered_columns);
+
+    ARROW_ASSIGN_OR_RAISE(auto file_system, create_parquet_file_system(fs_config));
+    reader = std::make_unique<ParquetChunkReader>(file_system, schema, column_group->paths, reader_properties,
+                                                  filtered_columns);
   }
 #ifdef BUILD_VORTEX_BRIDGE
   else if (column_group->format == LOON_FORMAT_VORTEX) {
-    reader = std::make_unique<milvus_storage::vortex::VortexChunkReader>(schema, column_group->paths, filtered_columns,
-                                                                         properties);
+    ARROW_ASSIGN_OR_RAISE(auto file_system, create_vortex_object_store(fs_config));
+    reader =
+        std::make_unique<VortexChunkReader>(file_system, schema, column_group->paths, filtered_columns, properties);
   }
-#endif
+#endif  // BUILD_VORTEX_BRIDGE
   else {
-    throw std::runtime_error("Unsupported file format: " + column_group->format);
+    return arrow::Status::Invalid("Unsupported file format: " + column_group->format);
   }
 
-  auto status = reader->open();
-  if (!status.ok()) {
-    throw std::runtime_error("Error opening column group reader: " + status.ToString());
-  }
-
+  ARROW_RETURN_NOT_OK(reader->open());
   return reader;
 }
 
 // ==================== ChunkWriterFactory Implementation ====================
 
-std::unique_ptr<ColumnGroupWriter> GroupWriterFactory::create(
+arrow::Result<std::unique_ptr<ColumnGroupWriter>> GroupWriterFactory::create(
     std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
     std::shared_ptr<arrow::Schema> schema,
-    std::shared_ptr<arrow::fs::FileSystem> fs,
     const milvus_storage::api::Properties& properties) {
   std::unique_ptr<ColumnGroupWriter> writer;
   assert(column_group && schema);
@@ -89,22 +112,27 @@ std::unique_ptr<ColumnGroupWriter> GroupWriterFactory::create(
   for (const auto& column_name : column_group->columns) {
     auto field = schema->GetFieldByName(column_name);
     if (!field) {
-      throw std::runtime_error("Column '" + column_name + "' not found in schema");
+      return arrow::Status::Invalid("Column '" + column_name + "' not found in schema");
     }
     fields.emplace_back(field);
   }
   auto column_group_schema = arrow::schema(fields);
 
+  // create the file system by cache
+  milvus_storage::ArrowFileSystemConfig fs_config;
+  ARROW_RETURN_NOT_OK(milvus_storage::ArrowFileSystemConfig::create_file_system_config(properties, fs_config));
   if (column_group->format == LOON_FORMAT_PARQUET) {
-    writer = std::make_unique<milvus_storage::parquet::ParquetFileWriter>(column_group, fs, schema, properties);
+    ARROW_ASSIGN_OR_RAISE(auto file_system, create_parquet_file_system(fs_config));
+    writer = std::make_unique<ParquetFileWriter>(column_group, file_system, schema, properties);
   }
 #ifdef BUILD_VORTEX_BRIDGE
   else if (column_group->format == LOON_FORMAT_VORTEX) {
-    writer = std::make_unique<milvus_storage::vortex::VortexFileWriter>(column_group, schema, properties);
+    ARROW_ASSIGN_OR_RAISE(auto file_system, create_vortex_object_store(fs_config));
+    writer = std::make_unique<VortexFileWriter>(column_group, file_system, schema, properties);
   }
-#endif
+#endif  // BUILD_VORTEX_BRIDGE
   else {
-    throw std::runtime_error("Unsupported file format: " + column_group->format);
+    return arrow::Status::Invalid("Unsupported file format: " + column_group->format);
   }
   return writer;
 }

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -28,17 +28,12 @@ namespace milvus_storage::vortex {
 using namespace milvus_storage::api;
 
 VortexFileWriter::VortexFileWriter(std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
+                                   std::shared_ptr<ObjectStoreWrapper> fs,
                                    std::shared_ptr<arrow::Schema> schema,
                                    const api::Properties& properties)
     : closed_(false),
-      obsw_(ObjectStoreWrapper::OpenObjectStore(
-          GetValueNoError<std::string>(properties, PROPERTY_FS_STORAGE_TYPE).c_str(),
-          GetValueNoError<std::string>(properties, PROPERTY_FS_ADDRESS).c_str(),
-          GetValueNoError<std::string>(properties, PROPERTY_FS_ACCESS_KEY_ID).c_str(),
-          GetValueNoError<std::string>(properties, PROPERTY_FS_ACCESS_KEY_VALUE).c_str(),
-          GetValueNoError<std::string>(properties, PROPERTY_FS_REGION).c_str(),
-          GetValueNoError<std::string>(properties, PROPERTY_FS_BUCKET_NAME).c_str())),
-      vx_writer_(std::move(VortexWriter::Open(obsw_, column_group->paths[0]))),
+      obsw_(std::move(fs)),
+      vx_writer_(std::move(VortexWriter::Open(*obsw_, column_group->paths[0]))),
       schema_(schema),
       properties_(properties) {}
 

--- a/cpp/test/format/fs_cache_test.cpp
+++ b/cpp/test/format/fs_cache_test.cpp
@@ -1,0 +1,192 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <thread>
+#include "test_util.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/common/lrucache.h"
+
+namespace milvus_storage {
+
+class FileSystemCacheTest : public testing::Test {
+  protected:
+  ArrowFileSystemConfig MakeConfig(const std::string& id) {
+    ArrowFileSystemConfig cfg;
+    // use address + bucket_name to differentiate configs
+    cfg.root_path = "/tmp/fs_test_" + id;
+    //   cfg.format = LOON_FORMAT_VORTEX;
+    return cfg;
+  }
+};
+
+TEST_F(FileSystemCacheTest, TemplateSingleton) {
+  // won't got different instances for different template types
+  auto& c1 = LRUCache<int, std::string>::getInstance();
+  auto& c2 = LRUCache<int, double>::getInstance();
+  ASSERT_NE((uintptr_t)&c1, (uintptr_t)&c2);
+
+  auto& c3 = LRUCache<int, std::string>::getInstance();
+  ASSERT_EQ((uintptr_t)&c1, (uintptr_t)&c3);
+}
+
+TEST_F(FileSystemCacheTest, Basic) {
+  ArrowFileSystemConfig config1 = MakeConfig("A");
+  ArrowFileSystemConfig config2 = MakeConfig("B");
+  auto& cache = LRUCache<ArrowFileSystemConfig, ArrowFileSystemPtr>::getInstance();
+
+  // Initially, cache size should be 0
+  EXPECT_EQ(cache.size(), 0);
+
+  // Get filesystem for config1
+  ASSERT_AND_ASSIGN(auto fs1, cache.get(config1, CreateArrowFileSystem));
+  EXPECT_EQ(cache.size(), 1);
+
+  // Get filesystem for config1 again, should return the same instance
+  ASSERT_AND_ASSIGN(auto fs1_again, cache.get(config1, CreateArrowFileSystem));
+  EXPECT_EQ(fs1, fs1_again);
+  EXPECT_EQ(cache.size(), 1);
+
+  // Get filesystem for config2
+  ASSERT_AND_ASSIGN(auto fs2, cache.get(config2, CreateArrowFileSystem));
+  EXPECT_EQ(cache.size(), 2);
+
+  // Remove config1 from cache
+  cache.remove(config1);
+  EXPECT_EQ(cache.size(), 1);
+
+  // Remove config2 from cache
+  cache.remove(config2);
+  EXPECT_EQ(cache.size(), 0);
+
+  cache.clean();
+}
+
+TEST_F(FileSystemCacheTest, FileSystemCacheLRUEviction) {
+  auto& cache = LRUCache<ArrowFileSystemConfig, ArrowFileSystemPtr>::getInstance();
+  cache.set_capacity(2);
+
+  auto cfg1 = MakeConfig("A");
+  auto cfg2 = MakeConfig("B");
+  auto cfg3 = MakeConfig("C");
+
+  // Insert two entries
+  ASSERT_AND_ASSIGN(auto res1, cache.get(cfg1, CreateArrowFileSystem));
+  ASSERT_AND_ASSIGN(auto res2, cache.get(cfg2, CreateArrowFileSystem));
+
+  // Insert third -> should evict least recently used (cfg1)
+  ASSERT_AND_ASSIGN(auto res3, cache.get(cfg3, CreateArrowFileSystem));
+  EXPECT_EQ(cache.size(), 2u);
+
+  // Accessing cfg1 should recreate it
+  ASSERT_AND_ASSIGN(auto res1b, cache.get(cfg1, CreateArrowFileSystem));
+  EXPECT_NE(res1, res1b);
+
+  cache.clean();
+  EXPECT_EQ(cache.size(), 0);
+}
+
+TEST_F(FileSystemCacheTest, FileSystemCacheLRUUpdateOnAccess) {
+  auto& cache = LRUCache<ArrowFileSystemConfig, ArrowFileSystemPtr>::getInstance();
+  cache.set_capacity(2);
+
+  auto A = MakeConfig("X");
+  auto B = MakeConfig("Y");
+  auto C = MakeConfig("Z");
+
+  // Insert A and B
+  ASSERT_AND_ASSIGN(auto res1, cache.get(A, CreateArrowFileSystem));
+  ASSERT_AND_ASSIGN(auto res2, cache.get(B, CreateArrowFileSystem));
+  EXPECT_EQ(cache.size(), 2u);
+
+  // Access A again to make it most-recent
+  ASSERT_AND_ASSIGN(auto res3, cache.get(A, CreateArrowFileSystem));
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_EQ(res1, res3);
+
+  // Insert C -> should evict B
+  ASSERT_AND_ASSIGN(auto res4, cache.get(C, CreateArrowFileSystem));
+  EXPECT_EQ(cache.size(), 2u);
+
+  // B should be gone and recreated when requested
+  ASSERT_AND_ASSIGN(auto res5, cache.get(B, CreateArrowFileSystem));
+  EXPECT_NE(res2, res5);  // B have been evicted earlier
+
+  // clean up
+  cache.clean();
+  EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST_F(FileSystemCacheTest, ConcurrentGetsSingleCreate) {
+  auto& cache = LRUCache<ArrowFileSystemConfig, ArrowFileSystemPtr>::getInstance();
+  cache.set_capacity(10);
+
+  auto cfg = MakeConfig("CONCURRENT");
+
+  const int thread_count = 8;
+  const int calls_per_thread = 50;
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+
+  for (int i = 0; i < thread_count; ++i) {
+    threads.emplace_back([&cache, &cfg, calls_per_thread]() {
+      for (int j = 0; j < calls_per_thread; ++j) {
+        ASSERT_AND_ASSIGN(auto res, cache.get(cfg, CreateArrowFileSystem));
+        // small yield to increase interleaving
+        std::this_thread::yield();
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  cache.clean();
+  EXPECT_EQ(cache.size(), 0u);
+  // Only one creation should have happened if the cache creation is properly synchronized.
+}
+
+TEST_F(FileSystemCacheTest, ConcurrentGetsAndCreate) {
+  const int thread_count = 20;
+  const int configs_per_thread = 100;
+  const int capacity = 50;
+  auto& cache = LRUCache<ArrowFileSystemConfig, ArrowFileSystemPtr>::getInstance();
+  cache.set_capacity(capacity);
+
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+
+  for (int i = 0; i < thread_count; ++i) {
+    threads.emplace_back([&]() {
+      for (int j = 0; j < configs_per_thread; ++j) {
+        auto cfg = MakeConfig("THREAD_" + std::to_string(j));
+        ASSERT_AND_ASSIGN(auto res, cache.get(cfg, CreateArrowFileSystem));
+        ASSERT_LE(cache.size(), std::min(capacity, configs_per_thread));
+        std::this_thread::yield();
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(cache.size(), std::min(capacity, configs_per_thread));
+
+  cache.clean();
+  EXPECT_EQ(cache.size(), 0u);
+}
+
+}  // namespace milvus_storage

--- a/cpp/test/include/test_util.h
+++ b/cpp/test/include/test_util.h
@@ -61,6 +61,6 @@ std::string GetEnvVar(const std::string& var_name);
 #define ENV_VAR_REGION "REGION"
 #define ENV_VAR_ROOT_PATH "ROOT_PATH"
 
-void InitTestProperties(api::Properties& properties, std::string root_path = "./");
+void InitTestProperties(api::Properties& properties, std::string address = "./", std::string root_path = "./");
 
 }  // namespace milvus_storage

--- a/cpp/test/test_util.cpp
+++ b/cpp/test/test_util.cpp
@@ -58,9 +58,10 @@ std::string GetEnvVar(const std::string& var_name) {
   return value ? std::string(value) : std::string();
 }
 
-void InitTestProperties(api::Properties& properties, std::string root_path) {
+void InitTestProperties(api::Properties& properties, std::string address, std::string root_path) {
   if (GetEnvVar(ENV_VAR_STORAGE_TYPE) == "local" || GetEnvVar(ENV_VAR_STORAGE_TYPE).empty()) {
-    api::SetValue(properties, PROPERTY_FS_ADDRESS, root_path.c_str());
+    api::SetValue(properties, PROPERTY_FS_ADDRESS, address.c_str());
+    api::SetValue(properties, PROPERTY_FS_ROOT_PATH, root_path.c_str());
 
   } else {
     // must be remote


### PR DESCRIPTION
In the milvus-storage, an LRUCache (template class) has been introduced, and the filesystem is cached using the filesystem config as the key.

Since the time required to create and destroy a filesystem is too long, caching the filesystem is necessary. Since the filesystems used by Parquet and Vortex are different (and there is very hard to create an adapter between two of format), the cache objects used for different entities in `format.cpp` are also different.