### PR TITLE
fix: add CreateArrowFileSystem back to header

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -136,6 +136,8 @@ struct ArrowFileSystemConfig {
   }
 };
 
+arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemConfig& config);
+
 class FileSystemProducer {
   public:
   virtual ~FileSystemProducer() = default;


### PR DESCRIPTION
In commit d7f75df8 remove the `CreateArrowFileSystem` declare in header. But this function still used in milvus.