### PR TITLE
enhance: Introduce new FFI API for caching layer

### DIFF
--- a/cpp/include/milvus-storage/common/macro.h
+++ b/cpp/include/milvus-storage/common/macro.h
@@ -56,4 +56,33 @@ namespace milvus_storage {
 
 #define ASSIGN_OR_RETURN_NOT_OK(lhs, rexpr) ASSIGN_OR_RETURN_NOT_OK_IMPL(CONCAT(_tmp_value, __COUNTER__), lhs, rexpr);
 
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_expect)
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define LIKELY(x)
+#define UNLIKELY(x)
+#endif
+#elif defined(__GNUC__) || defined(__clang__)
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define LIKELY(x)
+#define UNLIKELY(x)
+#endif
+
+#ifndef NDEBUG
+
+#define assert_if(condition, expr) \
+  do {                             \
+    if (condition) {               \
+      assert((expr));              \
+    }                              \
+  } while (0)
+
+#else
+#define assert_if(condition, expr)
+#endif
+
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/format.h
+++ b/cpp/include/milvus-storage/format/format.h
@@ -37,8 +37,8 @@ class ColumnGroupReader {
 
   virtual arrow::Result<std::shared_ptr<arrow::RecordBatch>> take(const std::vector<int64_t>& row_indices) = 0;
 
-  virtual arrow::Result<int64_t> get_chunk_size(int64_t chunk_index) = 0;
-  virtual arrow::Result<int64_t> get_chunk_rows(int64_t chunk_index) = 0;
+  virtual arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) = 0;
+  virtual arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) = 0;
 };
 
 /**

--- a/cpp/include/milvus-storage/format/parquet/reader.h
+++ b/cpp/include/milvus-storage/format/parquet/reader.h
@@ -70,9 +70,9 @@ class ParquetChunkReader : public internal::api::ColumnGroupReader {
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> take(
       const std::vector<int64_t>& row_indices) override;
 
-  [[nodiscard]] arrow::Result<int64_t> get_chunk_size(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) override;
 
-  [[nodiscard]] arrow::Result<int64_t> get_chunk_rows(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
 
   protected:
   std::shared_ptr<arrow::fs::FileSystem> fs_;

--- a/cpp/include/milvus-storage/format/vortex/vortex_chunk_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_chunk_reader.h
@@ -50,9 +50,9 @@ class VortexChunkReader final : public internal::api::ColumnGroupReader {
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> take(
       const std::vector<int64_t>& row_indices) override;
 
-  [[nodiscard]] arrow::Result<int64_t> get_chunk_size(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) override;
 
-  [[nodiscard]] arrow::Result<int64_t> get_chunk_rows(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
 
   private:
   // Information of a row group

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -42,6 +42,11 @@ class ChunkReader {
   virtual ~ChunkReader() = default;
 
   /**
+   * @brief Returns the total number of chunks in the column group
+   */
+  [[nodiscard]] virtual size_t total_number_of_chunks() const = 0;
+
+  /**
    * @brief Maps row indices to their corresponding chunk indices within the column group
    *
    * This method determines which chunks contain the specified rows, allowing for
@@ -78,6 +83,12 @@ class ChunkReader {
    */
   [[nodiscard]] virtual arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
       const std::vector<int64_t>& chunk_indices, int64_t parallelism) = 0;
+
+  /**
+   * @brief Retrieves the metadata of chunks
+   */
+  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_size() = 0;
+  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_rows() = 0;
 };
 
 /**
@@ -153,6 +164,12 @@ class Reader {
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> take(const std::vector<int64_t>& row_indices) const {
     return take(row_indices, 1);
   }
+
+  /**
+   * @brief Retrieves the column groups managed by this reader
+   * @return Vector of shared pointers to ColumnGroup instances
+   */
+  [[nodiscard]] virtual std::vector<std::shared_ptr<ColumnGroup>> get_column_groups() const = 0;
 
   /**
    * @brief Performs a full table scan with optional filtering and buffering

--- a/cpp/src/format/parquet/chunk_reader.cpp
+++ b/cpp/src/format/parquet/chunk_reader.cpp
@@ -34,6 +34,8 @@
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/common/arrow_util.h"
 
+#include "milvus-storage/common/macro.h"  // for UNLIKELY
+
 namespace milvus_storage::parquet {
 
 arrow::Status ParquetChunkReader::open() {
@@ -225,18 +227,18 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> ParquetChunkReader::take(cons
   return combined_batch;
 }
 
-arrow::Result<int64_t> ParquetChunkReader::get_chunk_size(int64_t chunk_index) {
+arrow::Result<uint64_t> ParquetChunkReader::get_chunk_size(int64_t chunk_index) {
   assert(!file_readers_.empty());
-  if (chunk_index < 0 || chunk_index >= row_group_indices_.size()) {
+  if (UNLIKELY(chunk_index < 0 || chunk_index >= row_group_indices_.size())) {
     return arrow::Status::Invalid("Chunk index out of range: " + std::to_string(chunk_index) + " out of " +
                                   std::to_string(row_group_indices_.size()));
   }
   return row_group_indices_[chunk_index].size;
 }
 
-arrow::Result<int64_t> ParquetChunkReader::get_chunk_rows(int64_t chunk_index) {
+arrow::Result<uint64_t> ParquetChunkReader::get_chunk_rows(int64_t chunk_index) {
   assert(!file_readers_.empty());
-  if (chunk_index < 0 || chunk_index >= row_group_indices_.size()) {
+  if (UNLIKELY(chunk_index < 0 || chunk_index >= row_group_indices_.size())) {
     return arrow::Status::Invalid("Chunk index out of range: " + std::to_string(chunk_index) + " out of " +
                                   std::to_string(row_group_indices_.size()));
   }


### PR DESCRIPTION
For the caching layer in Milvus, it requires the storage to precompute chunks and provide corresponding metadata (including the number of rows and memory size). Therefore, several new interfaces have been introduced in the storage to address this requirement.

- get_column_group_infos: Used to parse the information contained in the column groups within column_groups.
- get_number_of_chunks: Retrieves the number of chunks in the current column group.
- get_chunk_metadatas: Retrieves the metadata of all chunks in the current column group.

After this commit , the `ChunkReader` will become a reader generated based on "fixed" chunk divisions, while the `RecordBatchReader` will still as the "streaming" reader. Note that when using the `ChunkReader`, the `Properties` used to create the current chunk reader should not be altered to prevent changes in the number of chunks. In contrast, the `RecordBatchReader` can still use different properties to constrain the size of the returned record batches.