### PR TITLE
fix: The filesystem config root_path has no effect.

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -81,6 +81,11 @@ struct ArrowFileSystemConfig {
   std::string bucket_name = "a-bucket";
   std::string access_key_id = "minioadmin";
   std::string access_key_value = "minioadmin";
+
+  // Only applies to the local filesystem.
+  // It is used to pin the data directory to a specific path.
+  // Supports absolute and relative paths, A relative path
+  // is relative to the working directory of the current process.
   std::string root_path = "files";
   std::string storage_type = "local";
   std::string cloud_provider = "aws";

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -27,7 +27,6 @@
 #include <arrow/util/key_value_metadata.h>
 #include <arrow/testing/gtest_util.h>
 
-#include "include/test_env.h"
 #include "milvus-storage/transaction/transaction.h"
 #include "milvus-storage/writer.h"
 #include "milvus-storage/reader.h"

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -24,7 +24,6 @@
 #include <arrow/io/api.h>
 #include <arrow/testing/gtest_util.h>
 
-#include "include/test_env.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/writer.h"

--- a/cpp/test/include/test_env.h
+++ b/cpp/test/include/test_env.h
@@ -59,7 +59,7 @@
 
 namespace milvus_storage {
 bool IsCloudEnv();
-arrow::Status InitTestProperties(api::Properties& properties, std::string address = "/", std::string root_path = "/");
+arrow::Status InitTestProperties(api::Properties& properties, std::string address = "/", std::string root_path = "./");
 std::string GetTestBasePath(std::string dir);
 
 arrow::Result<milvus_storage::ArrowFileSystemConfig> GetFileSystemConfig(const api::Properties& properties);


### PR DESCRIPTION
The `root_path` parameter is designed for the `LocalFileSystem`, allowing it to read and write under a unified directory path. However, when this parameter was initially implemented, it only performed directory creation and did not actually make any operations performed through the `LocalFileSystem` under the specified `root_path`.

The current change wraps the `LocalFileSystem` with the `SubTreeFileSystem`, ensuring that `root_path` takes effect. If a relative path is passed as `root_path`, the storage will convert it to an absolute path (relative to the process’s working directory, caller can use `chdir` change it).