### PR TITLE
enhance: move multipart-upload-size to filesystem config.

### DIFF
--- a/cpp/include/milvus-storage/common/config.h
+++ b/cpp/include/milvus-storage/common/config.h
@@ -27,9 +27,8 @@ static constexpr int64_t DEFAULT_READ_BATCH_SIZE = 1024;
 static constexpr int64_t DEFAULT_READ_BUFFER_SIZE = 16 * 1024 * 1024;   // 16 MB
 static constexpr int64_t DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024 * 1024;  // 16 MB
 
-struct StorageConfig {
-  int64_t part_size = 0;
-};
+// Default part size for multi-part upload
+#define DEFAULT_MULTIPART_UPLOAD_PART_SIZE (10 * 1024 * 1024)  // 10 MB
 
 #define LOON_FORMAT_PARQUET "parquet"
 #define LOON_FORMAT_VORTEX "vortex"

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -108,6 +108,9 @@ struct ArrowFileSystemConfig {
   bool use_custom_part_upload = true;    // Deprecated
   uint32_t max_connections = 100;
 
+  // Work on MultiPartUploadS3FS, not worked on azurefs
+  uint64_t multi_part_upload_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
+
   // Alias for external filesystem identification (e.g., "prod", "backup")
   // Empty for default filesystem
   std::string alias = "";

--- a/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
+++ b/cpp/include/milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h
@@ -42,12 +42,6 @@ class ExtendFileSystem {
   public:
   virtual ~ExtendFileSystem() = default;
 
-  virtual arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(const std::string& s,
-                                                                                                 int64_t part_size) = 0;
-
-  virtual arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
-      const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t part_size) = 0;
-
   virtual arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(const std::string& s) = 0;
 
   static bool IsExtendFileSystem(const std::shared_ptr<arrow::fs::FileSystem>& fs) {
@@ -88,12 +82,6 @@ class MultiPartUploadS3FS : public arrow::fs::FileSystem, public ExtendFileSyste
 
   arrow::Status CopyFile(const std::string& src, const std::string& dest) override;
 
-  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(const std::string& s,
-                                                                                         int64_t part_size) override;
-
-  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
-      const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t part_size) override;
-
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(const std::string& s) override;
 
   static arrow::Result<std::shared_ptr<MultiPartUploadS3FS>> Make(
@@ -116,6 +104,9 @@ class MultiPartUploadS3FS : public arrow::fs::FileSystem, public ExtendFileSyste
   arrow::Result<std::shared_ptr<S3ClientMetrics>> GetMetrics();
 
   protected:
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
+      const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t part_size);
+
   explicit MultiPartUploadS3FS(const S3Options& options, const arrow::io::IOContext& io_context);
 
   /// Return the original S3 options when constructing the filesystem

--- a/cpp/include/milvus-storage/filesystem/s3/s3_options.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_options.h
@@ -21,6 +21,7 @@
 #include <arrow/result.h>
 #include <arrow/util/uri.h>
 
+#include "milvus-storage/common/config.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 
 namespace milvus_storage {
@@ -169,6 +170,9 @@ struct S3Options {
 
   /// \brief Maximum number of connections to the S3 server
   uint32_t max_connections = 100;
+
+  /// Multipart upload part size
+  uint64_t multi_part_upload_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
 
   /// Cloud provider name, e.g., "aws", "minio", "google", "azure", "aliyun", "tencent"
   std::string cloud_provider;

--- a/cpp/include/milvus-storage/format/parquet/parquet_writer.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_writer.h
@@ -39,7 +39,6 @@ class ParquetFileWriter : public api::ColumnGroupWriter {
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<arrow::fs::FileSystem> fs,
       const std::string& file_path,
-      const milvus_storage::StorageConfig& storage_config,
       std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
 
   protected:
@@ -51,7 +50,6 @@ class ParquetFileWriter : public api::ColumnGroupWriter {
   ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
                     std::shared_ptr<arrow::fs::FileSystem> fs,
                     const std::string& file_path,
-                    const milvus_storage::StorageConfig& storage_config,
                     std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
 
   arrow::Status init();
@@ -77,7 +75,6 @@ class ParquetFileWriter : public api::ColumnGroupWriter {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::shared_ptr<arrow::Schema> schema_;
   const std::string file_path_;
-  milvus_storage::StorageConfig storage_config_;
 
   std::shared_ptr<arrow::io::OutputStream> sink_;
   std::unique_ptr<::parquet::arrow::FileWriter> writer_;

--- a/cpp/include/milvus-storage/packed/writer.h
+++ b/cpp/include/milvus-storage/packed/writer.h
@@ -38,7 +38,6 @@ class PackedRecordBatchWriter {
       std::shared_ptr<arrow::fs::FileSystem> fs,
       std::vector<std::string>& paths,
       std::shared_ptr<arrow::Schema> schema,
-      StorageConfig& storage_config,
       std::vector<std::vector<int>>& column_groups,
       size_t buffer_size = DEFAULT_WRITE_BUFFER_SIZE,
       std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
@@ -59,7 +58,6 @@ class PackedRecordBatchWriter {
       std::shared_ptr<arrow::fs::FileSystem> fs,
       std::vector<std::string>& paths,
       std::shared_ptr<arrow::Schema> schema,
-      StorageConfig& storage_config,
       std::vector<std::vector<int>>& column_groups,
       size_t buffer_size = DEFAULT_WRITE_BUFFER_SIZE,
       std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
@@ -95,7 +93,6 @@ class PackedRecordBatchWriter {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::vector<std::string> paths_;
   std::shared_ptr<arrow::Schema> schema_;
-  StorageConfig storage_config_;
 
   GroupFieldIDList group_field_id_list_;
   size_t buffer_size_;

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -176,6 +176,8 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
   ARROW_ASSIGN_OR_RAISE(result.use_custom_part_upload,
                         api::GetValue<bool>(properties_map, PROPERTY_FS_USE_CUSTOM_PART_UPLOAD));
   ARROW_ASSIGN_OR_RAISE(result.max_connections, api::GetValue<uint32_t>(properties_map, PROPERTY_FS_MAX_CONNECTIONS));
+  ARROW_ASSIGN_OR_RAISE(result.multi_part_upload_size,
+                        api::GetValue<uint64_t>(properties_map, PROPERTY_WRITER_MULTI_PART_UPLOAD_SIZE));
   return arrow::Status::OK();
 }
 

--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -152,6 +152,7 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
   options.request_timeout = config_.request_timeout_ms <= 0 ? DEFAULT_ARROW_FILESYSTEM_S3_REQUEST_TIMEOUT_SEC
                                                             : config_.request_timeout_ms / 1000;
   options.max_connections = config_.max_connections;
+  options.multi_part_upload_size = config_.multi_part_upload_size;
   options.cloud_provider = config_.cloud_provider;
 
   if (config_.use_iam && config_.cloud_provider != "gcp") {

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -37,14 +37,12 @@ namespace milvus_storage {
 PackedRecordBatchWriter::PackedRecordBatchWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
                                                  std::vector<std::string>& paths,
                                                  std::shared_ptr<arrow::Schema> schema,
-                                                 StorageConfig& storage_config,
                                                  std::vector<std::vector<int>>& column_groups,
                                                  size_t buffer_size,
                                                  std::shared_ptr<::parquet::WriterProperties> writer_props)
     : fs_(std::move(fs)),
       paths_(paths),
       schema_(std::move(schema)),
-      storage_config_(storage_config),
       buffer_size_(buffer_size),
       group_indices_(column_groups),
       splitter_(column_groups),
@@ -55,12 +53,11 @@ arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> PackedRecordBatchWriter:
     std::shared_ptr<arrow::fs::FileSystem> fs,
     std::vector<std::string>& paths,
     std::shared_ptr<arrow::Schema> schema,
-    StorageConfig& storage_config,
     std::vector<std::vector<int>>& column_groups,
     size_t buffer_size,
     std::shared_ptr<::parquet::WriterProperties> writer_props) {
   auto writer = std::shared_ptr<PackedRecordBatchWriter>(
-      new PackedRecordBatchWriter(fs, paths, schema, storage_config, column_groups, buffer_size, writer_props));
+      new PackedRecordBatchWriter(fs, paths, schema, column_groups, buffer_size, writer_props));
   ARROW_RETURN_NOT_OK(writer->init());
   return writer;
 }
@@ -100,8 +97,8 @@ arrow::Status PackedRecordBatchWriter::init() {
   splitter_ = IndicesBasedSplitter(group_indices_);
   for (size_t i = 0; i < paths_.size(); ++i) {
     auto column_group_schema = getColumnGroupSchema(schema_, group_indices_[i]);
-    ARROW_ASSIGN_OR_RAISE(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(
-                                           column_group_schema, fs_, paths_[i], storage_config_, writer_props_));
+    ARROW_ASSIGN_OR_RAISE(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(column_group_schema, fs_,
+                                                                                        paths_[i], writer_props_));
     group_writers_.emplace_back(std::move(writer));
   }
   return arrow::Status::OK();

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -446,11 +446,15 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "The buffer size(Bytes) used in the writer.",
                       32 * 1024 * 1024,  // 32MB
                       ValidatePropertyType()),
-    REGISTER_PROPERTY(PROPERTY_WRITER_MULTI_PART_UPLOAD_SIZE,
-                      PropertyType::INT32,
-                      "The multi-part upload size(Bytes) used in the writer.",
-                      10 * 1024 * 1024,  // 10MB
-                      ValidatePropertyType()),
+    REGISTER_PROPERTY(
+        PROPERTY_WRITER_MULTI_PART_UPLOAD_SIZE,
+        PropertyType::UINT64,
+        "The multi-part upload size(Bytes) used in the writer.",
+        uint64_t(DEFAULT_MULTIPART_UPLOAD_PART_SIZE),  // 10 MB
+        // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+        // the part numbers can be 5MB ~ 5GB
+        // R2 limit is 10MB ~ 5GB
+        ValidatePropertyType() + ValidatePropertyRange<uint64_t>(10ULL * 1024 * 1024, 5ULL * 1024 * 1024 * 1024)),
     REGISTER_PROPERTY(PROPERTY_WRITER_COMPRESSION,
                       PropertyType::STRING,
                       "The compression type used in the writer.",

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -103,11 +103,9 @@ TEST_F(ParquetFileWriterTest, LargeRecordBatchSplitting) {
   std::string temp_file = "/tmp/test_large_batch.parquet";
 
   // Create packed writer and write record batch
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 2 * 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 2 * 1024 * 1024));
   for (int i = 0; i < 3; i++) {
     ASSERT_TRUE(writer->Write(record_batch).ok());
   }
@@ -149,11 +147,9 @@ TEST_F(ParquetFileWriterTest, EmptyRecordBatch) {
 
   std::string temp_file = "/tmp/test_empty_batch.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
 
   ASSERT_TRUE(writer->Write(empty_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -169,11 +165,9 @@ TEST_F(ParquetFileWriterTest, NullRecordBatch) {
   // Test writing null record batch
   std::string temp_file = "/tmp/test_null_batch.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
 
   // Should handle null batch gracefully
   ASSERT_TRUE(writer->Write(nullptr).ok());
@@ -207,10 +201,9 @@ TEST_F(ParquetFileWriterTest, VerySmallBufferSize) {
 
   std::string temp_file = "/tmp/test_small_buffer.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024));
 
   ASSERT_TRUE(writer->Write(record_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -230,11 +223,9 @@ TEST_F(ParquetFileWriterTest, LargeNumberOfSmallBatches) {
 
   std::string temp_file = "/tmp/test_many_small_batches.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
 
   for (int batch = 0; batch < num_batches; ++batch) {
     arrow::Int64Builder id_builder;
@@ -292,11 +283,9 @@ TEST_F(ParquetFileWriterTest, WriteWithNullArrays) {
 
   std::string temp_file = "/tmp/test_null_arrays.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
 
   ASSERT_TRUE(writer->Write(record_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -347,11 +336,9 @@ TEST_F(ParquetFileWriterTest, WriteWithMixedNullAndValidData) {
 
   std::string temp_file = "/tmp/test_mixed_data.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
 
   ASSERT_TRUE(writer->Write(record_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -377,12 +364,11 @@ TEST_F(ParquetFileWriterTest, WriteWithInvalidSchema) {
 
   std::string temp_file = "/tmp/test_invalid_schema.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
 
   // Should throw exception for null schema
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, nullptr, config, column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, nullptr, column_groups, 1024 * 1024).ok());
 
   std::remove(temp_file.c_str());
 }
@@ -403,11 +389,10 @@ TEST_F(ParquetFileWriterTest, WriteWithInvalidColumnGroups) {
 
   std::string temp_file = "/tmp/test_invalid_column_groups.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> invalid_column_groups = {{100, 200, 300}};  // Out of range
 
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, config, invalid_column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, invalid_column_groups, 1024 * 1024).ok());
 }
 
 TEST_F(ParquetFileWriterTest, WriteWithNullFileSystem) {
@@ -426,11 +411,10 @@ TEST_F(ParquetFileWriterTest, WriteWithNullFileSystem) {
 
   std::string temp_file = "/tmp/test_null_filesystem.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
   // Should throw exception for null file system
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(nullptr, paths, schema_, config, column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(nullptr, paths, schema_, column_groups, 1024 * 1024).ok());
 }
 
 TEST_F(ParquetFileWriterTest, WriteWithInvalidFilePath) {
@@ -449,11 +433,10 @@ TEST_F(ParquetFileWriterTest, WriteWithInvalidFilePath) {
 
   std::string invalid_path = "/invalid/path/test.parquet";
 
-  StorageConfig config;
   std::vector<std::string> paths = {invalid_path};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
   // Should throw exception for invalid file path
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024).ok());
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/packed/packed_integration_test.cpp
+++ b/cpp/test/packed/packed_integration_test.cpp
@@ -23,8 +23,7 @@ TEST_F(PackedIntegrationTest, TestOneFile) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -50,8 +49,7 @@ TEST_F(PackedIntegrationTest, TestSplitColumnGroup) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -77,8 +75,7 @@ TEST_F(PackedIntegrationTest, SchemaEvolutionFewerColumns) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -98,8 +95,7 @@ TEST_F(PackedIntegrationTest, SchemaEvolutionMoreColumns) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -140,8 +136,7 @@ TEST_F(PackedIntegrationTest, TestMultipleRowGroups) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, small_buffer));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, small_buffer));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
@@ -183,8 +178,7 @@ TEST_F(PackedIntegrationTest, TestComplexSchemaEvolution) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -252,8 +246,8 @@ TEST_F(PackedIntegrationTest, TestNullableFields) {
   int batch_size = 500;
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, nullable_schema, storage_config_,
-                                                               column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, nullable_schema, column_groups, writer_memory_));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(nullable_batch).ok());
@@ -307,8 +301,8 @@ TEST_F(PackedIntegrationTest, TestMixedNullableAndNonNullable) {
   int batch_size = 300;
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, mixed_schema, storage_config_, column_groups,
-                                                               writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, mixed_schema, column_groups, writer_memory_));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(mixed_batch).ok());
@@ -353,8 +347,7 @@ TEST_F(PackedIntegrationTest, TestLargeDataWithMultipleRowGroups) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, small_buffer));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, small_buffer));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
@@ -409,8 +402,7 @@ TEST_F(PackedIntegrationTest, TestReadNextWithSchemaEvolution) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -466,9 +458,8 @@ TEST_F(PackedIntegrationTest, TestCompressionFileSizeComparison) {
   auto column_groups = std::vector<std::vector<int>>{{0, 1, 2}};  // All columns in one file
 
   // Write data with default ZSTD compression
-  ASSERT_AND_ASSIGN(
-      auto compressed_writer,
-      PackedRecordBatchWriter::Make(fs_, compressed_paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto compressed_writer,
+                    PackedRecordBatchWriter::Make(fs_, compressed_paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(compressed_writer->Write(record_batch_).ok());
   }
@@ -476,8 +467,7 @@ TEST_F(PackedIntegrationTest, TestCompressionFileSizeComparison) {
 
   // Write data with no default writer properties, should override with zstd compression
   ASSERT_AND_ASSIGN(auto uncompressed_writer,
-                    PackedRecordBatchWriter::Make(fs_, no_writer_props_paths, schema_, storage_config_, column_groups,
-                                                  writer_memory_));
+                    PackedRecordBatchWriter::Make(fs_, no_writer_props_paths, schema_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(uncompressed_writer->Write(record_batch_).ok());
   }

--- a/cpp/test/packed/packed_test_base.h
+++ b/cpp/test/packed/packed_test_base.h
@@ -53,7 +53,6 @@ class PackedTestBase : public ::testing::Test {
     ASSERT_STATUS_OK(DeleteTestDir(fs_, path_));
     ASSERT_STATUS_OK(CreateTestDir(fs_, path_));
 
-    storage_config_ = StorageConfig();
     SetUpCommonData();
     writer_memory_ = (22 + 16) * 1024 * 1024;  // 22 MB for S3FS part upload
     reader_memory_ = 5 * 1024 * 1024;
@@ -102,8 +101,7 @@ class PackedTestBase : public ::testing::Test {
     std::vector<std::string> paths = {one_file_path_};
     int batch_size = 100;
     auto column_groups = std::vector<std::vector<int>>{{0, 1, 2}};
-    ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups,
-                                                                 writer_memory_));
+    ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
     for (int i = 0; i < batch_size; ++i) {
       EXPECT_TRUE(writer->Write(record_batch_).ok());
     }
@@ -185,7 +183,6 @@ class PackedTestBase : public ::testing::Test {
   std::vector<int64_t> int64_values;
   std::vector<std::basic_string<char>> str_values;
 
-  StorageConfig storage_config_;
   std::string one_file_path_;
 };
 


### PR DESCRIPTION
In the parquet writer, there has always been the practice of forcibly casting `arrow::fs::FileSystem` to the `class MultiPartUploadS3FS` and then calling methods not provided by `arrow::fs::FileSystem`. This breaks the encapsulation of the Arrow file system.

The current commit removes the forced cast of file system and allows users to decide the multipart upload size when creating the `arrow::fs::FileSystem`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary: Move Multipart Upload Size to Filesystem Configuration

**Core Invariant:** Multipart upload size must be known at filesystem creation time, not deferred to writer instantiation, to maintain proper Arrow filesystem abstraction boundaries.

**What Was Removed & Why:**
The PR eliminates the writer-time `StorageConfig` parameter and forced downcasting pattern that violated Arrow's filesystem encapsulation:
- Removed `struct StorageConfig` from public API—writers previously accepted this parameter, then performed an unsafe `static_cast<MultiPartUploadS3FS*>` on the generic `arrow::fs::FileSystem` to call `OpenOutputStreamWithUploadSize()` (a non-standard method not in Arrow's API).
- Removed public `OpenOutputStreamWithUploadSize()` overloads from the filesystem interface—these methods are now protected and used only internally.
- Simplified all writer signatures: `ParquetFileWriter::Make()` and `PackedRecordBatchWriter::Make()` no longer accept `storage_config` as a parameter.

**Why No Behavior Regression:**
The upload size is still fully configurable and defaults to the same value (10 MB):
1. **Configuration path preserved:** `ArrowFileSystemConfig::multi_part_upload_size` and `S3Options::multi_part_upload_size` are populated from `PROPERTY_WRITER_MULTI_PART_UPLOAD_SIZE` at filesystem creation time (verified in `fs.cpp` and `s3_fs.cpp`).
2. **Default unchanged:** `DEFAULT_MULTIPART_UPLOAD_PART_SIZE = 10 * 1024 * 1024` remains identical to the prior hardcoded default.
3. **Functionality preserved:** `MultiPartUploadS3FS::OpenOutputStream()` now retrieves upload size directly from `impl_->options().multi_part_upload_size` instead of expecting it as a runtime parameter.

**Concrete Fix:** Users now configure multipart behavior at S3 filesystem instantiation (via properties) rather than passing it through every writer, removing the need for unsafe downcasts and keeping writers filesystem-agnostic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->