### PR TITLE
enhance: Make FormatWriter output ColumnGroupFile upon closing

### DIFF
--- a/cpp/include/milvus-storage/format/column_group_writer.h
+++ b/cpp/include/milvus-storage/format/column_group_writer.h
@@ -14,9 +14,12 @@
 
 #pragma once
 
-#include <arrow/filesystem/filesystem.h>
 #include <memory>
+#include <vector>
 
+#include <arrow/filesystem/filesystem.h>
+
+#include "milvus-storage/column_groups.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/reader.h"
 #include "milvus-storage/writer.h"
@@ -32,10 +35,10 @@ namespace milvus_storage::api {
 class ColumnGroupWriter {
   public:
   virtual ~ColumnGroupWriter() = default;
-  virtual arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) = 0;
-  virtual arrow::Status Flush() = 0;
-  virtual arrow::Status Close() = 0;
-  virtual uint64_t written_rows() const = 0;
+
+  [[nodiscard]] virtual arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) = 0;
+  [[nodiscard]] virtual arrow::Status Flush() = 0;
+  [[nodiscard]] virtual arrow::Result<std::vector<ColumnGroupFile>> Close() = 0;
 
   /**
    * @brief Create a column group writer for a column group
@@ -46,9 +49,14 @@ class ColumnGroupWriter {
    * @return Unique pointer to the created column group writer
    */
   [[nodiscard]] static arrow::Result<std::unique_ptr<ColumnGroupWriter>> create(
+      const std::string& base_path,
+      const size_t& column_group_id,
       const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
       const std::shared_ptr<arrow::Schema>& schema,
       const milvus_storage::api::Properties& properties);
+
+  protected:
+  [[nodiscard]] virtual arrow::Status Open() = 0;
 };
 
 }  // namespace milvus_storage::api

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -23,6 +23,7 @@
 
 #include "milvus-storage/properties.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/column_groups.h"
 
 namespace milvus_storage {
 
@@ -86,7 +87,7 @@ class FormatReader {
   static arrow::Result<std::shared_ptr<FormatReader>> create(
       const std::shared_ptr<arrow::Schema>& schema,
       const std::string& format,
-      const std::string& path,
+      const api::ColumnGroupFile& file,
       const api::Properties& properties,
       const std::vector<std::string>& needed_columns,
       const std::function<std::string(const std::string&)>& key_retriever);

--- a/cpp/include/milvus-storage/format/format_writer.h
+++ b/cpp/include/milvus-storage/format/format_writer.h
@@ -1,0 +1,54 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <arrow/status.h>
+#include <arrow/result.h>
+#include <arrow/record_batch.h>
+
+#include "milvus-storage/column_groups.h"
+
+namespace milvus_storage {
+
+class FormatWriter {
+  public:
+  virtual ~FormatWriter() = default;
+  /**
+   * @brief Write a record batch to the file
+   *
+   * @param record Record batch to write
+   * @return arrow::Status
+   */
+  [[nodiscard]] virtual arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) = 0;
+
+  /**
+   * @brief Flush the writer
+   *        After call this function, the data should no longer exist in memory
+   * @return arrow::Status
+   */
+  [[nodiscard]] virtual arrow::Status Flush() = 0;
+
+  /**
+   * @brief Close the writer
+   *        After call this function, the writer should be closed and cannot be used again
+   * @return arrow::Status
+   */
+  [[nodiscard]] virtual arrow::Result<api::ColumnGroupFile> Close() = 0;
+};  // class FormatWriter
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/vortex/vortex_writer.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_writer.h
@@ -17,33 +17,33 @@
 #include <memory>
 
 #include "milvus-storage/common/config.h"
-#include "milvus-storage/format/column_group_writer.h"
+#include "milvus-storage/format/format_writer.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/ffi/filesystem_internal.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/column_groups.h"
 #include "bridgeimpl.hpp"  // from cpp/src/format/vortex/vx-bridge/src/include
 
 namespace milvus_storage::vortex {
 
-class VortexFileWriter final : public api::ColumnGroupWriter {
+class VortexFileWriter final : public FormatWriter {
   public:
-  VortexFileWriter(std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
-                   std::shared_ptr<arrow::fs::FileSystem> fs,
+  VortexFileWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
                    std::shared_ptr<arrow::Schema> schema,
+                   const std::string& file_path,
                    const api::Properties& properties);
 
   ~VortexFileWriter() = default;
 
-  arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) override;
+  [[nodiscard]] arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) override;
 
-  arrow::Status Flush() override;
+  [[nodiscard]] arrow::Status Flush() override;
 
-  arrow::Status Close() override;
-
-  uint64_t written_rows() const override { return written_rows_; }
+  [[nodiscard]] arrow::Result<api::ColumnGroupFile> Close() override;
 
   private:
   bool closed_;
-  std::shared_ptr<milvus_storage::api::ColumnGroup> column_group_;
+  std::string file_path_;
   std::unique_ptr<FileSystemWrapper> fs_holder_;
   VortexWriter vx_writer_;
   std::shared_ptr<arrow::Schema> schema_;

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -160,7 +160,7 @@ arrow::Result<std::shared_ptr<arrow::Table>> ColumnGroupLazyReaderImpl::take(con
                           get_index_and_offset_of_file(cg_files, row_index));
     if (!loaded_format_readers_[file_index]) {
       ARROW_ASSIGN_OR_RAISE(loaded_format_readers_[file_index],
-                            FormatReader::create(schema_, column_group_->format, cg_files[file_index].path, properties_,
+                            FormatReader::create(schema_, column_group_->format, cg_files[file_index], properties_,
                                                  needed_columns_, key_retriever_));
     }
   }

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -159,8 +159,8 @@ arrow::Status ColumnGroupReaderImpl::open() {
       return arrow::Status::Invalid("Invalid start/end index in [file_index=", file_idx, ", path=", cg_file.path, "]");
     }
 
-    ARROW_ASSIGN_OR_RAISE(auto format_reader, FormatReader::create(schema_, column_group_->format, cg_file.path,
-                                                                   properties_, needed_columns_, key_retriever_));
+    ARROW_ASSIGN_OR_RAISE(auto format_reader, FormatReader::create(schema_, column_group_->format, cg_file, properties_,
+                                                                   needed_columns_, key_retriever_));
     ARROW_ASSIGN_OR_RAISE(auto row_group_in_file, format_reader->get_row_group_infos());
     if (row_group_in_file.empty()) {
       continue;

--- a/cpp/src/format/column_group_writer.cpp
+++ b/cpp/src/format/column_group_writer.cpp
@@ -14,9 +14,22 @@
 
 #include "milvus-storage/format/column_group_writer.h"
 
+#include <memory>
+#include <string>
+#include <iostream>
+#include <regex>
+#include <sstream>
+#include <filesystem>
+
+#include <fmt/core.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#include "milvus-storage/common/layout.h"
+#include "milvus-storage/common/path_util.h"  // for kSep
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/column_group_reader.h"
 #include "milvus-storage/format/parquet/parquet_writer.h"
@@ -26,54 +39,124 @@
 
 namespace milvus_storage::api {
 
-arrow::Result<std::unique_ptr<ColumnGroupWriter>> ColumnGroupWriter::create(
-    const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
-    const std::shared_ptr<arrow::Schema>& schema,
-    const milvus_storage::api::Properties& properties) {
-  std::unique_ptr<ColumnGroupWriter> writer;
-  assert(column_group && schema);
+static inline std::filesystem::path generate_parent_path(const std::string& base_path) {
+  std::filesystem::path path(base_path);
+  return (path / kDataPath).lexically_normal();
+}
 
-  // Create schema with only the columns for this column group
-  std::vector<std::shared_ptr<arrow::Field>> fields;
-  for (const auto& column_name : column_group->columns) {
-    auto field = schema->GetFieldByName(column_name);
-    if (!field) {
-      return arrow::Status::Invalid("Column '" + column_name + "' not found in schema");
+static inline std::string generate_file_path(const std::string& base_path,
+                                             const size_t& column_group_id,
+                                             const std::string& format) {
+  static boost::uuids::random_generator random_gen;
+  boost::uuids::uuid random_uuid = random_gen();
+  const std::string uuid_str = boost::uuids::to_string(random_uuid);
+  // named as {group_id}_{uuid}.{format}
+  const std::string file_name = fmt::format("{}_{}.{}", column_group_id, uuid_str, format);
+
+  return (generate_parent_path(base_path) / file_name).lexically_normal().string();
+}
+
+// TODO(jiaqizho): implements file rolling in this class
+class ColumnGroupWriterImpl final : public ColumnGroupWriter {
+  public:
+  ColumnGroupWriterImpl(const std::string& base_path,
+                        const size_t& column_group_id,
+                        const std::shared_ptr<ColumnGroup>& column_group,
+                        const std::shared_ptr<arrow::Schema>& schema,
+                        const Properties& properties)
+      : base_path_(base_path),
+        column_group_id_(column_group_id),
+        column_group_(column_group),
+        schema_(schema),
+        properties_(properties) {}
+
+  [[nodiscard]] arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) override {
+    return format_writer_->Write(record);
+  }
+
+  [[nodiscard]] arrow::Status Flush() override { return format_writer_->Flush(); }
+
+  [[nodiscard]] arrow::Result<std::vector<ColumnGroupFile>> Close() override {
+    ARROW_ASSIGN_OR_RAISE(auto column_group_file, format_writer_->Close());
+    return std::vector<ColumnGroupFile>{std::move(column_group_file)};
+  }
+
+  [[nodiscard]] arrow::Status Open() override {
+    assert(!format_writer_);
+    ARROW_ASSIGN_OR_RAISE(auto writer,
+                          create_format_writer(base_path_, column_group_id_, column_group_, schema_, properties_));
+    format_writer_ = std::move(writer);
+    return arrow::Status::OK();
+  }
+
+  private:
+  static arrow::Result<std::unique_ptr<FormatWriter>> create_format_writer(
+      const std::string& base_path,
+      const size_t& column_group_id,
+      const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
+      const std::shared_ptr<arrow::Schema>& schema,
+      const milvus_storage::api::Properties& properties) {
+    std::unique_ptr<FormatWriter> writer;
+    assert(column_group && schema);
+    auto format = column_group->format;
+
+    // Create schema with only the columns for this column group
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (const auto& column_name : column_group->columns) {
+      auto field = schema->GetFieldByName(column_name);
+      if (!field) {
+        return arrow::Status::Invalid("Column '" + column_name + "' not found in schema");
+      }
+      fields.emplace_back(field);
     }
-    fields.emplace_back(field);
-  }
-  auto column_group_schema = arrow::schema(fields);
+    auto column_group_schema = arrow::schema(fields);
+    ARROW_ASSIGN_OR_RAISE(auto file_system, milvus_storage::FilesystemCache::getInstance().get(properties, base_path));
 
-  // create the file system by cache
-  // Use first file path if available, otherwise use empty string for default filesystem
-  if (UNLIKELY(column_group->files.empty())) {
-    return arrow::Status::Invalid("Logical fault, column group files is empty");
-  }
+    // If current file system is local, create the parent directory if not exist
+    // If current file system is remote, putobject will auto
+    // create the parent directory if not exist
+    if (IsLocalFileSystem(file_system)) {
+      ARROW_RETURN_NOT_OK(file_system->CreateDir(generate_parent_path(base_path).string()));
+    }
 
-  std::string path = column_group->files[0].path;
-  ARROW_ASSIGN_OR_RAISE(auto file_system, milvus_storage::FilesystemCache::getInstance().get(properties, path));
-
-  // If current file system is local, create the parent directory if not exist
-  // If current file system is remote, putobject will auto
-  // create the parent directory if not exist
-  if (IsLocalFileSystem(file_system)) {
-    boost::filesystem::path dir_path(path);
-    auto parent_dir_path = dir_path.parent_path();
-    ARROW_RETURN_NOT_OK(file_system->CreateDir(parent_dir_path.string()));
-  }
-
-  if (column_group->format == LOON_FORMAT_PARQUET) {
-    ARROW_ASSIGN_OR_RAISE(
-        writer, milvus_storage::parquet::ParquetFileWriter::Make(column_group, file_system, schema, properties));
-  }
+    if (format == LOON_FORMAT_PARQUET) {
+      ARROW_ASSIGN_OR_RAISE(writer, parquet::ParquetFileWriter::Make(
+                                        file_system, schema,
+                                        std::move(generate_file_path(base_path, column_group_id, format)), properties));
+    }
 #ifdef BUILD_VORTEX_BRIDGE
-  else if (column_group->format == LOON_FORMAT_VORTEX) {
-    writer = std::make_unique<vortex::VortexFileWriter>(column_group, file_system, schema, properties);
-  }
+    else if (format == LOON_FORMAT_VORTEX) {
+      writer = std::make_unique<vortex::VortexFileWriter>(
+          file_system, schema, std::move(generate_file_path(base_path, column_group_id, format)), properties);
+    }
 #endif  // BUILD_VORTEX_BRIDGE
-  else {
-    return arrow::Status::Invalid("Unsupported file format: " + column_group->format);
+    else {
+      return arrow::Status::Invalid("Unsupported file format: " + format);
+    }
+
+    return writer;
   }
+
+  private:
+  std::unique_ptr<FormatWriter> format_writer_;
+
+  std::string base_path_;
+  size_t column_group_id_;
+  std::shared_ptr<ColumnGroup> column_group_;
+  std::shared_ptr<arrow::Schema> schema_;
+  Properties properties_;
+};
+
+arrow::Result<std::unique_ptr<ColumnGroupWriter>> ColumnGroupWriter::create(
+    const std::string& base_path,
+    const size_t& column_group_id,
+    const std::shared_ptr<ColumnGroup>& column_group,
+    const std::shared_ptr<arrow::Schema>& schema,
+    const Properties& properties) {
+  std::unique_ptr<ColumnGroupWriterImpl> writer;
+  assert(column_group && schema);
+  writer = std::make_unique<ColumnGroupWriterImpl>(base_path, column_group_id, column_group, schema, properties);
+  ARROW_RETURN_NOT_OK(writer->Open());
   return writer;
 }
 

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -218,6 +218,7 @@ TEST_P(APIWriterReaderTest, TestWriteNotExistPath) {
   verify_writer("not-exist-path2", local_properties);
   verify_writer("not-exist-path3", local_properties);
   verify_writer("not-exist-path4/path1/path2/path3/path4", local_properties);
+  verify_writer("not-exist-path5///", local_properties);  // will do lexically_normal
 
   if (!IsCloudEnv()) {
     GTEST_SKIP() << "No cloud env, skipped.";
@@ -226,6 +227,7 @@ TEST_P(APIWriterReaderTest, TestWriteNotExistPath) {
   // use the properties_ which is the cloud env
   verify_writer("not-exist-path1", properties_);
   verify_writer("not-exist-path2/path1/path2/path3/path4", properties_);
+  verify_writer("not-exist-path5///", properties_);  // will do lexically_normal
 }
 
 TEST_P(APIWriterReaderTest, WriteWithTransactionAppendFiles) {

--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -213,27 +213,27 @@ class VortexBasicTest : public ::testing::Test {
 };
 
 TEST_F(VortexBasicTest, TestBasicWrite) {
-  auto vx_writer = vortex::VortexFileWriter(columngroup_, file_system_, schema_, properties_);
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
 
   ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_EQ(recordBatchsRows(), vx_writer.written_rows());
-  ASSERT_TRUE(vx_writer.Close().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 }
 
 TEST_F(VortexBasicTest, TestBasicRead) {
-  auto vx_writer = vortex::VortexFileWriter(columngroup_, file_system_, schema_, properties_);
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
 
   ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_EQ(recordBatchsRows(), vx_writer.written_rows());
-  ASSERT_TRUE(vx_writer.Close().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 
   auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
                                               std::vector<std::string>{"int32", "int64", "binary"});
@@ -256,14 +256,14 @@ TEST_F(VortexBasicTest, TestBasicRead) {
 }
 
 TEST_F(VortexBasicTest, TestEmptyWriteRead) {
-  auto vx_writer = vortex::VortexFileWriter(columngroup_, file_system_, schema_, properties_);
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   auto empty_rb = makeRecordBatch(0, 0, 0);
   ASSERT_TRUE(vx_writer.Write(empty_rb).ok());
 
   ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_EQ(0, vx_writer.written_rows());
-  ASSERT_TRUE(vx_writer.Close().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(0, cgfile.end_index);
 
   auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
                                               std::vector<std::string>{"int32", "int64", "binary"});
@@ -275,15 +275,15 @@ TEST_F(VortexBasicTest, TestEmptyWriteRead) {
 }
 
 TEST_F(VortexBasicTest, TestReaderProjection) {
-  auto vx_writer = vortex::VortexFileWriter(columngroup_, file_system_, schema_, properties_);
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
 
   ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_EQ(recordBatchsRows(), vx_writer.written_rows());
-  ASSERT_TRUE(vx_writer.Close().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 
   // all projection
   {
@@ -358,15 +358,15 @@ TEST_F(VortexBasicTest, TestReaderProjection) {
 }
 
 TEST_F(VortexBasicTest, TestBasicTake) {
-  auto vx_writer = vortex::VortexFileWriter(columngroup_, file_system_, schema_, properties_);
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
 
   ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_EQ(recordBatchsRows(), vx_writer.written_rows());
-  ASSERT_TRUE(vx_writer.Close().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 
   auto take_verify = [&](vortex::VortexFormatReader& vx_reader, const std::vector<int64_t>& row_indices,
                          int64_t expect_rows) {


### PR DESCRIPTION
Introduced the `FormatWriter` interface, which offloads some functionality from the column group writer and allows the column group writer to support splitting into multiple files.

Additionally, the `Close` method of `FormatWriter` will generate and return a `ColumnGroupFile` structure, making integration with `Lance` more convenient. The `Lance` no longer requires the caller to provide a filename and itself needs to perform specific population of the `ColumnGroupFile`. In fact, the same process applies for integration with `Paimon/Iceberg`.