### PR TITLE
enhance: Make the written file naming with the UUID

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -199,10 +199,6 @@ class StorageConan(ConanFile):
 
         self.cpp_info.components["libstorage"].libs = ["milvus-storage"]
 
-        # self.cpp_info.components["libstorage"].requires = [
-        #     "boost::uuid",
-        #     "boost::algorithm",
-        # ]
         if self.options.with_ut:
             self.cpp_info.components["libstorage"].requires.append("gtest::gtest")
 


### PR DESCRIPTION
In the storage, the files written by the top-level writer do not incorporate a UUID, which will lead to filename conflicts in the same directory.

After the current commit, the storage files will follow a unified naming rule: `column_group_{group_id}_{uuid}.{format}`.