### PR TITLE
enhance: Align the JNI with the latest FFI

### DIFF
--- a/cpp/include/milvus-storage/ffi_jni.h
+++ b/cpp/include/milvus-storage/ffi_jni.h
@@ -78,10 +78,10 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageProperties_allocateP
  * @param java_map Java/Scala Map<String, String>
  * @param properties_ptr Pointer to properties
  */
-JNIEXPORT void JNICALL Java_io_milvus_storage_Properties_createProperties(JNIEnv* env,
-                                                                          jobject obj,
-                                                                          jobject java_map,
-                                                                          jlong properties_ptr);
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_createProperties(JNIEnv* env,
+                                                                                       jobject obj,
+                                                                                       jobject java_map,
+                                                                                       jlong properties_ptr);
 
 /**
  * @brief Free properties
@@ -139,11 +139,11 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerFlush(JN
  * @param env JNI environment
  * @param obj Java object
  * @param writer_handle Writer handle
- * @return Manifest as string
+ * @return Manifest raw pointer
  */
-JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose(JNIEnv* env,
-                                                                                 jobject obj,
-                                                                                 jlong writer_handle);
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose(JNIEnv* env,
+                                                                               jobject obj,
+                                                                               jlong writer_handle);
 
 /**
  * @brief Destroy the writer
@@ -163,14 +163,14 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerDestroy(
  *
  * @param env JNI environment
  * @param obj Java object
- * @param manifest Manifest string
+ * @param manifest Manifest raw pointer
  * @param schema_ptr Pointer to Arrow schema
  * @param needed_columns Array of column names
  * @param properties_ptr Pointer to properties
  * @return Reader handle as long
  */
 JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(
-    JNIEnv* env, jobject obj, jstring manifest, jlong schema_ptr, jobjectArray needed_columns, jlong properties_ptr);
+    JNIEnv* env, jobject obj, jlong manifest, jlong schema_ptr, jobjectArray needed_columns, jlong properties_ptr);
 
 /**
  * @brief Get record batch reader
@@ -210,9 +210,9 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getChunkReade
  * @param reader_handle Reader handle
  * @param row_indices Array of row indices
  * @param parallelism Parallelism level
- * @return Arrow array pointer as long
+ * @return Arrow array pointer as long array
  */
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_take(
+JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageReader_take(
     JNIEnv* env, jobject obj, jlong reader_handle, jlongArray row_indices, jlong parallelism);
 
 /**
@@ -290,7 +290,7 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_chunkRead
  * @param stream_ptr Pointer to ArrowArrayStream
  * @return Arrow array pointer as long (0 if end of stream)
  */
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtils_00024_readNextBatch(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtilsNative_readNextBatch(JNIEnv* env,
                                                                               jobject obj,
                                                                               jlong stream_ptr);
 
@@ -300,11 +300,38 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtils_00024_readNextBatch(JN
  * @param env JNI environment
  * @param obj Java object
  * @param stream_ptr Pointer to ArrowArrayStream
+ * @param free_ptr Whether to free the pointer(If current ptr alloc in java, then false)
  */
-JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtils_00024_releaseArrowStream(JNIEnv* env,
+JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtilsNative_releaseArrowStream(JNIEnv* env,
                                                                                   jobject obj,
-                                                                                  jlong stream_ptr);
+                                                                                  jlong stream_ptr,
+                                                                                  jboolean free_ptr);
 
+/**
+ * @brief Release ArrowArray
+ *
+ * @param env JNI environment
+ * @param obj Java object
+ * @param array_ptr Pointer to ArrowArray
+ * @param free_ptr Whether to free the pointer(If current ptr alloc in java, then false)
+ */
+JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtilsNative_releaseArrowArray(JNIEnv* env,
+                                                                                 jobject obj,
+                                                                                 jlong array_ptr,
+                                                                                 jboolean free_ptr);
+
+/**
+ * @brief Release ArrowSchema
+ *
+ * @param env JNI environment
+ * @param obj Java object
+ * @param schema_ptr Pointer to ArrowSchema
+ * @param free_ptr Whether to free the pointer(If current ptr alloc in java, then false)
+ */
+JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtilsNative_releaseArrowSchema(JNIEnv* env,
+                                                                                  jobject obj,
+                                                                                  jlong schema_ptr,
+                                                                                  jboolean free_ptr);
 // ==================== JNI Manifest Interface ====================
 
 /**
@@ -314,10 +341,12 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtils_00024_releaseArrowStrea
  * @param obj Java object
  * @param base_path Base path string
  * @param properties_ptr Pointer to properties
- * @return Column groups as JSON string
+ * @return Column groups raw pointer
  */
-JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageManifest_00024_getLatestColumnGroupsNative(
-    JNIEnv* env, jobject obj, jstring base_path, jlong properties_ptr);
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageManifestNative_getLatestColumnGroups(JNIEnv* env,
+                                                                                                 jobject obj,
+                                                                                                 jstring base_path,
+                                                                                                 jlong properties_ptr);
 
 /**
  * @brief Begin a transaction
@@ -339,9 +368,9 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transact
  * @param env JNI environment
  * @param obj Java object
  * @param transaction_handle Transaction handle
- * @return Column groups as JSON string
+ * @return Column groups raw pointer
  */
-JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transactionGetColumnGroups(
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transactionGetColumnGroups(
     JNIEnv* env, jobject obj, jlong transaction_handle);
 
 /**
@@ -352,11 +381,11 @@ JNIEXPORT jstring JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transa
  * @param transaction_handle Transaction handle
  * @param update_id Update type ID (0=ADDFILES, 1=ADDFIELD)
  * @param resolve_id Resolution strategy ID (0=FAIL, 1=MERGE)
- * @param column_groups Column groups as JSON string
+ * @param column_groups Column groups raw pointer
  * @return true if commit succeeded, false if failed
  */
 JNIEXPORT jboolean JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transactionCommit(
-    JNIEnv* env, jobject obj, jlong transaction_handle, jint update_id, jint resolve_id, jstring column_groups);
+    JNIEnv* env, jobject obj, jlong transaction_handle, jint update_id, jint resolve_id, jlong column_groups);
 
 /**
  * @brief Abort a transaction

--- a/cpp/src/jni/arrow_utils_jni.cpp
+++ b/cpp/src/jni/arrow_utils_jni.cpp
@@ -18,47 +18,7 @@
 
 // ==================== JNI Arrow Resource Management ====================
 
-extern "C" {
-
-JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtils_00024_releaseArrowArray(JNIEnv* env,
-                                                                                 jobject obj,
-                                                                                 jlong array_ptr) {
-  try {
-    ArrowArray* array = reinterpret_cast<ArrowArray*>(array_ptr);
-    if (array != nullptr) {
-      if (array->release != nullptr) {
-        array->release(array);
-      }
-      free(array);
-    }
-  } catch (const std::exception& e) {
-    jclass exc_class = env->FindClass("java/lang/RuntimeException");
-    std::string error_msg = "Failed to release arrow array: " + std::string(e.what());
-    env->ThrowNew(exc_class, error_msg.c_str());
-    return;
-  }
-}
-
-JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtils_00024_releaseArrowStream(JNIEnv* env,
-                                                                                  jobject obj,
-                                                                                  jlong stream_ptr) {
-  try {
-    ArrowArrayStream* stream = reinterpret_cast<ArrowArrayStream*>(stream_ptr);
-    if (stream != nullptr) {
-      if (stream->release != nullptr) {
-        stream->release(stream);
-      }
-      free(stream);
-    }
-  } catch (const std::exception& e) {
-    jclass exc_class = env->FindClass("java/lang/RuntimeException");
-    std::string error_msg = "Failed to release arrow stream: " + std::string(e.what());
-    env->ThrowNew(exc_class, error_msg.c_str());
-    return;
-  }
-}
-
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtils_00024_readNextBatch(JNIEnv* env,
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtilsNative_readNextBatch(JNIEnv* env,
                                                                               jobject obj,
                                                                               jlong stream_ptr) {
   try {
@@ -106,4 +66,68 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtils_00024_readNextBatch(JN
   }
 }
 
-}  // extern "C"
+JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtilsNative_releaseArrowStream(JNIEnv* env,
+                                                                                  jobject obj,
+                                                                                  jlong stream_ptr,
+                                                                                  jboolean free_ptr) {
+  try {
+    ArrowArrayStream* stream = reinterpret_cast<ArrowArrayStream*>(stream_ptr);
+    if (stream != nullptr) {
+      if (stream->release != nullptr) {
+        stream->release(stream);
+      }
+      if (free_ptr) {
+        free(stream);
+      }
+    }
+  } catch (const std::exception& e) {
+    jclass exc_class = env->FindClass("java/lang/RuntimeException");
+    std::string error_msg = "Failed to release arrow stream: " + std::string(e.what());
+    env->ThrowNew(exc_class, error_msg.c_str());
+    return;
+  }
+}
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtilsNative_releaseArrowArray(JNIEnv* env,
+                                                                                 jobject obj,
+                                                                                 jlong array_ptr,
+                                                                                 jboolean free_ptr) {
+  try {
+    ArrowArray* array = reinterpret_cast<ArrowArray*>(array_ptr);
+    if (array != nullptr) {
+      if (array->release != nullptr) {
+        array->release(array);
+      }
+      if (free_ptr) {
+        free(array);
+      }
+    }
+  } catch (const std::exception& e) {
+    jclass exc_class = env->FindClass("java/lang/RuntimeException");
+    std::string error_msg = "Failed to release arrow array: " + std::string(e.what());
+    env->ThrowNew(exc_class, error_msg.c_str());
+    return;
+  }
+}
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_ArrowUtilsNative_releaseArrowSchema(JNIEnv* env,
+                                                                                  jobject obj,
+                                                                                  jlong schema_ptr,
+                                                                                  jboolean free_ptr) {
+  try {
+    ArrowSchema* schema = reinterpret_cast<ArrowSchema*>(schema_ptr);
+    if (schema != nullptr) {
+      if (schema->release != nullptr) {
+        schema->release(schema);
+      }
+      if (free_ptr) {
+        free(schema);
+      }
+    }
+  } catch (const std::exception& e) {
+    jclass exc_class = env->FindClass("java/lang/RuntimeException");
+    std::string error_msg = "Failed to release arrow schema: " + std::string(e.what());
+    env->ThrowNew(exc_class, error_msg.c_str());
+    return;
+  }
+}

--- a/cpp/src/jni/chunk_reader_jni.cpp
+++ b/cpp/src/jni/chunk_reader_jni.cpp
@@ -21,8 +21,6 @@
 
 // ==================== JNI ChunkReader Implementation ====================
 
-extern "C" {
-
 JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_getChunkIndices(JNIEnv* env,
                                                                                              jobject obj,
                                                                                              jlong chunk_reader_handle,
@@ -156,5 +154,3 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_chunkRead
     return;
   }
 }
-
-}  // extern "C"

--- a/cpp/src/jni/properties_jni.cpp
+++ b/cpp/src/jni/properties_jni.cpp
@@ -19,8 +19,6 @@
 
 // ==================== JNI Properties Implementation ====================
 
-extern "C" {
-
 JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageProperties_allocateProperties(JNIEnv* env, jobject obj) {
   try {
     Properties* properties = static_cast<Properties*>(malloc(sizeof(Properties)));
@@ -117,5 +115,3 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_freeProper
   }
   return;
 }
-
-}  // extern "C"

--- a/java/src/main/scala/io/milvus/storage/ArrowUtils.scala
+++ b/java/src/main/scala/io/milvus/storage/ArrowUtils.scala
@@ -7,7 +7,15 @@ import org.apache.arrow.memory.RootAllocator
  * Arrow utilities for working with Arrow C Data Interface
  * Provides core functionality for releasing Arrow structures and reading streams
  */
+class ArrowUtilsNative {
+  @native def readNextBatch(streamPtr: Long): Long
+  @native def releaseArrowSchema(schemaPtr: Long, freePtr: Boolean): Unit
+  @native def releaseArrowArray(arrayPtr: Long, freePtr: Boolean): Unit
+  @native def releaseArrowStream(streamPtr: Long, freePtr: Boolean): Unit
+}
+
 object ArrowUtils {
+  private val arrowUtilsNative = new ArrowUtilsNative()
 
   // Ensure native library is loaded
   NativeLibraryLoader.loadLibrary()
@@ -24,34 +32,33 @@ object ArrowUtils {
    * Release Arrow schema
    * @param schemaPtr Memory address of ArrowSchema
    */
-  def releaseArrowSchema(schemaPtr: Long): Unit = {
-    if (schemaPtr != 0) {
-      val arrowSchema = ArrowSchema.wrap(schemaPtr)
-      arrowSchema.close()
-    }
+  def releaseArrowSchema(schemaPtr: Long, freePtr: Boolean): Unit = {
+    arrowUtilsNative.releaseArrowSchema(schemaPtr, freePtr);
   }
 
   /**
    * Release Arrow array
    * @param arrayPtr Memory address of ArrowArray
    */
-  def releaseArrowArray(arrayPtr: Long): Unit = {
-    if (arrayPtr != 0) {
-      val arrowArray = ArrowArray.wrap(arrayPtr)
-      arrowArray.close()
-    }
+  def releaseArrowArray(arrayPtr: Long, freePtr: Boolean): Unit = {
+    arrowUtilsNative.releaseArrowArray(arrayPtr, freePtr);
   }
 
   /**
    * Release Arrow stream (record batch reader)
    * @param streamPtr Pointer to ArrowArrayStream
    */
-  @native def releaseArrowStream(streamPtr: Long): Unit
+  def releaseArrowStream(streamPtr: Long, freePtr: Boolean): Unit = {
+    arrowUtilsNative.releaseArrowStream(streamPtr, freePtr)
+  }
 
   /**
    * Read next batch from Arrow stream
    * @param streamPtr Pointer to ArrowArrayStream
    * @return Address of ArrowArray (0L if end of stream)
    */
-  @native def readNextBatch(streamPtr: Long): Long
+  def readNextBatch(streamPtr: Long): Long = {
+    arrowUtilsNative.readNextBatch(streamPtr)
+  }
+
 }

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageManifest.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageManifest.scala
@@ -4,29 +4,34 @@ package io.milvus.storage
  * Scala wrapper for MilvusStorage Manifest operations
  * Provides functionality to retrieve manifest information
  */
+class MilvusStorageManifestNative {
+  @native def getLatestColumnGroups(basePath: String, propertiesPtr: Long): Long
+}
+
 object MilvusStorageManifest {
   // Ensure native library is loaded
   NativeLibraryLoader.loadLibrary()
+
+  private val milvusStorageManifestNative = new MilvusStorageManifestNative()
+
 
   /**
    * Get latest column groups from manifest
    * @param basePath The base path for storage
    * @param properties MilvusStorage properties
-   * @return Column groups as JSON string
+   * @return Column groups as raw pointer
    */
-  def getLatestColumnGroups(basePath: String, properties: MilvusStorageProperties): String = {
-    getLatestColumnGroups(basePath, properties.getPtr)
+  def getLatestColumnGroupsScala(basePath: String, properties: MilvusStorageProperties): Long = {
+    milvusStorageManifestNative.getLatestColumnGroups(basePath, properties.getPtr)
   }
 
   /**
    * Get latest column groups from manifest with properties pointer
    * @param basePath The base path for storage
    * @param propertiesPtr Pointer to properties
-   * @return Column groups as JSON string
+   * @return Column groups as raw pointer
    */
-  def getLatestColumnGroups(basePath: String, propertiesPtr: Long): String = {
-    getLatestColumnGroupsNative(basePath, propertiesPtr)
+  def getLatestColumnGroupsScala(basePath: String, propertiesPtr: Long): Long = {
+    milvusStorageManifestNative.getLatestColumnGroups(basePath, propertiesPtr)
   }
-
-  @native private def getLatestColumnGroupsNative(basePath: String, propertiesPtr: Long): String
 }

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageReader.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageReader.scala
@@ -12,24 +12,24 @@ class MilvusStorageReader {
 
   /**
    * Create a new reader instance
-   * @param columnGroups The column groups JSON string
+   * @param columnGroups The column groups raw pointer
    * @param schemaPtr Pointer to Arrow schema
    * @param neededColumns Array of column names to read
    * @param properties MilvusStorage properties
    */
-  def create(columnGroups: String, schemaPtr: Long, neededColumns: Array[String], properties: MilvusStorageProperties): Unit = {
+  def create(columnGroups: Long, schemaPtr: Long, neededColumns: Array[String], properties: MilvusStorageProperties): Unit = {
     if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
     readerHandle = readerNew(columnGroups, schemaPtr, neededColumns, properties.getPtr)
   }
 
   /**
    * Create a new reader instance with properties pointer
-   * @param columnGroups The column groups JSON string
+   * @param columnGroups The column groups raw pointer
    * @param schemaPtr Pointer to Arrow schema
    * @param neededColumns Array of column names to read
    * @param propertiesPtr Pointer to properties
    */
-  def create(columnGroups: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Unit = {
+  def create(columnGroups: Long, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Unit = {
     if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
     readerHandle = readerNew(columnGroups, schemaPtr, neededColumns, propertiesPtr)
   }
@@ -73,7 +73,7 @@ class MilvusStorageReader {
    * @param parallelism Parallelism level
    * @return Pointer to Arrow array
    */
-  def takeRows(rowIndices: Array[Long], parallelism: Long): Long = {
+  def takeRows(rowIndices: Array[Long], parallelism: Long): Array[Long] = {
     if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
     if (readerHandle == 0) throw new IllegalStateException("Reader not initialized")
     take(readerHandle, rowIndices, parallelism)
@@ -84,7 +84,7 @@ class MilvusStorageReader {
    * @param rowIndices Array of row indices to take
    * @return Pointer to Arrow array
    */
-  def takeRows(rowIndices: Array[Long]): Long = {
+  def takeRows(rowIndices: Array[Long]): Array[Long] = {
     takeRows(rowIndices, 1)
   }
 
@@ -112,9 +112,9 @@ class MilvusStorageReader {
    */
   def isValid: Boolean = !isDestroyed && readerHandle != 0
 
-  @native private def readerNew(columnGroups: String, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Long
+  @native private def readerNew(columnGroups: Long, schemaPtr: Long, neededColumns: Array[String], propertiesPtr: Long): Long
   @native private def getRecordBatchReader(readerHandle: Long, predicate: String): Long
   @native private def getChunkReader(readerHandle: Long, columnGroupId: Long): Long
-  @native private def take(readerHandle: Long, rowIndices: Array[Long], parallelism: Long): Long
+  @native private def take(readerHandle: Long, rowIndices: Array[Long], parallelism: Long): Array[Long]
   @native private def readerDestroy(readerHandle: Long): Unit
 }

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageTransaction.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageTransaction.scala
@@ -59,9 +59,9 @@ class MilvusStorageTransaction {
 
   /**
    * Get column groups from current transaction
-   * @return Column groups as JSON string
+   * @return Column groups as raw pointer
    */
-  def getColumnGroups(): String = {
+  def getColumnGroups(): Long = {
     if (isDestroyed) throw new IllegalStateException("Transaction has been destroyed")
     if (transactionHandle == 0) throw new IllegalStateException("Transaction not initialized")
     transactionGetColumnGroups(transactionHandle)
@@ -71,13 +71,13 @@ class MilvusStorageTransaction {
    * Commit the transaction
    * @param updateType Update operation type
    * @param resolveStrategy Conflict resolution strategy
-   * @param columnGroups New column groups as JSON string
+   * @param columnGroups New column groups as raw pointer
    * @return true if commit succeeded, false if failed
    */
-  def commit(updateType: UpdateType.Value, resolveStrategy: ResolveStrategy.Value, columnGroups: String): Boolean = {
+  def commit(updateType: UpdateType.Value, resolveStrategy: ResolveStrategy.Value, columnGroups: Long): Boolean = {
     if (isDestroyed) throw new IllegalStateException("Transaction has been destroyed")
     if (transactionHandle == 0) throw new IllegalStateException("Transaction not initialized")
-    if (columnGroups == null) throw new IllegalArgumentException("columnGroups must not be null")
+    if (columnGroups == 0) throw new IllegalArgumentException("columnGroups must not be null")
     transactionCommit(transactionHandle, updateType.id, resolveStrategy.id, columnGroups)
   }
 
@@ -85,13 +85,13 @@ class MilvusStorageTransaction {
    * Commit the transaction with raw integer IDs
    * @param updateId Update operation type ID (0=ADDFILES, 1=ADDFIELD)
    * @param resolveId Conflict resolution strategy ID (0=FAIL, 1=MERGE)
-   * @param columnGroups New column groups as JSON string
+   * @param columnGroups New column groups as raw pointer
    * @return true if commit succeeded, false if failed
    */
-  def commit(updateId: Int, resolveId: Int, columnGroups: String): Boolean = {
+  def commit(updateId: Int, resolveId: Int, columnGroups: Long): Boolean = {
     if (isDestroyed) throw new IllegalStateException("Transaction has been destroyed")
     if (transactionHandle == 0) throw new IllegalStateException("Transaction not initialized")
-    if (columnGroups == null) throw new IllegalArgumentException("columnGroups must not be null")
+    if (columnGroups == 0) throw new IllegalArgumentException("columnGroups must not be null")
     transactionCommit(transactionHandle, updateId, resolveId, columnGroups)
   }
 
@@ -130,8 +130,8 @@ class MilvusStorageTransaction {
 
   // Native method declarations
   @native private def transactionBegin(basePath: String, propertiesPtr: Long): Long
-  @native private def transactionGetColumnGroups(transactionHandle: Long): String
-  @native private def transactionCommit(transactionHandle: Long, updateId: Int, resolveId: Int, columnGroups: String): Boolean
+  @native private def transactionGetColumnGroups(transactionHandle: Long): Long
+  @native private def transactionCommit(transactionHandle: Long, updateId: Int, resolveId: Int, columnGroups: Long): Boolean
   @native private def transactionAbort(transactionHandle: Long): Unit
   @native private def transactionDestroy(transactionHandle: Long): Unit
 }

--- a/java/src/main/scala/io/milvus/storage/MilvusStorageWriter.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusStorageWriter.scala
@@ -53,9 +53,9 @@ class MilvusStorageWriter {
 
   /**
    * Close the writer and return column groups
-   * @return The column groups JSON string
+   * @return The column groups raw pointer
    */
-  def close(): String = {
+  def close(): Long = {
     if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")
     if (writerHandle == 0) throw new IllegalStateException("Writer not initialized")
     writerClose(writerHandle)
@@ -88,6 +88,6 @@ class MilvusStorageWriter {
   @native private def writerNew(basePath: String, schemaPtr: Long, propertiesPtr: Long): Long
   @native private def writerWrite(writerHandle: Long, arrayPtr: Long): Unit
   @native private def writerFlush(writerHandle: Long): Unit
-  @native private def writerClose(writerHandle: Long): String
+  @native private def writerClose(writerHandle: Long): Long
   @native private def writerDestroy(writerHandle: Long): Unit
 }


### PR DESCRIPTION
The current commit aligns the JNI with the latest FFI. Also adjusts part of the JNI logic:

- Fixed the incorrect Java class name for `createProperties`.
- Removed unnecessary extern "C" usage in C++ code.
- No longer uses `_00024_` as a C function name prefix, `_00024_` was used to replace `$`, which is a symbol specific to Scala `object` keyword.