### PR TITLE
fix: huawei cloudprovider must open the virtual addressing

### DIFF
--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -141,7 +141,7 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
   options.endpoint_override = config_.address;
 
   options.force_virtual_addressing = config_.use_virtual_host;
-  if (config_.cloud_provider == "aliyun" || config_.cloud_provider == "tencent") {
+  if (config_.cloud_provider == "aliyun" || config_.cloud_provider == "tencent" || config_.cloud_provider == "huawei") {
     options.force_virtual_addressing = true;
   }
 


### PR DESCRIPTION
reproduce:

```
fs = ...; // get the file system with huawei cloud provider
ARROW_ASSIGN_OR_RAISE(auto output_stream, fs->OpenOutputStream(path));
ARROW_RETURN_NOT_OK(output_stream->Write(buffer));
ARROW_RETURN_NOT_OK(output_stream->Close());

```

Then got error:

```

［WARN］ 2025-11-21 03:35:55.747 AWSErrorMarshaller ［0x7ff84a3bbf80］ Encountered Unknown AWSError 'VirtualHostDomainRequired' ： Virtual host domain is required while acces
［ERROR］ 2025-11-21 03:35:55.747 AWSXmLClient ［0x7ff84a3bbf80］ HTTP response code: 403
```

Current commit set the `force_virtual_addressing` to true if cloud provider is "huawei".