### PR TITLE
enhance: Allow columngroups export/import and ajust the external table interface

### DIFF
--- a/cpp/include/milvus-storage/column_groups.h
+++ b/cpp/include/milvus-storage/column_groups.h
@@ -32,6 +32,9 @@ struct ColumnGroupFile {
   std::string path;     /// Physical file path where the column group is stored
   int64_t start_index;  /// Start index of data in the file
   int64_t end_index;    /// End index of data in the file
+
+  // private data for external table
+  std::optional<std::vector<uint8_t>> private_data;  ///< Optional private data of the file
 };
 
 /**

--- a/cpp/include/milvus-storage/common/layout.h
+++ b/cpp/include/milvus-storage/common/layout.h
@@ -49,4 +49,8 @@ static const std::string kDataPath = kDataDir + "/";
 
 static const std::string kManifestFilePrefix = kMetadataPath + kManifestFileNamePrefix;
 
+static std::string get_manifest_file_name(int64_t version) {
+  return kManifestFilePrefix + std::to_string(version) + kManifestFileNameSuffix;
+}
+
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/common/path_util.h
+++ b/cpp/include/milvus-storage/common/path_util.h
@@ -17,9 +17,9 @@
 #include <string>
 #include <arrow/status.h>
 
-namespace milvus_storage {
-
 constexpr char kSep = '/';
+
+namespace milvus_storage {
 
 static inline arrow::Status NotAFile(std::string_view path) {
   return arrow::Status::IOError("Not a regular file: " + std::string(path));

--- a/cpp/include/milvus-storage/ffi_internal/bridge.h
+++ b/cpp/include/milvus-storage/ffi_internal/bridge.h
@@ -1,0 +1,28 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/status.h>
+
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/column_groups.h"
+
+namespace milvus_storage {
+
+arrow::Status export_column_groups(const milvus_storage::api::ColumnGroups* cgs, CColumnGroups* out_ccgs);
+
+arrow::Status import_column_groups(const CColumnGroups* ccgs, milvus_storage::api::ColumnGroups* out_cgs);
+
+}  // namespace milvus_storage

--- a/cpp/src/column_groups.cpp
+++ b/cpp/src/column_groups.cpp
@@ -60,6 +60,12 @@ arrow::Result<std::string> ColumnGroups::serialize() const {
             avro::encode(*encoder, file.path);
             avro::encode(*encoder, file.start_index);
             avro::encode(*encoder, file.end_index);
+
+            bool has_private_data = file.private_data.has_value();
+            avro::encode(*encoder, has_private_data);
+            if (has_private_data) {
+              avro::encode(*encoder, file.private_data.value());
+            }
           }
           encoder->arrayEnd();
 
@@ -138,6 +144,14 @@ arrow::Status ColumnGroups::deserialize(const std::string_view& data) {
             avro::decode(*decoder, file.path);
             avro::decode(*decoder, file.start_index);
             avro::decode(*decoder, file.end_index);
+
+            bool has_private_data;
+            avro::decode(*decoder, has_private_data);
+            if (has_private_data) {
+              std::vector<uint8_t> val;
+              avro::decode(*decoder, val);
+              file.private_data = std::move(val);
+            }
             group->files.emplace_back(std::move(file));
           }
           file_count = decoder->arrayNext();

--- a/cpp/src/ffi/bridge.cpp
+++ b/cpp/src/ffi/bridge.cpp
@@ -1,0 +1,206 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_internal/bridge.h"
+
+#include <memory>
+#include <optional>
+#include <vector>
+#include <assert.h>
+
+namespace milvus_storage {
+using namespace milvus_storage::api;
+
+struct ColumnGroupFileExporter {
+  public:
+  void Export(const ColumnGroupFile* cgf, CColumnGroupFile* ccgf) {
+    path_ = cgf->path;
+    ccgf->path = path_.c_str();
+
+    ccgf->start_index = cgf->start_index;
+    ccgf->end_index = cgf->end_index;
+    if (cgf->private_data.has_value()) {
+      private_data_ = cgf->private_data.value();  // copy
+      ccgf->private_data = private_data_.data();
+      ccgf->private_data_size = private_data_.size();
+    } else {
+      ccgf->private_data = nullptr;
+      ccgf->private_data_size = 0;
+    }
+  }
+
+  private:
+  std::string path_;
+  std::vector<uint8_t> private_data_;
+};
+
+struct ColumnGroupExporter {
+  public:
+  void Export(const ColumnGroup* cg, CColumnGroup* ccg) {
+    assert(cg != nullptr && ccg != nullptr);
+
+    // export columns
+    size_t num_of_columns = cg->columns.size();
+    columns_holder_ = std::make_unique<const char*[]>(num_of_columns);
+    colnames_.resize(num_of_columns);
+    for (size_t i = 0; i < num_of_columns; i++) {
+      colnames_[i] = cg->columns[i];
+      columns_holder_[i] = colnames_[i].c_str();
+    }
+    ccg->columns = columns_holder_.get();
+    ccg->num_of_columns = num_of_columns;
+
+    // export format
+    format_ = cg->format;
+    ccg->format = format_.c_str();
+
+    // export files
+    size_t num_of_files = cg->files.size();
+    files_holder_ = std::make_unique<CColumnGroupFile[]>(num_of_files);
+    cgf_exporters_.resize(num_of_files);
+    for (size_t i = 0; i < num_of_files; i++) {
+      cgf_exporters_[i] = std::make_unique<ColumnGroupFileExporter>();
+      cgf_exporters_[i]->Export(&cg->files[i], files_holder_.get() + i);
+    }
+    ccg->files = files_holder_.get();
+    ccg->num_of_files = num_of_files;
+  }
+
+  private:
+  std::vector<std::string> colnames_;
+  std::unique_ptr<const char*[]> columns_holder_;
+
+  std::string format_;
+
+  std::unique_ptr<CColumnGroupFile[]> files_holder_;
+  std::vector<std::unique_ptr<ColumnGroupFileExporter>> cgf_exporters_;
+};
+
+struct ColumnGroupsExporter {
+  public:
+  static arrow::Status Export(const ColumnGroups* cgs, CColumnGroups* out_ccgs) {
+    ColumnGroupsExporter* exporter = new ColumnGroupsExporter();
+    return exporter->ExportInternal(cgs, out_ccgs);
+  }
+
+  private:
+  static void Release(CColumnGroups* ccg) {
+    delete reinterpret_cast<ColumnGroupsExporter*>(ccg->private_data);
+    ccg->release = nullptr;
+    ccg->private_data = nullptr;
+  }
+
+  arrow::Status ExportInternal(const ColumnGroups* cgs, CColumnGroups* ccgs) {
+    assert(cgs != nullptr && ccgs != nullptr);
+    ccgp_holder_ = std::make_unique<CColumnGroup[]>(cgs->size());
+    cg_exporters_.resize(cgs->size());
+    for (size_t i = 0; i < cgs->size(); i++) {
+      cg_exporters_[i] = std::make_unique<ColumnGroupExporter>();
+      cg_exporters_[i]->Export(cgs->get_column_group(i).get(), ccgp_holder_.get() + i);
+    }
+    ccgs->column_group_array = ccgp_holder_.get();
+    ccgs->num_of_column_groups = cgs->size();
+
+    ccgs->private_data = this;
+    ccgs->release = ColumnGroupsExporter::Release;
+
+    if (cgs->meta_size() > 0) {
+      meta_keys_holder_ = std::make_unique<const char*[]>(cgs->meta_size());
+      meta_values_holder_ = std::make_unique<const char*[]>(cgs->meta_size());
+      metadata_holder_.resize(cgs->meta_size());
+      for (size_t i = 0; i < cgs->meta_size(); i++) {
+        ARROW_ASSIGN_OR_RAISE(auto meta, cgs->get_metadata(i))
+        metadata_holder_[i] = std::make_pair(meta.first, meta.second);
+        meta_keys_holder_[i] = metadata_holder_[i].first.c_str();
+        meta_values_holder_[i] = metadata_holder_[i].second.c_str();
+      }
+
+      ccgs->meta_keys = meta_keys_holder_.get();
+      ccgs->meta_values = meta_values_holder_.get();
+      ccgs->meta_len = cgs->meta_size();
+    } else {
+      ccgs->meta_keys = nullptr;
+      ccgs->meta_values = nullptr;
+      ccgs->meta_len = 0;
+    }
+
+    return arrow::Status::OK();
+  }
+
+  private:
+  std::unique_ptr<CColumnGroup[]> ccgp_holder_;
+  std::vector<std::unique_ptr<ColumnGroupExporter>> cg_exporters_;
+
+  std::vector<std::pair<std::string, std::string>> metadata_holder_;
+  std::unique_ptr<const char*[]> meta_keys_holder_;
+  std::unique_ptr<const char*[]> meta_values_holder_;
+};
+
+struct ColumnGroupsImporter {
+  public:
+  static void ImportColumnGroupFile(const CColumnGroupFile* in_ccgf, ColumnGroupFile* cgf) {
+    assert(in_ccgf != nullptr && cgf != nullptr);
+    cgf->path = std::string(in_ccgf->path);
+    cgf->start_index = in_ccgf->start_index;
+    cgf->end_index = in_ccgf->end_index;
+
+    if (in_ccgf->private_data != nullptr) {
+      cgf->private_data =
+          std::vector<uint8_t>(in_ccgf->private_data, in_ccgf->private_data + in_ccgf->private_data_size);
+    }
+  }
+
+  static void ImportColumnGroup(const CColumnGroup* in_ccg, ColumnGroup* cg) {
+    assert(in_ccg != nullptr && cg != nullptr);
+    for (size_t i = 0; i < in_ccg->num_of_columns; i++) {
+      cg->columns.emplace_back(std::string(in_ccg->columns[i]));
+    }
+    cg->format = std::string(in_ccg->format);
+
+    for (size_t i = 0; i < in_ccg->num_of_files; i++) {
+      ColumnGroupFile cgf;
+      ImportColumnGroupFile(&in_ccg->files[i], &cgf);
+      cg->files.emplace_back(std::move(cgf));
+    }
+  }
+
+  static arrow::Status Import(const CColumnGroups* in_ccgs, ColumnGroups* cgs) {
+    assert(in_ccgs != nullptr && cgs != nullptr);
+    for (size_t i = 0; i < in_ccgs->num_of_column_groups; i++) {
+      std::shared_ptr<ColumnGroup> cg = std::make_shared<ColumnGroup>();
+      ImportColumnGroup(&in_ccgs->column_group_array[i], cg.get());
+      ARROW_RETURN_NOT_OK(cgs->add_column_group(cg));
+    }
+
+    std::vector<std::string_view> keys;
+    std::vector<std::string_view> values;
+    for (size_t i = 0; i < in_ccgs->meta_len; i++) {
+      keys.emplace_back(in_ccgs->meta_keys[i]);
+      values.emplace_back(in_ccgs->meta_values[i]);
+    }
+    ARROW_RETURN_NOT_OK(cgs->add_metadatas(keys, values));
+
+    return arrow::Status::OK();
+  }
+};
+
+arrow::Status export_column_groups(const ColumnGroups* cgs, CColumnGroups* out_ccgs) {
+  return ColumnGroupsExporter::Export(cgs, out_ccgs);
+}
+
+arrow::Status import_column_groups(const CColumnGroups* ccgs, ColumnGroups* out_cgs) {
+  return ColumnGroupsImporter::Import(ccgs, out_cgs);
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/ffi/column_groups_c.cpp
+++ b/cpp/src/ffi/column_groups_c.cpp
@@ -1,0 +1,107 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_c.h"
+
+#include <memory>
+#include <optional>
+#include <vector>
+#include <assert.h>
+
+#include "milvus-storage/ffi_internal/result.h"
+#include "milvus-storage/ffi_internal/bridge.h"
+#include "milvus-storage/transaction/manifest.h"
+
+using namespace milvus_storage::api;
+
+FFIResult column_groups_export(ColumnGroupsHandle handle, CColumnGroups* out_ccgs) {
+  if (!handle || !out_ccgs) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_ccgs must not be null");
+  }
+
+  std::shared_ptr<ColumnGroups> cgs = *reinterpret_cast<std::shared_ptr<ColumnGroups>*>(handle);
+  auto st = export_column_groups(cgs.get(), out_ccgs);
+  if (!st.ok()) {
+    RETURN_ERROR(LOON_LOGICAL_ERROR, st.ToString());
+  }
+
+  RETURN_SUCCESS();
+}
+
+FFIResult column_groups_import(CColumnGroups* in_cgs, ColumnGroupsHandle* handle) {
+  if (!in_cgs || !handle) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: in_cgs and handle must not be null");
+  }
+
+  std::shared_ptr<ColumnGroups> cgs = std::make_shared<ColumnGroups>();
+  auto st = import_column_groups(in_cgs, cgs.get());
+  if (!st.ok()) {
+    RETURN_ERROR(LOON_LOGICAL_ERROR, st.ToString());
+  }
+
+  *handle = reinterpret_cast<ColumnGroupsHandle>(new std::shared_ptr<ColumnGroups>(cgs));
+  RETURN_SUCCESS();
+}
+
+FFIResult column_groups_create(const char** columns,
+                               size_t col_lens,
+                               char* format,
+                               char** paths,
+                               int64_t* start_indices,
+                               int64_t* end_indices,
+                               size_t file_lens,
+                               ColumnGroupsHandle* out_column_groups) {
+  if (!columns || !col_lens || !paths || !format || !file_lens || !out_column_groups || !start_indices ||
+      !end_indices) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments");
+  }
+
+  try {
+    // The external table will generate a `single` column group
+    std::shared_ptr<ColumnGroups> cgs = std::make_shared<ColumnGroups>();
+    std::shared_ptr<ColumnGroup> cg = std::make_shared<ColumnGroup>();
+    cg->columns.reserve(col_lens);
+    for (size_t col_idx = 0; col_idx < col_lens; col_idx++) {
+      cg->columns.emplace_back(columns[col_idx]);
+    }
+
+    cg->files.reserve(file_lens);
+    for (size_t file_idx = 0; file_idx < file_lens; file_idx++) {
+      if (!paths[file_idx]) {
+        RETURN_ERROR(LOON_INVALID_ARGS, "Path is null [index=" + std::to_string(file_idx) + "]");
+      }
+
+      cg->files.emplace_back(ColumnGroupFile{paths[file_idx], start_indices[file_idx], end_indices[file_idx]});
+    }
+    cg->format = format;
+    auto status = cgs->add_column_group(std::move(cg));
+    if (!status.ok()) {
+      RETURN_ERROR(LOON_INVALID_ARGS, status.ToString());
+    }
+
+    *out_column_groups = reinterpret_cast<ColumnGroupsHandle>(new std::shared_ptr<ColumnGroups>(cgs));
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+void column_groups_ptr_destroy(ColumnGroupsHandle handle) {
+  if (handle) {
+    delete reinterpret_cast<std::shared_ptr<ColumnGroups>*>(handle);
+  }
+}

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -14,6 +14,10 @@
 
 #include "milvus-storage/ffi_c.h"
 
+#include <memory>
+#include <optional>
+#include <vector>
+
 #include "milvus-storage/ffi_internal/result.h"
 #include "milvus-storage/transaction/manifest.h"
 #include "milvus-storage/transaction/transaction.h"

--- a/cpp/src/ffi/properties_c.cpp
+++ b/cpp/src/ffi/properties_c.cpp
@@ -1,3 +1,16 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/ffi_internal/result.h"

--- a/cpp/src/ffi/writer_c.cpp
+++ b/cpp/src/ffi/writer_c.cpp
@@ -158,9 +158,3 @@ void writer_destroy(WriterHandle handle) {
     delete reinterpret_cast<Writer*>(handle);
   }
 }
-
-void column_groups_destroy(ColumnGroupsHandle handle) {
-  if (handle) {
-    delete reinterpret_cast<std::shared_ptr<ColumnGroups>*>(handle);
-  }
-}

--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -75,8 +75,6 @@
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/filesystem/s3/s3_client.h"
 
-static constexpr const char kSep = '/';
-
 using ::arrow::Buffer;
 using ::arrow::Future;
 using ::arrow::Result;

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -240,6 +240,9 @@ PropertyVariant GetPropertyValue(const PropertyInfo& property_info, const std::s
       assert(false && "unknown property type");
       return nullptr;
   }
+
+  assert(false && "unreachable");
+  return nullptr;
 }
 
 // Validator: check the type

--- a/cpp/test/ffi/bridge_test.cpp
+++ b/cpp/test/ffi/bridge_test.cpp
@@ -1,0 +1,157 @@
+
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <random>
+
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_internal/bridge.h"
+#include "test_env.h"
+
+namespace milvus_storage::test {
+
+using namespace milvus_storage::api;
+
+class BridgeTest : public ::testing::Test {};
+
+TEST_F(BridgeTest, ExportImportColumnGroups) {
+  // create column groups
+  ColumnGroups cgs;
+
+  ColumnGroupFile cgf1{
+      .path = "test_file1", .start_index = 0, .end_index = 10, .private_data = std::vector<uint8_t>({1, 2, 3, 4})};
+
+  ColumnGroupFile cgf2{
+      .path = "test_file2",
+      .start_index = 2000,
+      .end_index = 10000,
+      .private_data = std::nullopt,
+  };
+
+  ColumnGroupFile cgf3{
+      .path = "test_file2",
+      .start_index = 100,
+      .end_index = 200,
+      .private_data = std::vector<uint8_t>({1, 3, 4, 5}),
+  };
+
+  ColumnGroup cg1{
+      .columns = std::vector<std::string>({"col1", "col2"}),
+      .format = "parquet",
+      .files = std::vector<ColumnGroupFile>({cgf1, cgf2}),
+  };
+
+  ColumnGroup cg2{
+      .columns = std::vector<std::string>({"col3"}),
+      .format = "parquet",
+      .files = std::vector<ColumnGroupFile>({cgf3}),
+  };
+
+  ASSERT_STATUS_OK(cgs.add_column_group(std::make_shared<ColumnGroup>(cg1)));
+  ASSERT_STATUS_OK(cgs.add_column_group(std::make_shared<ColumnGroup>(cg2)));
+  ASSERT_STATUS_OK(cgs.add_metadatas({"key1", "key2"}, {"value1", "value2"}));
+
+  // test export and import
+  CColumnGroups ccgs;
+  ASSERT_STATUS_OK(export_column_groups(&cgs, &ccgs));
+
+  // verify export C struct
+  {
+    ASSERT_NE(ccgs.column_group_array, nullptr);
+    ASSERT_EQ(ccgs.num_of_column_groups, 2);
+
+    ASSERT_NE(ccgs.meta_keys, nullptr);
+    ASSERT_EQ(ccgs.meta_len, 2);
+    ASSERT_TRUE(strcmp(ccgs.meta_keys[0], "key1") == 0);
+    ASSERT_TRUE(strcmp(ccgs.meta_keys[1], "key2") == 0);
+    ASSERT_TRUE(strcmp(ccgs.meta_values[0], "value1") == 0);
+    ASSERT_TRUE(strcmp(ccgs.meta_values[1], "value2") == 0);
+
+    ASSERT_NE(ccgs.release, nullptr);
+    ASSERT_NE(ccgs.private_data, nullptr);
+
+    ASSERT_NE(ccgs.column_group_array[0].columns, nullptr);
+    ASSERT_EQ(ccgs.column_group_array[0].num_of_columns, 2);
+    ASSERT_EQ(ccgs.column_group_array[0].columns[0], cg1.columns[0]);
+    ASSERT_EQ(ccgs.column_group_array[0].columns[1], cg1.columns[1]);
+
+    ASSERT_EQ(ccgs.column_group_array[0].format, cg1.format);
+    ASSERT_NE(ccgs.column_group_array[0].files, nullptr);
+    ASSERT_EQ(ccgs.column_group_array[0].num_of_files, 2);
+    ASSERT_EQ(ccgs.column_group_array[0].files[0].path, cg1.files[0].path);
+    ASSERT_EQ(ccgs.column_group_array[0].files[0].start_index, cg1.files[0].start_index);
+    ASSERT_EQ(ccgs.column_group_array[0].files[0].end_index, cg1.files[0].end_index);
+    ASSERT_EQ(std::vector<uint8_t>(ccgs.column_group_array[0].files[0].private_data,
+                                   ccgs.column_group_array[0].files[0].private_data +
+                                       ccgs.column_group_array[0].files[0].private_data_size),
+              cg1.files[0].private_data.value());
+
+    ASSERT_EQ(ccgs.column_group_array[0].files[1].path, cg1.files[1].path);
+    ASSERT_EQ(ccgs.column_group_array[0].files[1].start_index, cg1.files[1].start_index);
+    ASSERT_EQ(ccgs.column_group_array[0].files[1].end_index, cg1.files[1].end_index);
+    ASSERT_EQ(ccgs.column_group_array[0].files[1].private_data, nullptr);
+
+    ASSERT_NE(ccgs.column_group_array[1].columns, nullptr);
+    ASSERT_EQ(ccgs.column_group_array[1].num_of_columns, 1);
+    ASSERT_EQ(ccgs.column_group_array[1].columns[0], cg2.columns[0]);
+
+    ASSERT_EQ(ccgs.column_group_array[1].format, cg2.format);
+    ASSERT_NE(ccgs.column_group_array[1].files, nullptr);
+    ASSERT_EQ(ccgs.column_group_array[1].num_of_files, 1);
+    ASSERT_EQ(ccgs.column_group_array[1].files[0].path, cgf3.path);
+    ASSERT_EQ(ccgs.column_group_array[1].files[0].start_index, cgf3.start_index);
+    ASSERT_EQ(ccgs.column_group_array[1].files[0].end_index, cgf3.end_index);
+    ASSERT_EQ(std::vector<uint8_t>(ccgs.column_group_array[1].files[0].private_data,
+                                   ccgs.column_group_array[1].files[0].private_data +
+                                       ccgs.column_group_array[1].files[0].private_data_size),
+              cgf3.private_data.value());
+  }
+
+  ColumnGroups imported_cgs;
+  ASSERT_STATUS_OK(import_column_groups(&ccgs, &imported_cgs));
+
+  // verify import column groups should same with origin one
+  {
+    ASSERT_EQ(cgs.size(), imported_cgs.size());
+    for (size_t i = 0; i < cgs.size(); ++i) {
+      auto left_cg = cgs.get_column_group(i);
+      auto right_cg = imported_cgs.get_column_group(i);
+
+      ASSERT_EQ(left_cg->columns, right_cg->columns);
+      ASSERT_EQ(left_cg->format, right_cg->format);
+      ASSERT_EQ(left_cg->files.size(), right_cg->files.size());
+      for (size_t j = 0; j < left_cg->files.size(); ++j) {
+        ASSERT_EQ(left_cg->files[j].path, right_cg->files[j].path);
+        ASSERT_EQ(left_cg->files[j].start_index, right_cg->files[j].start_index);
+        ASSERT_EQ(left_cg->files[j].end_index, right_cg->files[j].end_index);
+        ASSERT_EQ(left_cg->files[j].private_data, right_cg->files[j].private_data);
+      }
+    }
+
+    ASSERT_EQ(cgs.meta_size(), imported_cgs.meta_size());
+    for (size_t i = 0; i < cgs.meta_size(); ++i) {
+      ASSERT_AND_ASSIGN(auto leftmeta, cgs.get_metadata(i));
+      ASSERT_AND_ASSIGN(auto rightmeta, imported_cgs.get_metadata(i));
+      ASSERT_EQ(leftmeta, rightmeta);
+    }
+  }
+
+  ccgs.release(&ccgs);
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -132,7 +132,7 @@ static void test_empty_manifests(void) {
   }
   free(schema);
   reader_destroy(reader_handle);
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
 
   properties_free(&pp);
   remove_directory(TEST_BASE_PATH);
@@ -172,8 +172,8 @@ static void test_manifests_write_read(void) {
   ck_assert(last_manifest != 0);
   ck_assert_msg(read_version == 1, "read_version should be 1 after write manifest 1 time");
 
-  column_groups_destroy(out_manifest);
-  column_groups_destroy(last_manifest);
+  column_groups_ptr_destroy(out_manifest);
+  column_groups_ptr_destroy(last_manifest);
 
   properties_free(&pp);
   remove_directory(TEST_BASE_PATH);
@@ -212,8 +212,8 @@ static void test_abort(void) {
   // ck_assert_str_eq(last_manifest1, last_manifest2);
   ck_assert_msg(read_version == 0, "read_version should be 0 after abort");
 
-  column_groups_destroy(last_manifest1);
-  column_groups_destroy(last_manifest2);
+  column_groups_ptr_destroy(last_manifest1);
+  column_groups_ptr_destroy(last_manifest2);
 
   properties_free(&pp);
   remove_directory(TEST_BASE_PATH);

--- a/cpp/test/ffi/ffi_reader_test.c
+++ b/cpp/test/ffi/ffi_reader_test.c
@@ -144,7 +144,7 @@ static void test_basic(void) {
     free_chunk_arrays(arrays, num_arrays);
   }
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   reader_destroy(reader_handle);
   if (schema->release) {
     schema->release(schema);
@@ -208,7 +208,7 @@ static void test_empty_projection(void) {
     arraystream.release = NULL;
   }
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   reader_destroy(reader_handle);
   if (schema->release) {
     schema->release(schema);
@@ -275,7 +275,7 @@ static void test_record_batch_reader_verify_schema(void) {
   schema_result.release(&schema_result);
   arraystream.release(&arraystream);
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   reader_destroy(reader_handle);
 
   // recreated one need call the `release`
@@ -375,7 +375,7 @@ static void test_record_batch_reader_verify_arrowarray(void) {
 
   arraystream.release(&arraystream);
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   reader_destroy(reader_handle);
   if (schema->release) {
     schema->release(schema);
@@ -430,7 +430,7 @@ static void test_chunk_reader(void) {
   free_chunk_indices(chunk_indices);
   chunk_reader_destroy(chunk_reader_handle);
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   reader_destroy(reader_handle);
   if (schema->release) {
     schema->release(schema);
@@ -495,7 +495,7 @@ static void test_chunk_reader_get_chunks(void) {
 
   chunk_reader_destroy(chunk_reader_handle);
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   reader_destroy(reader_handle);
   if (schema->release) {
     schema->release(schema);
@@ -666,7 +666,7 @@ static void test_chunk_metadatas(void) {
   }
 
   // free resources
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   if (schema->release) {
     schema->release(schema);
   }

--- a/cpp/test/ffi/ffi_writer_test.c
+++ b/cpp/test/ffi/ffi_writer_test.c
@@ -141,7 +141,7 @@ static void test_basic(void) {
   }
   free(struct_array);
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
   writer_destroy(writer_handle);
 
   // still need release the schema(struct)
@@ -315,7 +315,7 @@ static void test_multi_write(void) {
 
   ck_assert_msg(out_manifest != 0, "out_manifest should not be NULL");
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
 }
 
 static void test_multi_no_close(void) {
@@ -367,7 +367,7 @@ static void test_multi_write_size_based(void) {
 
   ck_assert_msg(out_manifest != 0, "out_manifest should not be NULL");
 
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
 }
 
 static void test_write_with_meta(void) {
@@ -381,7 +381,7 @@ static void test_write_with_meta(void) {
                            false);
 
   ck_assert_msg(out_manifest != 0, "out_manifest should not be NULL");
-  column_groups_destroy(out_manifest);
+  column_groups_ptr_destroy(out_manifest);
 }
 
 void run_writer_suite(void) {


### PR DESCRIPTION
This commit defines the composition of column groups in the FFI and provides interfaces to export/import the structure of column groups. Also adjusts the external table interface:

- `column_groups_export`: Exports the column groups object from C++ into a C struct.
- `column_groups_import`: Imports the column groups C struct into a C++ object.
- `exttable_explore`: Lists the input explore_dir and generates column groups, outputting the number of files under explore_dir and the location of the temporary column group files created.
- `exttable_read_column_groups`: Reads column groups by file path and outputs the column groups as a C struct.