### PR TITLE
fix: fix use-after-free in FFIResult error handling

### DIFF
--- a/cpp/src/jni/chunk_reader_jni.cpp
+++ b/cpp/src/jni/chunk_reader_jni.cpp
@@ -44,8 +44,8 @@ JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_get
     env->ReleaseLongArrayElements(row_indices, indices_array, JNI_ABORT);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return nullptr;
     }
 
@@ -83,8 +83,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_getChunk
         array->release(array);
       }
       free(array);
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -118,8 +118,8 @@ JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_get
     env->ReleaseLongArrayElements(chunk_indices, indices_array, JNI_ABORT);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return nullptr;
     }
 

--- a/cpp/src/jni/manifest_jni.cpp
+++ b/cpp/src/jni/manifest_jni.cpp
@@ -36,8 +36,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageManifestNative_getLa
     env->ReleaseStringUTFChars(base_path, base_path_cstr);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -66,8 +66,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transact
     env->ReleaseStringUTFChars(base_path, base_path_cstr);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -89,8 +89,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transact
     FFIResult result = transaction_get_column_groups(handle, &column_groups);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -120,8 +120,8 @@ JNIEXPORT jboolean JNICALL Java_io_milvus_storage_MilvusStorageTransaction_trans
                                           column_groups_handle, &commit_result);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return JNI_FALSE;
     }
 
@@ -147,8 +147,8 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transacti
 
     FFIResult result = transaction_abort(handle);
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return;
     }
   } catch (const std::exception& e) {

--- a/cpp/src/jni/properties_jni.cpp
+++ b/cpp/src/jni/properties_jni.cpp
@@ -91,8 +91,8 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_createProp
 
     FFIResult result = properties_create(keys.data(), values.data(), keys.size(), properties);
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return;
     }
 

--- a/cpp/src/jni/reader_jni.cpp
+++ b/cpp/src/jni/reader_jni.cpp
@@ -42,8 +42,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(JNI
     FreeStringArray(env, columns, num_columns);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -76,8 +76,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getRecordBatc
         stream->release(stream);
       }
       free(stream);
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -101,8 +101,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getChunkReade
     FFIResult result = get_chunk_reader(handle, static_cast<int64_t>(column_group_id), &chunk_reader_handle);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -136,8 +136,8 @@ JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageReader_take(
     env->ReleaseLongArrayElements(row_indices, indices_array, JNI_ABORT);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return nullptr;
     }
 

--- a/cpp/src/jni/writer_jni.cpp
+++ b/cpp/src/jni/writer_jni.cpp
@@ -34,8 +34,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerNew(
     env->ReleaseStringUTFChars(base_path, base_path_cstr);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 
@@ -58,8 +58,8 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerWrite(JN
 
     FFIResult result = writer_write(handle, array);
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return;
     }
   } catch (const std::exception& e) {
@@ -78,8 +78,8 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerFlush(JN
 
     FFIResult result = writer_flush(handle);
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return;
     }
   } catch (const std::exception& e) {
@@ -101,8 +101,8 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose(J
     FFIResult result = writer_close(handle, nullptr, nullptr, 0, &column_groups);
 
     if (!IsSuccess(&result)) {
-      FreeFFIResult(&result);
       ThrowJavaExceptionFromFFIResult(env, &result);
+      FreeFFIResult(&result);
       return -1;
     }
 


### PR DESCRIPTION
Swap order of FreeFFIResult and ThrowJavaExceptionFromFFIResult to prevent accessing freed memory. Previously FreeFFIResult was called before ThrowJavaExceptionFromFFIResult, causing the error message pointer to be freed before being used, leading to SIGSEGV crashes.