### PR TITLE
enhance: support GCS condition write access via ak&sk

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
+++ b/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
@@ -50,6 +50,9 @@ class ExtendFileSystem {
 
   virtual arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(const std::string& s) = 0;
 
+  virtual arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(
+      const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) = 0;
+
   static bool IsExtendFileSystem(const std::shared_ptr<arrow::fs::FileSystem>& fs) {
     return std::dynamic_pointer_cast<ExtendFileSystem>(fs) != nullptr;
   }
@@ -95,6 +98,9 @@ class MultiPartUploadS3FS : public arrow::fs::FileSystem, public ExtendFileSyste
       const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t part_size) override;
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(const std::string& s) override;
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(
+      const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override;
 
   static arrow::Result<std::shared_ptr<MultiPartUploadS3FS>> Make(
       const S3Options& options, const arrow::io::IOContext& = arrow::io::default_io_context());

--- a/cpp/include/milvus-storage/filesystem/s3/s3_options.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_options.h
@@ -170,7 +170,7 @@ struct S3Options {
   /// \brief Maximum number of connections to the S3 server
   uint32_t max_connections = 100;
 
-  /// Cloud provider name, e.g., "aws", "minio", "google", "azure", "aliyun", "tencent"
+  /// Cloud provider name, e.g., "aws", "minio", "gcp", "azure", "aliyun", "tencent"
   std::string cloud_provider;
 
   S3Options();

--- a/cpp/include/milvus-storage/filesystem/s3/signer.h
+++ b/cpp/include/milvus-storage/filesystem/s3/signer.h
@@ -1,0 +1,31 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <aws/core/http/HttpRequest.h>
+#include <memory>
+#include <string>
+
+namespace signer::goog4 {
+
+// Sign the HTTP request using GOOG4-HMAC-SHA256 algorithm.
+// This is the signature method for Google Cloud Storage, equivalent to AWS Signature V4.
+bool SignRequest(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                 const std::string& access_key,
+                 const std::string& secret_key);
+
+}  // namespace signer::goog4

--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -15,11 +15,14 @@
 #include "milvus-storage/filesystem/s3/s3_fs.h"
 
 #include <cstdlib>
+#include <sstream>
 
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/curl/CurlHttpClient.h>
 #include <aws/s3/model/CreateBucketRequest.h>
 #include <aws/s3/model/DeleteBucketRequest.h>
 #include <aws/s3/model/DeleteObjectRequest.h>
@@ -43,6 +46,7 @@
 #include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
+#include "milvus-storage/filesystem/s3/signer.h"
 
 namespace milvus_storage {
 
@@ -52,10 +56,91 @@ static std::unordered_map<std::string, S3LogLevel> LogLevel_Map = {
 
 static const char* GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG = "GoogleHttpClientFactory";
 
+// GoogleHttpClientDelegator: Delegation-pattern HttpClient
+// Modifies request headers on MakeRequest, then delegates to the underlying CurlHttpClient
+class GoogleHttpClientDelegator : public Aws::Http::HttpClient {
+ public:
+  explicit GoogleHttpClientDelegator(const Aws::Client::ClientConfiguration& config,
+                                     bool use_iam,
+                                     const std::string& access_key = "",
+                                     const std::string& secret_key = "")
+      : use_iam_(use_iam), access_key_(access_key), secret_key_(secret_key) {
+    // Create underlying CurlHttpClient
+    underlying_client_ = Aws::MakeShared<Aws::Http::CurlHttpClient>(
+        GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, config);
+  }
+
+ public:
+
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override {
+    // Check header to see if this is a conditional write
+    bool is_conditional_write = request->HasHeader("x-goog-if-generation-match");
+    // Decide if GOOG4 signing is needed (HMAC mode + conditional write)
+    bool needs_goog4_signing = !use_iam_ && !access_key_.empty() && !secret_key_.empty() && is_conditional_write;
+    if (needs_goog4_signing) {
+      // Remove possible AWS signature headers
+      request->DeleteHeader("Authorization");
+      request->DeleteHeader("x-amz-date");
+      request->DeleteHeader("x-amz-content-sha256");
+      request->DeleteHeader("x-amz-security-token");
+
+      // Convert AWS metadata headers to GCS metadata headers
+      // AWS uses x-amz-meta-*, GCS uses x-goog-meta-*
+      std::vector<std::pair<std::string, std::string>> meta_headers_to_convert;
+      std::vector<std::string> old_keys_to_delete;
+      
+      // Collect all x-amz-meta-* headers to convert
+      for (const auto& [key, value] : request->GetHeaders()) {
+        std::string lower_key = key;
+        std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
+        
+        if (lower_key.find("x-amz-meta-") == 0) {
+          // Found x-amz-meta- prefix
+          std::string suffix = key.substr(11);  // strip "x-amz-meta-" (11 chars)
+          std::string new_key = "x-goog-meta-" + suffix;
+          meta_headers_to_convert.emplace_back(new_key, value);
+          old_keys_to_delete.push_back(key);
+        }
+      }
+      
+      // Remove old x-amz-meta-* headers, add new x-goog-meta-* headers
+      if (!meta_headers_to_convert.empty()) {
+        // Delete old headers
+        for (const auto& old_key : old_keys_to_delete) {
+          request->DeleteHeader(old_key.c_str());
+        }
+        
+        // Add new headers
+        for (const auto& [new_key, value] : meta_headers_to_convert) {
+          request->SetHeaderValue(new_key, value);
+        }
+      }
+
+      // Sign with GOOG4-HMAC-SHA256
+      signer::goog4::SignRequest(request, access_key_, secret_key_);
+    }
+    return underlying_client_->MakeRequest(request, readLimiter, writeLimiter);
+  }
+
+ private:
+  std::shared_ptr<Aws::Http::HttpClient> underlying_client_;
+  bool use_iam_;
+  std::string access_key_;
+  std::string secret_key_;
+};
+
 class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
   public:
-  explicit GoogleHttpClientFactory(std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials) {
-    credentials_ = credentials;
+  // Constructor: accepts both credentials (for IAM) and ak/sk (for HMAC)
+  explicit GoogleHttpClientFactory(
+      std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials,
+      bool use_iam,
+      const std::string& access_key = "",
+      const std::string& secret_key = "")
+      : credentials_(credentials), use_iam_(use_iam), access_key_(access_key), secret_key_(secret_key) {
   }
 
   void SetCredentials(std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials) {
@@ -64,7 +149,14 @@ class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
 
   std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
       const Aws::Client::ClientConfiguration& clientConfiguration) const override {
-    return Aws::MakeShared<Aws::Http::CurlHttpClient>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, clientConfiguration);
+    // Create GoogleHttpClientDelegator with use_iam and ak/sk.
+    // Delegator will decide whether to use GOOG4 signing based on use_iam
+    return Aws::MakeShared<GoogleHttpClientDelegator>(
+        GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, 
+        clientConfiguration,
+        use_iam_,
+        access_key_, 
+        secret_key_);
   }
 
   std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String& uri,
@@ -79,17 +171,31 @@ class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
     auto request =
         Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, uri, method);
     request->SetResponseStreamFactory(streamFactory);
+
+    if (!use_iam_) {
+      // HMAC mode: directly return unsigned request
+      // Actual signing will be handled in GoogleHttpClientDelegator::MakeRequest
+      return request;
+    }
+
+    // For IAM, add OAuth2 header
+    if (!credentials_) {
+      throw std::invalid_argument("GoogleHttpClientFactory: credentials_ is nullptr");
+    }
+    
     auto auth_header = credentials_->AuthorizationHeader();
     if (!auth_header.ok()) {
       throw std::invalid_argument("GoogleHttpClientFactory: create http request get authorization failed");
     }
     request->SetHeaderValue(auth_header->first.c_str(), auth_header->second.c_str());
-
     return request;
   }
 
   private:
   std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials_;
+  bool use_iam_;
+  std::string access_key_;
+  std::string secret_key_;
 };
 
 void S3FileSystemProducer::InitS3() {
@@ -97,12 +203,22 @@ void S3FileSystemProducer::InitS3() {
     S3GlobalOptions global_options;
     global_options.log_level = LogLevel_Map[config_.log_level];
 
-    if (config_.cloud_provider == "gcp" && config_.use_iam) {
+    if (config_.cloud_provider == "gcp") {
+      std::string ak = config_.access_key_id;
+      std::string sk = config_.access_key_value;
+      bool use_iam = config_.use_iam;
+
       Aws::HttpOptions http_options;
-      http_options.httpClientFactory_create_fn = []() {
+      http_options.httpClientFactory_create_fn = [ak, sk, use_iam]() {
         auto credentials =
             std::make_shared<google::cloud::oauth2_internal::GOOGLE_CLOUD_CPP_NS::ComputeEngineCredentials>();
-        return Aws::MakeShared<GoogleHttpClientFactory>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, credentials);
+        return Aws::MakeShared<GoogleHttpClientFactory>(
+            GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG,
+            credentials,
+            use_iam,            // Explicitly pass use_iam flag
+            use_iam ? "" : ak,  // IAM mode does not need ak
+            use_iam ? "" : sk   // IAM mode does not need sk
+        );
       };
       global_options.http_options = http_options;
       global_options.override_default_http_options = true;

--- a/cpp/src/filesystem/s3/signer.cpp
+++ b/cpp/src/filesystem/s3/signer.cpp
@@ -1,0 +1,282 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/s3/signer.h"
+
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <vector>
+
+namespace signer::goog4 {
+
+// SHA256 hash (returns hex string)
+static std::string SHA256Hex(const std::string& data) {
+  unsigned char hash[SHA256_DIGEST_LENGTH];
+  SHA256(reinterpret_cast<const unsigned char*>(data.c_str()), data.length(), hash);
+  
+  std::stringstream ss;
+  for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+    ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
+  }
+  return ss.str();
+}
+
+// HMAC-SHA256
+static std::vector<uint8_t> HMACSHA256(const std::vector<uint8_t>& key, const std::string& data) {
+  std::vector<uint8_t> result(EVP_MAX_MD_SIZE);
+  unsigned int len = 0;
+  
+  HMAC(EVP_sha256(), 
+       key.data(), key.size(),
+       reinterpret_cast<const unsigned char*>(data.c_str()), data.length(),
+       result.data(), &len);
+  
+  result.resize(len);
+  return result;
+}
+
+// Convert byte array to hex string
+static std::string BytesToHex(const std::vector<uint8_t>& bytes) {
+  std::stringstream ss;
+  for (uint8_t byte : bytes) {
+    ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(byte);
+  }
+  return ss.str();
+}
+
+// URL encode
+static std::string URLEncode(const std::string& value) {
+  std::ostringstream escaped;
+  escaped.fill('0');
+  escaped << std::hex;
+
+  for (char c : value) {
+    // Keep alphanumeric and other safe characters
+    if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+      escaped << c;
+      continue;
+    }
+    // Any other characters are percent-encoded
+    escaped << std::uppercase;
+    escaped << '%' << std::setw(2) << int((unsigned char)c);
+    escaped << std::nouppercase;
+  }
+
+  return escaped.str();
+}
+
+// Build canonicalized query string
+static std::string BuildCanonicalQueryString(const Aws::Http::URI& uri) {
+  auto query_params = uri.GetQueryStringParameters();
+  if (query_params.empty()) {
+    return "";
+  }
+
+  std::vector<std::pair<std::string, std::string>> sorted_params;
+  for (const auto& [key, val] : query_params) {
+    sorted_params.emplace_back(key, val);
+  }
+  std::sort(sorted_params.begin(), sorted_params.end());
+
+  std::vector<std::string> parts;
+  for (const auto& [key, val] : sorted_params) {
+    parts.push_back(URLEncode(key) + "=" + URLEncode(val));
+  }
+
+  std::string result;
+  for (size_t i = 0; i < parts.size(); i++) {
+    if (i > 0) result += "&";
+    result += parts[i];
+  }
+  return result;
+}
+
+// Build canonical headers
+static std::string BuildCanonicalHeaders(const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  std::map<std::string, std::string> headers_map;
+  
+  for (const auto& [key, val] : request->GetHeaders()) {
+    std::string lower_key = key;
+    std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
+    headers_map[lower_key] = val;
+  }
+
+  std::stringstream ss;
+  for (const auto& [key, val] : headers_map) {
+    ss << key << ":" << val << "\n";
+  }
+  return ss.str();
+}
+
+// Get signed headers list
+static std::string GetSignedHeaders(const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  std::vector<std::string> headers;
+  for (const auto& [key, val] : request->GetHeaders()) {
+    std::string lower_key = key;
+    std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
+    headers.push_back(lower_key);
+  }
+  std::sort(headers.begin(), headers.end());
+
+  std::string result;
+  for (size_t i = 0; i < headers.size(); i++) {
+    if (i > 0) result += ";";
+    result += headers[i];
+  }
+  return result;
+}
+
+// Calculate payload hash
+static std::string CalculatePayloadHash(const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  const static std::string EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  
+  auto& body_stream = request->GetContentBody();
+  if (!body_stream || !body_stream->good()) {
+    return EMPTY_SHA256;
+  }
+
+  // Read body content
+  std::stringstream buffer;
+  buffer << body_stream->rdbuf();
+  std::string body_content = buffer.str();
+
+  // Reset stream
+  body_stream->clear();
+  body_stream->seekg(0, std::ios::beg);
+
+  if (body_content.empty()) {
+    return EMPTY_SHA256;
+  }
+
+  return SHA256Hex(body_content);
+}
+
+// Build canonical request
+static std::string BuildCanonicalRequest(const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  // HTTP Method
+  std::string method;
+  switch (request->GetMethod()) {
+    case Aws::Http::HttpMethod::HTTP_GET: method = "GET"; break;
+    case Aws::Http::HttpMethod::HTTP_POST: method = "POST"; break;
+    case Aws::Http::HttpMethod::HTTP_PUT: method = "PUT"; break;
+    case Aws::Http::HttpMethod::HTTP_DELETE: method = "DELETE"; break;
+    case Aws::Http::HttpMethod::HTTP_HEAD: method = "HEAD"; break;
+    default: method = "GET"; break;
+  }
+
+  // Canonical URI
+  std::string canonical_uri = request->GetUri().GetPath();
+  if (canonical_uri.empty()) {
+    canonical_uri = "/";
+  }
+
+  // Canonical Query String
+  std::string canonical_query = BuildCanonicalQueryString(request->GetUri());
+
+  // Canonical Headers
+  std::string canonical_headers = BuildCanonicalHeaders(request);
+
+  // Signed Headers
+  std::string signed_headers = GetSignedHeaders(request);
+
+  // Payload Hash
+  std::string payload_hash = request->GetHeaderValue("x-goog-content-sha256").c_str();
+
+  return method + "\n" +
+         canonical_uri + "\n" +
+         canonical_query + "\n" +
+         canonical_headers + "\n" +
+         signed_headers + "\n" +
+         payload_hash;
+}
+
+// Calculate GOOG4 signature
+static std::string CalculateGoog4Signature(const std::string& secret_key,
+                                           const std::string& date_stamp,
+                                           const std::string& string_to_sign) {
+  // Key derivation (similar to AWS Signature V4)
+  std::string key_data = "GOOG4" + secret_key;
+  std::vector<uint8_t> k_date = HMACSHA256(
+      std::vector<uint8_t>(key_data.begin(), key_data.end()), 
+      date_stamp);
+  std::vector<uint8_t> k_region = HMACSHA256(k_date, "auto");
+  std::vector<uint8_t> k_service = HMACSHA256(k_region, "storage");
+  std::vector<uint8_t> k_signing = HMACSHA256(k_service, "goog4_request");
+
+  // Calculate signature
+  std::vector<uint8_t> signature = HMACSHA256(k_signing, string_to_sign);
+  return BytesToHex(signature);
+}
+
+// Sign request using GOOG4-HMAC-SHA256
+bool SignRequest(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                 const std::string& access_key,
+                 const std::string& secret_key) {
+  // Get current time
+  auto now = std::chrono::system_clock::now();
+  auto time_t_now = std::chrono::system_clock::to_time_t(now);
+  std::tm tm_now;
+  gmtime_r(&time_t_now, &tm_now);
+
+  std::stringstream date_stamp_ss, time_stamp_ss;
+  date_stamp_ss << std::put_time(&tm_now, "%Y%m%d");
+  time_stamp_ss << std::put_time(&tm_now, "%Y%m%dT%H%M%SZ");
+  std::string date_stamp = date_stamp_ss.str();
+  std::string time_stamp = time_stamp_ss.str();
+
+  // Calculate and set payload hash
+  std::string payload_hash = CalculatePayloadHash(request);
+  request->SetHeaderValue("x-goog-content-sha256", payload_hash);
+
+  // Add required headers
+  request->SetHeaderValue("x-goog-date", time_stamp);
+  if (!request->HasHeader("host")) {
+    request->SetHeaderValue("host", request->GetUri().GetAuthority());
+  }
+
+  // Step 1: Create canonical request
+  std::string canonical_request = BuildCanonicalRequest(request);
+
+  // Step 2: Create string to sign
+  std::string credential_scope = date_stamp + "/auto/storage/goog4_request";
+  std::string hashed_canonical_request = SHA256Hex(canonical_request);
+  std::string string_to_sign = 
+      "GOOG4-HMAC-SHA256\n" +
+      time_stamp + "\n" +
+      credential_scope + "\n" +
+      hashed_canonical_request;
+
+  // Step 3: Calculate signature
+  std::string signature = CalculateGoog4Signature(secret_key, date_stamp, string_to_sign);
+
+  // Step 4: Add Authorization header
+  std::string signed_headers = GetSignedHeaders(request);
+  std::string authorization = 
+      "GOOG4-HMAC-SHA256 Credential=" + access_key + "/" + credential_scope +
+      ", SignedHeaders=" + signed_headers +
+      ", Signature=" + signature;
+  request->SetHeaderValue("Authorization", authorization);
+
+  return true;
+}
+
+}  // namespace signer::goog4

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -14,7 +14,6 @@ set(CMAKE_CXX_FLAGS_DEBUG_INIT "-Wall")
 
 file(GLOB_RECURSE BUSTUB_TEST_SOURCES "${PROJECT_SOURCE_DIR}/test/*.cpp")
 
-add_executable(milvus_test ${BUSTUB_TEST_SOURCES})
 
 target_include_directories(milvus_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add GCS conditional write access support via access key and secret key

- Implement GOOG4-HMAC-SHA256 signing algorithm for GCS authentication

- Support metadata headers in conditional write operations

- Enable both IAM and HMAC authentication modes for GCS


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GCS Access Methods"] --> B["IAM Authentication"]
  A --> C["HMAC Authentication"]
  C --> D["GOOG4-HMAC-SHA256 Signer"]
  D --> E["Sign HTTP Requests"]
  E --> F["Conditional Write Operations"]
  B --> F
  G["Metadata Support"] --> H["Custom Metadata Headers"]
  H --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signer.cpp</strong><dd><code>Implement GOOG4-HMAC-SHA256 signing algorithm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/src/filesystem/s3/signer.cpp

<ul><li>Implement GOOG4-HMAC-SHA256 signing algorithm for Google Cloud Storage<br> <li> Provide cryptographic functions for SHA256 hashing and HMAC-SHA256 <br>computation<br> <li> Build canonical request format and string-to-sign for GCS signature <br>verification<br> <li> Handle URL encoding and header canonicalization for GCS requests</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-6c4add69a177c5b7bbffc816ac6249888464799ebad5118b2fa7ec0d1903cdff">+292/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>signer.h</strong><dd><code>Define GOOG4 signer interface header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/include/milvus-storage/filesystem/s3/signer.h

<ul><li>Define public interface for GOOG4-HMAC-SHA256 request signing<br> <li> Export SignRequest function for HTTP request authentication</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-54c1475352f3227f6a789bb9080975c877aab7cb4f0cb588636bbc03e0c370c6">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>s3_fs.cpp</strong><dd><code>Add GCS HTTP client delegator and dual auth support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/src/filesystem/s3/s3_fs.cpp

<ul><li>Add GoogleHttpClientDelegator class to intercept and modify HTTP <br>requests<br> <li> Support both IAM and HMAC authentication modes for GCS<br> <li> Convert AWS metadata headers to GCS metadata headers in delegator<br> <li> Implement conditional logic to apply GOOG4 signing only for HMAC mode <br>with conditional writes<br> <li> Update GoogleHttpClientFactory to accept and pass ak/sk credentials</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-e186876c8016a66c022e5f56971b74c19136b2d110a3070cba968379e7a4363c">+123/-7</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multi_part_upload_s3_fs.cpp</strong><dd><code>Add metadata support to conditional write operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp

<ul><li>Add metadata parameter to ConditionalOutputStream constructor<br> <li> Support custom metadata in conditional write operations via <br>SetObjectMetadata<br> <li> Add overloaded OpenConditionalOutputStream method accepting metadata <br>parameter<br> <li> Handle custom metadata retrieval from S3 responses<br> <li> Change cloud provider identifier from "google" to "gcp"</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-fa291ebc5f7091e8e5637879f8047b11505aa28e40336d9d6b58e2165192ac1d">+28/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multi_part_upload_s3_fs.h</strong><dd><code>Add metadata parameter to conditional write interface</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h

<ul><li>Add overloaded OpenConditionalOutputStream method with metadata <br>parameter<br> <li> Update ExtendFileSystem interface to support metadata in conditional <br>writes</ul>


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-91ff14fd11625f2d72368f4ca847f4fbb70b208cf54c7294fce27a35c02d0502">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>s3_options.h</strong><dd><code>Update cloud provider naming documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/include/milvus-storage/filesystem/s3/s3_options.h

- Update cloud provider documentation from "google" to "gcp"


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-37c7418096ff9a1924fa14695288673c45f46d46381539753a97c68a9ab507a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Fix CMakeLists.txt duplicate executable declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cpp/test/CMakeLists.txt

- Remove duplicate add_executable line for milvus_test


</details>


  </td>
  <td><a href="https://github.com/milvus-io/milvus-storage/pull/350/files#diff-d5a033b62a4c4c60c86931d10ba5f3b8b0a6e805342da7050829c7717c2305cc">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Core invariant: GOOG4/HMAC signing and AWS→GCS metadata header translation are applied only when explicit HMAC credentials (access_key/secret_key) are provided and conditional-write paths are detected (x-goog-if-generation-match); IAM/OAuth flows are unchanged and continue to use the existing Authorization header path.
- What was simplified/removed: signing logic was centralized into GoogleHttpClientDelegator + signer::goog4 (GOOG4-HMAC-SHA256) and header-translation is moved into the HTTP client layer, eliminating ad-hoc per-call header mutation and duplicated signing attempts across call sites (previously spread between request creation and upload code). Also removed a duplicate test executable declaration in cpp/test/CMakeLists.txt.
- Why this does NOT cause data loss or regress behavior: IAM mode still attaches OAuth2 Authorization headers via GoogleHttpClientFactory and delegates to the prior request flow; HMAC mode only mutates headers for conditional PUTs and maps AWS-style metadata keys into x-goog-meta-* before signing — metadata is added to S3 PutObject requests (SetObjectMetadata) rather than overwriting stored object payloads. Public API surface changes are additive (new OpenConditionalOutputStream overload accepting metadata and new signer functions); existing OpenConditionalOutputStream(s) delegates to the new overload with metadata=nullptr, preserving prior behavior and ensuring no existing callers lose data or see altered semantics.
- New capability added: conditional GCS write support using access-key/secret-key (HMAC) with full GOOG4-HMAC-SHA256 signing, per-upload metadata propagation (AWS→GCS metadata header conversion), and an HTTP client delegator that applies signing only in HMAC mode; surface changes are limited to added overloads and internal factory/delegator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->