### PR TITLE
fix: credentials provider defined conflict between the storage and milvus

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h
@@ -24,37 +24,37 @@
 #include <memory>
 #include "AliyunSTSClient.h"
 
-namespace Aws {
-namespace Auth {
+namespace milvus_storage {
+
 /**
  * To support retrieving credentials of STS AssumeRole with web identity.
  * Note that STS accepts request with protocol of queryxml. Calling GetAWSCredentials() will trigger (if expired)
  * a query request using AWSHttpResourceClient under the hood.
  */
-class AWS_CORE_API AliyunSTSAssumeRoleWebIdentityCredentialsProvider : public AWSCredentialsProvider {
+class AWS_CORE_API AliyunSTSAssumeRoleWebIdentityCredentialsProvider : public ::Aws::Auth::AWSCredentialsProvider {
   public:
   AliyunSTSAssumeRoleWebIdentityCredentialsProvider();
 
   /**
    * Retrieves the credentials if found, otherwise returns empty credential set.
    */
-  AWSCredentials GetAWSCredentials() override;
+  ::Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
   protected:
   void Reload() override;
 
   private:
   void RefreshIfExpired();
-  Aws::String CalculateQueryString() const;
+  ::Aws::String CalculateQueryString() const;
 
-  Aws::UniquePtr<Aws::Internal::AliyunSTSCredentialsClient> m_client;
-  Aws::Auth::AWSCredentials m_credentials;
-  Aws::String m_roleArn;
-  Aws::String m_tokenFile;
-  Aws::String m_sessionName;
-  Aws::String m_token;
+  ::Aws::UniquePtr<AliyunSTSCredentialsClient> m_client;
+  ::Aws::Auth::AWSCredentials m_credentials;
+  ::Aws::String m_roleArn;
+  ::Aws::String m_tokenFile;
+  ::Aws::String m_sessionName;
+  ::Aws::String m_token;
   bool m_initialized;
   bool ExpiresSoon() const;
 };
-}  // namespace Auth
-}  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunSTSClient.h
@@ -28,25 +28,18 @@
 #include <memory>
 #include <mutex>
 
-namespace Aws {
-namespace Http {
-class HttpClient;
-class HttpRequest;
-enum class HttpResponseCode;
-}  // namespace Http
-
-namespace Internal {
+namespace milvus_storage {
 /**
  * To support retrieving credentials from STS.
  * Note that STS accepts request with protocol of queryxml. Calling GetResource() will trigger
  * a query request using AWSHttpResourceClient under the hood.
  */
-class AWS_CORE_API AliyunSTSCredentialsClient : public AWSHttpResourceClient {
+class AWS_CORE_API AliyunSTSCredentialsClient : public ::Aws::Internal::AWSHttpResourceClient {
   public:
   /**
    * Initializes the provider to retrieve credentials from STS when it expires.
    */
-  explicit AliyunSTSCredentialsClient(const Client::ClientConfiguration& clientConfiguration);
+  explicit AliyunSTSCredentialsClient(const ::Aws::Client::ClientConfiguration& clientConfiguration);
 
   AliyunSTSCredentialsClient& operator=(AliyunSTSCredentialsClient& rhs) = delete;
   AliyunSTSCredentialsClient(const AliyunSTSCredentialsClient& rhs) = delete;
@@ -57,21 +50,20 @@ class AWS_CORE_API AliyunSTSCredentialsClient : public AWSHttpResourceClient {
   // AliyunSTSCredentialsClient client. If you want to make an AssumeRole call to sts, define the request/result
   // members class/struct like this.
   struct STSAssumeRoleWithWebIdentityRequest {
-    Aws::String roleSessionName;
-    Aws::String roleArn;
-    Aws::String webIdentityToken;
+    ::Aws::String roleSessionName;
+    ::Aws::String roleArn;
+    ::Aws::String webIdentityToken;
   };
 
   struct STSAssumeRoleWithWebIdentityResult {
-    Aws::Auth::AWSCredentials creds;
+    ::Aws::Auth::AWSCredentials creds;
   };
 
   STSAssumeRoleWithWebIdentityResult GetAssumeRoleWithWebIdentityCredentials(
       const STSAssumeRoleWithWebIdentityRequest& request);
 
   private:
-  Aws::String m_endpoint;
-  Aws::String m_aliyunOidcProviderArn;  // [aliyun]
+  ::Aws::String m_endpoint;
+  ::Aws::String m_aliyunOidcProviderArn;  // [aliyun]
 };
-}  // namespace Internal
-}  // namespace Aws
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h
@@ -3,12 +3,12 @@
 
 #include "HuaweiCloudSTSClient.h"
 
-namespace Aws {
-namespace Auth {
-class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public AWSCredentialsProvider {
+namespace milvus_storage {
+
+class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
   public:
   HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider();
-  AWSCredentials GetAWSCredentials() override;
+  Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
   protected:
   void Reload() override;
@@ -17,7 +17,7 @@ class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public AWSCredent
   void RefreshIfExpired();
   Aws::String CalculateQueryString() const;
 
-  Aws::UniquePtr<Aws::Internal::HuaweiCloudSTSCredentialsClient> m_client;
+  Aws::UniquePtr<HuaweiCloudSTSCredentialsClient> m_client;
   Aws::Auth::AWSCredentials m_credentials;
   Aws::String m_region;
   Aws::String m_providerId;
@@ -28,5 +28,5 @@ class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public AWSCredent
   bool m_initialized;
   bool ExpiresSoon() const;
 };
-}  // namespace Auth
-}  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudSTSClient.h
@@ -2,15 +2,9 @@
 
 #include <aws/core/internal/AWSHttpResourceClient.h>
 
-namespace Aws {
-namespace Http {
-class HttpClient;
-class HttpRequest;
-enum class HttpResponseCode;
-}  // namespace Http
+namespace milvus_storage {
 
-namespace Internal {
-class AWS_CORE_API HuaweiCloudSTSCredentialsClient : public AWSHttpResourceClient {
+class AWS_CORE_API HuaweiCloudSTSCredentialsClient : public ::Aws::Internal::AWSHttpResourceClient {
   public:
   explicit HuaweiCloudSTSCredentialsClient(const Aws::Client::ClientConfiguration& clientConfiguration);
 
@@ -46,5 +40,4 @@ class AWS_CORE_API HuaweiCloudSTSCredentialsClient : public AWSHttpResourceClien
 
   STSCallResult callHuaweiCloudSTS(const Aws::String& userToken, const STSAssumeRoleWithWebIdentityRequest& request);
 };
-}  // namespace Internal
-}  // namespace Aws
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h
@@ -24,21 +24,21 @@
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include "TencentCloudSTSClient.h"
 
-namespace Aws {
-namespace Auth {
+namespace milvus_storage {
+
 /**
  * To support retrieving credentials of STS AssumeRole with web identity.
  * Note that STS accepts request with protocol of queryxml. Calling GetAWSCredentials() will trigger (if expired)
  * a query request using AWSHttpResourceClient under the hood.
  */
-class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : public AWSCredentialsProvider {
+class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
   public:
   TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider();
 
   /**
    * Retrieves the credentials if found, otherwise returns empty credential set.
    */
-  AWSCredentials GetAWSCredentials() override;
+  Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
   protected:
   void Reload() override;
@@ -47,7 +47,7 @@ class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : pub
   void RefreshIfExpired();
   Aws::String CalculateQueryString() const;
 
-  Aws::UniquePtr<Aws::Internal::TencentCloudSTSCredentialsClient> m_client;
+  Aws::UniquePtr<TencentCloudSTSCredentialsClient> m_client;
   Aws::Auth::AWSCredentials m_credentials;
   Aws::String m_region;
   Aws::String m_roleArn;
@@ -58,5 +58,5 @@ class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : pub
   bool m_initialized;
   bool ExpiresSoon() const;
 };
-}  // namespace Auth
-}  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h
@@ -28,25 +28,19 @@
 #include <memory>
 #include <mutex>
 
-namespace Aws {
-namespace Http {
-class HttpClient;
-class HttpRequest;
-enum class HttpResponseCode;
-}  // namespace Http
+namespace milvus_storage {
 
-namespace Internal {
 /**
  * To support retrieving credentials from STS.
  * Note that STS accepts request with protocol of queryxml. Calling GetResource() will trigger
  * a query request using AWSHttpResourceClient under the hood.
  */
-class AWS_CORE_API TencentCloudSTSCredentialsClient : public AWSHttpResourceClient {
+class AWS_CORE_API TencentCloudSTSCredentialsClient : public Aws::Internal::AWSHttpResourceClient {
   public:
   /**
    * Initializes the provider to retrieve credentials from STS when it expires.
    */
-  explicit TencentCloudSTSCredentialsClient(const Client::ClientConfiguration& clientConfiguration);
+  explicit TencentCloudSTSCredentialsClient(const Aws::Client::ClientConfiguration& clientConfiguration);
 
   TencentCloudSTSCredentialsClient& operator=(TencentCloudSTSCredentialsClient& rhs) = delete;
   TencentCloudSTSCredentialsClient(const TencentCloudSTSCredentialsClient& rhs) = delete;
@@ -74,5 +68,5 @@ class AWS_CORE_API TencentCloudSTSCredentialsClient : public AWSHttpResourceClie
   private:
   Aws::String m_endpoint;
 };
-}  // namespace Internal
-}  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
@@ -30,13 +30,13 @@
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/utils/UUID.h>
 
+namespace milvus_storage {
+
 static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] =
     "AliyunSTSAssumeRoleWebIdentityCredentialsProvider";  // [aliyun]
 static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD =
     180 * 1000;  // [aliyun] supports 1800 second at most, here we use their default: 180s -> 180*1k ms
 
-namespace Aws {
-namespace Auth {
 AliyunSTSAssumeRoleWebIdentityCredentialsProvider::AliyunSTSAssumeRoleWebIdentityCredentialsProvider()
     : m_initialized(false) {
   // check environment variables
@@ -116,7 +116,7 @@ AliyunSTSAssumeRoleWebIdentityCredentialsProvider::AliyunSTSAssumeRoleWebIdentit
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
 
-  m_client = Aws::MakeUnique<Aws::Internal::AliyunSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
+  m_client = Aws::MakeUnique<AliyunSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
   AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
 }
@@ -143,8 +143,7 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
     return;
   }
-  Aws::Internal::AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_sessionName, m_roleArn,
-                                                                                         m_token};
+  AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_sessionName, m_roleArn, m_token};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
   AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
@@ -170,5 +169,5 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
 
   Reload();
 }
-}  // namespace Auth
-};  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
@@ -34,14 +34,11 @@
 #include <aws/core/client/CoreErrors.h>
 #include <aws/core/utils/xml/XmlSerializer.h>
 
-namespace Aws {
-namespace Http {
-class HttpClient;
-class HttpRequest;
-enum class HttpResponseCode;
-}  // namespace Http
+namespace milvus_storage {
 
-namespace Internal {
+using Aws::Http::HttpClient;
+using Aws::Http::HttpRequest;
+using Aws::Http::HttpResponseCode;
 
 static const char STS_RESOURCE_CLIENT_LOG_TAG[] = "AliyunSTSResourceClient";  // [aliyun]
 
@@ -147,32 +144,32 @@ AliyunSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
   //         <Expiration>2023-03-02T07:39:09Z</Expiration>
   //     </Credentials>
   // </AssumeRoleWithOIDCResponse>
-  const Utils::Xml::XmlDocument xmlDocument = Utils::Xml::XmlDocument::CreateFromXmlString(credentialsStr);
-  Utils::Xml::XmlNode rootNode = xmlDocument.GetRootElement();
-  Utils::Xml::XmlNode resultNode = rootNode;
+  const Aws::Utils::Xml::XmlDocument xmlDocument = Aws::Utils::Xml::XmlDocument::CreateFromXmlString(credentialsStr);
+  Aws::Utils::Xml::XmlNode rootNode = xmlDocument.GetRootElement();
+  Aws::Utils::Xml::XmlNode resultNode = rootNode;
   if (!rootNode.IsNull() && (rootNode.GetName() != "AssumeRoleWithOIDCResponse")) {
     resultNode = rootNode.FirstChild("AssumeRoleWithOIDCResponse");  // [aliyun]
   }
 
   if (!resultNode.IsNull()) {
-    Utils::Xml::XmlNode credentialsNode = resultNode.FirstChild("Credentials");
+    Aws::Utils::Xml::XmlNode credentialsNode = resultNode.FirstChild("Credentials");
     if (!credentialsNode.IsNull()) {
-      Utils::Xml::XmlNode accessKeyIdNode = credentialsNode.FirstChild("AccessKeyId");
+      Aws::Utils::Xml::XmlNode accessKeyIdNode = credentialsNode.FirstChild("AccessKeyId");
       if (!accessKeyIdNode.IsNull()) {
         result.creds.SetAWSAccessKeyId(accessKeyIdNode.GetText());
       }
 
-      Utils::Xml::XmlNode secretAccessKeyNode = credentialsNode.FirstChild("AccessKeySecret");  // [aliyun]
+      Aws::Utils::Xml::XmlNode secretAccessKeyNode = credentialsNode.FirstChild("AccessKeySecret");  // [aliyun]
       if (!secretAccessKeyNode.IsNull()) {
         result.creds.SetAWSSecretKey(secretAccessKeyNode.GetText());
       }
 
-      Utils::Xml::XmlNode sessionTokenNode = credentialsNode.FirstChild("SecurityToken");  // [aliyun]
+      Aws::Utils::Xml::XmlNode sessionTokenNode = credentialsNode.FirstChild("SecurityToken");  // [aliyun]
       if (!sessionTokenNode.IsNull()) {
         result.creds.SetSessionToken(sessionTokenNode.GetText());
       }
 
-      Utils::Xml::XmlNode expirationNode = credentialsNode.FirstChild("Expiration");
+      Aws::Utils::Xml::XmlNode expirationNode = credentialsNode.FirstChild("Expiration");
       if (!expirationNode.IsNull()) {
         result.creds.SetExpiration(Aws::Utils::DateTime(
             Aws::Utils::StringUtils::Trim(expirationNode.GetText().c_str()).c_str(), Aws::Utils::DateFormat::ISO_8601));
@@ -181,5 +178,5 @@ AliyunSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
   }
   return result;
 }
-}  // namespace Internal
-}  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -6,10 +6,10 @@
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/utils/UUID.h>
 
+namespace milvus_storage {
+
 static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] = "HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider";
 static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 7200;  // huawei cloud support 7200s.
-namespace Aws {
-namespace Auth {
 
 HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider()
     : m_initialized(false) {
@@ -85,8 +85,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
 
-  m_client =
-      Aws::MakeUnique<Aws::Internal::HuaweiCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
+  m_client = Aws::MakeUnique<HuaweiCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
   AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
 }
@@ -114,8 +113,8 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
     return;
   }
-  Aws::Internal::HuaweiCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
-      m_region, m_providerId, m_token, m_roleArn, m_sessionName};
+  HuaweiCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_region, m_providerId, m_token,
+                                                                               m_roleArn, m_sessionName};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
   AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
@@ -142,5 +141,4 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() 
   Reload();
 }
 
-}  // namespace Auth
-}  // namespace Aws
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
@@ -6,14 +6,10 @@
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/utils/DateTime.h>
 
-namespace Aws {
-namespace Http {
-class HttpClient;
-class HttpRequest;
-enum class HttpResponseCode;
-}  // namespace Http
-
-namespace Internal {
+namespace milvus_storage {
+using Aws::Http::HttpClient;
+using Aws::Http::HttpRequest;
+using Aws::Http::HttpResponseCode;
 
 static const char STS_RESOURCE_CLIENT_LOG_TAG[] = "HuaweiCloudSTSResourceClient";
 
@@ -98,15 +94,15 @@ HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
 
 HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::callHuaweiCloudSTS(
     const Aws::String& userToken, const STSAssumeRoleWithWebIdentityRequest& request) {
-  auto respFactory = []() -> IOStream* { return Aws::New<StringStream>("STS_RESPONSE"); };
+  auto respFactory = []() -> Aws::IOStream* { return Aws::New<Aws::StringStream>("STS_RESPONSE"); };
 
   Aws::String stsEndpoint = "https://iam." + request.region + ".myhuaweicloud.com/v3.0/OS-CREDENTIAL/securitytokens";
-  auto req = Aws::Http::CreateHttpRequest(stsEndpoint, Http::HttpMethod::HTTP_POST, respFactory);
+  auto req = Aws::Http::CreateHttpRequest(stsEndpoint, Aws::Http::HttpMethod::HTTP_POST, respFactory);
   req->SetHeaderValue("Content-Type", "application/json;charset=utf8");
   req->SetHeaderValue("Accept", "application/json");
   req->SetHeaderValue("X-Auth-Token", userToken);
 
-  auto body = Aws::MakeShared<StringStream>("STS_REQUEST");
+  auto body = Aws::MakeShared<Aws::StringStream>("STS_REQUEST");
   *body << R"({
             "auth": {
             "identity": {
@@ -130,7 +126,7 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
     result.errorMessage = "Get an empty credential from Huawei Cloud STS";
     return result;
   }
-  auto json = Utils::Json::JsonView(credentialsStr);
+  auto json = Aws::Utils::Json::JsonView(credentialsStr);
   auto rootNode = json.GetObject("credential");
   if (rootNode.IsNull()) {
     result.errorMessage = "Get credential from STS result failed";
@@ -149,5 +145,4 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   return result;
 }
 
-}  // namespace Internal
-}  // namespace Aws
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
@@ -24,11 +24,10 @@
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/utils/UUID.h>
 
+namespace milvus_storage {
 static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] = "TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider";
 static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 7200;  // tencent cloud support 7200s.
 
-namespace Aws {
-namespace Auth {
 TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider()
     : m_initialized(false) {
   m_region = Aws::Environment::GetEnv("TKE_REGION");
@@ -103,8 +102,7 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
 
-  m_client =
-      Aws::MakeUnique<Aws::Internal::TencentCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
+  m_client = Aws::MakeUnique<TencentCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
   AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
 }
@@ -134,8 +132,8 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
     return;
   }
-  Aws::Internal::TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
-      m_region, m_providerId, m_token, m_roleArn, m_sessionName};
+  TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_region, m_providerId, m_token,
+                                                                                m_roleArn, m_sessionName};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
   AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
@@ -161,5 +159,5 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired()
 
   Reload();
 }
-}  // namespace Auth
-};  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
@@ -29,14 +29,10 @@
 #include <aws/core/platform/Environment.h>
 #include <aws/core/client/AWSError.h>
 
-namespace Aws {
-namespace Http {
-class HttpClient;
-class HttpRequest;
-enum class HttpResponseCode;
-}  // namespace Http
-
-namespace Internal {
+namespace milvus_storage {
+using Aws::Http::HttpClient;
+using Aws::Http::HttpRequest;
+using Aws::Http::HttpResponseCode;
 
 static const char STS_RESOURCE_CLIENT_LOG_TAG[] = "TencentCloudSTSResourceClient";  // [tencent cloud]
 
@@ -101,7 +97,7 @@ TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     return result;
   }
 
-  auto json = Utils::Json::JsonView(credentialsStr);
+  auto json = Aws::Utils::Json::JsonView(credentialsStr);
   auto rootNode = json.GetObject("Response");
   if (rootNode.IsNull()) {
     AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Get Response from credential result failed");
@@ -122,5 +118,5 @@ TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
 
   return result;
 }
-}  // namespace Internal
-}  // namespace Aws
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -185,7 +185,7 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateC
 }
 
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateHuaweiCredentialsProvider() {
-  static auto provider = Aws::MakeShared<Aws::Auth::HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
+  static auto provider = Aws::MakeShared<HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
       "HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider");
   return provider;
 }
@@ -196,13 +196,13 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateA
 }
 
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateAliyunCredentialsProvider() {
-  static auto provider = Aws::MakeShared<Aws::Auth::AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(
+  static auto provider = Aws::MakeShared<AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(
       "AliyunSTSAssumeRoleWebIdentityCredentialsProvider");
   return provider;
 }
 
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateTencentCredentialsProvider() {
-  static auto provider = Aws::MakeShared<Aws::Auth::TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
+  static auto provider = Aws::MakeShared<TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider>(
       "TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider");
   return provider;
 }


### PR DESCRIPTION
Both Milvus and Storage have defined the same C++ credentials provider class (with the same namespace) for different cloud providers. While I'm not entirely sure why a redefinition error doesn’t occur during compilation, it is indeed happening that the stack trace from Storage calls into Milvus’s stack.

problem stack:

```
_ZN3Aws4Auth49AliyunSTSAssumeRoleWebIdentityCredentialsProviderC2Ev /root/milvus/internal/core/src/storage/AliyunCredentialsProvider.cpp:102 pc=0x7f849c5ebf5
_ZNSt15__new_a1locatorIN3Aw$4Auth49AliyunSTSAssumeRoleWebIdentityCredentialsProviderEE9constructIS2_JEEEVPT_DpOTO_ /usr/include/c++/12/bits/new_allocator.h:175 pc=0x7f84967d06df
...
_ZN14milvus_storage20S3FileSystemProducer31CreateAliyunCredentialsProviderEv /root/milvus/cmake_build/thirdparty/milvus-storage/milvus-storage-src/cpp/src/filesystem/$3/$3_fs.cpp:198 pc=0x7f84967d06d
```

Even if the two implementations are identical, they could still be affected by different configurations and cause issues. Therefore, this commit changes the cloud provider namespace defined in Storage to `milvus_storage` to distinguish between the different definitions.