### PR TITLE
enhance: Replace fixed-interval retry with exponential backoff

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -272,7 +272,7 @@ class ConnectRetryStrategy : public Aws::Client::DefaultRetryStrategy {
   static const long kDefaultMaxRetries = 10;  // NOLINT runtime/int
 
   explicit ConnectRetryStrategy(long max_retries = kDefaultMaxRetries)  // NOLINT runtime/int
-      : Aws::Client::DefaultRetryStrategy(max_retries) {}
+      : Aws::Client::DefaultRetryStrategy(max_retries), max_retries_(max_retries) {}
 
   bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
                    long attempted_retries) const override {  // NOLINT runtime/int
@@ -281,10 +281,13 @@ class ConnectRetryStrategy : public Aws::Client::DefaultRetryStrategy {
     if (!IsConnectError(error)) {
       return false;
     }
-    return attempted_retries < GetMaxRetries();
+    return attempted_retries < max_retries_;
   }
 
   // Use DefaultRetryStrategy's exponential backoff for CalculateDelayBeforeNextRetry
+
+  private:
+  long max_retries_;  // NOLINT runtime/int
 };
 
 }  // namespace internal


### PR DESCRIPTION
Replace the fixed 200ms interval retry strategy with AWS SDK's `DefaultRetryStrategy` which uses exponential backoff.

**Before:**
- Fixed 200ms retry interval
- Max retry duration: 6 seconds (~30 retries)

**After:**
- Inherits from `Aws::Client::DefaultRetryStrategy`
- Exponential backoff: delay = scaleFactor × 2^(retries), where scaleFactor = 25ms
- Default max retries: 10
- Retains MinIO-specific error handling (SlowDown, XMinioServerNotInitialized) via `IsConnectError`

This improves retry behavior under high load by gradually increasing wait time between retries, reducing pressure on the server.