### PR TITLE
fix: empty expire time in iam credential for tencent cloud

### DIFF
--- a/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
@@ -136,8 +136,10 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
                                                                                 m_roleArn, m_sessionName};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
-  AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                      "Successfully retrieved credentials with AWS_ACCESS_KEY: " << result.creds.GetAWSAccessKeyId());
+  AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+                      "Successfully retrieved credentials with AWS_ACCESS_KEY: "
+                          << result.creds.GetAWSAccessKeyId() << ", expiration_count_diff_ms: "
+                          << (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
   m_credentials = result.creds;
 }
 

--- a/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
@@ -97,7 +97,8 @@ TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     return result;
   }
 
-  auto json = Aws::Utils::Json::JsonView(credentialsStr);
+  Aws::Utils::Json::JsonValue jsonValue(credentialsStr);
+  auto json = jsonValue.View();
   auto rootNode = json.GetObject("Response");
   if (rootNode.IsNull()) {
     AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Get Response from credential result failed");


### PR DESCRIPTION
missing change from lastest commit d3f1d5d

The JsonView does not extend the lifetime of the given JsonValue. It's your responsibility to ensure the lifetime of the JsonValue is extended beyond the lifetime of its view.
So the logical:

```
  auto json = Aws::Utils::Json::JsonView(credentialsStr);
```
will be a problem here.