### PR TITLE
fix: update is_initialized_ flag after DoInitialize completes

### DIFF
--- a/cpp/src/filesystem/s3/s3_global.cpp
+++ b/cpp/src/filesystem/s3/s3_global.cpp
@@ -80,10 +80,11 @@ struct AwsInstance {
     // EnsureInitialized() can be called concurrently by FileSystemFromUri,
     // therefore we need to serialize initialization (GH-39897).
     std::call_once(initialize_flag_, [&]() {
-      bool was_initialized = is_initialized_.exchange(true);
+      bool was_initialized = is_initialized_.load();
       DCHECK(!was_initialized);
       DoInitialize(options);
       newly_initialized = true;
+      is_initialized_.exchange(true);
     });
     return newly_initialized;
   }


### PR DESCRIPTION
Move the is_initialized_ flag update from before DoInitialize() to after it completes. This ensures the initialization flag is only set to true after the actual initialization is done, preventing potential issues if DoInitialize() fails or if other code checks the flag during initialization.