### PR TITLE
enhance: Use the Sub-Tree filesystem to treat the S3 bucket name as the path prefix in S3 filesystem

### DIFF
--- a/cpp/src/filesystem/azure/azure_fs.cpp
+++ b/cpp/src/filesystem/azure/azure_fs.cpp
@@ -49,7 +49,6 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
   }
 
   ARROW_ASSIGN_OR_RAISE(auto fs, arrow::fs::AzureFileSystem::Make(options));
-  ARROW_RETURN_NOT_OK(fs->CreateDir(config_.root_path, true));
   return ArrowFileSystemPtr(fs);
 }
 

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -92,8 +92,8 @@ arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemCon
       switch (cloud_provider) {
 #ifdef MILVUS_AZURE_FS
         case CloudProviderType::AZURE: {
-          auto producer = std::make_shared<AzureFileSystemProducer>(config);
-          return producer->Make();
+          ARROW_ASSIGN_OR_RAISE(auto azure_fs, AzureFileSystemProducer(config).Make());
+          return std::make_shared<arrow::fs::SubTreeFileSystem>(config.bucket_name, std::move(azure_fs));
         }
 #endif
         case CloudProviderType::AWS:
@@ -101,8 +101,8 @@ arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemCon
         case CloudProviderType::ALIYUN:
         case CloudProviderType::TENCENTCLOUD:
         case CloudProviderType::HUAWEICLOUD: {
-          auto producer = std::make_shared<S3FileSystemProducer>(config);
-          return producer->Make();
+          ARROW_ASSIGN_OR_RAISE(auto s3fs, S3FileSystemProducer(config).Make());
+          return std::make_shared<arrow::fs::SubTreeFileSystem>(config.bucket_name, std::move(s3fs));
         }
         default: {
           return arrow::Status::Invalid("Unsupported cloud provider: " + config.cloud_provider);

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -187,11 +187,6 @@ TEST_P(APIWriterReaderTest, SizeBasedColumnGroupPolicy) {
 
 TEST_P(APIWriterReaderTest, TestWriteNotExistPath) {
   auto verify_writer = [&](std::string base_path, api::Properties& properties) {
-    if (IsCloudEnv()) {
-      auto bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("test-bucket");
-      base_path = bucket_name + "/" + base_path;
-    }
-
     ASSERT_AND_ASSIGN(auto temp_fs, GetFileSystem(properties));
     ASSERT_STATUS_OK(DeleteTestDir(temp_fs, base_path));
 

--- a/cpp/test/include/test_env.h
+++ b/cpp/test/include/test_env.h
@@ -61,7 +61,7 @@
 namespace milvus_storage {
 bool IsCloudEnv();
 arrow::Status InitTestProperties(api::Properties& properties, std::string address = "/", std::string root_path = "./");
-std::string GetTestBasePath(std::string dir);
+std::string GetTestBasePath(const std::string& dir);
 
 arrow::Result<milvus_storage::ArrowFileSystemConfig> GetFileSystemConfig(const api::Properties& properties);
 arrow::Result<milvus_storage::ArrowFileSystemPtr> GetFileSystem(const api::Properties& properties);

--- a/cpp/test/s3_file_system_test.cpp
+++ b/cpp/test/s3_file_system_test.cpp
@@ -45,8 +45,7 @@ class S3FsTest : public ::testing::Test {
 };
 
 TEST_F(S3FsTest, ConditionalWrite) {
-  std::string bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("");
-  std::string file_to = bucket_name + "/test_conditional_write.txt";
+  std::string file_to = "/test_conditional_write.txt";
 
   // Ensure source file does not exist
   (void)fs_->DeleteFile(file_to);
@@ -92,8 +91,7 @@ TEST_F(S3FsTest, ConditionalWrite) {
 }
 
 TEST_F(S3FsTest, TestPredefinedMetadata) {
-  std::string bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("");
-  std::string file_to = bucket_name + "/predefined_metadata.txt";
+  std::string file_to = "/predefined_metadata.txt";
 
   (void)fs_->DeleteFile(file_to);
 

--- a/cpp/test/test_env.cpp
+++ b/cpp/test/test_env.cpp
@@ -76,16 +76,7 @@ arrow::Result<milvus_storage::ArrowFileSystemPtr> GetFileSystem(const api::Prope
   return milvus_storage::FilesystemCache::getInstance().get(properties);
 }
 
-std::string GetTestBasePath(std::string dir) {
-  std::string base_path;
-  if (!IsCloudEnv()) {
-    base_path = dir;
-    return base_path;
-  }
-  auto bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("test-bucket");
-  base_path = bucket_name + "/" + dir;
-  return base_path;
-}
+std::string GetTestBasePath(const std::string& dir) { return dir; }
 
 arrow::Status CreateTestDir(const milvus_storage::ArrowFileSystemPtr& fs, const std::string& path) {
   assert(fs != nullptr);


### PR DESCRIPTION
All cloud-backed filesystems (S3-like and Azure) are constructed as an `arrow::fs::SubTreeFileSystem` with `config.bucket_name` (or `config.root_path` when use the local filesystem) as the virtual root so callers may use root‑relative paths (e.g. "/x") which map to "bucket_name/x"/"root_path/x" on the underlying provider filesystem.