### PR TITLE
enhance: Chunk reader support start/end indices.

### DIFF
--- a/cpp/include/milvus-storage/common/arrow_util.h
+++ b/cpp/include/milvus-storage/common/arrow_util.h
@@ -32,8 +32,8 @@ size_t GetArrowArrayMemorySize(const std::shared_ptr<arrow::Array>& array);
 
 size_t GetTableMemorySize(const std::shared_ptr<arrow::Table>& table);
 
-arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertTableToRecordBatch(
-    const std::shared_ptr<arrow::Table>& table);
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertTableToRecordBatch(const std::shared_ptr<arrow::Table>& table,
+                                                                             bool allow_concat = false);
 
 arrow::Result<std::string> GetEnvVar(const char* name);
 

--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -1,0 +1,114 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/filesystem/filesystem.h>
+
+#include "milvus-storage/format/format.h"
+#include "milvus-storage/properties.h"
+
+namespace internal::api {
+
+struct ChunkInfo {
+  public:
+  size_t file_index;               // current chunk belong which file
+  size_t row_offset_in_row_group;  // the starting row offset of this row group in its file
+  size_t row_offset_in_file;       // the starting row offset of file
+  size_t number_of_rows;           // number of rows in this row group
+  size_t row_group_index_in_file;  // the index of this row group in its file
+  size_t global_row_end;           // the ending row offset of this row group in the whole chunk reader
+  size_t avg_memory_size;          // average memory usage of this row group
+
+  ChunkInfo() = default;
+  std::string ToString() const;
+};
+
+struct RowGroupInfo {
+  public:
+  size_t start_offset;
+  size_t end_offset;
+  size_t memory_size;
+
+  RowGroupInfo() = default;
+  std::string ToString() const;
+};
+
+class ColumnGroupReaderInternal;
+
+class ColumnGroupReaderImpl : public ColumnGroupReader {
+  public:
+  ColumnGroupReaderImpl(const std::shared_ptr<arrow::Schema>& schema,
+                        const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
+                        const milvus_storage::api::Properties& properties,
+                        const std::vector<std::string>& needed_columns,
+                        const std::function<std::string(const std::string&)>& key_retriever);
+
+  ~ColumnGroupReaderImpl() = default;
+
+  [[nodiscard]] arrow::Status open() override;
+  [[nodiscard]] size_t total_number_of_chunks() const override;
+  [[nodiscard]] size_t total_rows() const override;
+  [[nodiscard]] arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) override;
+
+  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) override;
+
+  [[nodiscard]] arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
+      const std::vector<int64_t>& chunk_indices) override;
+
+  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> take(
+      const std::vector<int64_t>& row_indices) override;
+
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
+
+  protected:
+  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<milvus_storage::api::ColumnGroup> column_group_;
+  milvus_storage::api::Properties properties_;
+  std::vector<std::string> needed_columns_;
+  std::function<std::string(const std::string&)> key_retriever_;
+  size_t num_of_files_;
+
+  // will be initialized after call open()
+  std::vector<ChunkInfo> chunk_infos_;
+  std::vector<std::vector<RowGroupInfo>> row_group_infos_;
+  size_t total_rows_;
+
+  std::unique_ptr<ColumnGroupReaderInternal> internal_;
+
+};  // ColumnGroupReaderImpl
+
+class ColumnGroupReaderInternal {
+  public:
+  virtual ~ColumnGroupReaderInternal() = default;
+
+  [[nodiscard]] virtual arrow::Result<std::shared_ptr<arrow::Table>> get_chunk(
+      size_t file_index, const std::vector<RowGroupInfo>& row_group_info, const int& rg_index_in_file) = 0;
+  [[nodiscard]] virtual arrow::Result<std::shared_ptr<arrow::Table>> get_chunks(
+      size_t file_index,
+      const std::vector<RowGroupInfo>& row_group_info,
+      const std::vector<int>& rg_indices_in_file) = 0;
+
+  [[nodiscard]] virtual arrow::Result<std::pair<std::vector<ChunkInfo>, std::vector<std::vector<RowGroupInfo>>>>
+  open() = 0;
+  static arrow::Result<std::unique_ptr<ColumnGroupReaderInternal>> create(
+      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
+      const milvus_storage::api::Properties& properties,
+      const std::vector<std::string>& needed_columns,
+      const std::function<std::string(const std::string&)>& key_retriever);
+};  // ColumnGroupReaderInternal
+
+}  // namespace internal::api

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -1,0 +1,306 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/format/column_group_reader.h"
+
+#include <unordered_map>
+#include <vector>
+#include <algorithm>
+
+#include <arrow/array/util.h>
+#include <arrow/chunked_array.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/table_builder.h>
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+
+#include "milvus-storage/format/parquet/parquet_chunk_reader.h"
+#include "milvus-storage/format/vortex/vortex_chunk_reader.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/common/lrucache.h"
+#include "milvus-storage/common/metadata.h"
+#include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/macro.h"  // for UNLIKELY
+
+namespace internal::api {
+
+// TODO: move to the file_system.h
+using namespace milvus_storage::parquet;
+static inline arrow::Result<milvus_storage::ArrowFileSystemPtr> create_arrow_file_system(
+    const milvus_storage::ArrowFileSystemConfig& fs_config) {
+  auto& fs_cache = milvus_storage::LRUCache<milvus_storage::ArrowFileSystemConfig,
+                                            milvus_storage::ArrowFileSystemPtr>::getInstance();
+  return fs_cache.get(fs_config, milvus_storage::CreateArrowFileSystem);
+}
+
+#ifdef BUILD_VORTEX_BRIDGE
+using namespace milvus_storage::vortex;
+#endif  // BUILD_VORTEX_BRIDGE
+
+std::string ChunkInfo::ToString() const {
+  std::stringstream ss;
+  ss << "ChunkInfo{"
+     << "file_index=" << file_index << ", row_offset_in_row_group=" << row_offset_in_row_group
+     << ", row_offset_in_file=" << row_offset_in_file << ", number_of_rows=" << number_of_rows
+     << ", row_group_index_in_file=" << row_group_index_in_file << ", global_row_end=" << global_row_end
+     << ", avg_memory_size=" << avg_memory_size << "}";
+  return ss.str();
+}
+
+std::string RowGroupInfo::ToString() const {
+  std::stringstream ss;
+  ss << "RowGroupInfo{"
+     << "start_offset=" << start_offset << ", end_offset=" << end_offset << ", memory_size=" << memory_size << "}";
+  return ss.str();
+}
+
+ColumnGroupReaderImpl::ColumnGroupReaderImpl(const std::shared_ptr<arrow::Schema>& schema,
+                                             const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
+                                             const milvus_storage::api::Properties& properties,
+                                             const std::vector<std::string>& needed_columns,
+                                             const std::function<std::string(const std::string&)>& key_retriever)
+    : schema_(schema),
+      column_group_(column_group),
+      properties_(properties),
+      needed_columns_(needed_columns),
+      key_retriever_(key_retriever),
+      num_of_files_(column_group->files.size()) {}
+
+arrow::Status ColumnGroupReaderImpl::open() {
+  // create internal reader
+  ARROW_ASSIGN_OR_RAISE(internal_, ColumnGroupReaderInternal::create(schema_, column_group_, properties_,
+                                                                     needed_columns_, key_retriever_));
+  // open internal reader
+  ARROW_ASSIGN_OR_RAISE(std::tie(chunk_infos_, row_group_infos_), internal_->open());
+
+  total_rows_ = 0;
+  for (const auto& chunk_info : chunk_infos_) {
+    total_rows_ += chunk_info.number_of_rows;
+  }
+
+  return arrow::Status::OK();
+}
+
+size_t ColumnGroupReaderImpl::total_number_of_chunks() const {
+  assert(internal_);
+  return chunk_infos_.size();
+}
+
+size_t ColumnGroupReaderImpl::total_rows() const {
+  assert(internal_);
+  return total_rows_;
+}
+
+arrow::Result<std::vector<int64_t>> ColumnGroupReaderImpl::get_chunk_indices(const std::vector<int64_t>& row_indices) {
+  assert(internal_);
+  std::unordered_set<int64_t> unique_chunk_indices;
+  std::vector<int64_t> chunk_indices;
+  for (int64_t row_index : row_indices) {
+    auto it = std::upper_bound(chunk_infos_.begin(), chunk_infos_.end(), row_index,
+                               [](int64_t a, const ChunkInfo& b) { return a < b.global_row_end; });
+    auto chunk_index = std::distance(chunk_infos_.begin(), it);
+    if (chunk_index >= chunk_infos_.size()) {
+      return arrow::Status::Invalid("Row index out of range: " + std::to_string(row_index));
+    }
+
+    if (unique_chunk_indices.find(chunk_index) == unique_chunk_indices.end()) {
+      unique_chunk_indices.insert(chunk_index);
+      chunk_indices.emplace_back(chunk_index);
+    }
+  }
+
+  return chunk_indices;
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> ColumnGroupReaderImpl::get_chunk(int64_t chunk_index) {
+  assert(internal_);
+  if (chunk_index < 0 || chunk_index >= chunk_infos_.size()) {
+    return arrow::Status::Invalid("Chunk index out of range: " + std::to_string(chunk_index) + " out of " +
+                                  std::to_string(chunk_infos_.size()));
+  }
+  auto chunk_info = chunk_infos_[chunk_index];
+
+  ARROW_ASSIGN_OR_RAISE(auto table, internal_->get_chunk(chunk_info.file_index, row_group_infos_[chunk_info.file_index],
+                                                         chunk_info.row_group_index_in_file));
+  assert(table);
+
+  if (chunk_info.row_offset_in_row_group != 0 || chunk_info.number_of_rows != table->num_rows()) {
+    table = table->Slice(chunk_info.row_offset_in_row_group, chunk_info.number_of_rows);
+  }
+
+  return milvus_storage::ConvertTableToRecordBatch(table, false);
+}
+
+struct ChunkMapEntry {
+  std::vector<int> row_group_indices;
+  std::shared_ptr<arrow::Table> table;
+  std::vector<int64_t> row_group_offsets;
+};
+
+arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> ColumnGroupReaderImpl::get_chunks(
+    const std::vector<int64_t>& chunk_indices) {
+  assert(internal_);
+  std::vector<std::vector<int>> row_groups_in_files(num_of_files_);
+  std::vector<std::shared_ptr<arrow::RecordBatch>> result;
+  std::vector<std::optional<ChunkMapEntry>> chunk_map(num_of_files_);
+
+  // 1. Grouping row groups by file
+  //
+  // the row_groups_in_files will stored as
+  // row_groups_in_files[file_index] = [row_group_index_in_file]
+  // example:
+  //   file 0: row group 0, 1, 1, 2
+  //   file 1: row group 0, 1
+  //   file 2: row group 0
+  //   file 0: row group 1, 2 <- same file 0, but we have to read it again
+  //   then row_groups_in_files = [[0, 1, 1, 2], [0, 1], [0], [1, 2]]
+  for (int64_t chunk_index : chunk_indices) {
+    if (chunk_index < 0 || chunk_index >= chunk_infos_.size()) {
+      return arrow::Status::Invalid("Chunk index out of range: " + std::to_string(chunk_index) + " out of " +
+                                    std::to_string(chunk_infos_.size()));
+    }
+
+    auto row_group = chunk_infos_[chunk_index];
+    row_groups_in_files[row_group.file_index].emplace_back(row_group.row_group_index_in_file);
+  }
+
+  // 2. Deduplicate row groups to avoid reading the same row group multiple times
+  //    Also sort the row groups to make it continuous
+  //
+  // example:
+  //   row_groups_in_files = [[0, 1, 1, 2], [0, 1], [0], [1, 2]]
+  //   then row_groups_in_files = [[0, 1, 2], [0, 1], [0], [1, 2]]
+  for (auto& row_groups : row_groups_in_files) {
+    std::sort(row_groups.begin(), row_groups.end());
+    row_groups.erase(std::unique(row_groups.begin(), row_groups.end()), row_groups.end());
+  }
+
+  // 3. Read row groups and store them in chunk_map
+  //
+  // example:
+  //   row_groups_in_files = [[0, 1, 2], [0, 1], [0], [1, 2]]
+  //   then chunk_map = [{row_group_indices=[0, 1, 2], table=table0},
+  //                     {row_group_indices=[0, 1], table=table1},
+  //                     {row_group_indices=[0], table=table2},
+  //                     {row_group_indices=[1, 2], table=table3}]
+  for (size_t file_idx = 0; file_idx < row_groups_in_files.size(); ++file_idx) {
+    const auto& row_group_indices = row_groups_in_files[file_idx];
+    if (row_group_indices.empty()) {
+      continue;
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto table, internal_->get_chunks(file_idx, row_group_infos_[file_idx], row_group_indices));
+
+    // calculate the offset of each row group
+    std::vector<int64_t> offsets;
+    int64_t current_offset = 0;
+    const auto& row_group_infos = row_group_infos_[file_idx];
+    for (int rg_idx : row_group_indices) {
+      offsets.emplace_back(current_offset);
+      current_offset += row_group_infos[rg_idx].end_offset - row_group_infos[rg_idx].start_offset;
+    }
+
+    chunk_map[file_idx] =
+        ChunkMapEntry{.row_group_indices = row_group_indices, .table = table, .row_group_offsets = offsets};
+  }
+
+  // 4. Remapping chunk indices with row groups also slice the record batch with the chunk info
+  // notice that: the range of row groups may not match the range from chunk info
+  // example:
+  //   chunk_indices = [3, 1, 2, 0]
+  //   then chunk_map = [{row_group_indices=[1, 2], table=table3, row_group_offsets=[0, 100, 200]},
+  //                     {row_group_indices=[0, 1], table=table1, row_group_offsets=[0, 100]},
+  //                     {row_group_indices=[0], table=table2, row_group_offsets=[0]},
+  //                     {row_group_indices=[0, 1, 2], table=table0, row_group_offsets=[100, 200]}
+  //   then result = [table3, table1, table2, table0]
+  for (int64_t chunk_index : chunk_indices) {
+    auto row_group = chunk_infos_[chunk_index];
+
+    // current file have not been requested
+    if (!chunk_map[row_group.file_index].has_value()) {
+      continue;
+    }
+
+    const auto& entry = chunk_map[row_group.file_index].value();
+
+    // Find the index of the row group in the read row groups
+    auto it = std::lower_bound(entry.row_group_indices.begin(), entry.row_group_indices.end(),
+                               row_group.row_group_index_in_file);
+    if (it == entry.row_group_indices.end() || *it != row_group.row_group_index_in_file) {
+      return arrow::Status::Invalid("Row group index not found in chunk map entry");
+    }
+    size_t rg_idx_in_read_list = std::distance(entry.row_group_indices.begin(), it);
+
+    // Calculate the offset in the table
+    int64_t offset_in_table = entry.row_group_offsets[rg_idx_in_read_list];
+    offset_in_table += row_group.row_offset_in_row_group;
+
+    auto sliced_table = entry.table->Slice(offset_in_table, row_group.number_of_rows);
+
+    ARROW_ASSIGN_OR_RAISE(auto batch, milvus_storage::ConvertTableToRecordBatch(sliced_table, false));
+    result.emplace_back(batch);
+  }
+
+  return result;
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> ColumnGroupReaderImpl::take(
+    const std::vector<int64_t>& row_indices) {
+  assert(internal_);
+  return arrow::Status::NotImplemented("take is not implemented");
+}
+
+arrow::Result<uint64_t> ColumnGroupReaderImpl::get_chunk_size(int64_t chunk_index) {
+  assert(internal_);
+  if (UNLIKELY(chunk_index < 0 || chunk_index >= chunk_infos_.size())) {
+    return arrow::Status::Invalid("Chunk index out of range: " + std::to_string(chunk_index) + " out of " +
+                                  std::to_string(chunk_infos_.size()));
+  }
+  return chunk_infos_[chunk_index].avg_memory_size;
+}
+
+arrow::Result<uint64_t> ColumnGroupReaderImpl::get_chunk_rows(int64_t chunk_index) {
+  assert(internal_);
+  if (UNLIKELY(chunk_index < 0 || chunk_index >= chunk_infos_.size())) {
+    return arrow::Status::Invalid("Chunk index out of range: " + std::to_string(chunk_index) + " out of " +
+                                  std::to_string(chunk_infos_.size()));
+  }
+  return chunk_infos_[chunk_index].number_of_rows;
+}
+
+arrow::Result<std::unique_ptr<ColumnGroupReaderInternal>> ColumnGroupReaderInternal::create(
+    const std::shared_ptr<arrow::Schema>& schema,
+    const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
+    const milvus_storage::api::Properties& properties,
+    const std::vector<std::string>& needed_columns,
+    const std::function<std::string(const std::string&)>& key_retriever) {
+  milvus_storage::ArrowFileSystemConfig fs_config;
+  ARROW_RETURN_NOT_OK(milvus_storage::ArrowFileSystemConfig::create_file_system_config(properties, fs_config));
+  ARROW_ASSIGN_OR_RAISE(auto file_system, create_arrow_file_system(fs_config));
+  if (column_group->format == LOON_FORMAT_PARQUET) {
+    return std::make_unique<ParquetChunkReader>(file_system, column_group, properties, needed_columns, key_retriever);
+  }
+#ifdef BUILD_VORTEX_BRIDGE
+  else if (column_group->format == LOON_FORMAT_VORTEX) {
+    return std::make_unique<VortexChunkReader>(file_system, schema, column_group, properties, needed_columns);
+  }
+#endif  // BUILD_VORTEX_BRIDGE
+  else {
+    return arrow::Status::Invalid("Unsupported file format: " + column_group->format);
+  }
+}
+
+}  // namespace internal::api

--- a/cpp/test/format/column_groups_wr_test.cpp
+++ b/cpp/test/format/column_groups_wr_test.cpp
@@ -1,0 +1,315 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/testing/gtest_util.h>
+
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/format.h"
+#include "test_env.h"
+
+namespace milvus_storage::test {
+
+using namespace milvus_storage::api;
+
+class ColumnGroupsWRTest : public ::testing::TestWithParam<std::string> {
+  protected:
+  void SetUp() override {
+    // Create temporary directory for test files
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+
+    base_path_ = GetTestBasePath("column-group-writer-reader-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
+
+    // Create a simple test schema with field IDs required by packed writer
+    ASSERT_AND_ASSIGN(schema_, CreateTestSchema());
+
+    // Create test data
+    ASSERT_AND_ASSIGN(test_batch_, CreateTestData(schema_));
+  }
+
+  void TearDown() override {
+    // Clean up test directory
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+  }
+
+  arrow::Result<std::unique_ptr<ColumnGroupPolicy>> CreateSinglePolicy(
+      const std::string& format, std::shared_ptr<arrow::Schema> schema = nullptr) {
+    auto properties = milvus_storage::api::Properties{};
+    SetValue(properties, PROPERTY_WRITER_POLICY, LOON_COLUMN_GROUP_POLICY_SINGLE);
+    SetValue(properties, PROPERTY_FORMAT, format.c_str());
+
+    return ColumnGroupPolicy::create_column_group_policy(properties, schema ? schema : schema_);
+  }
+
+  arrow::Result<std::unique_ptr<ColumnGroupPolicy>> CreateSchemaBasePolicy(
+      const std::string& patterns, const std::string& format, std::shared_ptr<arrow::Schema> schema = nullptr) {
+    auto properties = milvus_storage::api::Properties{};
+    SetValue(properties, PROPERTY_WRITER_POLICY, LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED);
+    SetValue(properties, PROPERTY_WRITER_SCHEMA_BASE_PATTERNS, patterns.c_str());
+    SetValue(properties, PROPERTY_FORMAT, format.c_str());
+
+    return ColumnGroupPolicy::create_column_group_policy(properties, schema ? schema : schema_);
+  }
+
+  protected:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> schema_;
+  std::string base_path_;
+  std::shared_ptr<arrow::RecordBatch> test_batch_;
+  milvus_storage::api::Properties properties_;
+};
+
+TEST_P(ColumnGroupsWRTest, TestGetChunksSliced) {
+  std::string format = GetParam();
+
+  // Test writing and reading with parallelism
+  int total_rows = 1000000;
+
+  // Create multiple column groups
+  std::vector<std::string> patterns = {"id|name|value|vector"};
+  ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns[0], format));
+
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+
+  // Write test data in parallel
+  for (int i = 0; i < total_rows / 1000; ++i) {
+    ASSERT_AND_ASSIGN(auto batch, CreateTestData(schema_, true, 1000, (i % 24) + 1));
+    ASSERT_OK(writer->write(batch));
+  }
+
+  auto cgs_result = writer->close();
+  ASSERT_TRUE(cgs_result.ok()) << cgs_result.status().ToString();
+  auto cgs = std::move(cgs_result).ValueOrDie();
+
+  // Read and verify data
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+
+  std::vector<int64_t> row_indices;
+  for (int i = 0; i < total_rows; i += 500) {
+    row_indices.emplace_back(i);
+  }
+
+  ASSERT_AND_ASSIGN(auto chunk_rows_for_check, chunk_reader->get_chunk_rows());
+  ASSERT_AND_ASSIGN(auto chunk_indices, chunk_reader->get_chunk_indices(row_indices));
+
+  // all
+  {
+    ASSERT_AND_ASSIGN(auto chunks, chunk_reader->get_chunks(chunk_indices, 0 /* parallelism */));
+    ASSERT_EQ(chunks.size(), chunk_indices.size());
+
+    for (size_t i = 0; i < chunks.size(); ++i) {
+      const auto& chunk = chunks[i];
+      ASSERT_NE(chunk, nullptr);
+      EXPECT_EQ(chunk->num_rows(), chunk_rows_for_check[chunk_indices[i]]);
+    }
+  }
+
+  // random test
+  {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    size_t random_times = 5;
+    for (size_t i = 1; i <= random_times; ++i) {
+      std::vector<int64_t> chunkidx_samples;
+
+      float fraction = static_cast<float>(i) / random_times;
+      size_t samples_size = static_cast<size_t>(chunk_indices.size() * fraction);
+
+      std::sample(chunk_indices.begin(), chunk_indices.end(), std::back_inserter(chunkidx_samples), samples_size, gen);
+
+      std::cout << "sample indices: ";
+      for (int sample_id : chunkidx_samples) std::cout << sample_id << " ";
+      std::cout << std::endl;
+
+      ASSERT_AND_ASSIGN(auto chunks, chunk_reader->get_chunks(chunkidx_samples, 0 /* parallelism */));
+      ASSERT_EQ(chunks.size(), chunkidx_samples.size());
+
+      for (size_t j = 0; j < chunks.size(); ++j) {
+        const auto& chunk = chunks[j];
+        ASSERT_NE(chunk, nullptr);
+        EXPECT_EQ(chunk->num_rows(), chunk_rows_for_check[chunkidx_samples[j]]);
+      }
+    }
+  }
+}
+
+TEST_P(ColumnGroupsWRTest, TestStartEndIndex) {
+  std::string format = GetParam();
+
+  ASSERT_AND_ASSIGN(auto two_cols_schema, CreateTestSchema(std::array<bool, 4>{true, false, false, true}));
+
+  // Test writing with SinglePolicy
+  // make sure parquet will make new column group for each write
+  ASSERT_AND_ASSIGN(
+      auto rb_256_rows,
+      CreateTestData(two_cols_schema /* schema */, false /* randdata */, 256 /* num_rows */, 1024 /* vector_dim */,
+                     0 /* str_length */, std::array<bool, 4>{true, false, false, true} /*needed_columns */));
+
+  std::vector<std::shared_ptr<ColumnGroups>> cgsvec;
+  // two files, col0 is [0~25600], col1 always (1024 * 4)B used to fill row groups
+  for (int i = 0; i < 2; i++) {
+    ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, two_cols_schema));
+    auto writer = Writer::create(base_path_, two_cols_schema, std::move(policy), properties_);
+    ASSERT_NE(writer, nullptr);
+
+    // Write test data
+    for (int j = 0; j < 100; ++j) {
+      arrow::Int64Builder builder;
+      ASSERT_STATUS_OK(builder.Reserve(256));
+      for (int k = 0; k < 256; ++k) {
+        builder.UnsafeAppend(j * 256 + k);
+      }
+      std::shared_ptr<arrow::Array> id_array;
+      ASSERT_STATUS_OK(builder.Finish(&id_array));
+
+      auto new_batch_result = rb_256_rows->SetColumn(0, arrow::field("id", arrow::int64()), id_array);
+      ASSERT_TRUE(new_batch_result.ok());
+      ASSERT_STATUS_OK(writer->write(*new_batch_result));
+    }
+
+    // Close and get cgs
+    auto cgs_result = writer->close();
+    ASSERT_TRUE(cgs_result.ok()) << cgs_result.status().ToString();
+    auto cgs = std::move(cgs_result).ValueOrDie();
+    cgsvec.emplace_back(cgs);
+  }
+
+  // reconstruct column group
+  std::shared_ptr<ColumnGroup> file_cg;
+  {
+    ASSERT_EQ(cgsvec[0]->size(), 1);
+    ASSERT_EQ(cgsvec[0]->get_column_group(0)->files.size(), 1);
+
+    ASSERT_EQ(cgsvec[1]->size(), 1);
+    ASSERT_EQ(cgsvec[1]->get_column_group(0)->files.size(), 1);
+    auto origin_cg0 = cgsvec[0]->get_column_group(0);
+    auto origin_cg1 = cgsvec[1]->get_column_group(0);
+
+    file_cg = std::make_shared<ColumnGroup>();
+    file_cg->columns = origin_cg0->columns;
+    file_cg->format = origin_cg0->format;
+    file_cg->files = {
+        ColumnGroupFile{
+            .path = origin_cg0->files[0].path,
+            .start_index = 1000,
+            .end_index = 2000,
+        },
+        ColumnGroupFile{
+            .path = origin_cg0->files[0].path,
+            .start_index = 2000,
+            .end_index = 18789,
+        },
+        ColumnGroupFile{
+            .path = origin_cg1->files[0].path,
+            .start_index = 0,
+            .end_index = 5000,
+        },
+        ColumnGroupFile{
+            .path = origin_cg1->files[0].path,
+            .start_index = 5000,
+            .end_index = 20000,
+        },
+        ColumnGroupFile{
+            .path = origin_cg1->files[0].path,
+            .start_index = std::nullopt,
+            .end_index = std::nullopt,
+        },
+    };
+  }
+
+  // make sure vortex chunk rows is 256
+  EXPECT_EQ(SetValue(properties_, PROPERTY_READER_VORTEX_CHUNK_ROWS, "256"), std::nullopt);
+
+  // reader
+  ASSERT_AND_ASSIGN(auto chunk_reader,
+                    internal::api::ColumnGroupReader::create(two_cols_schema, file_cg, {"id", "vector"}, properties_,
+                                                             nullptr /* key_retriever */));
+  auto total_number_of_chunks = chunk_reader->total_number_of_chunks();
+  auto total_rows = chunk_reader->total_rows();
+  // 25600 + 15000 + 5000 + 16789 + 1000
+  EXPECT_EQ(total_rows, 63389);
+
+  std::vector<int64_t> expected_ids;
+  expected_ids.reserve(total_rows);
+  // 1 & 2. origin_cg0: 1000-18789
+  for (int i = 1000; i < 18789; ++i) expected_ids.emplace_back(i);
+  // 3 & 4. origin_cg1: 0-20000
+  for (int i = 0; i < 20000; ++i) expected_ids.emplace_back(i);
+  // 5. origin_cg1: all (0-25600)
+  for (int i = 0; i < 25600; ++i) expected_ids.emplace_back(i);
+
+  ASSERT_EQ(expected_ids.size(), total_rows);
+
+  // verification get_chunk
+  {
+    int64_t current_row = 0;
+    for (size_t i = 0; i < total_number_of_chunks; ++i) {
+      ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(i));
+      ASSERT_NE(chunk, nullptr);
+      auto id_array = std::static_pointer_cast<arrow::Int64Array>(chunk->column(0));
+      for (int64_t j = 0; j < chunk->num_rows(); ++j) {
+        ASSERT_EQ(id_array->Value(j), expected_ids[current_row])
+            << "Row " << current_row << " mismatch. Chunk " << i << " row " << j;
+        current_row++;
+      }
+    }
+  }
+
+  // verification get_chunks
+  {
+    std::vector<int64_t> chunk_indices;
+    int64_t current_row = 0;
+    for (size_t i = 0; i < total_number_of_chunks; ++i) {
+      chunk_indices.push_back(i);
+    }
+    ASSERT_AND_ASSIGN(auto chunks, chunk_reader->get_chunks(chunk_indices));
+    size_t total_rows = 0;
+    for (size_t i = 0; i < chunks.size(); ++i) {
+      total_rows += chunks[i]->num_rows();
+    }
+
+    for (size_t i = 0; i < chunks.size(); ++i) {
+      const auto& chunk = chunks[i];
+      ASSERT_NE(chunk, nullptr);
+      auto id_array = std::static_pointer_cast<arrow::Int64Array>(chunk->column(0));
+      for (int64_t j = 0; j < chunk->num_rows(); ++j) {
+        ASSERT_EQ(id_array->Value(j), expected_ids[current_row])
+            << "Row " << current_row << " mismatch. Chunk " << i << " row " << j;
+        current_row++;
+      }
+    }
+
+    ASSERT_EQ(current_row, total_rows);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ColumnGroupsWRTestP,
+                         ColumnGroupsWRTest,
+#ifdef BUILD_VORTEX_BRIDGE
+                         ::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX)
+#else
+                         ::testing::Values(LOON_FORMAT_PARQUET)
+#endif
+);
+
+}  // namespace milvus_storage::test


### PR DESCRIPTION
In a previous commit (bfbe28c), the column group was modified to support reading with start/end indices. The current commit enables the chunk reader support reading with start/end indices.

`ColumnGroupReaderImpl` is specifically designed to handle the relationship between `ChunkInfo()` and `RowGroupInfo()`. This allows most of the logic to be reused, making the implementation of the format reader simpler. However, vortex may experience read amplification similar to parquet, which can be avoided.