### PR TITLE
enhance: add a warning message when IOError happend in s3fs

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -188,10 +188,11 @@ arrow::Status ErrorToStatus(const std::string& prefix,
                          "' while the bucket is located in '" + maybe_region.value() + "'.";
     }
   }
+  std::string message = "AWS Error " + ss.str() + " during " + operation + " operation: " + error.GetMessage() +
+                        wrong_region_msg.value_or("");
+  ARROW_LOG(WARNING) << message;
 
   if (error_type == Aws::S3::S3Errors::NO_SUCH_UPLOAD) {
-    std::string message = "AWS Error " + ss.str() + " during " + operation + " operation: " + error.GetMessage() +
-                          wrong_region_msg.value_or("");
     return MakeExtendError(ExtendStatusCode::NoSuchUpload, message, message /* extra_info */);
   }
 


### PR DESCRIPTION
S3FS storage often fails for various reasons. Add a log line to ensure that information is not lost due to improper closing from the outside.