### PR TITLE
enhance: Files created in storage are stored using relative paths.

### DIFF
--- a/cpp/include/milvus-storage/column_groups.h
+++ b/cpp/include/milvus-storage/column_groups.h
@@ -49,4 +49,16 @@ struct ColumnGroup {
  */
 using ColumnGroups = std::vector<std::shared_ptr<ColumnGroup>>;
 
+static ColumnGroups copy_column_groups(const ColumnGroups& source) {
+  ColumnGroups dest(source.size());
+  for (size_t i = 0; i < source.size(); ++i) {
+    if (source[i]) {
+      dest[i] = std::make_shared<ColumnGroup>(*source[i]);
+    } else {
+      dest[i] = nullptr;
+    }
+  }
+  return dest;
+}
+
 }  // namespace milvus_storage::api

--- a/cpp/include/milvus-storage/common/layout.h
+++ b/cpp/include/milvus-storage/common/layout.h
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include "milvus-storage/common/path_util.h"
+
 namespace milvus_storage {
 
 /**
@@ -44,13 +46,16 @@ inline const std::string kManifestFileNamePrefix = "manifest-";
 inline const std::string kManifestFileNameSuffix = ".avro";
 
 // Full paths relative to base path
-inline const std::string kMetadataPath = kMetadataDir + "/";
-inline const std::string kDataPath = kDataDir + "/";
+inline const std::string kMetadataPath = kMetadataDir + kSep;
+inline const std::string kDataPath = kDataDir + kSep;
 
-inline const std::string kManifestFilePrefix = kMetadataPath + kManifestFileNamePrefix;
+std::string get_manifest_path(const std::string& base_path);
+std::string get_manifest_filename(const size_t& version);
+std::string get_manifest_filepath(const std::string& base_path, const size_t& version);
 
-static std::string get_manifest_file_name(int64_t version) {
-  return kManifestFilePrefix + std::to_string(version) + kManifestFileNameSuffix;
-}
+std::string get_data_path(const std::string& base_path);
+std::string get_data_filename(const size_t& column_group_id, const std::string& format);
+std::string get_data_filepath(const std::string& base_path, const size_t& column_group_id, const std::string& format);
+std::string get_data_filepath(const std::string& base_path, const std::string& file_name);
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -61,10 +61,6 @@ class Manifest final {
                     const std::map<std::string, std::vector<std::string>>& stats = {},
                     uint32_t version = MANIFEST_VERSION);
 
-  // Disable default copy constructor and assignment operator
-  Manifest(const Manifest&) = delete;
-  Manifest& operator=(const Manifest&) = delete;
-
   // Enable move constructor and assignment operator
   Manifest(Manifest&&) = default;
   Manifest& operator=(Manifest&&) = default;
@@ -74,12 +70,13 @@ class Manifest final {
   /**
    * @brief Serializes the manifest to a standard output stream
    */
-  [[nodiscard]] arrow::Status serialize(std::ostream& output_stream) const;
+  [[nodiscard]] arrow::Status serialize(std::ostream& output_stream,
+                                        const std::optional<std::string>& base_path = std::nullopt) const;
 
   /**
    * @brief Deserializes the manifest from a standard input stream
    */
-  arrow::Status deserialize(std::istream& input_stream);
+  arrow::Status deserialize(std::istream& input_stream, const std::optional<std::string>& base_path = std::nullopt);
 
   /**
    * @brief Get all column groups
@@ -104,15 +101,23 @@ class Manifest final {
   [[nodiscard]] std::map<std::string, std::vector<std::string>>& stats() { return stats_; }
 
   /**
-   * @brief Resolve relative paths to absolute paths using base path
-   * @param base_path Base path to prepend to relative paths
-   */
-  arrow::Status resolve_paths(const std::string& base_path);
-
-  /**
    * @brief Get the manifest format version
    */
   [[nodiscard]] int32_t version() const { return version_; }
+
+  private:
+  Manifest(const Manifest&);
+  Manifest& operator=(const Manifest&);
+
+  /**
+   * @brief Copy the manifest and normalize paths
+   */
+  Manifest NormalizePaths(const std::string& base_path) const;
+
+  /**
+   * @brief Copy the manifest and denormalize paths
+   */
+  void DenormalizePaths(const std::string& base_path) const;
 
   private:
   int32_t version_;                                        ///< Manifest format version

--- a/cpp/src/common/layout.cpp
+++ b/cpp/src/common/layout.cpp
@@ -1,0 +1,68 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/common/layout.h"
+
+#include <string>
+#include <filesystem>
+
+#include <fmt/core.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
+
+#include "milvus-storage/common/path_util.h"
+
+namespace milvus_storage {
+
+std::string get_manifest_path(const std::string& base_path) {
+  std::filesystem::path path(base_path);
+  return (path / kMetadataPath).lexically_normal().string();
+}
+
+std::string get_manifest_filename(const size_t& version) {
+  return fmt::format("{}{}{}", kManifestFileNamePrefix, version, kManifestFileNameSuffix);
+}
+
+std::string get_manifest_filepath(const std::string& base_path, const size_t& version) {
+  std::filesystem::path manifest_path(get_manifest_path(base_path));
+  return (manifest_path / get_manifest_filename(version)).lexically_normal().string();
+}
+
+std::string get_data_path(const std::string& base_path) {
+  std::filesystem::path path(base_path);
+  return (path / kDataPath).lexically_normal().string();
+}
+
+std::string get_data_filename(const size_t& column_group_id, const std::string& format) {
+  static boost::uuids::random_generator random_gen;
+  boost::uuids::uuid random_uuid = random_gen();
+  const std::string uuid_str = boost::uuids::to_string(random_uuid);
+  // named as {group_id}_{uuid}.{format}
+  return fmt::format("{}_{}.{}", column_group_id, uuid_str, format);
+}
+
+std::string get_data_filepath(const std::string& base_path, const size_t& column_group_id, const std::string& format) {
+  std::filesystem::path data_path(get_data_path(base_path));
+  return (data_path / get_data_filename(column_group_id, format)).lexically_normal().string();
+}
+
+std::string get_data_filepath(const std::string& base_path, const std::string& file_name) {
+  std::filesystem::path data_path(get_data_path(base_path));
+  return (data_path / file_name).lexically_normal().string();
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -150,8 +150,7 @@ FFIResult exttable_explore(const char** columns,
     auto committed_version = commit_result.ValueOrDie();
 
     *out_num_of_files = files.size();
-    *out_column_groups_file_path =
-        strdup((std::string(base_path) + kSep + milvus_storage::get_manifest_file_name(committed_version)).c_str());
+    *out_column_groups_file_path = strdup(milvus_storage::get_manifest_filepath(base_path, committed_version).c_str());
 
     RETURN_SUCCESS();
   } catch (std::exception& e) {

--- a/cpp/test/format/column_groups_wr_test.cpp
+++ b/cpp/test/format/column_groups_wr_test.cpp
@@ -104,8 +104,6 @@ class ColumnGroupsWRTest : public ::testing::TestWithParam<std::tuple<std::strin
     assert(cgsvec.size() == 2);
     assert(cgsvec[0]->size() == 1);
     assert(cgsvec[1]->size() == 1);
-    assert(cgsvec[0]->get_column_group(0)->files.size() == 1);
-    assert(cgsvec[1]->get_column_group(0)->files.size() == 1);
 
     auto origin_cg0 = (*cgsvec[0])[0];
     auto origin_cg1 = (*cgsvec[1])[0];

--- a/cpp/test/include/test_env.h
+++ b/cpp/test/include/test_env.h
@@ -62,6 +62,9 @@ namespace milvus_storage {
 bool IsCloudEnv();
 arrow::Status InitTestProperties(api::Properties& properties, std::string address = "/", std::string root_path = "./");
 std::string GetTestBasePath(const std::string& dir);
+arrow::Status MoveTestBasePath(const milvus_storage::ArrowFileSystemPtr& fs,
+                               const std::string& old_dir,
+                               const std::string& new_dir);
 
 arrow::Result<milvus_storage::ArrowFileSystemConfig> GetFileSystemConfig(const api::Properties& properties);
 arrow::Result<milvus_storage::ArrowFileSystemPtr> GetFileSystem(const api::Properties& properties);


### PR DESCRIPTION
In Storage, there are internal tables and external tables. Internal tables contain data generated via `write.h`, while external tables contain imported data.

- The `ColumnGroupFiles.path` written by internal tables will always be stored using relative paths.
- The `ColumnGroupFiles.path` generated by external tables will always be stored using absolute paths.

This process occurs during the serialization and deserialization of column groups. During serialization, the path in the `ColumnGroupFile` of an internal table has the `{base_path}/{data_dir_prefix}` removed before being written into Avro. During deserialization, the system checks whether the path in the current `ColumnGroupFile` is a relative path. If it is a relative path, the `{base_path}/{data_dir_prefix}` will be appended to the path. Therefore, the `ColumnGroupFile` in memory always contains an absolute path.
