### PR TITLE
enhance: fill NULL datum in missing field in column groups

### DIFF
--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -353,7 +353,7 @@ TEST_F(VortexBasicTest, TestReaderProjection) {
     ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
     ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-    ASSERT_EQ(0, rb->num_columns());
+    ASSERT_EQ(3, rb->num_columns());
   }
 }
 


### PR DESCRIPTION
When no column group in the column groups contains some projection, the reader can determine exactly how many rows to return by hitting the projection’s column group and then fill the missing fields.

But if none of the projections belong to any column group, then the reader will not know which column group to open in order to fill missing fields on a per‑row basis. After detecting this situation, the current commit will open the first column group to obtain the row count for filling missing fields. Finally, the reader will reconstruct the output schema based on the projection and only return the fields present in the projection.