### PR TITLE
fix: empty expire time in iam credential for huawei cloud

### DIFF
--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -117,8 +117,10 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
                                                                                m_roleArn, m_sessionName};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
-  AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                      "Successfully retrieved credentials with AWS_ACCESS_KEY: " << result.creds.GetAWSAccessKeyId());
+  AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+                      "Successfully retrieved credentials with AWS_ACCESS_KEY: "
+                          << result.creds.GetAWSAccessKeyId() << ", expiration_count_diff_ms: "
+                          << (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
   m_credentials = result.creds;
 }
 

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
@@ -126,7 +126,8 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
     result.errorMessage = "Get an empty credential from Huawei Cloud STS";
     return result;
   }
-  auto json = Aws::Utils::Json::JsonView(credentialsStr);
+  Aws::Utils::Json::JsonValue jsonValue(credentialsStr);
+  auto json = jsonValue.View();
   auto rootNode = json.GetObject("credential");
   if (rootNode.IsNull()) {
     result.errorMessage = "Get credential from STS result failed";


### PR DESCRIPTION
in the way before, the input json value constructed by input string become invalid after creating jsonview
but the created json view reference the former json value by reference, so some properties were lost and lead to errors