### PR TITLE
fix: CI failed cause by confilct in merge

### DIFF
--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -1328,8 +1328,8 @@ TEST_P(APIWriterReaderTest, TestGetChunksSliced) {
   int total_rows = 1000000;
 
   // Create multiple column groups
-  std::vector<std::string> patterns = {"id|name|value|vector"};
-  auto policy = std::make_unique<SchemaBasedColumnGroupPolicy>(schema_, patterns, format);
+  std::string patterns = "id|value|name|vector";
+  ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns, format));
 
   auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
 


### PR DESCRIPTION
The commit (37fb388) fail the CI caused by CI congestion and did not rebase before merge into to master. Current commit repair the main branch CI.