### PR TITLE
refactor: align JNI/Scala naming with FFI interface for column groups

### DIFF
--- a/cpp/src/jni/reader_jni.cpp
+++ b/cpp/src/jni/reader_jni.cpp
@@ -24,10 +24,14 @@
 
 extern "C" {
 
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(
-    JNIEnv* env, jobject obj, jstring manifest, jlong schema_ptr, jobjectArray needed_columns, jlong properties_ptr) {
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(JNIEnv* env,
+                                                                             jobject obj,
+                                                                             jstring column_groups,
+                                                                             jlong schema_ptr,
+                                                                             jobjectArray needed_columns,
+                                                                             jlong properties_ptr) {
   try {
-    const char* manifest_cstr = env->GetStringUTFChars(manifest, nullptr);
+    const char* column_groups_cstr = env->GetStringUTFChars(column_groups, nullptr);
     ArrowSchema* schema = reinterpret_cast<ArrowSchema*>(schema_ptr);
     Properties* properties = reinterpret_cast<Properties*>(properties_ptr);
 
@@ -36,9 +40,9 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(
 
     ReaderHandle reader_handle;
     FFIResult result =
-        reader_new(const_cast<char*>(manifest_cstr), schema, columns, num_columns, properties, &reader_handle);
+        reader_new(const_cast<char*>(column_groups_cstr), schema, columns, num_columns, properties, &reader_handle);
 
-    env->ReleaseStringUTFChars(manifest, manifest_cstr);
+    env->ReleaseStringUTFChars(column_groups, column_groups_cstr);
     FreeStringArray(env, columns, num_columns);
 
     if (!IsSuccess(&result)) {

--- a/cpp/src/jni/writer_jni.cpp
+++ b/cpp/src/jni/writer_jni.cpp
@@ -98,8 +98,8 @@ JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose
   try {
     WriterHandle handle = static_cast<WriterHandle>(writer_handle);
 
-    char* manifest = nullptr;
-    FFIResult result = writer_close(handle, &manifest);
+    char* column_groups = nullptr;
+    FFIResult result = writer_close(handle, &column_groups);
 
     if (!IsSuccess(&result)) {
       FreeFFIResult(&result);
@@ -107,10 +107,10 @@ JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose
       return nullptr;
     }
 
-    jstring java_manifest = env->NewStringUTF(manifest);
-    free_cstr(manifest);
+    jstring java_column_groups = env->NewStringUTF(column_groups);
+    free_cstr(column_groups);
 
-    return java_manifest;
+    return java_column_groups;
   } catch (const std::exception& e) {
     jclass exc_class = env->FindClass("java/lang/RuntimeException");
     std::string error_msg = "Failed to close writer: " + std::string(e.what());

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageReader.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageReader.scala
@@ -12,26 +12,26 @@ class MilvusStorageReader {
 
   /**
    * Create a new reader instance
-   * @param manifest The manifest string
+   * @param columnGroups The column groups JSON string
    * @param schemaPtr Pointer to Arrow schema
    * @param neededColumns Array of column names to read
    * @param properties MilvusStorage properties
    */
-  def create(manifest: String, schemaPtr: Long, neededColumns: Array[String], properties: MilvusStorageProperties): Unit = {
+  def create(columnGroups: String, schemaPtr: Long, neededColumns: Array[String], properties: MilvusStorageProperties): Unit = {
     if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
-    readerHandle = readerNew(manifest, schemaPtr, neededColumns, properties.getPtr)
+    readerHandle = readerNew(columnGroups, schemaPtr, neededColumns, properties.getPtr)
   }
 
   /**
    * Create a new reader instance with properties pointer
-   * @param manifest The manifest string
+   * @param columnGroups The column groups JSON string
    * @param schemaPtr Pointer to Arrow schema
    * @param neededColumns Array of column names to read
    * @param propertiesPtr Pointer to properties
    */
-  def create(manifest: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Unit = {
+  def create(columnGroups: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Unit = {
     if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
-    readerHandle = readerNew(manifest, schemaPtr, neededColumns, propertiesPtr)
+    readerHandle = readerNew(columnGroups, schemaPtr, neededColumns, propertiesPtr)
   }
 
   /**
@@ -112,7 +112,7 @@ class MilvusStorageReader {
    */
   def isValid: Boolean = !isDestroyed && readerHandle != 0
 
-  @native private def readerNew(manifest: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Long
+  @native private def readerNew(columnGroups: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Long
   @native private def getRecordBatchReader(readerHandle: Long, predicate: String): Long
   @native private def getChunkReader(readerHandle: Long, columnGroupId: Long): Long
   @native private def take(readerHandle: Long, rowIndices: Array[Long], parallelism: Long): Long

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageWriter.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageWriter.scala
@@ -52,8 +52,8 @@ class MilvusStorageWriter {
   }
 
   /**
-   * Close the writer and return manifest
-   * @return The manifest string
+   * Close the writer and return column groups
+   * @return The column groups JSON string
    */
   def close(): String = {
     if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")

--- a/java/src/test/scala/io/milvus/storage/MilvusStorageIntegrationTest.scala
+++ b/java/src/test/scala/io/milvus/storage/MilvusStorageIntegrationTest.scala
@@ -75,11 +75,11 @@ class MilvusStorageIntegrationTest extends AnyFlatSpec with Matchers with Before
     writer.create(TEST_BASE_PATH, schema, writerProperties)
     writer.write(structArray)
     writer.flush()
-    val manifest = writer.close()
-    manifest should not be null
-    manifest should not be empty
-    println(s"Writer closed. Manifest size: ${manifest.length} bytes")
-    println(s"Manifest preview: ${manifest.take(200)}...")
+    val columnGroups = writer.close()
+    columnGroups should not be null
+    columnGroups should not be empty
+    println(s"Writer closed. Column groups size: ${columnGroups.length} bytes")
+    println(s"Column groups preview: ${columnGroups.take(200)}...")
     writer.destroy()
 
     // Create reader properties
@@ -94,7 +94,7 @@ class MilvusStorageIntegrationTest extends AnyFlatSpec with Matchers with Before
     val reader = new MilvusStorageReader()
     val neededColumns = Array("int64_field", "int32_field", "string_field")
     val readerSchema = ArrowTestUtils.createTestStructSchema()
-    reader.create(manifest, readerSchema, neededColumns, readerProperties)
+    reader.create(columnGroups, readerSchema, neededColumns, readerProperties)
     val recordBatchReader = reader.getRecordBatchReaderScala(null)
     val arrowArray = ArrowUtils.readNextBatch(recordBatchReader)
 


### PR DESCRIPTION
Rename all occurrences of 'manifest' to 'columnGroups'/'column_groups' in JNI and Scala layers to align with the FFI C interface naming convention used in transaction and manifest APIs.

Changes:
- JNI layer: Update parameter and variable names in reader_jni.cpp and writer_jni.cpp
- Scala API: Update MilvusStorageReader and MilvusStorageWriter method parameters and documentation
- Tests: Update MilvusStorageIntegrationTest to use new naming