### PR TITLE
fix: getLatestColumnGroups undefined in JNI

### DIFF
--- a/cpp/src/jni/manifest_jni.cpp
+++ b/cpp/src/jni/manifest_jni.cpp
@@ -22,10 +22,10 @@
 
 // ==================== JNI Manifest Implementation ====================
 
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageManifest_getLatestColumnGroups(JNIEnv* env,
-                                                                                           jobject obj,
-                                                                                           jstring base_path,
-                                                                                           jlong properties_ptr) {
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageManifestNative_getLatestColumnGroups(JNIEnv* env,
+                                                                                                 jobject obj,
+                                                                                                 jstring base_path,
+                                                                                                 jlong properties_ptr) {
   try {
     const char* base_path_cstr = env->GetStringUTFChars(base_path, nullptr);
     Properties* properties = reinterpret_cast<Properties*>(properties_ptr);


### PR DESCRIPTION
Problem generated by commit 9015cf6. The function name in header and cpp is miss matched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal native method bindings for storage operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->