### PR TITLE
enhance: Enable arrow::Status to be extended

### DIFF
--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -1,0 +1,66 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <arrow/status.h>
+#include <arrow/result.h>
+
+namespace milvus_storage {
+enum class ExtendStatusCode : char {
+  // arrow::StatusCode biggest is 45
+  NoSuchUpload = 101,
+};
+
+class ExtendStatusDetail : public arrow::StatusDetail {
+  public:
+  explicit ExtendStatusDetail(ExtendStatusCode code);
+  explicit ExtendStatusDetail(ExtendStatusCode code, std::string extra_info);
+
+  [[nodiscard]] const char* type_id() const override;
+
+  [[nodiscard]] std::string ToString() const override;
+
+  /// \brief Get the Flight status code.
+  [[nodiscard]] ExtendStatusCode code() const;
+
+  /// \brief Get the extra error info
+  [[nodiscard]] std::string extra_info() const;
+
+  /// \brief Get the human-readable name of the status code.
+  [[nodiscard]] std::string CodeAsString() const;
+
+  /// \brief Set the extra error info
+  void set_extra_info(std::string extra_info);
+
+  /// \brief Try to extract a \a ExtendStatusDetail from any Arrow
+  /// status.
+  ///
+  /// \return a \a ExtendStatusDetail if it could be unwrapped, \a
+  /// nullptr otherwise
+  static std::shared_ptr<ExtendStatusDetail> UnwrapStatus(const arrow::Status& status);
+
+  private:
+  ExtendStatusCode code_;
+  std::string extra_info_;
+};
+
+arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info);
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -1,3 +1,16 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 
@@ -15,11 +28,14 @@
 #include <aws/core/utils/DateTime.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/s3/S3Errors.h>
+
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/status.h>
 #include <arrow/util/logging.h>
 #include <arrow/util/print.h>
 #include <arrow/util/string.h>
+
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage {
 namespace fs {
@@ -172,6 +188,13 @@ arrow::Status ErrorToStatus(const std::string& prefix,
                          "' while the bucket is located in '" + maybe_region.value() + "'.";
     }
   }
+
+  if (error_type == Aws::S3::S3Errors::NO_SUCH_UPLOAD) {
+    std::string message = "AWS Error " + ss.str() + " during " + operation + " operation: " + error.GetMessage() +
+                          wrong_region_msg.value_or("");
+    return MakeExtendError(ExtendStatusCode::NoSuchUpload, message, message /* extra_info */);
+  }
+
   return arrow::Status::IOError(prefix, "AWS Error ", ss.str(), " during ", operation,
                                 " operation: ", error.GetMessage(), wrong_region_msg.value_or(""));
 }

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -1,0 +1,64 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "milvus-storage/common/extend_status.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <arrow/status.h>
+#include <arrow/result.h>
+
+namespace milvus_storage {
+
+const char* kErrorDetailTypeId = "milvus_storage::ExtendStatusDetail";
+
+ExtendStatusDetail::ExtendStatusDetail(ExtendStatusCode code) : code_{code} {}
+ExtendStatusDetail::ExtendStatusDetail(ExtendStatusCode code, std::string extra_info)
+    : code_{code}, extra_info_(std::move(extra_info)) {}
+
+const char* ExtendStatusDetail::type_id() const { return kErrorDetailTypeId; }
+
+std::string ExtendStatusDetail::ToString() const { return CodeAsString() + ": " + extra_info_; }
+
+ExtendStatusCode ExtendStatusDetail::code() const { return code_; }
+
+std::string ExtendStatusDetail::extra_info() const { return extra_info_; }
+
+std::string ExtendStatusDetail::CodeAsString() const {
+  switch (code()) {
+    case ExtendStatusCode::NoSuchUpload:
+      return "NoSuchUpload";
+    default:
+      return "Unknown";
+  }
+}
+
+void ExtendStatusDetail::set_extra_info(std::string extra_info) { extra_info_ = std::move(extra_info); }
+
+std::shared_ptr<ExtendStatusDetail> ExtendStatusDetail::UnwrapStatus(const arrow::Status& status) {
+  if (!status.detail() || status.detail()->type_id() != kErrorDetailTypeId) {
+    return nullptr;
+  }
+  return std::dynamic_pointer_cast<ExtendStatusDetail>(status.detail());
+}
+
+arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info) {
+  arrow::StatusCode arrow_code = arrow::StatusCode::IOError;
+  return arrow::Status(arrow_code, std::move(message),
+                       std::make_shared<ExtendStatusDetail>(code, std::move(extra_info)));
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
This requirement originates from the `NO_SUCH_UPLOAD` error. When this error occurs, the `S3Client` can no longer retry, but the caller still has the possibility to retry. However, in milvus_storage, such errors are all wrapped as an `arrow::Status` of type `IOError`, preventing the caller from distinguishing the specific error type. Therefore, this commit introduces an extension to arrow::Status to differentiate between specific error types.

example:

```

arrow::Status io_status = MakeExtendError(...);  // create a error status

auto extend_status = ExtendStatusDetail::UnwrapStatus(status);
if (extend_status) // it's the extend_status
{
	if (extend_status->code(), ExtendStatusCode::{Any}) { // match the code
		... // do some thing
	}
}

```