### PR TITLE
fix: Remove duplicate AWS SDK initialization to prevent init conflicts

### DIFF
--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -42,20 +42,6 @@
 namespace milvus_storage {
 
 void S3FileSystemProducer::InitS3() {
-  if (!arrow::fs::IsS3Initialized()) {
-    arrow::fs::S3GlobalOptions arrow_global_options;
-    arrow_global_options.log_level = LogLevel_Map[config_.log_level];
-    auto status = arrow::fs::InitializeS3(arrow_global_options);
-    if (!status.ok()) {
-      throw std::invalid_argument("Arrow S3 initialization failed: " + status.ToString());
-    }
-    std::atexit([]() {
-      auto status = arrow::fs::EnsureS3Finalized();
-      if (!status.ok()) {
-        throw std::invalid_argument("ArrowFileSystem failed to finalize arrow S3: " + status.ToString());
-      }
-    });
-  }
   if (!IsS3Initialized()) {
     ExtendS3GlobalOptions global_options;
     global_options.log_level = LogLevel_Map[config_.log_level];


### PR DESCRIPTION
Remove redundant `arrow::fs::InitializeS3()` call that was causing duplicate `Aws::InitAPI()` initialization. This was resulting in the warning: "AWS-SDK-CPP is already initialized 1 times. Consequent calls to InitAPI are ignored."

Root Cause:

The code was initializing AWS SDK twice:
1. First via `arrow::fs::InitializeS3()` at cpp/src/filesystem/s3/s3_fs.cpp:46-59
2. Then via the extended `InitializeS3()` at cpp/src/filesystem/s3/s3_fs.cpp:60-88

Both functions internally call `Aws::InitAPI()`, but AWS SDK only allows initialization once. The second call's configuration (including custom HTTP client for GCP IAM) was being ignored.

Keep only the extended S3 initialization which:
- Properly initializes AWS SDK with custom configurations
- Supports GCP IAM authentication via custom HTTP client factory
- Provides all functionality needed by both Arrow and the extended S3 implementation

Relates to milvus-io/milvus#44745 - This fix ensures that custom AWS SDK options (particularly for GCP Workload Identity) are properly applied during initialization, rather than being silently ignored due to duplicate initialization.