### PR TITLE
enhance: fix the compiler warning from GCC

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -84,7 +84,7 @@ struct ArrowFileSystemConfig {
   std::string root_path = "files";
   std::string storage_type = "local";
   std::string cloud_provider = "aws";
-  [[maybe_unused]] std::string iam_endpoint = "";
+  std::string iam_endpoint = "";   // Deprecated
   std::string log_level = "warn";  // only use on global config
   std::string region = "";
   bool use_ssl = false;
@@ -92,9 +92,9 @@ struct ArrowFileSystemConfig {
   bool use_iam = false;
   bool use_virtual_host = false;
   int64_t request_timeout_ms = 3000;
-  [[maybe_unused]] bool gcp_native_without_auth = false;
-  [[maybe_unused]] std::string gcp_credential_json = "";
-  [[maybe_unused]] bool use_custom_part_upload = true;
+  bool gcp_native_without_auth = false;  // Deprecated
+  std::string gcp_credential_json = "";  // Deprecated
+  bool use_custom_part_upload = true;    // Deprecated
   uint32_t max_connections = 100;
 
   // Alias for external filesystem identification (e.g., "prod", "backup")

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -218,6 +218,7 @@ T GetPropertyValue(const PropertyInfo& property_info, const std::string& v) {
   }
 
   assert(false && "type mismatch and no default value");
+  throw std::runtime_error("Logical fault: type mismatch and no default value");
 }
 
 PropertyVariant GetPropertyValue(const PropertyInfo& property_info, const std::string& v) {

--- a/cpp/test/ffi/ffi_external_test.c
+++ b/cpp/test/ffi/ffi_external_test.c
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "milvus-storage/ffi_c.h"
-#include "milvus-storage/ffi_exttable_c.h"
 #include "test_runner.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,7 +21,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <inttypes.h>
+
 #include <arrow/c/abi.h>
+
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_exttable_c.h"
 
 #define TEST_BASE_PATH "external-test-dir"
 
@@ -176,7 +180,7 @@ static void test_exttable_get_file_info_single_file(const char* format) {
   ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
   ck_assert_int_eq(num_rows, 100);
 
-  printf("num_rows=%llu\n", num_rows);
+  printf("num_rows=%" PRIu64 "\n", num_rows);
 
   // Clean up
   properties_free(&rp);
@@ -205,7 +209,7 @@ static void test_exttable_explore_and_read(void) {
 
   uint64_t num_of_files = 0;
   char* out_column_groups_file_path = NULL;
-  char data_path_with_prefix[512];
+  char data_path_with_prefix[1024];
   snprintf(data_path_with_prefix, sizeof(data_path_with_prefix), "%s/_data/", data_path);
 
   rc = exttable_explore((const char**)(columns_cstrs), 3, "parquet", base_dir, data_path_with_prefix, &rp,

--- a/cpp/test/ffi/ffi_reader_test.c
+++ b/cpp/test/ffi/ffi_reader_test.c
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "milvus-storage/ffi_c.h"
 #include "test_runner.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
+#include <inttypes.h>
+
 #include <arrow/c/abi.h>
+
+#include "milvus-storage/ffi_c.h"
 
 #define TEST_BASE_PATH "reader-test-dir"
 
@@ -104,7 +108,6 @@ static void test_basic(void) {
   const char* needed_columns[] = {"int64_field", "int32_field", "string_field"};
 
   create_writer_test_file(TEST_BASE_PATH, &out_manifest, 10 /*loop_times*/, 20 /*str_max_len*/, false /*with_flush*/);
-  // printf("out_manifest: %s\n", out_manifest); // out_manifest is handle, cannot print
   schema = create_test_struct_schema();
 
   rc = create_test_reader_pp(&rp);
@@ -617,8 +620,9 @@ static void test_chunk_metadatas(void) {
 
       rc = get_number_of_chunks(chunk_reader, &num_chunks);
       ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
-      ck_assert_msg(num_chunks > 0, "expected num_chunks > 0, got %lld", num_chunks);
-      printf("column_group_id: %lld, num_chunks: %lld\n", column_group_infos.cg_infos[i].column_group_id, num_chunks);
+      ck_assert_msg(num_chunks > 0, "expected num_chunks > 0, got %" PRIu64, num_chunks);
+      printf("column_group_id: %" PRId64 ", num_chunks: %" PRIu64 "\n", column_group_infos.cg_infos[i].column_group_id,
+             num_chunks);
 
       ChunkMetadatas chunk_mds1, chunk_mds2, chunk_mds3;
 
@@ -644,16 +648,17 @@ static void test_chunk_metadatas(void) {
 
       for (uint64_t k = 0; k < chunk_mds1.metadatas[0].number_of_chunks; k++) {
         ck_assert_msg(chunk_mds1.metadatas[0].data[k].estimated_memsz > 0,
-                      "expected chunk estimated_memsz > 0, got %llu", chunk_mds1.metadatas[0].data[k].estimated_memsz);
+                      "expected chunk estimated_memsz > 0, got %llu",
+                      (unsigned long long)chunk_mds1.metadatas[0].data[k].estimated_memsz);
         ck_assert_msg(chunk_mds2.metadatas[0].data[k].number_of_rows > 0, "expected chunk number_of_rows > 0, got %llu",
-                      chunk_mds2.metadatas[0].data[k].number_of_rows);
+                      (unsigned long long)chunk_mds2.metadatas[0].data[k].number_of_rows);
 
         ck_assert_int_eq(chunk_mds1.metadatas[0].data[k].estimated_memsz,
                          chunk_mds3.metadatas[0].data[k].estimated_memsz);
         ck_assert_int_eq(chunk_mds2.metadatas[0].data[k].estimated_memsz,
                          chunk_mds3.metadatas[1].data[k].estimated_memsz);
 
-        printf("  chunk %llu: estimated_memsz=%llu number_of_rows=%llu \n", k,
+        printf("  chunk %" PRIu64 ": estimated_memsz=%" PRIu64 " number_of_rows=%" PRIu64 "\n", k,
                chunk_mds1.metadatas[0].data[k].estimated_memsz, chunk_mds2.metadatas[0].data[k].number_of_rows);
       }
 


### PR DESCRIPTION
The current commit fixes some warnings generated during GCC compilation, primarily addressing two types:

- [[ maybe_unused ]] does not take effect on member variables in GCC
- The format for `printf` is different between GCC and Clang, and the `PRI*` been used as a replacement.