### PR TITLE
enhance: move Aws S3 global instance to separate header and cpp

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
+++ b/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
@@ -24,8 +24,9 @@
 #include <aws/core/http/HttpClientFactory.h>
 
 #include <arrow/util/key_value_metadata.h>
-#include "arrow/filesystem/filesystem.h"
-#include "arrow/io/interfaces.h"
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
 #include "milvus-storage/filesystem/s3/s3_client.h"
@@ -104,47 +105,5 @@ class MultiPartUploadS3FS : public arrow::fs::FileSystem {
   class Impl;
   std::shared_ptr<Impl> impl_;
 };
-
-// TODO: should move this logical out
-/// \brief Initialize the S3 APIs with the specified set of options.
-///
-/// It is required to call this function at least once before using S3FileSystem.
-///
-/// Once this function is called you MUST call FinalizeS3 before the end of the
-/// application in order to avoid a segmentation fault at shutdown.
-arrow::Status InitializeS3(const S3GlobalOptions& options);
-
-/// \brief Ensure the S3 APIs are initialized, but only if not already done.
-///
-/// If necessary, this will call InitializeS3() with some default options.
-arrow::Status EnsureS3Initialized();
-
-/// Whether S3 was initialized, and not finalized.
-bool IsS3Initialized();
-
-/// Whether S3 was finalized.
-bool IsS3Finalized();
-
-/// \brief Check if S3 is initialized and return an error if not.
-///
-/// This function checks if S3 has been initialized and returns an appropriate
-/// error status if it has not been initialized or has been finalized.
-arrow::Status CheckS3Initialized();
-
-/// \brief Shutdown the S3 APIs.
-///
-/// This can wait for some S3 concurrent calls to finish so as to avoid
-/// race conditions.
-/// After this function has been called, all S3 calls will fail with an error.
-///
-/// Calls to InitializeS3() and FinalizeS3() should be serialized by the
-/// application (this also applies to EnsureS3Initialized() and
-/// EnsureS3Finalized()).
-arrow::Status FinalizeS3();
-
-/// \brief Ensure the S3 APIs are shutdown, but only if not already done.
-///
-/// If necessary, this will call FinalizeS3().
-arrow::Status EnsureS3Finalized();
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_client.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_client.h
@@ -106,7 +106,7 @@ class S3Client : public Aws::S3::S3Client {
   std::shared_ptr<S3ClientMetrics> GetMetrics() const;
 
   public:
-  std::shared_ptr<arrow::fs::S3RetryStrategy> s3_retry_strategy_;
+  std::shared_ptr<S3RetryStrategy> s3_retry_strategy_;
 
   private:
   std::shared_ptr<S3ClientMetrics> metrics_ = std::make_shared<S3ClientMetrics>();

--- a/cpp/include/milvus-storage/filesystem/s3/s3_global.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_global.h
@@ -1,0 +1,108 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <aws/core/Aws.h>
+#include <aws/core/http/HttpTypes.h>
+
+#include <arrow/status.h>
+#include <arrow/util/logging.h>
+
+namespace milvus_storage {
+
+enum class S3LogLevel : int8_t { Off, Fatal, Error, Warn, Info, Debug, Trace };
+
+struct S3GlobalOptions {
+  /// The log level for S3-originating messages.
+  S3LogLevel log_level;
+
+  /// The number of threads to configure when creating AWS' I/O event loop
+  ///
+  /// Defaults to 1 as recommended by AWS' doc when the # of connections is
+  /// expected to be, at most, in the hundreds
+  ///
+  /// For more details see Aws::Crt::Io::EventLoopGroup
+  int num_event_loop_threads = 1;
+
+  /// Whether to install a process-wide SIGPIPE handler
+  ///
+  /// The AWS SDK may sometimes emit SIGPIPE signals for certain errors;
+  /// by default, they would abort the current process.
+  /// This option, if enabled, will install a process-wide signal handler
+  /// that logs and otherwise ignore incoming SIGPIPE signals.
+  ///
+  /// This option has no effect on Windows.
+  bool install_sigpipe_handler = false;
+
+  /// \brief AWS SDK wide options for http
+  Aws::HttpOptions http_options;
+
+  /// \brief Override default http options
+  bool override_default_http_options = false;
+
+  /// \brief Initialize with default options
+  ///
+  /// For log_level, this method first tries to extract a suitable value from the
+  /// environment variable ARROW_S3_LOG_LEVEL.
+  static S3GlobalOptions Defaults();
+};
+
+///
+/// Global S3 initialization and finalization functions
+/// These functions manage the lifecycle of the AWS SDK used by S3FileSystem.
+///
+
+/// \brief Initialize the S3 APIs with the specified set of options.
+///
+/// It is required to call this function at least once before using S3FileSystem.
+///
+/// Once this function is called you MUST call FinalizeS3 before the end of the
+/// application in order to avoid a segmentation fault at shutdown.
+arrow::Status InitializeS3(const S3GlobalOptions& options);
+
+/// \brief Ensure the S3 APIs are initialized, but only if not already done.
+///
+/// If necessary, this will call InitializeS3() with some default options.
+arrow::Status EnsureS3Initialized();
+
+/// Whether S3 was initialized, and not finalized.
+bool IsS3Initialized();
+
+/// \brief Check if S3 is initialized and return an error if not.
+///
+/// This function checks if S3 has been initialized and returns an appropriate
+/// error status if it has not been initialized or has been finalized.
+arrow::Status CheckS3Initialized();
+
+/// \brief Shutdown the S3 APIs.
+///
+/// This can wait for some S3 concurrent calls to finish so as to avoid
+/// race conditions.
+/// After this function has been called, all S3 calls will fail with an error.
+///
+/// Calls to InitializeS3() and FinalizeS3() should be serialized by the
+/// application (this also applies to EnsureS3Initialized() and
+/// EnsureS3Finalized()).
+arrow::Status FinalizeS3();
+
+/// Whether S3 was finalized.
+bool IsS3Finalized();
+
+/// \brief Ensure the S3 APIs are shutdown, but only if not already done.
+///
+/// If necessary, this will call FinalizeS3().
+arrow::Status EnsureS3Finalized();
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -16,7 +16,6 @@
 #include <aws/core/utils/StringUtils.h>
 #include <aws/s3/S3Errors.h>
 #include <arrow/filesystem/filesystem.h>
-#include <arrow/filesystem/s3fs.h>
 #include <arrow/status.h>
 #include <arrow/util/logging.h>
 #include <arrow/util/print.h>

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <arrow/filesystem/localfs.h>
 #include "milvus-storage/filesystem/fs.h"
+
+#include <arrow/filesystem/localfs.h>
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
+
 #include "milvus-storage/filesystem/s3/s3_fs.h"
 #include "milvus-storage/common/path_util.h"
-#include "boost/filesystem/path.hpp"
-#include <boost/filesystem/operations.hpp>
 
 #ifdef MILVUS_AZURE_FS
 #include "milvus-storage/filesystem/azure/azure_fs.h"

--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -13,23 +13,6 @@
 // limitations under the License.
 
 #include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
-#include "milvus-storage/filesystem/s3/s3_internal.h"
-#include "milvus-storage/filesystem/s3/util_internal.h"
-
-#include "milvus-storage/common/path_util.h"
-#include "milvus-storage/filesystem/io/io_util.h"
-#include "milvus-storage/filesystem/s3/s3_client.h"
-#include "arrow/util/async_generator.h"
-#include "arrow/util/logging.h"
-#include "arrow/buffer.h"
-#include "arrow/result.h"
-#include "arrow/io/memory.h"
-#include "arrow/util/future.h"
-#include "arrow/util/thread_pool.h"
-#include "arrow/filesystem/path_util.h"
-#include "arrow/io/interfaces.h"
-#include "arrow/util/key_value_metadata.h"
-#include "arrow/util/string.h"
 
 #include <algorithm>
 #include <atomic>
@@ -39,6 +22,18 @@
 #include <optional>
 #include <shared_mutex>
 #include <thread>
+
+#include <arrow/util/async_generator.h>
+#include <arrow/util/logging.h>
+#include <arrow/buffer.h>
+#include <arrow/result.h>
+#include <arrow/io/memory.h>
+#include <arrow/util/future.h>
+#include <arrow/util/thread_pool.h>
+#include <arrow/filesystem/path_util.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/util/key_value_metadata.h>
+#include <arrow/util/string.h>
 
 #include <aws/core/Aws.h>
 #include <aws/core/Region.h>
@@ -54,7 +49,6 @@
 #include <aws/core/utils/xml/XmlSerializer.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 #include <aws/s3/S3Client.h>
-#include <aws/s3/S3Errors.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/CompletedMultipartUpload.h>
@@ -74,6 +68,14 @@
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
 
+#include "milvus-storage/filesystem/s3/s3_internal.h"
+#include "milvus-storage/filesystem/s3/s3_global.h"
+#include "milvus-storage/filesystem/s3/util_internal.h"
+
+#include "milvus-storage/common/path_util.h"
+#include "milvus-storage/filesystem/io/io_util.h"
+#include "milvus-storage/filesystem/s3/s3_client.h"
+
 static constexpr const char kSep = '/';
 
 using ::arrow::Buffer;
@@ -87,26 +89,24 @@ using ::arrow::fs::FileSelector;
 using ::arrow::fs::FileType;
 using ::arrow::fs::kNoSize;
 using ::arrow::fs::S3FileSystem;
-using ::arrow::fs::S3LogLevel;
-using ::arrow::fs::S3RetryStrategy;
 using ::arrow::fs::internal::RemoveTrailingSlash;
 using ::Aws::Client::AWSError;
-using ::Aws::S3::S3Errors;
 using ::milvus_storage::S3Options;
 using ::milvus_storage::fs::internal::ConnectRetryStrategy;
 using ::milvus_storage::fs::internal::DetectS3Backend;
 using ::milvus_storage::fs::internal::ErrorToStatus;
 using ::milvus_storage::fs::internal::FromAwsDatetime;
+using ::milvus_storage::fs::internal::FromAwsString;
 using ::milvus_storage::fs::internal::IsAlreadyExists;
 using ::milvus_storage::fs::internal::IsNotFound;
 using ::milvus_storage::fs::internal::OutcomeToResult;
 using ::milvus_storage::fs::internal::OutcomeToStatus;
 using ::milvus_storage::fs::internal::S3Backend;
+using ::milvus_storage::fs::internal::ToAwsString;
 
 namespace S3Model = Aws::S3::Model;
 
 namespace milvus_storage {
-using namespace fs::internal;
 // -----------------------------------------------------------------------
 // MultiPartUploadS3FS implementation
 
@@ -2193,145 +2193,5 @@ arrow::Result<std::shared_ptr<arrow::io::OutputStream>> MultiPartUploadS3FS::Ope
 }
 
 arrow::Result<std::shared_ptr<S3ClientMetrics>> MultiPartUploadS3FS::GetMetrics() { return impl_->GetMetrics(); }
-
-// -----------------------------------------------------------------------
-// AWS SDK Initialization and finalization
-
-namespace {
-
-struct AwsInstance {
-  AwsInstance() : is_initialized_(false), is_finalized_(false) {}
-  ~AwsInstance() { Finalize(/*from_destructor=*/true); }
-
-  // Returns true iff the instance was newly initialized with `options`
-  arrow::Result<bool> EnsureInitialized(const S3GlobalOptions& options) {
-    // NOTE: The individual accesses are atomic but the entire sequence below is not.
-    // The application should serialize calls to InitializeS3() and FinalizeS3()
-    // (see docstrings).
-    if (is_finalized_.load()) {
-      return arrow::Status::Invalid("Attempt to initialize S3 after it has been finalized");
-    }
-    bool newly_initialized = false;
-    // EnsureInitialized() can be called concurrently by FileSystemFromUri,
-    // therefore we need to serialize initialization (GH-39897).
-    std::call_once(initialize_flag_, [&]() {
-      bool was_initialized = is_initialized_.exchange(true);
-      DCHECK(!was_initialized);
-      DoInitialize(options);
-      newly_initialized = true;
-    });
-    return newly_initialized;
-  }
-
-  bool IsInitialized() { return !is_finalized_ && is_initialized_; }
-
-  bool IsFinalized() { return is_finalized_; }
-
-  void Finalize(bool from_destructor = false) {
-    if (is_finalized_.exchange(true)) {
-      // Already finalized
-      return;
-    }
-    auto client_finalizer = GetClientFinalizer();
-    if (is_initialized_.exchange(false)) {
-      // Was initialized
-      if (from_destructor) {
-        ARROW_LOG(WARNING) << " arrow::fs::FinalizeS3 was not called even though S3 was initialized.  "
-                              "This could lead to a segmentation fault at exit";
-        auto* leaked_shared_ptr = new std::shared_ptr<S3ClientFinalizer>(client_finalizer);
-        ARROW_UNUSED(leaked_shared_ptr);
-        return;
-      }
-      client_finalizer->Finalize();
-#ifdef ARROW_S3_HAS_S3CLIENT_CONFIGURATION
-      EndpointProviderCache::Instance()->Reset();
-#endif
-      Aws::ShutdownAPI(aws_options_);
-    }
-  }
-
-  private:
-  void DoInitialize(const S3GlobalOptions& options) {
-    Aws::Utils::Logging::LogLevel aws_log_level;
-
-#define LOG_LEVEL_CASE(level_name)                             \
-  case S3LogLevel::level_name:                                 \
-    aws_log_level = Aws::Utils::Logging::LogLevel::level_name; \
-    break;
-
-    switch (options.log_level) {
-      LOG_LEVEL_CASE(Fatal)
-      LOG_LEVEL_CASE(Error)
-      LOG_LEVEL_CASE(Warn)
-      LOG_LEVEL_CASE(Info)
-      LOG_LEVEL_CASE(Debug)
-      LOG_LEVEL_CASE(Trace)
-      default:
-        aws_log_level = Aws::Utils::Logging::LogLevel::Off;
-    }
-
-#undef LOG_LEVEL_CASE
-
-    aws_options_.loggingOptions.logLevel = aws_log_level;
-    // By default the AWS SDK logs to files, log to console instead
-    aws_options_.loggingOptions.logger_create_fn = [this] {
-      return std::make_shared<Aws::Utils::Logging::ConsoleLogSystem>(aws_options_.loggingOptions.logLevel);
-    };
-    if (options.override_default_http_options) {
-      aws_options_.httpOptions = options.http_options;
-    }
-    Aws::InitAPI(aws_options_);
-  }
-
-  Aws::SDKOptions aws_options_;
-  std::atomic<bool> is_initialized_;
-  std::atomic<bool> is_finalized_;
-  std::once_flag initialize_flag_;
-};
-
-AwsInstance* GetAwsInstance() {
-  // make sure ClientFinializer is initialized before the AwsInstance
-  // so that the static object destructor is called later
-  GetClientFinalizer();
-  static auto instance = std::make_unique<AwsInstance>();
-  return instance.get();
-}
-
-arrow::Result<bool> EnsureAwsInstanceInitialized(const S3GlobalOptions& options) {
-  return GetAwsInstance()->EnsureInitialized(options);
-}
-
-}  // namespace
-
-arrow::Status InitializeS3(const S3GlobalOptions& options) {
-  ARROW_ASSIGN_OR_RAISE(bool successfully_initialized, EnsureAwsInstanceInitialized(options));
-  if (!successfully_initialized) {
-    return arrow::Status::Invalid(
-        "S3 was already initialized.  It is safe to use but the options passed in this "
-        "call have been ignored.");
-  }
-  return arrow::Status::OK();
-}
-
-arrow::Status EnsureS3Initialized() { return EnsureAwsInstanceInitialized(S3GlobalOptions::Defaults()).status(); }
-
-arrow::Status FinalizeS3() {
-  // GetAwsInstance()->Finalize();
-  auto instance = GetAwsInstance();
-  // The AWS instance might already be destroyed in case FinalizeS3
-  // is called from an atexit handler (which is a bad idea anyway as the
-  // AWS SDK is not safe anymore to shutdown by this time). See GH-44071.
-  if (instance == nullptr) {
-    return arrow::Status::Invalid("FinalizeS3 called too late");
-  }
-  instance->Finalize();
-  return arrow::Status::OK();
-}
-
-arrow::Status EnsureS3Finalized() { return FinalizeS3(); }
-
-bool IsS3Initialized() { return GetAwsInstance()->IsInitialized(); }
-
-bool IsS3Finalized() { return GetAwsInstance()->IsFinalized(); }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "milvus-storage/filesystem/s3/s3_fs.h"
+
+#include <cstdlib>
+
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
@@ -26,28 +30,25 @@
 #include <aws/s3/model/PutObjectRequest.h>
 
 #include <arrow/status.h>
-#include <arrow/filesystem/s3fs.h>
 #include <arrow/util/uri.h>
-#include <cstdlib>
+
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/macro.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunSTSClient.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
-#include "milvus-storage/filesystem/s3/provider//HuaweiCloudCredentialsProvider.h"
-#include "milvus-storage/common/macro.h"
-#include "milvus-storage/filesystem/s3/s3_fs.h"
-#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
+#include "milvus-storage/filesystem/s3/s3_global.h"
 
 namespace milvus_storage {
 
-static std::unordered_map<std::string, arrow::fs::S3LogLevel> LogLevel_Map = {
-    {"off", arrow::fs::S3LogLevel::Off},     {"fatal", arrow::fs::S3LogLevel::Fatal},
-    {"error", arrow::fs::S3LogLevel::Error}, {"warn", arrow::fs::S3LogLevel::Warn},
-    {"info", arrow::fs::S3LogLevel::Info},   {"debug", arrow::fs::S3LogLevel::Debug},
-    {"trace", arrow::fs::S3LogLevel::Trace}};
+static std::unordered_map<std::string, S3LogLevel> LogLevel_Map = {
+    {"off", S3LogLevel::Off},   {"fatal", S3LogLevel::Fatal}, {"error", S3LogLevel::Error}, {"warn", S3LogLevel::Warn},
+    {"info", S3LogLevel::Info}, {"debug", S3LogLevel::Debug}, {"trace", S3LogLevel::Trace}};
 
 static const char* GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG = "GoogleHttpClientFactory";
 

--- a/cpp/src/filesystem/s3/s3_global.cpp
+++ b/cpp/src/filesystem/s3/s3_global.cpp
@@ -1,0 +1,200 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/s3/s3_global.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <arrow/status.h>
+#include <arrow/result.h>
+#include <arrow/util/logging.h>
+#include <arrow/util/string.h>
+#include <arrow/util/uri.h>
+#include <arrow/filesystem/path_util.h>
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/logging/ConsoleLogSystem.h>
+
+#include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/filesystem/s3/s3_internal.h"
+#include "milvus-storage/filesystem/s3/s3_client.h"
+namespace milvus_storage {
+
+S3GlobalOptions S3GlobalOptions::Defaults() {
+  auto log_level = S3LogLevel::Fatal;
+  int num_event_loop_threads = 1;
+  // Extract, trim, and downcase the value of the environment variable
+  auto value = GetEnvVar("ARROW_S3_LOG_LEVEL")
+                   .Map(arrow::internal::AsciiToLower)
+                   .Map(arrow::internal::TrimString)
+                   .ValueOr("fatal");
+  if (value == "fatal") {
+    log_level = S3LogLevel::Fatal;
+  } else if (value == "error") {
+    log_level = S3LogLevel::Error;
+  } else if (value == "warn") {
+    log_level = S3LogLevel::Warn;
+  } else if (value == "info") {
+    log_level = S3LogLevel::Info;
+  } else if (value == "debug") {
+    log_level = S3LogLevel::Debug;
+  } else if (value == "trace") {
+    log_level = S3LogLevel::Trace;
+  } else if (value == "off") {
+    log_level = S3LogLevel::Off;
+  }
+
+  return S3GlobalOptions{log_level, 1};
+}
+
+// -----------------------------------------------------------------------
+// AWS SDK Initialization and finalization
+
+struct AwsInstance {
+  AwsInstance() : is_initialized_(false), is_finalized_(false) {}
+  ~AwsInstance() { Finalize(/*from_destructor=*/true); }
+
+  // Returns true iff the instance was newly initialized with `options`
+  arrow::Result<bool> EnsureInitialized(const S3GlobalOptions& options) {
+    // NOTE: The individual accesses are atomic but the entire sequence below is not.
+    // The application should serialize calls to InitializeS3() and FinalizeS3()
+    // (see docstrings).
+    if (is_finalized_.load()) {
+      return arrow::Status::Invalid("Attempt to initialize S3 after it has been finalized");
+    }
+    bool newly_initialized = false;
+    // EnsureInitialized() can be called concurrently by FileSystemFromUri,
+    // therefore we need to serialize initialization (GH-39897).
+    std::call_once(initialize_flag_, [&]() {
+      bool was_initialized = is_initialized_.exchange(true);
+      DCHECK(!was_initialized);
+      DoInitialize(options);
+      newly_initialized = true;
+    });
+    return newly_initialized;
+  }
+
+  bool IsInitialized() { return !is_finalized_ && is_initialized_; }
+
+  bool IsFinalized() { return is_finalized_; }
+
+  void Finalize(bool from_destructor = false) {
+    if (is_finalized_.exchange(true)) {
+      // Already finalized
+      return;
+    }
+    auto client_finalizer = GetClientFinalizer();
+    if (is_initialized_.exchange(false)) {
+      // Was initialized
+      if (from_destructor) {
+        ARROW_LOG(WARNING) << " arrow::fs::FinalizeS3 was not called even though S3 was initialized.  "
+                              "This could lead to a segmentation fault at exit";
+        auto* leaked_shared_ptr = new std::shared_ptr<S3ClientFinalizer>(client_finalizer);
+        ARROW_UNUSED(leaked_shared_ptr);
+        return;
+      }
+      client_finalizer->Finalize();
+#ifdef ARROW_S3_HAS_S3CLIENT_CONFIGURATION
+      EndpointProviderCache::Instance()->Reset();
+#endif
+      Aws::ShutdownAPI(aws_options_);
+    }
+  }
+
+  private:
+  void DoInitialize(const S3GlobalOptions& options) {
+    Aws::Utils::Logging::LogLevel aws_log_level;
+
+#define LOG_LEVEL_CASE(level_name)                             \
+  case S3LogLevel::level_name:                                 \
+    aws_log_level = Aws::Utils::Logging::LogLevel::level_name; \
+    break;
+
+    switch (options.log_level) {
+      LOG_LEVEL_CASE(Fatal)
+      LOG_LEVEL_CASE(Error)
+      LOG_LEVEL_CASE(Warn)
+      LOG_LEVEL_CASE(Info)
+      LOG_LEVEL_CASE(Debug)
+      LOG_LEVEL_CASE(Trace)
+      default:
+        aws_log_level = Aws::Utils::Logging::LogLevel::Off;
+    }
+
+#undef LOG_LEVEL_CASE
+
+    aws_options_.loggingOptions.logLevel = aws_log_level;
+    // By default the AWS SDK logs to files, log to console instead
+    aws_options_.loggingOptions.logger_create_fn = [this] {
+      return std::make_shared<Aws::Utils::Logging::ConsoleLogSystem>(aws_options_.loggingOptions.logLevel);
+    };
+    if (options.override_default_http_options) {
+      aws_options_.httpOptions = options.http_options;
+    }
+    Aws::InitAPI(aws_options_);
+  }
+
+  Aws::SDKOptions aws_options_;
+  std::atomic<bool> is_initialized_;
+  std::atomic<bool> is_finalized_;
+  std::once_flag initialize_flag_;
+};
+
+AwsInstance* GetAwsInstance() {
+  // make sure ClientFinializer is initialized before the AwsInstance
+  // so that the static object destructor is called later
+  GetClientFinalizer();
+  static auto instance = std::make_unique<AwsInstance>();
+  return instance.get();
+}
+
+arrow::Result<bool> EnsureAwsInstanceInitialized(const S3GlobalOptions& options) {
+  return GetAwsInstance()->EnsureInitialized(options);
+}
+
+arrow::Status InitializeS3(const S3GlobalOptions& options) {
+  ARROW_ASSIGN_OR_RAISE(bool successfully_initialized, EnsureAwsInstanceInitialized(options));
+  if (!successfully_initialized) {
+    return arrow::Status::Invalid(
+        "S3 was already initialized.  It is safe to use but the options passed in this "
+        "call have been ignored.");
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status EnsureS3Initialized() { return EnsureAwsInstanceInitialized(S3GlobalOptions::Defaults()).status(); }
+
+arrow::Status FinalizeS3() {
+  // GetAwsInstance()->Finalize();
+  auto instance = GetAwsInstance();
+  // The AWS instance might already be destroyed in case FinalizeS3
+  // is called from an atexit handler (which is a bad idea anyway as the
+  // AWS SDK is not safe anymore to shutdown by this time). See GH-44071.
+  if (instance == nullptr) {
+    return arrow::Status::Invalid("FinalizeS3 called too late");
+  }
+  instance->Finalize();
+  return arrow::Status::OK();
+}
+
+arrow::Status EnsureS3Finalized() { return FinalizeS3(); }
+
+bool IsS3Initialized() { return GetAwsInstance()->IsInitialized(); }
+
+bool IsS3Finalized() { return GetAwsInstance()->IsFinalized(); }
+
+}  // namespace milvus_storage

--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -21,7 +21,6 @@
 #include <cstdint>
 
 #include <arrow/filesystem/filesystem.h>
-#include <arrow/filesystem/s3fs.h>
 #include <arrow/filesystem/localfs.h>
 #include <arrow/api.h>
 #include <arrow/array/builder_binary.h>

--- a/cpp/test/packed/packed_test_base.h
+++ b/cpp/test/packed/packed_test_base.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <arrow/filesystem/filesystem.h>
-#include <arrow/filesystem/s3fs.h>
 #include <arrow/filesystem/localfs.h>
 #include <arrow/api.h>
 #include <arrow/array/builder_binary.h>

--- a/cpp/test/s3_client_metrics_test.cpp
+++ b/cpp/test/s3_client_metrics_test.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <arrow/status.h>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
@@ -21,10 +20,13 @@
 #include <chrono>
 #include <thread>
 
+#include <arrow/status.h>
+#include <arrow/testing/gtest_util.h>
+
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_global.h"
 #include "test_util.h"
-#include "arrow/testing/gtest_util.h"
 
 namespace milvus_storage {
 
@@ -46,7 +48,7 @@ class S3ClientMetricsTest : public ::testing::Test {
     }
     // Initialize S3 once for the entire test suite
     S3GlobalOptions global_options;
-    global_options.log_level = arrow::fs::S3LogLevel::Off;  // Disable logging for tests
+    global_options.log_level = S3LogLevel::Off;  // Disable logging for tests
     auto status = InitializeS3(global_options);
     S3ClientMetricsTest::s3_initialized = status.ok();
     if (!status.ok()) {


### PR DESCRIPTION
Move AWS S3 global instance initialization/finalization from `multi_part_upload_s3_fs` to `s3_global`. Additionally, port the missing class `S3RetryStrategy` from `s3_options`. This change eliminates the need for the entire storage module to `include <arrow/filesystem/s3fs.h>`.