### PR TITLE
fix: add nullptr check for credentials_provider to prevent crash

### DIFF
--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -481,7 +481,7 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> ClientBuilder::BuildClient(
                      << "This indicates a race condition or missing initialization. "
                      << "Using AnonymousCredentialsProvider as fallback. "
                      << "Please report this error with stack trace.";
-    credentials_provider_ = std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>();
+    return arrow::Status::Invalid("credentials_provider is nullptr");
   }
 
   if (!options_.region.empty()) {


### PR DESCRIPTION
Defensive hotfix for intermittent GCP IAM nullptr crashes. Fallback to AnonymousCredentialsProvider when credentials_provider is null.