### PR TITLE
fix: Update JNI bindings to match current FFI API and add Java CI

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -1,0 +1,60 @@
+name: java
+
+on:
+  push:
+    paths:
+      - 'cpp/**'
+      - 'java/**'
+      - '!go/**'
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'java/**'
+      - '!go/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install C++ dependencies
+        uses: aminya/setup-cpp@v1
+        with:
+          conan: 1.61.0
+          cmake: true
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup conan
+        run:
+          conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert
+          && conan remote list
+
+      - name: Conan package cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.conan
+          key: conan-java-${{ hashFiles('./cpp/conanfile.py') }}
+          restore-keys: conan-java-
+
+      - name: Build JNI library
+        working-directory: ./cpp
+        run: |
+          make java-lib
+
+      - name: Copy JNI library
+        run: |
+          cp ./cpp/build/Release/lib/libmilvus-storage-jni.so ./java/
+
+      - name: Compile Scala code
+        working-directory: ./java
+        run: |
+          sbt compile

--- a/cpp/src/jni/reader_jni.cpp
+++ b/cpp/src/jni/reader_jni.cpp
@@ -29,7 +29,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(JNI
                                                                              jobjectArray needed_columns,
                                                                              jlong properties_ptr) {
   try {
-    ColumnGroupsHandle column_groups_handle = static_cast<ColumnGroupsHandle>(column_groups);
+    CColumnGroups* column_groups_ptr = reinterpret_cast<CColumnGroups*>(column_groups);
     ArrowSchema* schema = reinterpret_cast<ArrowSchema*>(schema_ptr);
     Properties* properties = reinterpret_cast<Properties*>(properties_ptr);
 
@@ -37,7 +37,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_readerNew(JNI
     const char** columns = ConvertFromJavaStringArray(env, needed_columns, &num_columns);
 
     ReaderHandle reader_handle;
-    FFIResult result = reader_new(column_groups_handle, schema, columns, num_columns, properties, &reader_handle);
+    FFIResult result = reader_new(column_groups_ptr, schema, columns, num_columns, properties, &reader_handle);
 
     FreeStringArray(env, columns, num_columns);
 

--- a/cpp/src/jni/writer_jni.cpp
+++ b/cpp/src/jni/writer_jni.cpp
@@ -96,7 +96,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose(J
   try {
     WriterHandle handle = static_cast<WriterHandle>(writer_handle);
 
-    ColumnGroupsHandle column_groups = 0;
+    CColumnGroups* column_groups = nullptr;
     // no need use the metadata parameters
     FFIResult result = writer_close(handle, nullptr, nullptr, 0, &column_groups);
 
@@ -106,7 +106,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose(J
       return -1;
     }
 
-    return static_cast<jlong>(column_groups);
+    return reinterpret_cast<jlong>(column_groups);
   } catch (const std::exception& e) {
     jclass exc_class = env->FindClass("java/lang/RuntimeException");
     std::string error_msg = "Failed to close writer: " + std::string(e.what());


### PR DESCRIPTION
  - Replace deprecated ColumnGroupsHandle with CColumnGroups* in JNI code
  - Use transaction_begin + transaction_get_manifest for getLatestColumnGroups
  - Use transaction_get_manifest instead of transaction_get_column_groups
  - Use transaction_append_files + transaction_commit with new signature
  - Replace transaction_abort with transaction_destroy
  - Add GitHub Actions workflow for Java/Scala build (make java-lib + sbt compile)