### PR TITLE
enhance: Introduce kv metadata in column groups

### DIFF
--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -169,7 +169,7 @@ class Reader {
    * @brief Retrieves the column groups managed by this reader
    * @return Vector of shared pointers to ColumnGroup instances
    */
-  [[nodiscard]] virtual std::vector<std::shared_ptr<ColumnGroup>> get_column_groups() const = 0;
+  [[nodiscard]] virtual std::shared_ptr<ColumnGroups> get_column_groups() const = 0;
 
   /**
    * @brief Performs a full table scan with optional filtering and buffering

--- a/cpp/include/milvus-storage/writer.h
+++ b/cpp/include/milvus-storage/writer.h
@@ -269,7 +269,9 @@ class Writer {
    * @note This method should be called exactly once per writer instance.
    *       Subsequent calls will return an error.
    */
-  virtual arrow::Result<std::shared_ptr<ColumnGroups>> close() = 0;
+  virtual arrow::Result<std::shared_ptr<ColumnGroups>> close(
+      const std::vector<std::string_view>& config_keys = {},
+      const std::vector<std::string_view>& config_values = {}) = 0;
 };
 
 }  // namespace milvus_storage::api

--- a/cpp/src/jni/manifest_jni.cpp
+++ b/cpp/src/jni/manifest_jni.cpp
@@ -30,7 +30,7 @@ JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageManifest_00024_get
     Properties* properties = reinterpret_cast<Properties*>(properties_ptr);
 
     char* column_groups = nullptr;
-    FFIResult result = get_latest_column_groups(base_path_cstr, properties, &column_groups);
+    FFIResult result = get_latest_column_groups(base_path_cstr, properties, &column_groups, nullptr /* read_version */);
 
     env->ReleaseStringUTFChars(base_path, base_path_cstr);
 

--- a/cpp/src/jni/writer_jni.cpp
+++ b/cpp/src/jni/writer_jni.cpp
@@ -99,7 +99,8 @@ JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose
     WriterHandle handle = static_cast<WriterHandle>(writer_handle);
 
     char* column_groups = nullptr;
-    FFIResult result = writer_close(handle, &column_groups);
+    // no need use the metadata parameters
+    FFIResult result = writer_close(handle, nullptr, nullptr, 0, &column_groups);
 
     if (!IsSuccess(&result)) {
       FreeFFIResult(&result);

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -696,9 +696,9 @@ class ReaderImpl : public Reader {
     assert(!needed_columns_.empty());
   }
 
-  std::vector<std::shared_ptr<ColumnGroup>> get_column_groups() const override {
+  std::shared_ptr<ColumnGroups> get_column_groups() const override {
     assert(cgs_);
-    return cgs_->get_all();
+    return cgs_;
   }
 
   /**

--- a/cpp/src/transaction/transupdate.cpp
+++ b/cpp/src/transaction/transupdate.cpp
@@ -46,11 +46,7 @@ class PendingAddField : public PendingUpdate<Manifest> {
       return arrow::Status::Invalid("New column groups should contain exactly one column group for AddField.");
     }
 
-    auto ok = base_cgs_->add_column_group(new_cg_->get_column_group(0));
-
-    if (!ok) {
-      return arrow::Status::Invalid("Failed to add new column group, due to duplicate ID.");
-    }
+    ARROW_RETURN_NOT_OK(base_cgs_->add_column_group(new_cg_->get_column_group(0)));
     return base_cgs_;
   }
 

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -95,7 +95,7 @@ _ffi.cdef("""
 
     FFIResult writer_write(WriterHandle handle, struct ArrowArray* array);
     FFIResult writer_flush(WriterHandle handle);
-    FFIResult writer_close(WriterHandle handle, char** out_cloumngroups);
+    FFIResult writer_close(WriterHandle handle, char **config_key, char **config_value, uint16_t config_len, char** out_cloumngroups);
     void writer_destroy(WriterHandle handle);
     void free_cstr(char* c_str);
 
@@ -151,11 +151,13 @@ _ffi.cdef("""
     // ==================== Transaction C Interface ====================
     typedef uintptr_t TransactionHandle;
 
-    FFIResult get_latest_column_groups(const char* base_path, const Properties* properties, char** out_column_groups);
+    FFIResult get_latest_column_groups(const char* base_path, const Properties* properties, char** out_column_groups, int64_t* read_version);
 
     FFIResult transaction_begin(const char* base_path, const Properties* properties, TransactionHandle* out_handle);
 
     FFIResult transaction_get_column_groups(TransactionHandle handle, char** out_column_groups);
+          
+    int64_t transaction_get_read_version(TransactionHandle handle);
 
     FFIResult transaction_commit(TransactionHandle handle, int16_t update_id, int16_t reslove_id, char* in_column_groups, bool* out_commit_result);
 


### PR DESCRIPTION
The current changes enable putting custom key-value pairs in column groups. However, both the key and value must be C strings (i.e., null-terminated char*). The metadata can be added when `writer_close` is called and read out in the function `get_column_group_infos`.

Additionally, the transaction interface now returns with the `read_version`.