### PR TITLE
enhance: allow s3fs change the multipart upload size by metadata

### DIFF
--- a/cpp/include/milvus-storage/common/config.h
+++ b/cpp/include/milvus-storage/common/config.h
@@ -19,15 +19,21 @@
 namespace milvus_storage {
 
 // current config will be used in packed writer/reader layer
-inline constexpr int64_t DEFAULT_MAX_ROW_GROUP_SIZE = 1024 * 1024;  // 1 MB
+inline constexpr int64_t DEFAULT_MAX_ROW_GROUP_SIZE = 1024LL * 1024;  // 1 MB
 
 // Default number of rows to read when using ::arrow::RecordBatchReader
-inline constexpr int64_t DEFAULT_READ_BATCH_SIZE = 1024;
-inline constexpr int64_t DEFAULT_READ_BUFFER_SIZE = 16 * 1024 * 1024;   // 16 MB
-inline constexpr int64_t DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024 * 1024;  // 16 MB
+inline constexpr int64_t DEFAULT_READ_BATCH_SIZE = 1024LL;
+inline constexpr int64_t DEFAULT_READ_BUFFER_SIZE = 16LL * 1024 * 1024;   // 16 MB
+inline constexpr int64_t DEFAULT_WRITE_BUFFER_SIZE = 16LL * 1024 * 1024;  // 16 MB
 
 // Default part size for multi-part upload
-#define DEFAULT_MULTIPART_UPLOAD_PART_SIZE (10 * 1024 * 1024)  // 10 MB
+#define MINIMAL_MULTIPART_UPLOAD_PART_SIZE (10LL * 1024 * 1024)        // 10 MB
+#define DEFAULT_MULTIPART_UPLOAD_PART_SIZE (10LL * 1024 * 1024)        // 10 MB
+#define MAXIMAL_MULTIPART_UPLOAD_PART_SIZE (5LL * 1024 * 1024 * 1024)  // 5 GB
+
+struct StorageConfig {
+  int64_t part_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
+};
 
 #define LOON_FORMAT_PARQUET "parquet"
 #define LOON_FORMAT_VORTEX "vortex"

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -49,6 +49,7 @@ using ArrowFileSystemPtr = std::shared_ptr<arrow::fs::FileSystem>;
  * If current filesystem is "SubTreeFileSystem", it will return the base filesystem type name
  */
 arrow::Result<std::string> GetFileSystemTypeName(const ArrowFileSystemPtr& fs);
+
 /**
  * Check current filesystem is local filesystem
  * If current filesystem is "SubTreeFileSystem", it will check the base filesystem
@@ -122,8 +123,9 @@ struct ArrowFileSystemConfig {
   bool use_custom_part_upload = true;    // Deprecated
   uint32_t max_connections = 100;
 
-  // Work on MultiPartUploadS3FS, not worked on azurefs
-  uint64_t multi_part_upload_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
+  // Work on S3FileSystem, not worked on azurefs
+  // To align with the old logical, set to `int64_t`(should be `uint64_t`)
+  int64_t multi_part_upload_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
 
   // Alias for external filesystem identification (e.g., "prod", "backup")
   // Empty for default filesystem

--- a/cpp/include/milvus-storage/filesystem/s3/s3_delegator_filesystem.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_delegator_filesystem.h
@@ -1,0 +1,93 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <cstdlib>
+
+#include <aws/core/Aws.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpClientFactory.h>
+
+#include <arrow/util/key_value_metadata.h>
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+
+#define kMultiPartUploadFileSystemType "multipart-upload"
+#define kMultiPartUploadSizeKey "multi_part_upload_size"
+
+namespace milvus_storage {
+
+/// \brief A FileSystem implementation that delegates to another
+/// implementation after do metrics or provider private function.
+class S3DelegatorFileSystem : public arrow::fs::FileSystem {
+  public:
+  // This constructor may abort if base_path is invalid.
+  explicit S3DelegatorFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs);
+  ~S3DelegatorFileSystem() override = default;
+
+  std::string type_name() const override { return kMultiPartUploadFileSystemType; }
+  std::shared_ptr<arrow::fs::FileSystem> base_fs() const { return base_fs_; }
+
+  arrow::Result<std::string> NormalizePath(std::string path) override;
+  arrow::Result<std::string> PathFromUri(const std::string& uri_string) const override;
+
+  bool Equals(const arrow::fs::FileSystem& other) const override;
+
+  arrow::Result<arrow::fs::FileInfo> GetFileInfo(const std::string& path) override;
+  arrow::Result<arrow::fs::FileInfoVector> GetFileInfo(const arrow::fs::FileSelector& select) override;
+
+  arrow::fs::FileInfoGenerator GetFileInfoGenerator(const arrow::fs::FileSelector& select) override;
+
+  arrow::Status CreateDir(const std::string& path, bool recursive) override;
+
+  arrow::Status DeleteDir(const std::string& path) override;
+  arrow::Status DeleteDirContents(const std::string& path, bool missing_dir_ok) override;
+  arrow::Status DeleteRootDirContents() override;
+
+  arrow::Status DeleteFile(const std::string& path) override;
+
+  arrow::Status Move(const std::string& src, const std::string& dest) override;
+
+  arrow::Status CopyFile(const std::string& src, const std::string& dest) override;
+
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override;
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const arrow::fs::FileInfo& info) override;
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override;
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override;
+
+  arrow::Future<std::shared_ptr<arrow::io::InputStream>> OpenInputStreamAsync(const std::string& path) override;
+  arrow::Future<std::shared_ptr<arrow::io::InputStream>> OpenInputStreamAsync(const arrow::fs::FileInfo& info) override;
+  arrow::Future<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFileAsync(const std::string& path) override;
+  arrow::Future<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFileAsync(
+      const arrow::fs::FileInfo& info) override;
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override;
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenAppendStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override;
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, const int64_t part_size);
+
+  protected:
+  S3DelegatorFileSystem() = default;
+  std::shared_ptr<arrow::fs::FileSystem> base_fs_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_filesystem.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_filesystem.h
@@ -36,9 +36,9 @@ using ::arrow::fs::FileInfoGenerator;
 
 namespace milvus_storage {
 
-class MultiPartUploadS3FS : public arrow::fs::FileSystem {
+class S3FileSystem : public arrow::fs::FileSystem {
   public:
-  ~MultiPartUploadS3FS() override;
+  ~S3FileSystem() override;
 
   std::string type_name() const override;
 
@@ -68,7 +68,7 @@ class MultiPartUploadS3FS : public arrow::fs::FileSystem {
 
   arrow::Status CopyFile(const std::string& src, const std::string& dest) override;
 
-  static arrow::Result<std::shared_ptr<MultiPartUploadS3FS>> Make(
+  static arrow::Result<std::shared_ptr<S3FileSystem>> Make(
       const S3Options& options, const arrow::io::IOContext& = arrow::io::default_io_context());
 
   arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override;
@@ -87,11 +87,11 @@ class MultiPartUploadS3FS : public arrow::fs::FileSystem {
 
   arrow::Result<std::shared_ptr<S3ClientMetrics>> GetMetrics();
 
-  protected:
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
       const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t part_size);
 
-  explicit MultiPartUploadS3FS(const S3Options& options, const arrow::io::IOContext& io_context);
+  protected:
+  explicit S3FileSystem(const S3Options& options, const arrow::io::IOContext& io_context);
 
   /// Return the original S3 options when constructing the filesystem
   const S3Options& options() const;

--- a/cpp/include/milvus-storage/filesystem/s3/s3_filesystem_producer.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_filesystem_producer.h
@@ -27,7 +27,7 @@
 #include <cstdlib>
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/fs.h"
-#include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
 
 namespace milvus_storage {

--- a/cpp/include/milvus-storage/filesystem/s3/s3_options.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_options.h
@@ -172,7 +172,7 @@ struct S3Options {
   uint32_t max_connections = 100;
 
   /// Multipart upload part size
-  uint64_t multi_part_upload_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
+  int64_t multi_part_upload_size = DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
 
   /// Cloud provider name, e.g., "aws", "gcp", "azure", "aliyun", "tencent", "huawei"
   std::string cloud_provider;

--- a/cpp/include/milvus-storage/format/parquet/parquet_writer.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_writer.h
@@ -39,6 +39,7 @@ class ParquetFileWriter : public api::ColumnGroupWriter {
       std::shared_ptr<arrow::Schema> schema,
       std::shared_ptr<arrow::fs::FileSystem> fs,
       const std::string& file_path,
+      const milvus_storage::StorageConfig& storage_config,
       std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
 
   protected:
@@ -50,6 +51,7 @@ class ParquetFileWriter : public api::ColumnGroupWriter {
   ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
                     std::shared_ptr<arrow::fs::FileSystem> fs,
                     const std::string& file_path,
+                    const milvus_storage::StorageConfig& storage_config,
                     std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
 
   arrow::Status init();
@@ -75,6 +77,7 @@ class ParquetFileWriter : public api::ColumnGroupWriter {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::shared_ptr<arrow::Schema> schema_;
   const std::string file_path_;
+  milvus_storage::StorageConfig storage_config_;
 
   std::shared_ptr<arrow::io::OutputStream> sink_;
   std::unique_ptr<::parquet::arrow::FileWriter> writer_;

--- a/cpp/include/milvus-storage/packed/writer.h
+++ b/cpp/include/milvus-storage/packed/writer.h
@@ -38,6 +38,7 @@ class PackedRecordBatchWriter {
       std::shared_ptr<arrow::fs::FileSystem> fs,
       std::vector<std::string>& paths,
       std::shared_ptr<arrow::Schema> schema,
+      StorageConfig& storage_config,
       std::vector<std::vector<int>>& column_groups,
       size_t buffer_size = DEFAULT_WRITE_BUFFER_SIZE,
       std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
@@ -58,6 +59,7 @@ class PackedRecordBatchWriter {
       std::shared_ptr<arrow::fs::FileSystem> fs,
       std::vector<std::string>& paths,
       std::shared_ptr<arrow::Schema> schema,
+      StorageConfig& storage_config,
       std::vector<std::vector<int>>& column_groups,
       size_t buffer_size = DEFAULT_WRITE_BUFFER_SIZE,
       std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
@@ -93,6 +95,7 @@ class PackedRecordBatchWriter {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::vector<std::string> paths_;
   std::shared_ptr<arrow::Schema> schema_;
+  StorageConfig storage_config_;
 
   GroupFieldIDList group_field_id_list_;
   size_t buffer_size_;

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -90,6 +90,7 @@ struct PropertyInfo {
 #define PROPERTY_FS_GCP_CREDENTIAL_JSON "fs.gcp_credential_json"
 #define PROPERTY_FS_USE_CUSTOM_PART_UPLOAD "fs.use_custom_part_upload"
 #define PROPERTY_FS_MAX_CONNECTIONS "fs.max_connections"
+#define PROPERTY_FS_MULTI_PART_UPLOAD_SIZE "fs.multi_part_upload_size"
 
 // --- External Filesystem Properties ---
 // External filesystems are configured with properties following the pattern:
@@ -122,7 +123,7 @@ struct PropertyInfo {
 #define PROPERTY_WRITER_SIZE_BASE_MACS "writer.split.size_based.max_avg_column_size"
 #define PROPERTY_WRITER_SIZE_BASE_MCIG "writer.split.size_based.max_columns_in_group"
 #define PROPERTY_WRITER_BUFFER_SIZE "writer.buffer_size"
-#define PROPERTY_WRITER_MULTI_PART_UPLOAD_SIZE "writer.multi_part_upload_size"
+
 #define PROPERTY_WRITER_COMPRESSION "writer.compression"
 #define PROPERTY_WRITER_COMPRESSION_LEVEL "writer.compression_level"
 #define PROPERTY_WRITER_ENABLE_DICTIONARY "writer.enable_dictionary"

--- a/cpp/src/filesystem/filesystem_extend.cpp
+++ b/cpp/src/filesystem/filesystem_extend.cpp
@@ -18,7 +18,7 @@
 #include <arrow/result.h>
 #include <arrow/util/key_value_metadata.h>
 
-#include "milvus-storage/filesystem/s3/s3_fs.h"
+#include "milvus-storage/filesystem/fs.h"
 
 namespace milvus_storage {
 

--- a/cpp/src/filesystem/s3/s3_delegator_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_delegator_filesystem.cpp
@@ -1,0 +1,168 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/s3/s3_delegator_filesystem.h"
+
+#include <arrow/util/async_generator.h>
+#include <arrow/util/logging.h>
+#include <arrow/buffer.h>
+#include <arrow/result.h>
+#include <arrow/io/memory.h>
+#include <arrow/util/future.h>
+#include <arrow/util/thread_pool.h>
+#include <arrow/filesystem/path_util.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/util/key_value_metadata.h>
+#include <arrow/util/string.h>
+
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
+
+namespace milvus_storage {
+
+S3DelegatorFileSystem::S3DelegatorFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs) : base_fs_(base_fs) {}
+
+arrow::Result<std::string> S3DelegatorFileSystem::NormalizePath(std::string path) {
+  return base_fs_->NormalizePath(path);
+}
+
+arrow::Result<std::string> S3DelegatorFileSystem::PathFromUri(const std::string& uri_string) const {
+  return base_fs_->PathFromUri(uri_string);
+}
+
+bool S3DelegatorFileSystem::Equals(const arrow::fs::FileSystem& other) const {
+  if (this == &other) {
+    return true;
+  }
+  if (other.type_name() != type_name()) {
+    return false;
+  }
+  const auto& subfs = ::arrow::internal::checked_cast<const S3DelegatorFileSystem&>(other);
+  return base_fs_->Equals(subfs.base_fs_);
+}
+
+arrow::Result<arrow::fs::FileInfo> S3DelegatorFileSystem::GetFileInfo(const std::string& path) {
+  return base_fs_->GetFileInfo(path);
+}
+
+arrow::Result<arrow::fs::FileInfoVector> S3DelegatorFileSystem::GetFileInfo(const arrow::fs::FileSelector& select) {
+  return base_fs_->GetFileInfo(select);
+}
+
+arrow::fs::FileInfoGenerator S3DelegatorFileSystem::GetFileInfoGenerator(const arrow::fs::FileSelector& select) {
+  return base_fs_->GetFileInfoGenerator(select);
+}
+
+arrow::Status S3DelegatorFileSystem::CreateDir(const std::string& path, bool recursive) {
+  return base_fs_->CreateDir(path, recursive);
+}
+
+arrow::Status S3DelegatorFileSystem::DeleteDir(const std::string& path) { return base_fs_->DeleteDir(path); }
+
+arrow::Status S3DelegatorFileSystem::DeleteDirContents(const std::string& path, bool missing_dir_ok) {
+  return base_fs_->DeleteDirContents(path, missing_dir_ok);
+}
+
+arrow::Status S3DelegatorFileSystem::DeleteRootDirContents() { return base_fs_->DeleteRootDirContents(); }
+
+arrow::Status S3DelegatorFileSystem::DeleteFile(const std::string& path) { return base_fs_->DeleteFile(path); }
+
+arrow::Status S3DelegatorFileSystem::Move(const std::string& src, const std::string& dest) {
+  return base_fs_->Move(src, dest);
+}
+
+arrow::Status S3DelegatorFileSystem::CopyFile(const std::string& src, const std::string& dest) {
+  return base_fs_->CopyFile(src, dest);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::InputStream>> S3DelegatorFileSystem::OpenInputStream(const std::string& path) {
+  return base_fs_->OpenInputStream(path);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::InputStream>> S3DelegatorFileSystem::OpenInputStream(
+    const arrow::fs::FileInfo& info) {
+  return base_fs_->OpenInputStream(info);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> S3DelegatorFileSystem::OpenInputFile(
+    const std::string& path) {
+  return base_fs_->OpenInputFile(path);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> S3DelegatorFileSystem::OpenInputFile(
+    const arrow::fs::FileInfo& info) {
+  return base_fs_->OpenInputFile(info);
+}
+
+arrow::Future<std::shared_ptr<arrow::io::InputStream>> S3DelegatorFileSystem::OpenInputStreamAsync(
+    const std::string& path) {
+  return base_fs_->OpenInputStreamAsync(path);
+}
+
+arrow::Future<std::shared_ptr<arrow::io::InputStream>> S3DelegatorFileSystem::OpenInputStreamAsync(
+    const arrow::fs::FileInfo& info) {
+  return base_fs_->OpenInputStreamAsync(info);
+}
+
+arrow::Future<std::shared_ptr<arrow::io::RandomAccessFile>> S3DelegatorFileSystem::OpenInputFileAsync(
+    const std::string& path) {
+  return base_fs_->OpenInputFileAsync(path);
+}
+arrow::Future<std::shared_ptr<arrow::io::RandomAccessFile>> S3DelegatorFileSystem::OpenInputFileAsync(
+    const arrow::fs::FileInfo& info) {
+  return base_fs_->OpenInputFileAsync(info);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::OutputStream>> S3DelegatorFileSystem::OpenOutputStream(
+    const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) {
+  std::shared_ptr<S3FileSystem> base_s3_fs = std::dynamic_pointer_cast<S3FileSystem>(base_fs_);
+
+  if (metadata && base_s3_fs) {
+    int64_t part_upload_size = -1;
+    int64_t keyidx = metadata->FindKey(kMultiPartUploadSizeKey);
+    if (keyidx != -1) {
+      auto part_size_str = metadata->value(keyidx);
+
+      int64_t part_size_result;
+      auto [ptr, ec] =
+          std::from_chars(part_size_str.data(), part_size_str.data() + part_size_str.size(), part_size_result);
+
+      if (ec == std::errc() && ptr == part_size_str.data() + part_size_str.size()) {
+        part_upload_size = part_size_result;
+      } else {
+        ARROW_LOG(WARNING) << "Failed to parse MultiPartUploadSize: " << part_size_str;
+      }
+    }
+
+    if (part_upload_size != -1) {
+      if (part_upload_size < MINIMAL_MULTIPART_UPLOAD_PART_SIZE ||
+          part_upload_size > MAXIMAL_MULTIPART_UPLOAD_PART_SIZE) {
+        return arrow::Status::Invalid("Invalid MultiPartUploadSize: ", part_upload_size);
+      }
+
+      // re-construct the metadata
+      auto new_metadata = metadata->Copy();
+      ARROW_RETURN_NOT_OK(new_metadata->Delete(keyidx));
+      return base_s3_fs->OpenOutputStreamWithUploadSize(path, new_metadata, part_upload_size);
+    }
+  }
+
+  return base_fs_->OpenOutputStream(path, metadata);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::OutputStream>> S3DelegatorFileSystem::OpenAppendStream(
+    const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) {
+  return base_fs_->OpenAppendStream(path, metadata);
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "milvus-storage/filesystem/s3/s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
 
 #include <cstdlib>
 
@@ -40,7 +40,7 @@
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
-#include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 
@@ -216,7 +216,7 @@ arrow::Result<ArrowFileSystemPtr> S3FileSystemProducer::Make() {
   InitS3();
 
   ARROW_ASSIGN_OR_RAISE(auto s3_options, CreateS3Options());
-  ARROW_ASSIGN_OR_RAISE(auto fs, MultiPartUploadS3FS::Make(s3_options));
+  ARROW_ASSIGN_OR_RAISE(auto fs, S3FileSystem::Make(s3_options));
   return ArrowFileSystemPtr(fs);
 }
 

--- a/cpp/src/filesystem/s3/s3_options.cpp
+++ b/cpp/src/filesystem/s3/s3_options.cpp
@@ -28,7 +28,7 @@
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
-#include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
 
 using ::milvus_storage::fs::internal::FromAwsString;
 using ::milvus_storage::fs::internal::ToAwsString;

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -452,15 +452,15 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "The buffer size(Bytes) used in the writer.",
                       32 * 1024 * 1024,  // 32MB
                       ValidatePropertyType()),
-    REGISTER_PROPERTY(
-        PROPERTY_WRITER_MULTI_PART_UPLOAD_SIZE,
-        PropertyType::UINT64,
-        "The multi-part upload size(Bytes) used in the writer.",
-        uint64_t(DEFAULT_MULTIPART_UPLOAD_PART_SIZE),  // 10 MB
-        // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
-        // the part numbers can be 5MB ~ 5GB
-        // R2 limit is 10MB ~ 5GB
-        ValidatePropertyType() + ValidatePropertyRange<uint64_t>(10ULL * 1024 * 1024, 5ULL * 1024 * 1024 * 1024)),
+    REGISTER_PROPERTY(PROPERTY_FS_MULTI_PART_UPLOAD_SIZE,
+                      PropertyType::INT64,
+                      "The multi-part upload size(Bytes) used in the writer.",
+                      int64_t(DEFAULT_MULTIPART_UPLOAD_PART_SIZE),  // 10 MB
+                      // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+                      // the part numbers can be 5MB ~ 5GB
+                      // R2 limit is 10MB ~ 5GB
+                      ValidatePropertyType() + ValidatePropertyRange<int64_t>(MINIMAL_MULTIPART_UPLOAD_PART_SIZE,
+                                                                              MAXIMAL_MULTIPART_UPLOAD_PART_SIZE)),
     REGISTER_PROPERTY(PROPERTY_WRITER_COMPRESSION,
                       PropertyType::STRING,
                       "The compression type used in the writer.",

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -103,9 +103,11 @@ TEST_F(ParquetFileWriterTest, LargeRecordBatchSplitting) {
   std::string temp_file = "/tmp/test_large_batch.parquet";
 
   // Create packed writer and write record batch
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 2 * 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 2 * 1024 * 1024));
   for (int i = 0; i < 3; i++) {
     ASSERT_TRUE(writer->Write(record_batch).ok());
   }
@@ -147,9 +149,11 @@ TEST_F(ParquetFileWriterTest, EmptyRecordBatch) {
 
   std::string temp_file = "/tmp/test_empty_batch.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
 
   ASSERT_TRUE(writer->Write(empty_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -165,9 +169,11 @@ TEST_F(ParquetFileWriterTest, NullRecordBatch) {
   // Test writing null record batch
   std::string temp_file = "/tmp/test_null_batch.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
 
   // Should handle null batch gracefully
   ASSERT_TRUE(writer->Write(nullptr).ok());
@@ -201,9 +207,10 @@ TEST_F(ParquetFileWriterTest, VerySmallBufferSize) {
 
   std::string temp_file = "/tmp/test_small_buffer.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024));
 
   ASSERT_TRUE(writer->Write(record_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -223,9 +230,11 @@ TEST_F(ParquetFileWriterTest, LargeNumberOfSmallBatches) {
 
   std::string temp_file = "/tmp/test_many_small_batches.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
 
   for (int batch = 0; batch < num_batches; ++batch) {
     arrow::Int64Builder id_builder;
@@ -283,9 +292,11 @@ TEST_F(ParquetFileWriterTest, WriteWithNullArrays) {
 
   std::string temp_file = "/tmp/test_null_arrays.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
 
   ASSERT_TRUE(writer->Write(record_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -336,9 +347,11 @@ TEST_F(ParquetFileWriterTest, WriteWithMixedNullAndValidData) {
 
   std::string temp_file = "/tmp/test_mixed_data.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024));
 
   ASSERT_TRUE(writer->Write(record_batch).ok());
   ASSERT_TRUE(writer->Close().ok());
@@ -364,11 +377,12 @@ TEST_F(ParquetFileWriterTest, WriteWithInvalidSchema) {
 
   std::string temp_file = "/tmp/test_invalid_schema.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
 
   // Should throw exception for null schema
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, nullptr, column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, nullptr, config, column_groups, 1024 * 1024).ok());
 
   std::remove(temp_file.c_str());
 }
@@ -389,10 +403,11 @@ TEST_F(ParquetFileWriterTest, WriteWithInvalidColumnGroups) {
 
   std::string temp_file = "/tmp/test_invalid_column_groups.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> invalid_column_groups = {{100, 200, 300}};  // Out of range
 
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, invalid_column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, config, invalid_column_groups, 1024 * 1024).ok());
 }
 
 TEST_F(ParquetFileWriterTest, WriteWithNullFileSystem) {
@@ -411,10 +426,11 @@ TEST_F(ParquetFileWriterTest, WriteWithNullFileSystem) {
 
   std::string temp_file = "/tmp/test_null_filesystem.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {temp_file};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
   // Should throw exception for null file system
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(nullptr, paths, schema_, column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(nullptr, paths, schema_, config, column_groups, 1024 * 1024).ok());
 }
 
 TEST_F(ParquetFileWriterTest, WriteWithInvalidFilePath) {
@@ -433,10 +449,11 @@ TEST_F(ParquetFileWriterTest, WriteWithInvalidFilePath) {
 
   std::string invalid_path = "/invalid/path/test.parquet";
 
+  StorageConfig config;
   std::vector<std::string> paths = {invalid_path};
   std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
   // Should throw exception for invalid file path
-  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, 1024 * 1024).ok());
+  ASSERT_FALSE(PackedRecordBatchWriter::Make(fs_, paths, schema_, config, column_groups, 1024 * 1024).ok());
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/packed/packed_integration_test.cpp
+++ b/cpp/test/packed/packed_integration_test.cpp
@@ -23,7 +23,8 @@ TEST_F(PackedIntegrationTest, TestOneFile) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{0, 1, 2}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -49,7 +50,8 @@ TEST_F(PackedIntegrationTest, TestSplitColumnGroup) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -75,7 +77,8 @@ TEST_F(PackedIntegrationTest, SchemaEvolutionFewerColumns) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -95,7 +98,8 @@ TEST_F(PackedIntegrationTest, SchemaEvolutionMoreColumns) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -136,7 +140,8 @@ TEST_F(PackedIntegrationTest, TestMultipleRowGroups) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, small_buffer));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, small_buffer));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
@@ -178,7 +183,8 @@ TEST_F(PackedIntegrationTest, TestComplexSchemaEvolution) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -246,8 +252,8 @@ TEST_F(PackedIntegrationTest, TestNullableFields) {
   int batch_size = 500;
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, nullable_schema, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, nullable_schema, storage_config_,
+                                                               column_groups, writer_memory_));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(nullable_batch).ok());
@@ -301,8 +307,8 @@ TEST_F(PackedIntegrationTest, TestMixedNullableAndNonNullable) {
   int batch_size = 300;
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer,
-                    PackedRecordBatchWriter::Make(fs_, paths, mixed_schema, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, mixed_schema, storage_config_, column_groups,
+                                                               writer_memory_));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(mixed_batch).ok());
@@ -347,7 +353,8 @@ TEST_F(PackedIntegrationTest, TestLargeDataWithMultipleRowGroups) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, small_buffer));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, small_buffer));
 
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
@@ -402,7 +409,8 @@ TEST_F(PackedIntegrationTest, TestReadNextWithSchemaEvolution) {
 
   auto paths = std::vector<std::string>{path_ + "/10000.parquet", path_ + "/10001.parquet"};
   auto column_groups = std::vector<std::vector<int>>{{2}, {0, 1}};
-  ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(writer->Write(record_batch_).ok());
   }
@@ -458,8 +466,9 @@ TEST_F(PackedIntegrationTest, TestCompressionFileSizeComparison) {
   auto column_groups = std::vector<std::vector<int>>{{0, 1, 2}};  // All columns in one file
 
   // Write data with default ZSTD compression
-  ASSERT_AND_ASSIGN(auto compressed_writer,
-                    PackedRecordBatchWriter::Make(fs_, compressed_paths, schema_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(
+      auto compressed_writer,
+      PackedRecordBatchWriter::Make(fs_, compressed_paths, schema_, storage_config_, column_groups, writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(compressed_writer->Write(record_batch_).ok());
   }
@@ -467,7 +476,8 @@ TEST_F(PackedIntegrationTest, TestCompressionFileSizeComparison) {
 
   // Write data with no default writer properties, should override with zstd compression
   ASSERT_AND_ASSIGN(auto uncompressed_writer,
-                    PackedRecordBatchWriter::Make(fs_, no_writer_props_paths, schema_, column_groups, writer_memory_));
+                    PackedRecordBatchWriter::Make(fs_, no_writer_props_paths, schema_, storage_config_, column_groups,
+                                                  writer_memory_));
   for (int i = 0; i < batch_size; ++i) {
     EXPECT_TRUE(uncompressed_writer->Write(record_batch_).ok());
   }

--- a/cpp/test/packed/packed_test_base.h
+++ b/cpp/test/packed/packed_test_base.h
@@ -53,6 +53,7 @@ class PackedTestBase : public ::testing::Test {
     ASSERT_STATUS_OK(DeleteTestDir(fs_, path_));
     ASSERT_STATUS_OK(CreateTestDir(fs_, path_));
 
+    storage_config_ = StorageConfig();
     SetUpCommonData();
     writer_memory_ = (22 + 16) * 1024 * 1024;  // 22 MB for S3FS part upload
     reader_memory_ = 5 * 1024 * 1024;
@@ -101,7 +102,8 @@ class PackedTestBase : public ::testing::Test {
     std::vector<std::string> paths = {one_file_path_};
     int batch_size = 100;
     auto column_groups = std::vector<std::vector<int>>{{0, 1, 2}};
-    ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, column_groups, writer_memory_));
+    ASSERT_AND_ASSIGN(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups,
+                                                                 writer_memory_));
     for (int i = 0; i < batch_size; ++i) {
       EXPECT_TRUE(writer->Write(record_batch_).ok());
     }
@@ -183,6 +185,7 @@ class PackedTestBase : public ::testing::Test {
   std::vector<int64_t> int64_values;
   std::vector<std::basic_string<char>> str_values;
 
+  StorageConfig storage_config_;
   std::string one_file_path_;
 };
 

--- a/cpp/test/s3_client_test.cpp
+++ b/cpp/test/s3_client_test.cpp
@@ -20,7 +20,7 @@
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 
 #include "milvus-storage/filesystem/s3/s3_client.h"
-#include "milvus-storage/filesystem/s3/s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
 
 #include "test_env.h"
 

--- a/cpp/test/s3_file_system_test.cpp
+++ b/cpp/test/s3_file_system_test.cpp
@@ -21,8 +21,7 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "milvus-storage/filesystem/filesystem_extend.h"
-#include "milvus-storage/filesystem/s3/multi_part_upload_s3_fs.h"
-#include "milvus-storage/filesystem/s3/s3_fs.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 
 #include "test_env.h"


### PR DESCRIPTION
Introduce the delegtor filesystem to deal the different multiupload size in write path. If user not set the value of multipart upload size in `OpenOutputStream`, then use the default value which defined in filesystem config. 

`StorageConfig.part_size` (int64_t, default DEFAULT_MULTIPART_UPLOAD_PART_SIZE) is carried from `callers → PackedRecordBatchWriter → ParquetFileWriter` and written into Arrow KeyValueMetadata as "MultiPartUploadSize". 
