### PR TITLE
enhance: allow vortex reader use the logical size to split chunks

### DIFF
--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -28,10 +28,10 @@ struct Properties;
 namespace milvus_storage::api {
 struct PropertyInfo;
 // Define property types and variants
-enum class PropertyType { STRING, INT32, INT64, BOOL, VECTOR_STR, UINT32 };
+enum class PropertyType { STRING, INT32, INT64, UINT32, UINT64, BOOL, VECTOR_STR };
 // A variant that can hold any of the property types
 using PropertyVariant =
-    std::variant<std::string, int32_t, int64_t, bool, std::vector<std::string>, uint32_t, std::nullptr_t>;
+    std::variant<std::string, int32_t, int64_t, uint32_t, uint64_t, bool, std::vector<std::string>, std::nullptr_t>;
 // A map of property names to their variants
 using Properties = std::unordered_map<std::string, PropertyVariant>;
 // Validator function type
@@ -107,6 +107,7 @@ struct PropertyInfo {
 // --- Define Reader property keys ---
 #define PROPERTY_READER_RECORD_BATCH_MAX_ROWS "reader.record_batch_max_rows"
 #define PROPERTY_READER_RECORD_BATCH_MAX_SIZE "reader.record_batch_max_size"
+#define PROPERTY_READER_VORTEX_CHUNK_ROWS "reader.vortex.chunk_rows"
 
 // --- Define Transaction property keys ---
 #define PROPERTY_TRANSACTION_HANDLER_TYPE "transaction.handler_type"

--- a/cpp/src/format/vortex/vortex_chunk_reader.cpp
+++ b/cpp/src/format/vortex/vortex_chunk_reader.cpp
@@ -27,24 +27,31 @@ namespace milvus_storage::vortex {
 using namespace milvus_storage::api;
 
 VortexChunkReader::VortexChunkReader(std::shared_ptr<ObjectStoreWrapper> fs,
-                                     std::shared_ptr<arrow::Schema> schema,
+                                     const std::shared_ptr<arrow::Schema>& schema,
                                      const std::vector<std::string>& paths,
-                                     const std::vector<std::string>& needed_columns,
-                                     const api::Properties& properties)
+                                     const api::Properties& properties,
+                                     const std::vector<std::string>& needed_columns)
     : obsw_(std::move(fs)),
-      number_of_chunks_(paths.size()),
-      schema_(std::move(schema)),
+      schema_(schema),
       proj_cols_(std::move(needed_columns)),
       properties_(properties),
-      paths_(std::move(paths)) {
+      paths_(std::move(paths)),
+      vxfiles_(paths.size()),
+      logical_chunk_rows_(0),
+      rginfos_(),
+      offsets_in_paths_(paths.size() + 1),
+      total_rows_(0) {
   assert(paths_.empty() == false);
 }
 
-size_t VortexChunkReader::total_number_of_chunks() const { return number_of_chunks_; }
+size_t VortexChunkReader::total_number_of_chunks() const {
+  assert(!rginfos_.empty());
+  return rginfos_.size();
+}
 
 size_t VortexChunkReader::total_rows() const {
-  assert(!idx_offsets_.empty());
-  return idx_offsets_.back();
+  assert(!rginfos_.empty());
+  return total_rows_;
 }
 
 VortexChunkReader::~VortexChunkReader() {
@@ -56,48 +63,136 @@ VortexChunkReader::~VortexChunkReader() {
   obsw_.reset();
 }
 
-arrow::Status VortexChunkReader::open() {
-  size_t last_offset = 0;
-  vxfiles_.reserve(number_of_chunks_);
-  idx_offsets_.reserve(number_of_chunks_ + 1);
-  idx_offsets_.emplace_back(last_offset);
+static arrow::Result<std::vector<std::vector<int64_t>>> calc_idxs_in_paths(
+    const std::vector<int64_t>& row_indices, const std::vector<uint64_t>& offsets_in_paths) {
+  std::vector<std::vector<int64_t>> result(offsets_in_paths.size());
+  for (const auto& row_index : row_indices) {
+    auto it = std::lower_bound(offsets_in_paths.begin(), offsets_in_paths.end(), (size_t)row_index);
+    if (it == offsets_in_paths.end()) {
+      return arrow::Status::Invalid("Row index out of range: " + std::to_string(row_index));
+    }
 
-  for (const auto& path : paths_) {
-    auto format_reader = std::make_unique<VortexFormatReader>(*(obsw_.get()),  // unsafe, but ok here
-                                                              path, proj_cols_);
-    last_offset += format_reader->rows();
-    idx_offsets_.emplace_back(last_offset);
-    vxfiles_.emplace_back(std::move(format_reader));
+    auto chunk_index = -1;
+    if (*it == row_index) {
+      chunk_index = std::distance(offsets_in_paths.begin(), it);
+    } else if (it != offsets_in_paths.begin()) {
+      chunk_index = std::distance(offsets_in_paths.begin(), it - 1);
+    }
+
+    assert(chunk_index >= 0 && chunk_index < offsets_in_paths.size());
+
+    int64_t local_ridx = row_index - offsets_in_paths[chunk_index];
+    result[chunk_index].emplace_back(local_ridx);
   }
 
-  assert(idx_offsets_.size() == vxfiles_.size() + 1 && number_of_chunks_ == vxfiles_.size());
+  return result;
+}
+
+static std::vector<uint64_t> recalc_row_ranges(const std::vector<uint64_t>& original_ranges,
+                                               size_t logical_chunk_rows) {
+  std::vector<uint64_t> new_ranges;
+  for (const auto& range : original_ranges) {
+    size_t full_chunks = range / logical_chunk_rows;
+    size_t remainder = range % logical_chunk_rows;
+
+    for (size_t i = 0; i < full_chunks; i++) {
+      new_ranges.emplace_back(logical_chunk_rows);
+    }
+
+    if (remainder > 0) {
+      new_ranges.emplace_back(remainder);
+    }
+  }
+
+  return new_ranges;
+}
+
+arrow::Status VortexChunkReader::open() {
+  // should not be called twice
+  assert(rginfos_.empty());
+
+  ARROW_ASSIGN_OR_RAISE(logical_chunk_rows_, api::GetValue<uint64_t>(properties_, PROPERTY_READER_VORTEX_CHUNK_ROWS));
+
+  assert(!offsets_in_paths_.empty());
+  offsets_in_paths_[0] = 0;
+
+  size_t last_offset = 0;
+  // load vortex files and build chunk infos
+  for (size_t path_idx = 0; path_idx < paths_.size(); path_idx++) {
+    vxfiles_[path_idx] = std::make_unique<VortexFormatReader>(*obsw_, schema_,  // unsafe, but ok here
+                                                              paths_[path_idx], proj_cols_);
+
+    auto memory_usage_in_file = vxfiles_[path_idx]->total_mem_usage();
+    auto rows_in_file = vxfiles_[path_idx]->rows();
+    auto row_ranges = vxfiles_[path_idx]->row_ranges();
+    row_ranges = recalc_row_ranges(row_ranges, logical_chunk_rows_);
+
+    size_t last_offset_in_file = 0;
+    for (size_t rgidx = 0; rgidx < row_ranges.size(); rgidx++) {
+      rginfos_.emplace_back(std::move(ChunkInfo{
+          .belong_which_file = path_idx,
+          .global_row_offset = last_offset_in_file + last_offset,
+          .row_index_in_file = last_offset_in_file,
+          .number_of_rows = row_ranges[rgidx],
+
+          // if memory_usage_in_file is 0 will be fine
+          .avg_memory_usage = memory_usage_in_file * (row_ranges[rgidx] / rows_in_file),
+      }));
+      last_offset_in_file += row_ranges[rgidx];
+    }
+
+    assert(last_offset_in_file == rows_in_file);
+    last_offset += rows_in_file;
+
+    assert(offsets_in_paths_.size() > path_idx + 1);
+    offsets_in_paths_[path_idx + 1] = last_offset;
+  }
+  total_rows_ = last_offset;
+
+#ifndef NDEBUG
+  // verify total rows
+  uint64_t verify_total_rows = 0;
+  for (size_t i = 0; i < offsets_in_paths_.size(); ++i) {
+    verify_total_rows += offsets_in_paths_[i];
+  }
+  assert(verify_total_rows == total_rows_);
+
+  // rginfos_ correctness and order
+  verify_total_rows = 0;
+  for (size_t i = 0; i < rginfos_.size(); ++i) {
+    if (i > 0) {
+      assert(rginfos_[i].row_index_in_file == rginfos_[i - 1].row_index_in_file + rginfos_[i - 1].number_of_rows);
+    }
+    verify_total_rows += rginfos_[i].number_of_rows;
+  }
+  assert(verify_total_rows == total_rows_);
+#endif
 
   // already opened in constructor
   return arrow::Status::OK();
-}
-
-static inline expr::Expr build_projection(const std::vector<std::string>& ncs) {
-  return expr::select(std::vector<std::string_view>(ncs.begin(), ncs.end()), expr::root());
 }
 
 arrow::Result<std::vector<int64_t>> VortexChunkReader::get_chunk_indices(const std::vector<int64_t>& row_indices) {
   std::unordered_set<int64_t> unique_chunk_indices;
   std::vector<int64_t> chunk_indices;
 
-  for (const auto& row_index : row_indices) {
-    auto it = std::lower_bound(idx_offsets_.begin(), idx_offsets_.end(), (size_t)row_index);
-    if (it == idx_offsets_.end()) {
+  assert(!rginfos_.empty());
+  for (int64_t row_index : row_indices) {
+    // use upper_bound find the first position which global_row_offset > row_index
+    auto it =
+        std::upper_bound(rginfos_.begin(), rginfos_.end(), row_index,
+                         [](uint64_t row_idx, const ChunkInfo& info) { return row_idx < info.global_row_offset; });
+    assert(it != rginfos_.begin());
+
+    // move to the correct chunks
+    --it;
+
+    // check row_index in range
+    if (row_index >= it->global_row_offset + it->number_of_rows) {
       return arrow::Status::Invalid("Row index out of range: " + std::to_string(row_index));
     }
-    auto chunk_index = -1;
-    if (*it == row_index) {
-      chunk_index = std::distance(idx_offsets_.begin(), it);
-    } else if (it != idx_offsets_.begin()) {
-      chunk_index = std::distance(idx_offsets_.begin(), it - 1);
-    }
-
-    assert(chunk_index >= 0 && chunk_index < number_of_chunks_);
-
+    auto chunk_index = std::distance(rginfos_.begin(), it);
+    assert(chunk_index >= 0 && chunk_index < rginfos_.size());
     if (unique_chunk_indices.find(chunk_index) == unique_chunk_indices.end()) {
       unique_chunk_indices.insert(chunk_index);
       chunk_indices.emplace_back(chunk_index);
@@ -108,47 +203,73 @@ arrow::Result<std::vector<int64_t>> VortexChunkReader::get_chunk_indices(const s
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexChunkReader::get_chunk(int64_t chunk_index) {
-  if (chunk_index < 0 || chunk_index >= number_of_chunks_) {
+  assert(!rginfos_.empty());
+  if (chunk_index < 0 || chunk_index >= rginfos_.size()) {
     return arrow::Status::Invalid("Chunk index out of range: ", std::to_string(chunk_index), " out of ",
-                                  std::to_string(number_of_chunks_));
+                                  std::to_string(rginfos_.size()));
   }
 
-  return vxfiles_[chunk_index]->readall();
+  const auto& rg_info = rginfos_[chunk_index];
+  ARROW_ASSIGN_OR_RAISE(auto chunkedarray,
+                        vxfiles_[rg_info.belong_which_file]->read(rg_info.row_index_in_file,
+                                                                  rg_info.row_index_in_file + rg_info.number_of_rows));
+  // won't split as multi-chunk in vortex
+  assert(chunkedarray != nullptr && chunkedarray->num_chunks() == 1);
+
+  return arrow::RecordBatch::FromStructArray(chunkedarray->chunk(0));
 }
 
 arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> VortexChunkReader::get_chunks(
     const std::vector<int64_t>& chunk_indices) {
-  std::vector<std::shared_ptr<arrow::RecordBatch>> rbs(chunk_indices.size());
-  for (int i = 0; i < chunk_indices.size(); i++) {
-    ARROW_ASSIGN_OR_RAISE(rbs[i], get_chunk(chunk_indices[i]));
+  std::vector<std::shared_ptr<arrow::RecordBatch>> rbs;
+  std::vector<std::vector<int>> chunks_in_files(vxfiles_.size());
+
+  assert(!rginfos_.empty());
+
+  for (const auto chunk_idx : chunk_indices) {
+    const auto& rg_info = rginfos_[chunk_idx];
+    chunks_in_files[rg_info.belong_which_file].emplace_back(chunk_idx);
+  }
+
+  for (auto& chunks_in_single_file : chunks_in_files) {
+    std::vector<std::pair<uint64_t, uint64_t>> rg_idx_ranges;
+    // do sort chunks_in_single_file
+    std::sort(chunks_in_single_file.begin(), chunks_in_single_file.end());
+
+    // calc continuous ranges
+    // ex. [1, 2, 3, 5] -> [(1, 3), (5, 5)]
+    size_t start_idx = 0;
+    for (size_t i = 1; i < chunks_in_single_file.size(); ++i) {
+      if (chunks_in_single_file[i] != chunks_in_single_file[i - 1] + 1) {
+        rg_idx_ranges.emplace_back(chunks_in_single_file[start_idx], chunks_in_single_file[i - 1]);
+        start_idx = i;
+      }
+    }
+
+    if (start_idx < chunks_in_single_file.size()) {
+      rg_idx_ranges.emplace_back(chunks_in_single_file[start_idx], chunks_in_single_file.back());
+    }
+
+    // begin to read continuous ranges
+    // for each range, read once, then split to record batches
+    // and assign to rbs
+    for (const auto& rg_range : rg_idx_ranges) {
+      // load continuous chunks in one read
+      const auto& start_rg_info = rginfos_[rg_range.first];
+      const auto& end_rg_info = rginfos_[rg_range.second];
+
+      ARROW_ASSIGN_OR_RAISE(auto chunked_array, vxfiles_[start_rg_info.belong_which_file]->read(
+                                                    start_rg_info.row_index_in_file,
+                                                    end_rg_info.row_index_in_file + end_rg_info.number_of_rows));
+      // assign to rbs
+      for (size_t j = 0; j < chunked_array->num_chunks(); ++j) {
+        ARROW_ASSIGN_OR_RAISE(auto rb, arrow::RecordBatch::FromStructArray(chunked_array->chunk(j)));
+        rbs.emplace_back(rb);
+      }
+    }
   }
 
   return rbs;
-}
-
-arrow::Result<std::vector<std::vector<int64_t>>> VortexChunkReader::calc_ridxs_in_chunks(
-    const std::vector<int64_t>& row_indices) {
-  std::vector<std::vector<int64_t>> result(number_of_chunks_);
-  for (const auto& row_index : row_indices) {
-    auto it = std::lower_bound(idx_offsets_.begin(), idx_offsets_.end(), (size_t)row_index);
-    if (it == idx_offsets_.end()) {
-      return arrow::Status::Invalid("Row index out of range: " + std::to_string(row_index));
-    }
-
-    auto chunk_index = -1;
-    if (*it == row_index) {
-      chunk_index = std::distance(idx_offsets_.begin(), it);
-    } else if (it != idx_offsets_.begin()) {
-      chunk_index = std::distance(idx_offsets_.begin(), it - 1);
-    }
-
-    assert(chunk_index >= 0 && chunk_index < number_of_chunks_);
-
-    int64_t local_ridx = row_index - idx_offsets_[chunk_index];
-    result[chunk_index].emplace_back(local_ridx);
-  }
-
-  return result;
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexChunkReader::take(const std::vector<int64_t>& row_indices) {
@@ -157,7 +278,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexChunkReader::take(const
   std::shared_ptr<arrow::RecordBatch> record_batch = nullptr;
 
   // calc row idxs in each chunk
-  ARROW_ASSIGN_OR_RAISE(offset_in_chunks, calc_ridxs_in_chunks(row_indices));
+  ARROW_ASSIGN_OR_RAISE(offset_in_chunks, calc_idxs_in_paths(row_indices, offsets_in_paths_));
   assert(offset_in_chunks.size() == vxfiles_.size());
 
   for (size_t chunk_idx = 0; chunk_idx < offset_in_chunks.size(); chunk_idx++) {
@@ -174,26 +295,29 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexChunkReader::take(const
 
   // collapse row slices
   ARROW_ASSIGN_OR_RAISE(auto combined_table, arrow::Table::FromRecordBatches(rbs));
+
+  // FIXME: will it do concatenation(means copy)?
   ARROW_ASSIGN_OR_RAISE(auto combined_batch, combined_table->CombineChunksToBatch());
   return combined_batch;
 }
 
 arrow::Result<int64_t> VortexChunkReader::get_chunk_size(int64_t chunk_index) {
-  if (chunk_index < 0 || chunk_index >= (number_of_chunks_)) {
+  assert(!rginfos_.empty());
+  if (chunk_index < 0 || chunk_index >= rginfos_.size()) {
     return arrow::Status::Invalid("Chunk index out of range: ", std::to_string(chunk_index), " out of ",
-                                  std::to_string(number_of_chunks_));
+                                  std::to_string(rginfos_.size()));
   }
-  // no implements
-  // FIXME: return actual size
-  return 0;
+
+  return rginfos_[chunk_index].avg_memory_usage;
 }
 
 arrow::Result<int64_t> VortexChunkReader::get_chunk_rows(int64_t chunk_index) {
-  if (chunk_index < 0 || chunk_index >= (number_of_chunks_)) {
+  assert(!rginfos_.empty());
+  if (chunk_index < 0 || chunk_index >= rginfos_.size()) {
     return arrow::Status::Invalid("Chunk index out of range: ", std::to_string(chunk_index), " out of ",
-                                  std::to_string(number_of_chunks_));
+                                  std::to_string(rginfos_.size()));
   }
-  return idx_offsets_[chunk_index + 1] - idx_offsets_[chunk_index];
+  return rginfos_[chunk_index].number_of_rows;
 }
 
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -23,35 +23,68 @@
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
 #include <arrow/status.h>
+#include <arrow/result.h>
 
 namespace milvus_storage::vortex {
 
 using namespace milvus_storage::api;
 
-VortexFormatReader::VortexFormatReader(const ObjectStoreWrapper& obsw_ref,
-                                       const std::string& path,
-                                       std::vector<std::string> needed_columns)
-    : obsw_ref_(obsw_ref),
-      vxfile_(std::move(VortexFile::Open(obsw_ref_, path))),
-      proj_cols_(std::move(needed_columns)) {}
-
 static inline expr::Expr build_projection(const std::vector<std::string>& ncs) {
   return expr::select(std::vector<std::string_view>(ncs.begin(), ncs.end()), expr::root());
 }
 
-arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::readall() {
-  auto array_stream = vxfile_.CreateScanBuilder().WithProjection(build_projection(proj_cols_)).IntoStream();
+VortexFormatReader::VortexFormatReader(const ObjectStoreWrapper& obsw_ref,
+                                       const std::shared_ptr<arrow::Schema>& schema,
+                                       const std::string& path,
+                                       std::vector<std::string> needed_columns)
+    : obsw_ref_(obsw_ref),
+      // if ::Open throws exception, current memory still clear
+      vxfile_(std::move(VortexFile::Open(obsw_ref_, path))),
+      proj_cols_(std::move(needed_columns)),
+      schema_(schema) {
+  assert(schema_);
+}
+
+static void remove_metadata_from_schema(ArrowSchema* schema) {
+  assert(schema != nullptr);
+  for (int64_t i = 0; i < schema->n_children; ++i) {
+    remove_metadata_from_schema(schema->children[i]);
+  }
+  schema->metadata = nullptr;
+}
+
+static inline arrow::Result<ArrowSchema> export_c_arrow_schema(std::shared_ptr<arrow::Schema> schema) {
+  ArrowSchema c_arrow_schema;
+
+  ARROW_RETURN_NOT_OK(arrow::ExportSchema(*schema, &c_arrow_schema));
+  // Can't use metadata in vortex, because different implementation of arrow in rust and c++:
+  // the datatype compare in rust will check the metadata equality, but vortex won't record the metadata
+  // in writer side. So caller have to set metadata to nullptr here.
+  // Don't consider memory leak here, direct set to nullptr is safe, because the metadata alloced by arrow::ExportSchema
+  // which stored in the private_data of c_schema_, so when c_schema_ destructed, the metadata will be freed too.
+  remove_metadata_from_schema(&c_arrow_schema);
+
+  return std::move(c_arrow_schema);
+}
+
+arrow::Result<std::shared_ptr<arrow::ChunkedArray>> VortexFormatReader::read(uint64_t row_start, uint64_t row_end) {
+  ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(schema_));
+  auto array_stream = vxfile_.CreateScanBuilder()
+                          .WithProjection(build_projection(proj_cols_))
+                          .WithRowRange(row_start, row_end)
+                          .WithOutputSchema(c_arrow_schema)
+                          .IntoStream();
 
   ARROW_ASSIGN_OR_RAISE(auto chunkedarray, arrow::ImportChunkedArray(&array_stream));
-  assert(chunkedarray->num_chunks() == 1);
-
-  return arrow::RecordBatch::FromStructArray(chunkedarray->chunk(0));
+  return chunkedarray;
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::take(const std::vector<int64_t>& row_indices) {
+  ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(schema_));
   auto array_stream = vxfile_.CreateScanBuilder()
                           .WithProjection(build_projection(proj_cols_))
                           .WithIncludeByIndex((const uint64_t*)row_indices.data(), row_indices.size())
+                          .WithOutputSchema(c_arrow_schema)
                           .IntoStream();
 
   ARROW_ASSIGN_OR_RAISE(auto chunkedarray, arrow::ImportChunkedArray(&array_stream));
@@ -62,6 +95,29 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::take(cons
   assert(chunkedarray->num_chunks() == 1);
 
   return arrow::RecordBatch::FromStructArray(chunkedarray->chunk(0));
+}
+
+uint64_t VortexFormatReader::total_mem_usage() {
+  auto sizes = vxfile_.GetUncompressedSizes();
+  if (sizes.empty()) {
+    return 0;
+  }
+  uint64_t total_size = 0;
+  for (auto size : sizes) {
+    if (size == UINT64_MAX) {
+      return 0;
+    }
+    total_size += size;
+  }
+  return total_size;
+}
+
+uint64_t VortexFormatReader::mem_usage(size_t idx_in_column_group) {
+  auto sizes = vxfile_.GetUncompressedSizes();
+  if (idx_in_column_group >= static_cast<int64_t>(sizes.size())) {
+    return 0;
+  }
+  return sizes[idx_in_column_group] == UINT64_MAX ? 0 : sizes[idx_in_column_group];
 }
 
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/vortex/vx-bridge/src/bridgeimpl.cc
+++ b/cpp/src/format/vortex/vx-bridge/src/bridgeimpl.cc
@@ -260,6 +260,10 @@ ScanBuilder VortexFile::CreateScanBuilder() const {
     return ScanBuilder(impl_->scan_builder());
 }
 
+ScanBuilder VortexFile::CreateScanBuilderWithSchema(ArrowSchema &in_schema) const {
+    return ScanBuilder(impl_->scan_builder_with_schema(reinterpret_cast<uint8_t *>(&in_schema)));
+}
+
 std::vector<uint64_t> VortexFile::Splits() const {
     try {
         ::rust::Vec<::rust::u64> rs_splits = impl_->splits();

--- a/cpp/src/format/vortex/vx-bridge/src/include/bridgeimpl.hpp
+++ b/cpp/src/format/vortex/vx-bridge/src/include/bridgeimpl.hpp
@@ -269,6 +269,9 @@ public:
     /// The scan builder can be used to scan the file.
     ScanBuilder CreateScanBuilder() const;
 
+    /// Create a scan builder with arrow schema for the file.
+    ScanBuilder CreateScanBuilderWithSchema(ArrowSchema &in_schema) const;
+
     // get the row splits of the file
     std::vector<uint64_t> Splits() const;
 

--- a/cpp/src/format/vortex/vx-bridge/src/lib.rs
+++ b/cpp/src/format/vortex/vx-bridge/src/lib.rs
@@ -81,6 +81,7 @@ mod ffi {
         type VortexFile;
         fn row_count(self: &VortexFile) -> u64;
         fn scan_builder(self: &VortexFile) -> Result<Box<VortexScanBuilder>>;
+        unsafe fn scan_builder_with_schema(self: &VortexFile, in_schema: *mut u8) -> Result<Box<VortexScanBuilder>>;
         fn splits(self: &VortexFile) -> Result<Vec<u64>>;
         fn uncompressed_sizes(self: &VortexFile) -> Vec<u64>;
 

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -63,13 +63,13 @@ class APIWriterReaderTest : public ::testing::TestWithParam<std::string> {
     ASSERT_OK(fs_->DeleteDirContents(GetTempDir()));
   }
 
-  void CreateTestData() {
+  void CreateTestData(uint64_t num_rows = 100, uint64_t vector_dim = 4) {
     arrow::Int64Builder id_builder;
     arrow::StringBuilder name_builder;
     arrow::DoubleBuilder value_builder;
     arrow::ListBuilder vector_builder(arrow::default_memory_pool(), std::make_shared<arrow::FloatBuilder>());
 
-    for (int64_t i = 0; i < 100; ++i) {
+    for (int64_t i = 0; i < num_rows; ++i) {
       ASSERT_OK(id_builder.Append(i));
       ASSERT_OK(name_builder.Append("name_" + std::to_string(i)));
       ASSERT_OK(value_builder.Append(i * 1.5));
@@ -77,7 +77,7 @@ class APIWriterReaderTest : public ::testing::TestWithParam<std::string> {
       // Create vector data
       auto vector_element_builder = static_cast<arrow::FloatBuilder*>(vector_builder.value_builder());
       ASSERT_OK(vector_builder.Append());
-      for (int j = 0; j < 4; ++j) {
+      for (int j = 0; j < vector_dim; ++j) {
         ASSERT_OK(vector_element_builder->Append(i * 0.1f + j));
       }
     }
@@ -1211,9 +1211,6 @@ TEST_P(APIWriterReaderTest, TestAllNullFields) {
 
 TEST_P(APIWriterReaderTest, TestLargeBatch) {
   std::string format = GetParam();
-  if (format == LOON_FORMAT_VORTEX) {
-    GTEST_SKIP();
-  }
 
   // Test writing and reading a large record batch
   int large_batch_size = 100000;  // 100k rows


### PR DESCRIPTION
This commit adds support for the vortex chunk reader to split chunks 
using the logical chunk size (PROPERTY_READER_VORTEX_CHUNK_ROWS). 
Note that the final chunk size may not be equal to the logical size. 
because that vortex splits chunks according to the layout size by 
default, so when the logical chunk size exceeds the layout size,
the final chunk size becomes the layout size.

Additionally, this PR fixes an issue where `arrow::utf8` is read 
as `arrow::utf8view`. The vortex performs canonical encoding 
operations and converts the arrow schema according to the rules
`in vortex-dtype/src/arrow.rs` by default. Therefore, in the 
format reader, it is necessary to pass an `arrow::schema` to
ensure read type are consistent with write type.