### PR TITLE
enhance: Add `Loon` as the prefix to FFI

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -44,41 +44,41 @@ extern "C" {
 
 // usage example(caller must free the message string):
 //
-// FFIResult result = SomeFFIFunction(...);
-// if (!IsSuccess(&result)) {
-//    printf("Error: %s\n", GetErrorMessage(&result));
+// LoonFFIResult result = SomeFFIFunction(...);
+// if (!loon_ffi_is_success(&result)) {
+//    printf("Error: %s\n", loon_ffi_get_errmsg(&result));
 //    ... // handle error, e.g. log result.message
-//    FreeFFIResult(&result); // free the message string
+//    loon_ffi_free_result(&result); // free the message string
 // }
-typedef struct ffi_result {
+typedef struct LoonFFIResult {
   int err_code;
   char* message;
-} FFIResult;
+} LoonFFIResult;
 
 // check result is success
-FFI_EXPORT int IsSuccess(FFIResult* result);
+FFI_EXPORT int loon_ffi_is_success(LoonFFIResult* result);
 
 // get the error message, return NULL if success
-FFI_EXPORT const char* GetErrorMessage(FFIResult* result);
+FFI_EXPORT const char* loon_ffi_get_errmsg(LoonFFIResult* result);
 
-// free the message string inside FFIResult
-FFI_EXPORT void FreeFFIResult(FFIResult* result);
+// free the message string inside LoonFFIResult
+FFI_EXPORT void loon_ffi_free_result(LoonFFIResult* result);
 
 // ==================== End of Result C Interface ====================
 
 // ==================== Properties C Interface ====================
 
 /// C struct for a single property key-value pair
-typedef struct Property {
+typedef struct LoonProperty {
   char* key;    ///< Property key (caller owns memory)
   char* value;  ///< Property value (caller owns memory)
-} Property;
+} LoonProperty;
 
 /// C struct for read properties (array of key-value pairs)
-typedef struct Properties {
-  Property* properties;
+typedef struct LoonProperties {
+  LoonProperty* properties;
   size_t count;
-} Properties;
+} LoonProperties;
 
 /**
  * @brief Creates read properties from key-value arrays
@@ -88,10 +88,10 @@ typedef struct Properties {
  * @param count Number of key-value pairs
  * @param properties Output parameter for created properties (caller must free)
  */
-FFI_EXPORT FFIResult properties_create(const char* const* keys,
-                                       const char* const* values,
-                                       size_t count,
-                                       Properties* properties);
+FFI_EXPORT LoonFFIResult loon_properties_create(const char* const* keys,
+                                                const char* const* values,
+                                                size_t count,
+                                                LoonProperties* properties);
 
 /**
  * @brief Gets a property value by key
@@ -100,19 +100,19 @@ FFI_EXPORT FFIResult properties_create(const char* const* keys,
  * @param key Property key to find
  * @return Property value if found, NULL otherwise (do not free)
  */
-FFI_EXPORT const char* properties_get(const Properties* properties, const char* key);
+FFI_EXPORT const char* loon_properties_get(const LoonProperties* properties, const char* key);
 
 /**
  * @brief Frees memory allocated for Properties
  *
  * @param properties Properties to free
  */
-FFI_EXPORT void properties_free(Properties* properties);
+FFI_EXPORT void loon_properties_free(LoonProperties* properties);
 
 // ==================== End of Properties C Interface ====================
 
 // ==================== ColumnGroups C Interface ====================
-typedef struct CColumnGroupFile {
+typedef struct LoonColumnGroupFile {
   const char* path;
   int64_t start_index;
   int64_t end_index;
@@ -120,61 +120,61 @@ typedef struct CColumnGroupFile {
   // producer-specific data
   uint8_t* metadata;
   uint64_t metadata_size;
-} CColumnGroupFile;
+} LoonColumnGroupFile;
 
-typedef struct CColumnGroup {
+typedef struct LoonColumnGroup {
   const char** columns;
   uint32_t num_of_columns;
   const char* format;
 
-  CColumnGroupFile* files;
+  LoonColumnGroupFile* files;
   uint32_t num_of_files;
-} CColumnGroup;
+} LoonColumnGroup;
 
-typedef struct CColumnGroups {
-  CColumnGroup* column_group_array;
+typedef struct LoonColumnGroups {
+  LoonColumnGroup* column_group_array;
   uint32_t num_of_column_groups;
-} CColumnGroups;
+} LoonColumnGroups;
 
 /**
  * @brief C structure representing delta logs
  */
-typedef struct DeltaLogs {
+typedef struct LoonDeltaLogs {
   const char** delta_log_paths;
   uint32_t* delta_log_num_entries;
   uint32_t num_delta_logs;
-} DeltaLogs;
+} LoonDeltaLogs;
 
 /**
  * @brief C structure representing stats
  */
-typedef struct StatsLog {
+typedef struct LoonStatsLog {
   const char** stat_keys;
   const char*** stat_files;
   uint32_t* stat_file_counts;
   uint32_t num_stats;
-} StatsLog;
+} LoonStatsLog;
 
 /**
  * @brief C structure representing a Manifest
  */
-typedef struct CManifest {
+typedef struct LoonManifest {
   // Embedded ColumnGroups
-  CColumnGroups column_groups;
+  LoonColumnGroups column_groups;
 
   // Delta logs (PRIMARY_KEY type only)
-  DeltaLogs delta_logs;
+  LoonDeltaLogs delta_logs;
 
   // Stats
-  StatsLog stats;
-} CManifest;
+  LoonStatsLog stats;
+} LoonManifest;
 
 /**
  * @brief Destroys a CManifest and frees all allocated memory
  *
  * @param manifest CManifest to destroy (can be null)
  */
-FFI_EXPORT void manifest_destroy(CManifest* manifest);
+FFI_EXPORT void loon_manifest_destroy(LoonManifest* manifest);
 
 /**
  * @brief Generate column groups from external files
@@ -186,25 +186,25 @@ FFI_EXPORT void manifest_destroy(CManifest* manifest);
  * @param start_indices Array of start indices
  * @param end_indices Array of end indices
  * @param file_lens Number of files
- * @param out_column_groups Output parameter for generated CColumnGroups (function allocates and returns pointer)
- *                          Caller must call column_groups_destroy to free allocated memory
+ * @param out_column_groups Output parameter for generated LoonColumnGroups (function allocates and returns pointer)
+ *                          Caller must call `loon_column_groups_destroy` to free allocated memory
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult column_groups_create(const char** columns,
-                                          size_t col_lens,
-                                          char* format,
-                                          char** paths,
-                                          int64_t* start_indices,
-                                          int64_t* end_indices,
-                                          size_t file_lens,
-                                          CColumnGroups** out_column_groups);
+FFI_EXPORT LoonFFIResult loon_column_groups_create(const char** columns,
+                                                   size_t col_lens,
+                                                   char* format,
+                                                   char** paths,
+                                                   int64_t* start_indices,
+                                                   int64_t* end_indices,
+                                                   size_t file_lens,
+                                                   LoonColumnGroups** out_column_groups);
 
 /**
- * @brief Destroys a CColumnGroups and frees all allocated memory
+ * @brief Destroys a LoonColumnGroups and frees all allocated memory
  *
- * @param cgroups CColumnGroups to destroy (can be null)
+ * @param cgroups LoonColumnGroups to destroy (can be null)
  */
-FFI_EXPORT void column_groups_destroy(CColumnGroups* cgroups);
+FFI_EXPORT void loon_column_groups_destroy(LoonColumnGroups* cgroups);
 
 // ==================== End of ColumnGroups C Interface ====================
 
@@ -216,19 +216,19 @@ FFI_EXPORT void column_groups_destroy(CColumnGroups* cgroups);
  *
  * @param num_of_thread Number of threads in the thread pool
  */
-FFI_EXPORT FFIResult thread_pool_singleton(size_t num_of_thread);
+FFI_EXPORT LoonFFIResult loon_thread_pool_singleton(size_t num_of_thread);
 
 /**
  * @brief Release the thread pool singleton
  *        If current singleton thread pool is not null, waiting
  *        all threads join and release the thread pool singleton
  */
-FFI_EXPORT void thread_pool_singleton_release();
+FFI_EXPORT void loon_thread_pool_singleton_release();
 
 // ==================== End of ThreadPool C Interface ====================
 
 // ==================== Writer C Interface ====================
-typedef uintptr_t WriterHandle;
+typedef uintptr_t LoonWriterHandle;
 
 /**
  * @brief Creates a new Writer for a milvus storage dataset
@@ -239,10 +239,10 @@ typedef uintptr_t WriterHandle;
  * @param out_handle Output (caller must call `writer_destroy` to destory the handle)
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult writer_new(const char* base_path,
-                                struct ArrowSchema* schema,
-                                const Properties* properties,
-                                WriterHandle* out_handle);
+FFI_EXPORT LoonFFIResult loon_writer_new(const char* base_path,
+                                         struct ArrowSchema* schema,
+                                         const LoonProperties* properties,
+                                         LoonWriterHandle* out_handle);
 
 /**
  * @brief Writes a record batch to the dataset
@@ -250,45 +250,48 @@ FFI_EXPORT FFIResult writer_new(const char* base_path,
  * @param array Arrow array representing the record batch to write
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult writer_write(WriterHandle handle, struct ArrowArray* array);
+FFI_EXPORT LoonFFIResult loon_writer_write(LoonWriterHandle handle, struct ArrowArray* array);
 
 /**
  * @brief Flushes the buffer to the storage
  * @param handle Writer handle
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult writer_flush(WriterHandle handle);
+FFI_EXPORT LoonFFIResult loon_writer_flush(LoonWriterHandle handle);
 
 /**
  * @brief Closes the writer and returns the columngroups
  * @param handle Writer handle
- * @param out_columngroups Output CColumnGroups structure (function allocates and returns pointer)
- *                         Caller must call column_groups_destroy to free allocated memory
+ * @param out_columngroups Output LoonColumnGroups structure (function allocates and returns pointer)
+ *                         Caller must call `loon_column_groups_destroy` to free allocated memory
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult writer_close(
-    WriterHandle handle, char** meta_keys, char** meta_vals, uint16_t meta_len, CColumnGroups** out_columngroups);
+FFI_EXPORT LoonFFIResult loon_writer_close(LoonWriterHandle handle,
+                                           char** meta_keys,
+                                           char** meta_vals,
+                                           uint16_t meta_len,
+                                           LoonColumnGroups** out_columngroups);
 
 /**
  * @brief Destroys a Writer
  *
  * @param handle Writer handle to destroy
  */
-FFI_EXPORT void writer_destroy(WriterHandle handle);
+FFI_EXPORT void loon_writer_destroy(LoonWriterHandle handle);
 
 /**
  * @brief Frees a column groups buffer allocated by writer_close
  *
  * @param c_str buffer to free
  */
-FFI_EXPORT void free_cstr(char* c_str);
+FFI_EXPORT void loon_free_cstr(char* c_str);
 
 // ==================== End of Writer C Interface ====================
 
 // ==================== ChunkReader C Interface ====================
 
 /// Opaque handle for ChunkReader
-typedef uintptr_t ChunkReaderHandle;
+typedef uintptr_t LoonChunkReaderHandle;
 
 // Metadata type flags(maximum 32 bits)
 #define LOON_CHUNK_METADATA_ESTIMATED_MEMORY 0x01
@@ -296,7 +299,7 @@ typedef uintptr_t ChunkReaderHandle;
 #define LOON_CHUNK_METADATA_ALL (LOON_CHUNK_METADATA_ESTIMATED_MEMORY | LOON_CHUNK_METADATA_NUMOFROWS)
 
 // Chunk metadata struct
-typedef struct ChunkMetadata {
+typedef struct LoonChunkMetadata {
   // metadata type, 32bits is enough
   uint32_t metadata_type;
 
@@ -309,12 +312,12 @@ typedef struct ChunkMetadata {
   /* clang-format on */
 
   uint64_t number_of_chunks;
-} ChunkMetadata;
+} LoonChunkMetadata;
 
-typedef struct ChunkMetadatas {
-  ChunkMetadata* metadatas;
+typedef struct LoonChunkMetadatas {
+  LoonChunkMetadata* metadatas;
   uint8_t metadatas_size;
-} ChunkMetadatas;
+} LoonChunkMetadatas;
 
 /**
  * @brief Get the total number of chunks in the ChunkReader
@@ -323,7 +326,7 @@ typedef struct ChunkMetadatas {
  * @param out_number_of_chunks Output total number of chunks
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult get_number_of_chunks(ChunkReaderHandle chunk_reader, uint64_t* out_number_of_chunks);
+FFI_EXPORT LoonFFIResult loon_get_number_of_chunks(LoonChunkReaderHandle chunk_reader, uint64_t* out_number_of_chunks);
 
 /**
  * @brief Get chunk metadata for a specific column group
@@ -331,9 +334,9 @@ FFI_EXPORT FFIResult get_number_of_chunks(ChunkReaderHandle chunk_reader, uint64
  * @param reader Reader handle
  * @param out_chunk_metadata Output chunk metadata (caller must call `free_chunk_metadata` to free)
  */
-FFI_EXPORT FFIResult get_chunk_metadatas(ChunkReaderHandle reader,
-                                         uint32_t metadata_type,
-                                         ChunkMetadatas* out_chunk_metadata);
+FFI_EXPORT LoonFFIResult loon_get_chunk_metadatas(LoonChunkReaderHandle reader,
+                                                  uint32_t metadata_type,
+                                                  LoonChunkMetadatas* out_chunk_metadata);
 
 /**
  * @brief Maps row indices to their corresponding chunk indices
@@ -345,18 +348,18 @@ FFI_EXPORT FFIResult get_chunk_metadatas(ChunkReaderHandle reader,
  * @param num_chunk_indices Output number of chunk indices
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult get_chunk_indices(ChunkReaderHandle reader,
-                                       const int64_t* row_indices,
-                                       size_t num_indices,
-                                       int64_t** chunk_indices,
-                                       size_t* num_chunk_indices);
+FFI_EXPORT LoonFFIResult loon_get_chunk_indices(LoonChunkReaderHandle reader,
+                                                const int64_t* row_indices,
+                                                size_t num_indices,
+                                                int64_t** chunk_indices,
+                                                size_t* num_chunk_indices);
 
 /**
  * @brief Frees a chunk indices array allocated by get_chunk_indices
  *
  * @param chunk_indices Chunk indices array to free
  */
-FFI_EXPORT void free_chunk_indices(int64_t* chunk_indices);
+FFI_EXPORT void loon_free_chunk_indices(int64_t* chunk_indices);
 
 /**
  * @brief Retrieves a single chunk by its index
@@ -366,7 +369,9 @@ FFI_EXPORT void free_chunk_indices(int64_t* chunk_indices);
  * @param array Output array of RecordBatch (caller must free)
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult get_chunk(ChunkReaderHandle reader, int64_t chunk_index, struct ArrowArray* out_array);
+FFI_EXPORT LoonFFIResult loon_get_chunk(LoonChunkReaderHandle reader,
+                                        int64_t chunk_index,
+                                        struct ArrowArray* out_array);
 
 /**
  * @brief Retrieves multiple chunks by their indices with optional parallel processing
@@ -379,12 +384,12 @@ FFI_EXPORT FFIResult get_chunk(ChunkReaderHandle reader, int64_t chunk_index, st
  * @param num_arrays Output number of record batches
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult get_chunks(ChunkReaderHandle reader,
-                                const int64_t* chunk_indices,
-                                size_t num_indices,
-                                size_t parallelism,
-                                struct ArrowArray** arrays,
-                                size_t* num_arrays);
+FFI_EXPORT LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
+                                         const int64_t* chunk_indices,
+                                         size_t num_indices,
+                                         size_t parallelism,
+                                         struct ArrowArray** arrays,
+                                         size_t* num_arrays);
 
 /**
  * @brief Frees an array of ArrowArray allocated by get_chunks
@@ -392,26 +397,26 @@ FFI_EXPORT FFIResult get_chunks(ChunkReaderHandle reader,
  * @param arrays Array of ArrowArray to free
  * @param num_arrays Number of arrays in the array
  */
-FFI_EXPORT void free_chunk_arrays(struct ArrowArray* arrays, size_t num_arrays);
+FFI_EXPORT void loon_free_chunk_arrays(struct ArrowArray* arrays, size_t num_arrays);
 
 /**
- * @brief Frees a ChunkMetadatas allocated by `get_chunk_metadata`
+ * @brief Frees a ChunkMetadatas allocated by `loon_get_chunk_metadatas`
  *
  * @param chunk_metadata ChunkMetadatas to free
  */
-FFI_EXPORT void free_chunk_metadatas(ChunkMetadatas* chunk_metadata);
+FFI_EXPORT void loon_free_chunk_metadatas(LoonChunkMetadatas* chunk_metadata);
 
 /**
  * @brief Destroys a ChunkReader
  *
  * @param reader ChunkReader handle to destroy
  */
-FFI_EXPORT void chunk_reader_destroy(ChunkReaderHandle reader);
+FFI_EXPORT void loon_chunk_reader_destroy(LoonChunkReaderHandle reader);
 
 // ==================== Reader C Interface ====================
 
 /// Opaque handle for Reader
-typedef uintptr_t ReaderHandle;
+typedef uintptr_t LoonReaderHandle;
 
 /**
  * @brief Creates a new Reader for a milvus storage dataset
@@ -432,18 +437,19 @@ typedef uintptr_t ReaderHandle;
  *       must ensure the memory of thread_pool is valid during the
  *       lifetime of reader.
  */
-FFI_EXPORT FFIResult reader_new(const CColumnGroups* column_groups,
-                                struct ArrowSchema* schema,
-                                const char* const* needed_columns,
-                                size_t num_columns,
-                                const Properties* properties,
-                                ReaderHandle* out_handle);
+FFI_EXPORT LoonFFIResult loon_reader_new(const LoonColumnGroups* column_groups,
+                                         struct ArrowSchema* schema,
+                                         const char* const* needed_columns,
+                                         size_t num_columns,
+                                         const LoonProperties* properties,
+                                         LoonReaderHandle* out_handle);
 
 /**
  * @brief Sets a key retriever callback for dynamic key retrieval
  * use to the KMS(key management system) integration
  */
-FFI_EXPORT void reader_set_keyretriever(ReaderHandle reader, const char* (*key_retriever)(const char* metadata));
+FFI_EXPORT void loon_reader_set_keyretriever(LoonReaderHandle reader,
+                                             const char* (*key_retriever)(const char* metadata));
 
 /**
  * @brief Performs a full table scan with optional filtering and buffering
@@ -459,9 +465,9 @@ FFI_EXPORT void reader_set_keyretriever(ReaderHandle reader, const char* (*key_r
  * @param out_array_stream Output the ArrowArrayStream (caller must call `out_array_stream->release()`)
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult get_record_batch_reader(ReaderHandle reader,
-                                             const char* predicate,
-                                             struct ArrowArrayStream* out_array_stream);
+FFI_EXPORT LoonFFIResult loon_get_record_batch_reader(LoonReaderHandle reader,
+                                                      const char* predicate,
+                                                      struct ArrowArrayStream* out_array_stream);
 
 /**
  * @brief Get a chunk reader for a specific column group.
@@ -470,10 +476,12 @@ FFI_EXPORT FFIResult get_record_batch_reader(ReaderHandle reader,
  *
  * @param reader Reader handle
  * @param column_group_id ID of the column group to read from
- * @param out_handle Output (caller must call `chunk_reader_destroy` to destory the handle)
+ * @param out_handle Output (caller must call `loon_chunk_reader_destroy` to destory the handle)
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult get_chunk_reader(ReaderHandle reader, int64_t column_group_id, ChunkReaderHandle* out_handle);
+FFI_EXPORT LoonFFIResult loon_get_chunk_reader(LoonReaderHandle reader,
+                                               int64_t column_group_id,
+                                               LoonChunkReaderHandle* out_handle);
 
 /**
  * @brief Extracts specific rows by their global indices with parallel processing
@@ -490,24 +498,24 @@ FFI_EXPORT FFIResult get_chunk_reader(ReaderHandle reader, int64_t column_group_
  * @param num_arrays Number of record batches in the output array
  * @return 0 on success, others is error code
  */
-FFI_EXPORT FFIResult take(ReaderHandle reader,
-                          const int64_t* row_indices,
-                          size_t num_indices,
-                          size_t parallelism,
-                          struct ArrowArray** out_arrays,
-                          size_t* num_arrays);
+FFI_EXPORT LoonFFIResult loon_take(LoonReaderHandle reader,
+                                   const int64_t* row_indices,
+                                   size_t num_indices,
+                                   size_t parallelism,
+                                   struct ArrowArray** out_arrays,
+                                   size_t* num_arrays);
 
 /**
  * @brief Destroys a Reader
  *
  * @param reader Reader handle to destroy
  */
-FFI_EXPORT void reader_destroy(ReaderHandle reader);
+FFI_EXPORT void loon_reader_destroy(LoonReaderHandle reader);
 
 // ==================== End of Reader C Interface ====================
 
 // ==================== Manifest C Interface ====================
-typedef uintptr_t TransactionHandle;
+typedef uintptr_t LoonTransactionHandle;
 
 #define LOON_TRANSACTION_RESOLVE_FAIL 0
 #define LOON_TRANSACTION_RESOLVE_MERGE 1
@@ -523,11 +531,11 @@ typedef uintptr_t TransactionHandle;
  * @param out_handle Output transaction handle
  * @return result of FFI
  */
-FFIResult transaction_begin(const char* base_path,
-                            const Properties* properties,
-                            int64_t read_version,
-                            uint32_t retry_limit,
-                            TransactionHandle* out_handle);
+FFI_EXPORT LoonFFIResult loon_transaction_begin(const char* base_path,
+                                                const LoonProperties* properties,
+                                                int64_t read_version,
+                                                uint32_t retry_limit,
+                                                LoonTransactionHandle* out_handle);
 
 /**
  * @brief get the manifest of the transaction
@@ -537,7 +545,7 @@ FFIResult transaction_begin(const char* base_path,
  *                     Caller must call manifest_destroy to free allocated memory
  * @return result of FFI
  */
-FFIResult transaction_get_manifest(TransactionHandle handle, CManifest** out_manifest);
+FFI_EXPORT LoonFFIResult loon_transaction_get_manifest(LoonTransactionHandle handle, LoonManifest** out_manifest);
 
 /**
  * @brief Get the read version of the transaction
@@ -546,7 +554,7 @@ FFIResult transaction_get_manifest(TransactionHandle handle, CManifest** out_man
  * @param out_read_version Output read version number
  * @return result of FFI
  */
-FFIResult transaction_get_read_version(TransactionHandle handle, int64_t* out_read_version);
+FFI_EXPORT LoonFFIResult loon_transaction_get_read_version(LoonTransactionHandle handle, int64_t* out_read_version);
 
 /**
  * @brief Commits the transaction with the provided manifest
@@ -558,32 +566,34 @@ FFIResult transaction_get_read_version(TransactionHandle handle, int64_t* out_re
  * @param out_committed_version Output committed version (valid only if commit succeeds)
  * @return result of FFI
  */
-FFIResult transaction_commit(TransactionHandle handle, int64_t* out_committed_version);
+FFI_EXPORT LoonFFIResult loon_transaction_commit(LoonTransactionHandle handle, int64_t* out_committed_version);
 
 /**
  * @brief Destroys a Transaction
  *
  * @param handle Transaction handle to destroy
  */
-void transaction_destroy(TransactionHandle handle);
+FFI_EXPORT void loon_transaction_destroy(LoonTransactionHandle handle);
 
 /**
  * @brief Add a new column group to the transaction updates
  *
  * @param handle Transaction handle
- * @param column_group CColumnGroup structure to add
+ * @param column_group LoonColumnGroup structure to add
  * @return result of FFI
  */
-FFIResult transaction_add_column_group(TransactionHandle handle, const CColumnGroup* column_group);
+FFI_EXPORT LoonFFIResult loon_transaction_add_column_group(LoonTransactionHandle handle,
+                                                           const LoonColumnGroup* column_group);
 
 /**
  * @brief Append files to existing column groups in the transaction updates
  *
  * @param handle Transaction handle
- * @param column_groups CColumnGroups structure containing files to append
+ * @param column_groups LoonColumnGroups structure containing files to append
  * @return result of FFI
  */
-FFIResult transaction_append_files(TransactionHandle handle, const CColumnGroups* column_groups);
+FFI_EXPORT LoonFFIResult loon_transaction_append_files(LoonTransactionHandle handle,
+                                                       const LoonColumnGroups* column_groups);
 
 /**
  * @brief Add a delta log to the transaction updates
@@ -594,7 +604,9 @@ FFIResult transaction_append_files(TransactionHandle handle, const CColumnGroups
  * @return result of FFI
  * @note Type is hardcoded to PRIMARY_KEY internally
  */
-FFIResult transaction_add_delta_log(TransactionHandle handle, const char* path, int64_t num_entries);
+FFI_EXPORT LoonFFIResult loon_transaction_add_delta_log(LoonTransactionHandle handle,
+                                                        const char* path,
+                                                        int64_t num_entries);
 
 /**
  * @brief Add a stat entry to the transaction updates
@@ -605,10 +617,10 @@ FFIResult transaction_add_delta_log(TransactionHandle handle, const char* path, 
  * @param files_len Number of files in the array
  * @return result of FFI
  */
-FFIResult transaction_update_stat(TransactionHandle handle,
-                                  const char* key,
-                                  const char* const* files,
-                                  size_t files_len);
+FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle handle,
+                                                      const char* key,
+                                                      const char* const* files,
+                                                      size_t files_len);
 
 /**
  * @brief Cleans the global filesystem cache
@@ -616,7 +628,7 @@ FFIResult transaction_update_stat(TransactionHandle handle,
  * This function clears the LRUCache used for storing ArrowFileSystem instances.
  * Useful for testing or when resetting the environment.
  */
-FFI_EXPORT void close_filesystems();
+FFI_EXPORT void loon_close_filesystems();
 
 // ==================== End of Manifest C Interface ====================
 

--- a/cpp/include/milvus-storage/ffi_exttable_c.h
+++ b/cpp/include/milvus-storage/ffi_exttable_c.h
@@ -24,13 +24,13 @@ extern "C" {
 #include <stdint.h>
 #include <arrow/c/abi.h>
 
-struct ffi_result;
-struct Properties;
-struct CManifest;
+struct LoonFFIResult;
+struct LoonProperties;
+struct LoonManifest;
 
-typedef struct ffi_result FFIResult;
-typedef struct Properties Properties;
-typedef struct CManifest CManifest;
+typedef struct LoonFFIResult LoonFFIResult;
+typedef struct LoonProperties LoonProperties;
+typedef struct LoonManifest LoonManifest;
 
 /**
  * @brief Import external files into a dataset
@@ -43,16 +43,16 @@ typedef struct CManifest CManifest;
  * @param properties Configuration properties for filesystem access (e.g., S3 credentials, Azure config)
  * @param out_num_of_files output number of files
  * @param out_column_groups_file_path output column groups file path, need call `free_cstr` to free memory
- * @return FFIResult
+ * @return LoonFFIResult
  */
-FFIResult exttable_explore(const char** columns,
-                           size_t col_lens,
-                           const char* format,
-                           const char* base_dir,
-                           const char* explore_dir,
-                           const Properties* properties,
-                           uint64_t* out_num_of_files,
-                           char** out_column_groups_file_path);
+LoonFFIResult loon_exttable_explore(const char** columns,
+                                    size_t col_lens,
+                                    const char* format,
+                                    const char* base_dir,
+                                    const char* explore_dir,
+                                    const LoonProperties* properties,
+                                    uint64_t* out_num_of_files,
+                                    char** out_column_groups_file_path);
 
 /**
  * @brief Get file info
@@ -62,12 +62,12 @@ FFIResult exttable_explore(const char** columns,
  * @param properties Configuration properties for filesystem access (e.g., S3 credentials, Azure config)
  * @param out_num_of_rows output number of rows
  * @param out_schema output schema
- * @return FFIResult
+ * @return LoonFFIResult
  */
-FFIResult exttable_get_file_info(const char* format,
-                                 const char* file_path,
-                                 const Properties* properties,
-                                 uint64_t* out_num_of_rows);
+LoonFFIResult loon_exttable_get_file_info(const char* format,
+                                          const char* file_path,
+                                          const LoonProperties* properties,
+                                          uint64_t* out_num_of_rows);
 
 /**
  * @brief Read manifest from file
@@ -75,11 +75,11 @@ FFIResult exttable_get_file_info(const char* format,
  * @param manifest_file_path manifest file path
  * @param properties Configuration properties for filesystem access (e.g., S3 credentials, Azure config)
  * @param out_manifest output manifest (includes column groups, delta logs, and stats)
- * @return FFIResult
+ * @return LoonFFIResult
  */
-FFIResult exttable_read_manifest(const char* manifest_file_path,
-                                 const Properties* properties,
-                                 CManifest** out_manifest);
+LoonFFIResult loon_exttable_read_manifest(const char* manifest_file_path,
+                                          const LoonProperties* properties,
+                                          LoonManifest** out_manifest);
 
 #endif  // LOON_FFI_EXTERNAL_TABLE_C
 

--- a/cpp/include/milvus-storage/ffi_filesystem_c.h
+++ b/cpp/include/milvus-storage/ffi_filesystem_c.h
@@ -35,14 +35,14 @@ typedef uintptr_t FileSystemReaderHandle;
  * @param out_handle The output filesystem instance.
  * @return result of FFI
  */
-FFIResult filesystem_create(const Properties* properties, FileSystemHandle* out_handle);
+LoonFFIResult loon_filesystem_create(const LoonProperties* properties, FileSystemHandle* out_handle);
 
 /**
  * Destroy a filesystem instance.
  *
  * @param handle The filesystem instance to destroy.
  */
-void filesystem_destroy(FileSystemHandle handle);
+void loon_filesystem_destroy(FileSystemHandle handle);
 
 /**
  * Open a outputstream for a file.
@@ -53,10 +53,10 @@ void filesystem_destroy(FileSystemHandle handle);
  * @param out_handle The output writer instance.
  * @return result of FFI
  */
-FFIResult filesystem_open_writer(FileSystemHandle handle,
-                                 const char* path_ptr,
-                                 uint32_t path_len,
-                                 FileSystemWriterHandle* out_handle);
+LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
+                                          const char* path_ptr,
+                                          uint32_t path_len,
+                                          FileSystemWriterHandle* out_handle);
 
 /**
  * Write data to the outputstream.
@@ -66,7 +66,7 @@ FFIResult filesystem_open_writer(FileSystemHandle handle,
  * @param size The size of the data.
  * @return result of FFI
  */
-FFIResult filesystem_writer_write(FileSystemWriterHandle handle, const uint8_t* data, uint64_t size);
+LoonFFIResult loon_filesystem_writer_write(FileSystemWriterHandle handle, const uint8_t* data, uint64_t size);
 
 /**
  * Flush the outputstream.
@@ -74,7 +74,7 @@ FFIResult filesystem_writer_write(FileSystemWriterHandle handle, const uint8_t* 
  * @param handle The outputstream instance.
  * @return result of FFI
  */
-FFIResult filesystem_writer_flush(FileSystemWriterHandle handle);
+LoonFFIResult loon_filesystem_writer_flush(FileSystemWriterHandle handle);
 
 /**
  * Close the outputstream.
@@ -82,14 +82,14 @@ FFIResult filesystem_writer_flush(FileSystemWriterHandle handle);
  * @param handle The outputstream instance.
  * @return result of FFI
  */
-FFIResult filesystem_writer_close(FileSystemWriterHandle handle);
+LoonFFIResult loon_filesystem_writer_close(FileSystemWriterHandle handle);
 
 /**
  * Destroy the outputstream.
  *
  * @param handle The outputstream instance.
  */
-void filesystem_writer_destroy(FileSystemWriterHandle handle);
+void loon_filesystem_writer_destroy(FileSystemWriterHandle handle);
 
 /**
  * Get the size of the file.
@@ -100,10 +100,10 @@ void filesystem_writer_destroy(FileSystemWriterHandle handle);
  * @param out_size The size of the file.
  * @return result of FFI
  */
-FFIResult filesystem_get_file_info(FileSystemHandle handle,
-                                   const char* path_ptr,
-                                   uint32_t path_len,
-                                   uint64_t* out_size);
+LoonFFIResult loon_filesystem_get_file_info(FileSystemHandle handle,
+                                            const char* path_ptr,
+                                            uint32_t path_len,
+                                            uint64_t* out_size);
 
 /**
  * Get the content of the file.
@@ -116,12 +116,12 @@ FFIResult filesystem_get_file_info(FileSystemHandle handle,
  * @param out_data The buffer to read bytes into
  * @return result of FFI
  */
-FFIResult filesystem_read_file(FileSystemHandle handle,
-                               const char* path_ptr,
-                               uint32_t path_len,
-                               uint64_t offset,
-                               uint64_t nbytes,
-                               uint8_t* out_data);
+LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
+                                        const char* path_ptr,
+                                        uint32_t path_len,
+                                        uint64_t offset,
+                                        uint64_t nbytes,
+                                        uint8_t* out_data);
 
 /**
  * Open a inputstream for a file.
@@ -131,10 +131,10 @@ FFIResult filesystem_read_file(FileSystemHandle handle,
  * @param path_len The length of the path.
  * @return result of FFI
  */
-FFIResult filesystem_open_reader(FileSystemHandle handle,
-                                 const char* path_ptr,
-                                 uint32_t path_len,
-                                 FileSystemReaderHandle* out_reader_ptr);
+LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
+                                          const char* path_ptr,
+                                          uint32_t path_len,
+                                          FileSystemReaderHandle* out_reader_ptr);
 
 /**
  * Read data from the inputstream.
@@ -146,7 +146,10 @@ FFIResult filesystem_open_reader(FileSystemHandle handle,
  *                 The `out_data` must be allocated by caller, the allocated size must GE `nbytes`.
  * @return result of FFI
  */
-FFIResult filesystem_reader_readat(FileSystemReaderHandle handle, uint64_t offset, uint64_t nbytes, uint8_t* out_data);
+LoonFFIResult loon_filesystem_reader_readat(FileSystemReaderHandle handle,
+                                            uint64_t offset,
+                                            uint64_t nbytes,
+                                            uint8_t* out_data);
 
 /**
  * Close the inputstream.
@@ -154,14 +157,14 @@ FFIResult filesystem_reader_readat(FileSystemReaderHandle handle, uint64_t offse
  * @param handle The inputstream instance.
  * @return result of FFI
  */
-FFIResult filesystem_reader_close(FileSystemReaderHandle handle);
+LoonFFIResult loon_filesystem_reader_close(FileSystemReaderHandle handle);
 
 /**
  * Destroy the inputstream.
  *
  * @param handle The inputstream instance.
  */
-void filesystem_reader_destroy(FileSystemReaderHandle handle);
+void loon_filesystem_reader_destroy(FileSystemReaderHandle handle);
 
 #endif  // LOON_FILESYSTEM_C
 

--- a/cpp/include/milvus-storage/ffi_internal/bridge.h
+++ b/cpp/include/milvus-storage/ffi_internal/bridge.h
@@ -28,16 +28,17 @@ struct ColumnGroup;
 }  // namespace api
 
 // Main functions for exporting/importing Manifest (includes column groups, delta logs, and stats)
-// Export function allocates and returns the structure - caller must call manifest_destroy to free
+// Export function allocates and returns the structure - caller must call loon_manifest_destroy to free
 arrow::Status export_manifest(const std::shared_ptr<milvus_storage::api::Manifest>& manifest,
-                              CManifest** out_cmanifest);
+                              LoonManifest** out_cmanifest);
 
-arrow::Status import_manifest(const CManifest* cmanifest, std::shared_ptr<milvus_storage::api::Manifest>* out_manifest);
+arrow::Status import_manifest(const LoonManifest* cmanifest,
+                              std::shared_ptr<milvus_storage::api::Manifest>* out_manifest);
 
 // Helper functions for column groups only (for backward compatibility)
-// Export function allocates and returns the structure - caller must call column_groups_destroy to free
-arrow::Status export_column_groups(const milvus_storage::api::ColumnGroups& cgs, CColumnGroups** out_ccgs);
+// Export function allocates and returns the structure - caller must call `loon_column_groups_destroy` to free
+arrow::Status export_column_groups(const milvus_storage::api::ColumnGroups& cgs, LoonColumnGroups** out_ccgs);
 
-arrow::Status import_column_groups(const CColumnGroups* ccgs, milvus_storage::api::ColumnGroups* out_cgs);
+arrow::Status import_column_groups(const LoonColumnGroups* ccgs, milvus_storage::api::ColumnGroups* out_cgs);
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/ffi_internal/result.h
+++ b/cpp/include/milvus-storage/ffi_internal/result.h
@@ -24,9 +24,9 @@
 #include <cassert>
 #include <iostream>
 
-#define RETURN_SUCCESS()                     \
-  do {                                       \
-    return FFIResult{LOON_SUCCESS, nullptr}; \
+#define RETURN_SUCCESS()                         \
+  do {                                           \
+    return LoonFFIResult{LOON_SUCCESS, nullptr}; \
   } while (0)
 
 #define RETURN_ERROR(code, ...)                    \
@@ -39,8 +39,8 @@
 std::string error_to_string(int code);
 
 template <typename... Args>
-FFIResult CreateFFIResult(int code, Args&&... args) {
-  FFIResult result;
+LoonFFIResult CreateFFIResult(int code, Args&&... args) {
+  LoonFFIResult result;
   std::ostringstream ss;
   assert(code != LOON_SUCCESS);
 

--- a/cpp/include/milvus-storage/ffi_jni.h
+++ b/cpp/include/milvus-storage/ffi_jni.h
@@ -24,12 +24,12 @@ extern "C" {
 // ==================== JNI Result Utilities ====================
 
 /**
- * @brief Throws a Java exception based on FFIResult
+ * @brief Throws a Java exception based on LoonFFIResult
  *
  * @param env JNI environment
- * @param result FFI result to convert to exception
+ * @param result LoonFFIResult to convert to exception
  */
-void ThrowJavaExceptionFromFFIResult(JNIEnv* env, const struct ffi_result* result);
+void ThrowJavaExceptionFromFFIResult(JNIEnv* env, const struct LoonFFIResult* result);
 
 /**
  * @brief Converts string array to Java string array

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -23,7 +23,7 @@
 #include <cstdint>
 #include <arrow/result.h>
 
-struct Properties;
+struct LoonProperties;
 
 namespace milvus_storage::api {
 struct PropertyInfo;
@@ -169,6 +169,6 @@ std::optional<std::string> SetValue(Properties& properties,
                                     const char* key,
                                     const char* value,
                                     bool allow_undefined_key = true);
-std::optional<std::string> ConvertFFIProperties(Properties& result, const ::Properties* properties);
+std::optional<std::string> ConvertFFIProperties(Properties& result, const ::LoonProperties* properties);
 
 }  // namespace milvus_storage::api

--- a/cpp/src/ffi/column_groups_c.cpp
+++ b/cpp/src/ffi/column_groups_c.cpp
@@ -20,14 +20,14 @@
 
 using namespace milvus_storage::api;
 
-FFIResult column_groups_create(const char** columns,
-                               size_t col_lens,
-                               char* format,
-                               char** paths,
-                               int64_t* start_indices,
-                               int64_t* end_indices,
-                               size_t file_lens,
-                               CColumnGroups** out_column_groups) {
+LoonFFIResult loon_column_groups_create(const char** columns,
+                                        size_t col_lens,
+                                        char* format,
+                                        char** paths,
+                                        int64_t* start_indices,
+                                        int64_t* end_indices,
+                                        size_t file_lens,
+                                        LoonColumnGroups** out_column_groups) {
   if (!columns || !col_lens || !paths || !format || !file_lens || !out_column_groups || !start_indices ||
       !end_indices) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments");
@@ -53,7 +53,7 @@ FFIResult column_groups_create(const char** columns,
     cg->format = format;
     cgs.push_back(cg);
 
-    // Export to CColumnGroups structure
+    // Export to LoonColumnGroups structure
     auto st = milvus_storage::export_column_groups(cgs, out_column_groups);
     if (!st.ok()) {
       RETURN_ERROR(LOON_LOGICAL_ERROR, st.ToString());
@@ -67,7 +67,7 @@ FFIResult column_groups_create(const char** columns,
   RETURN_UNREACHABLE();
 }
 
-static void destroy_column_group_file(CColumnGroupFile* ccgf) {
+static void destroy_column_group_file(LoonColumnGroupFile* ccgf) {
   if (!ccgf)
     return;
 
@@ -85,7 +85,7 @@ static void destroy_column_group_file(CColumnGroupFile* ccgf) {
   }
 }
 
-void destroy_column_group(CColumnGroup* ccg) {
+void destroy_column_group(LoonColumnGroup* ccg) {
   if (!ccg)
     return;
 
@@ -118,8 +118,8 @@ void destroy_column_group(CColumnGroup* ccg) {
   }
 }
 
-// Helper function to destroy embedded column groups (used by manifest_destroy)
-void destroy_column_groups_contents(CColumnGroups* cgroups) {
+// Helper function to destroy embedded column groups (used by loon_manifest_destroy)
+void destroy_column_groups_contents(LoonColumnGroups* cgroups) {
   if (!cgroups)
     return;
 
@@ -134,7 +134,7 @@ void destroy_column_groups_contents(CColumnGroups* cgroups) {
   }
 }
 
-void column_groups_destroy(CColumnGroups* cgroups) {
+void loon_column_groups_destroy(LoonColumnGroups* cgroups) {
   if (!cgroups)
     return;
 

--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -74,14 +74,14 @@ static inline arrow::Result<std::vector<milvus_storage::api::ColumnGroupFile>> g
   return files;
 }
 
-FFIResult exttable_explore(const char** columns,
-                           size_t col_lens,
-                           const char* format,
-                           const char* base_path,
-                           const char* explore_dir,
-                           const ::Properties* properties,
-                           uint64_t* out_num_of_files,
-                           char** out_column_groups_file_path) {
+LoonFFIResult loon_exttable_explore(const char** columns,
+                                    size_t col_lens,
+                                    const char* format,
+                                    const char* base_path,
+                                    const char* explore_dir,
+                                    const ::LoonProperties* properties,
+                                    uint64_t* out_num_of_files,
+                                    char** out_column_groups_file_path) {
   if (!columns || !format || !base_path || !explore_dir || !properties || !out_num_of_files ||
       !out_column_groups_file_path) {
     RETURN_ERROR(LOON_INVALID_ARGS,
@@ -160,10 +160,10 @@ FFIResult exttable_explore(const char** columns,
   RETURN_UNREACHABLE();
 }
 
-FFIResult exttable_get_file_info(const char* format,
-                                 const char* file_path,
-                                 const ::Properties* properties,
-                                 uint64_t* out_num_of_rows) {
+LoonFFIResult loon_exttable_get_file_info(const char* format,
+                                          const char* file_path,
+                                          const ::LoonProperties* properties,
+                                          uint64_t* out_num_of_rows) {
   if (!format || !file_path || !properties || !out_num_of_rows) {
     RETURN_ERROR(LOON_INVALID_ARGS,
                  "Invalid arguments: format, file_path, properties, and out_num_of_rows must not be null");
@@ -242,7 +242,7 @@ FFIResult exttable_get_file_info(const char* format,
 }
 
 static arrow::Result<std::shared_ptr<milvus_storage::api::Manifest>> read_manifest(const char* path,
-                                                                                   const ::Properties* properties) {
+                                                                                   const ::LoonProperties* properties) {
   milvus_storage::ArrowFileSystemConfig fs_config;
   milvus_storage::api::Properties properties_map;
 
@@ -275,9 +275,9 @@ static arrow::Result<std::shared_ptr<milvus_storage::api::Manifest>> read_manife
   return manifest;
 }
 
-FFIResult exttable_read_manifest(const char* manifest_file_path,
-                                 const ::Properties* properties,
-                                 CManifest** out_manifest) {
+LoonFFIResult loon_exttable_read_manifest(const char* manifest_file_path,
+                                          const ::LoonProperties* properties,
+                                          LoonManifest** out_manifest) {
   if (!manifest_file_path || !properties || !out_manifest) {
     RETURN_ERROR(LOON_INVALID_ARGS,
                  "Invalid arguments: manifest_file_path, properties, and out_manifest must not be null");

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -27,7 +27,7 @@
 using namespace milvus_storage::api;
 using namespace milvus_storage;
 
-FFIResult filesystem_create(const ::Properties* properties, FileSystemHandle* out_fs_ptr) {
+LoonFFIResult loon_filesystem_create(const ::LoonProperties* properties, FileSystemHandle* out_fs_ptr) {
   try {
     if (!properties) {
       RETURN_ERROR(LOON_INVALID_ARGS, "properties is null");
@@ -63,16 +63,16 @@ FFIResult filesystem_create(const ::Properties* properties, FileSystemHandle* ou
   RETURN_UNREACHABLE();
 }
 
-void filesystem_destroy(FileSystemHandle ptr) {
+void loon_filesystem_destroy(FileSystemHandle ptr) {
   if (ptr) {
     delete reinterpret_cast<FileSystemWrapper*>(ptr);
   }
 }
 
-FFIResult filesystem_open_writer(FileSystemHandle handle,
-                                 const char* path_ptr,
-                                 uint32_t path_len,
-                                 FileSystemWriterHandle* out_writer_ptr) {
+LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
+                                          const char* path_ptr,
+                                          uint32_t path_len,
+                                          FileSystemWriterHandle* out_writer_ptr) {
   try {
     if (!handle || !path_ptr || path_len == 0 || !out_writer_ptr) {
       RETURN_ERROR(LOON_INVALID_ARGS,
@@ -98,7 +98,7 @@ FFIResult filesystem_open_writer(FileSystemHandle handle,
   RETURN_UNREACHABLE();
 }
 
-FFIResult filesystem_writer_write(FileSystemWriterHandle handle, const uint8_t* data, uint64_t size) {
+LoonFFIResult loon_filesystem_writer_write(FileSystemWriterHandle handle, const uint8_t* data, uint64_t size) {
   try {
     if (!handle || !data || size == 0) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, data, and size must not be null");
@@ -117,7 +117,7 @@ FFIResult filesystem_writer_write(FileSystemWriterHandle handle, const uint8_t* 
   RETURN_UNREACHABLE();
 }
 
-FFIResult filesystem_writer_flush(FileSystemWriterHandle handle) {
+LoonFFIResult loon_filesystem_writer_flush(FileSystemWriterHandle handle) {
   try {
     if (!handle) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
@@ -136,7 +136,7 @@ FFIResult filesystem_writer_flush(FileSystemWriterHandle handle) {
   RETURN_UNREACHABLE();
 }
 
-FFIResult filesystem_writer_close(FileSystemWriterHandle handle) {
+LoonFFIResult loon_filesystem_writer_close(FileSystemWriterHandle handle) {
   try {
     if (!handle) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
@@ -155,17 +155,17 @@ FFIResult filesystem_writer_close(FileSystemWriterHandle handle) {
   RETURN_UNREACHABLE();
 }
 
-void filesystem_writer_destroy(FileSystemWriterHandle handle) {
+void loon_filesystem_writer_destroy(FileSystemWriterHandle handle) {
   if (handle) {
     auto* wrapper = reinterpret_cast<OutputStreamWrapper*>(handle);
     delete wrapper;
   }
 }
 
-FFIResult filesystem_get_file_info(FileSystemHandle handle,
-                                   const char* path_ptr,
-                                   uint32_t path_len,
-                                   uint64_t* out_size) {
+LoonFFIResult loon_filesystem_get_file_info(FileSystemHandle handle,
+                                            const char* path_ptr,
+                                            uint32_t path_len,
+                                            uint64_t* out_size) {
   try {
     if (!handle || !path_ptr || path_len == 0 || !out_size) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, path_ptr, path_len, and out_size must not be null");
@@ -189,12 +189,12 @@ FFIResult filesystem_get_file_info(FileSystemHandle handle,
   RETURN_UNREACHABLE();
 }
 
-FFIResult filesystem_read_file(FileSystemHandle handle,
-                               const char* path_ptr,
-                               uint32_t path_len,
-                               uint64_t offset,
-                               uint64_t nbytes,
-                               uint8_t* out_data) {
+LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
+                                        const char* path_ptr,
+                                        uint32_t path_len,
+                                        uint64_t offset,
+                                        uint64_t nbytes,
+                                        uint8_t* out_data) {
   try {
     if (!handle || !path_ptr || path_len == 0 || !out_data || nbytes == 0) {
       RETURN_ERROR(LOON_INVALID_ARGS,
@@ -247,10 +247,10 @@ FFIResult filesystem_read_file(FileSystemHandle handle,
   RETURN_UNREACHABLE();
 }
 
-FFIResult filesystem_open_reader(FileSystemHandle handle,
-                                 const char* path_ptr,
-                                 uint32_t path_len,
-                                 FileSystemReaderHandle* out_reader_ptr) {
+LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
+                                          const char* path_ptr,
+                                          uint32_t path_len,
+                                          FileSystemReaderHandle* out_reader_ptr) {
   try {
     if (!handle || !path_ptr || path_len == 0 || !out_reader_ptr) {
       RETURN_ERROR(LOON_INVALID_ARGS,
@@ -277,7 +277,10 @@ FFIResult filesystem_open_reader(FileSystemHandle handle,
   RETURN_UNREACHABLE();
 }
 
-FFIResult filesystem_reader_readat(FileSystemReaderHandle handle, uint64_t offset, uint64_t nbytes, uint8_t* out_data) {
+LoonFFIResult loon_filesystem_reader_readat(FileSystemReaderHandle handle,
+                                            uint64_t offset,
+                                            uint64_t nbytes,
+                                            uint8_t* out_data) {
   try {
     if (!handle || !out_data || nbytes == 0) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, out_data, and nbytes must not be null");
@@ -310,7 +313,7 @@ FFIResult filesystem_reader_readat(FileSystemReaderHandle handle, uint64_t offse
  * @param handle The inputstream instance.
  * @return result of FFI
  */
-FFIResult filesystem_reader_close(FileSystemReaderHandle handle) {
+LoonFFIResult loon_filesystem_reader_close(FileSystemReaderHandle handle) {
   try {
     if (!handle) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
@@ -330,7 +333,7 @@ FFIResult filesystem_reader_close(FileSystemReaderHandle handle) {
   RETURN_UNREACHABLE();
 }
 
-void filesystem_reader_destroy(FileSystemReaderHandle handle) {
+void loon_filesystem_reader_destroy(FileSystemReaderHandle handle) {
   if (handle) {
     auto* wrapper = reinterpret_cast<RandomAccessFileWrapper*>(handle);
     delete wrapper;

--- a/cpp/src/ffi/properties_c.cpp
+++ b/cpp/src/ffi/properties_c.cpp
@@ -31,10 +31,10 @@ using namespace milvus_storage;
 using namespace milvus_storage::api;
 // ==================== Properties C Implementation ====================
 
-FFIResult properties_create(const char* const* keys,
-                            const char* const* values,
-                            size_t count,
-                            ::Properties* properties) {
+LoonFFIResult loon_properties_create(const char* const* keys,
+                                     const char* const* values,
+                                     size_t count,
+                                     ::LoonProperties* properties) {
   // used to make sure no duplicate keys
   std::unordered_set<std::string_view> key_set;
   if (!properties) {
@@ -48,9 +48,9 @@ FFIResult properties_create(const char* const* keys,
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid keys/values");
   }
 
-  properties->properties = static_cast<Property*>(malloc(sizeof(Property) * count));
+  properties->properties = static_cast<LoonProperty*>(malloc(sizeof(LoonProperty) * count));
   if (!properties->properties) {
-    RETURN_ERROR(LOON_MEMORY_ERROR, "Failed to malloc [size=", sizeof(Property) * count, "]");
+    RETURN_ERROR(LOON_MEMORY_ERROR, "Failed to malloc [size=", sizeof(LoonProperty) * count, "]");
   }
   properties->count = count;
 
@@ -67,7 +67,7 @@ FFIResult properties_create(const char* const* keys,
 
       key_set.insert(keys[i]);
     } else {
-      properties_free(properties);
+      loon_properties_free(properties);
       if (keys[i]) {
         RETURN_ERROR(LOON_INVALID_PROPERTIES, "Duplicate key: ", keys[i], " at index: ", i);
       } else {
@@ -82,7 +82,7 @@ FFIResult properties_create(const char* const* keys,
         strcpy(properties->properties[i].value, values[i]);
       }
     } else {
-      properties_free(properties);
+      loon_properties_free(properties);
       RETURN_ERROR(LOON_INVALID_PROPERTIES, "The value index: ", i, " is invalid, key: ", keys[i]);
     }
   }
@@ -90,7 +90,7 @@ FFIResult properties_create(const char* const* keys,
   RETURN_SUCCESS();
 }
 
-const char* properties_get(const ::Properties* properties, const char* key) {
+const char* loon_properties_get(const ::LoonProperties* properties, const char* key) {
   if (!properties || !properties->properties || !key) {
     return nullptr;
   }
@@ -104,7 +104,7 @@ const char* properties_get(const ::Properties* properties, const char* key) {
   return nullptr;
 }
 
-void properties_free(::Properties* properties) {
+void loon_properties_free(::LoonProperties* properties) {
   if (!properties) {
     return;
   }

--- a/cpp/src/ffi/result_c.cpp
+++ b/cpp/src/ffi/result_c.cpp
@@ -36,20 +36,20 @@ std::string error_to_string(int code) {
   return error_strings[code];
 }
 
-int IsSuccess(FFIResult* result) {
+int loon_ffi_is_success(LoonFFIResult* result) {
   assert(result);
   return result->err_code == LOON_SUCCESS;
 }
 
-const char* GetErrorMessage(FFIResult* result) {
+const char* loon_ffi_get_errmsg(LoonFFIResult* result) {
   assert(result);
-  if (IsSuccess(result)) {
+  if (loon_ffi_is_success(result)) {
     return NULL;
   }
   return result->message;
 }
 
-void FreeFFIResult(FFIResult* result) {
+void loon_ffi_free_result(LoonFFIResult* result) {
   assert(result);
   free(result->message);
 }

--- a/cpp/src/ffi/threadpool_c.cpp
+++ b/cpp/src/ffi/threadpool_c.cpp
@@ -18,7 +18,7 @@
 #include "milvus-storage/thread_pool.h"
 
 using namespace milvus_storage;
-FFIResult thread_pool_singleton(size_t num_of_thread) {
+LoonFFIResult loon_thread_pool_singleton(size_t num_of_thread) {
   if (num_of_thread == 0) {
     RETURN_ERROR(LOON_INVALID_ARGS, "num_of_thread must be greater than 0");
   }
@@ -26,4 +26,4 @@ FFIResult thread_pool_singleton(size_t num_of_thread) {
   RETURN_SUCCESS();
 }
 
-void thread_pool_singleton_release() { ThreadPoolHolder::Release(); }
+void loon_thread_pool_singleton_release() { ThreadPoolHolder::Release(); }

--- a/cpp/src/ffi/writer_c.cpp
+++ b/cpp/src/ffi/writer_c.cpp
@@ -24,10 +24,10 @@
 using namespace milvus_storage::api;
 using namespace milvus_storage;
 
-FFIResult writer_new(const char* base_path,
-                     ArrowSchema* schema_raw,
-                     const ::Properties* properties,
-                     WriterHandle* out_handle) {
+LoonFFIResult loon_writer_new(const char* base_path,
+                              ArrowSchema* schema_raw,
+                              const ::LoonProperties* properties,
+                              LoonWriterHandle* out_handle) {
   if (!base_path || !schema_raw || !properties || !out_handle) {
     RETURN_ERROR(LOON_INVALID_ARGS,
                  "Invalid arguments: base_path, schema_raw, properties, and out_handle must not be null");
@@ -54,14 +54,14 @@ FFIResult writer_new(const char* base_path,
   auto cpp_writer =
       Writer::create(std::move(std::string(base_path)), schema, std::move(policy), std::move(properties_map));
 
-  auto raw_cpp_writer = reinterpret_cast<WriterHandle>(cpp_writer.release());
+  auto raw_cpp_writer = reinterpret_cast<LoonWriterHandle>(cpp_writer.release());
   assert(raw_cpp_writer);
   *out_handle = raw_cpp_writer;
 
   RETURN_SUCCESS();
 }
 
-FFIResult writer_write(WriterHandle handle, struct ArrowArray* array) {
+LoonFFIResult loon_writer_write(LoonWriterHandle handle, struct ArrowArray* array) {
   if (!handle || !array) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and array must not be null");
   }
@@ -88,7 +88,7 @@ FFIResult writer_write(WriterHandle handle, struct ArrowArray* array) {
   RETURN_UNREACHABLE();
 }
 
-FFIResult writer_flush(WriterHandle handle) {
+LoonFFIResult loon_writer_flush(LoonWriterHandle handle) {
   if (!handle) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
   }
@@ -107,8 +107,11 @@ FFIResult writer_flush(WriterHandle handle) {
   RETURN_UNREACHABLE();
 }
 
-FFIResult writer_close(
-    WriterHandle handle, char** meta_keys, char** meta_vals, uint16_t meta_len, CColumnGroups** out_column_groups) {
+LoonFFIResult loon_writer_close(LoonWriterHandle handle,
+                                char** meta_keys,
+                                char** meta_vals,
+                                uint16_t meta_len,
+                                LoonColumnGroups** out_column_groups) {
   if (!handle) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
   }
@@ -140,7 +143,7 @@ FFIResult writer_close(
     }
     auto cgs = result.ValueOrDie();
 
-    // Export to CColumnGroups structure
+    // Export to LoonColumnGroups structure
     auto st = milvus_storage::export_column_groups(*cgs, out_column_groups);
     if (!st.ok()) {
       RETURN_ERROR(LOON_LOGICAL_ERROR, st.ToString());
@@ -154,12 +157,12 @@ FFIResult writer_close(
   RETURN_UNREACHABLE();
 }
 
-void free_cstr(char* cstr) {
+void loon_free_cstr(char* cstr) {
   if (cstr)
     free(cstr);
 }
 
-void writer_destroy(WriterHandle handle) {
+void loon_writer_destroy(LoonWriterHandle handle) {
   if (handle) {
     delete reinterpret_cast<Writer*>(handle);
   }

--- a/cpp/src/jni/jni_utils.cpp
+++ b/cpp/src/jni/jni_utils.cpp
@@ -26,12 +26,12 @@
   Should return after throwing an exception, otherwise the function will continue to execute until the end of the
 function.
 **/
-void ThrowJavaExceptionFromFFIResult(JNIEnv* env, const struct ffi_result* result) {
-  if (IsSuccess(const_cast<FFIResult*>(result))) {
+void ThrowJavaExceptionFromFFIResult(JNIEnv* env, const struct LoonFFIResult* result) {
+  if (loon_ffi_is_success(const_cast<LoonFFIResult*>(result))) {
     return;
   }
 
-  const char* message = GetErrorMessage(const_cast<FFIResult*>(result));
+  const char* message = loon_ffi_get_errmsg(const_cast<LoonFFIResult*>(result));
   const char* exception_class = "java/lang/RuntimeException";
 
   switch (result->err_code) {

--- a/cpp/src/jni/properties_jni.cpp
+++ b/cpp/src/jni/properties_jni.cpp
@@ -21,7 +21,7 @@
 
 JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageProperties_allocateProperties(JNIEnv* env, jobject obj) {
   try {
-    Properties* properties = static_cast<Properties*>(malloc(sizeof(Properties)));
+    LoonProperties* properties = static_cast<LoonProperties*>(malloc(sizeof(LoonProperties)));
     if (properties == nullptr) {
       jclass exc_class = env->FindClass("java/lang/OutOfMemoryError");
       env->ThrowNew(exc_class, "Failed to allocate memory for Properties");
@@ -46,7 +46,7 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_createProp
                                                                                        jobject java_map,
                                                                                        jlong properties_ptr) {
   try {
-    Properties* properties = reinterpret_cast<Properties*>(properties_ptr);
+    LoonProperties* properties = reinterpret_cast<LoonProperties*>(properties_ptr);
 
     jclass map_class = env->GetObjectClass(java_map);
     jmethodID entry_set_method = env->GetMethodID(map_class, "entrySet", "()Ljava/util/Set;");
@@ -89,10 +89,10 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_createProp
       values.push_back(value_storage[i].c_str());
     }
 
-    FFIResult result = properties_create(keys.data(), values.data(), keys.size(), properties);
-    if (!IsSuccess(&result)) {
+    LoonFFIResult result = loon_properties_create(keys.data(), values.data(), keys.size(), properties);
+    if (!loon_ffi_is_success(&result)) {
       ThrowJavaExceptionFromFFIResult(env, &result);
-      FreeFFIResult(&result);
+      loon_ffi_free_result(&result);
       return;
     }
 
@@ -109,9 +109,9 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_createProp
 JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageProperties_freeProperties(JNIEnv* env,
                                                                                      jobject obj,
                                                                                      jlong properties_ptr) {
-  Properties* properties = reinterpret_cast<Properties*>(properties_ptr);
+  LoonProperties* properties = reinterpret_cast<LoonProperties*>(properties_ptr);
   if (properties != nullptr) {
-    properties_free(properties);
+    loon_properties_free(properties);
   }
   return;
 }

--- a/cpp/src/jni/writer_jni.cpp
+++ b/cpp/src/jni/writer_jni.cpp
@@ -26,16 +26,16 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerNew(
   try {
     const char* base_path_cstr = env->GetStringUTFChars(base_path, nullptr);
     ArrowSchema* schema = reinterpret_cast<ArrowSchema*>(schema_ptr);
-    Properties* properties = reinterpret_cast<Properties*>(properties_ptr);
+    LoonProperties* properties = reinterpret_cast<LoonProperties*>(properties_ptr);
 
-    WriterHandle writer_handle;
-    FFIResult result = writer_new(base_path_cstr, schema, properties, &writer_handle);
+    LoonWriterHandle writer_handle;
+    LoonFFIResult result = loon_writer_new(base_path_cstr, schema, properties, &writer_handle);
 
     env->ReleaseStringUTFChars(base_path, base_path_cstr);
 
-    if (!IsSuccess(&result)) {
+    if (!loon_ffi_is_success(&result)) {
       ThrowJavaExceptionFromFFIResult(env, &result);
-      FreeFFIResult(&result);
+      loon_ffi_free_result(&result);
       return -1;
     }
 
@@ -53,13 +53,13 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerWrite(JN
                                                                               jlong writer_handle,
                                                                               jlong array_ptr) {
   try {
-    WriterHandle handle = static_cast<WriterHandle>(writer_handle);
+    LoonWriterHandle handle = static_cast<LoonWriterHandle>(writer_handle);
     ArrowArray* array = reinterpret_cast<ArrowArray*>(array_ptr);
 
-    FFIResult result = writer_write(handle, array);
-    if (!IsSuccess(&result)) {
+    LoonFFIResult result = loon_writer_write(handle, array);
+    if (!loon_ffi_is_success(&result)) {
       ThrowJavaExceptionFromFFIResult(env, &result);
-      FreeFFIResult(&result);
+      loon_ffi_free_result(&result);
       return;
     }
   } catch (const std::exception& e) {
@@ -74,12 +74,12 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerFlush(JN
                                                                               jobject obj,
                                                                               jlong writer_handle) {
   try {
-    WriterHandle handle = static_cast<WriterHandle>(writer_handle);
+    LoonWriterHandle handle = static_cast<LoonWriterHandle>(writer_handle);
 
-    FFIResult result = writer_flush(handle);
-    if (!IsSuccess(&result)) {
+    LoonFFIResult result = loon_writer_flush(handle);
+    if (!loon_ffi_is_success(&result)) {
       ThrowJavaExceptionFromFFIResult(env, &result);
-      FreeFFIResult(&result);
+      loon_ffi_free_result(&result);
       return;
     }
   } catch (const std::exception& e) {
@@ -94,15 +94,15 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerClose(J
                                                                                jobject obj,
                                                                                jlong writer_handle) {
   try {
-    WriterHandle handle = static_cast<WriterHandle>(writer_handle);
+    LoonWriterHandle handle = static_cast<LoonWriterHandle>(writer_handle);
 
-    CColumnGroups* column_groups = nullptr;
+    LoonColumnGroups* column_groups = nullptr;
     // no need use the metadata parameters
-    FFIResult result = writer_close(handle, nullptr, nullptr, 0, &column_groups);
+    LoonFFIResult result = loon_writer_close(handle, nullptr, nullptr, 0, &column_groups);
 
-    if (!IsSuccess(&result)) {
+    if (!loon_ffi_is_success(&result)) {
       ThrowJavaExceptionFromFFIResult(env, &result);
-      FreeFFIResult(&result);
+      loon_ffi_free_result(&result);
       return -1;
     }
 
@@ -119,8 +119,8 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageWriter_writerDestroy(
                                                                                 jobject obj,
                                                                                 jlong writer_handle) {
   try {
-    WriterHandle handle = static_cast<WriterHandle>(writer_handle);
-    writer_destroy(handle);
+    LoonWriterHandle handle = static_cast<LoonWriterHandle>(writer_handle);
+    loon_writer_destroy(handle);
   } catch (const std::exception& e) {
     jclass exc_class = env->FindClass("java/lang/RuntimeException");
     std::string error_msg = "Failed to destroy writer: " + std::string(e.what());

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -614,7 +614,7 @@ std::optional<std::string> SetValue(Properties& properties,
   return std::nullopt;
 }
 
-std::optional<std::string> ConvertFFIProperties(Properties& result, const ::Properties* properties) {
+std::optional<std::string> ConvertFFIProperties(Properties& result, const ::LoonProperties* properties) {
   if (properties && properties->properties && properties->count > 0) {
     for (size_t i = 0; i < properties->count; ++i) {
       const auto& prop = properties->properties[i];

--- a/cpp/test/api_properties_test.cpp
+++ b/cpp/test/api_properties_test.cpp
@@ -58,9 +58,9 @@ TEST_F(APIPropertiesTest, test_ffi_convert) {
 
   // Test FFI properties conversion
   {
-    ::Properties ffi_props;
+    ::LoonProperties ffi_props;
     ffi_props.count = 3;
-    ::Property kvp[3];
+    ::LoonProperty kvp[3];
     kvp[0].key = const_cast<char*>(PROPERTY_WRITER_COMPRESSION);
     kvp[0].value = const_cast<char*>("gzip");
     kvp[1].key = const_cast<char*>(PROPERTY_WRITER_COMPRESSION_LEVEL);
@@ -78,9 +78,9 @@ TEST_F(APIPropertiesTest, test_ffi_convert) {
 
   // Test FFI properties with invalid type
   {
-    ::Properties ffi_props;
+    ::LoonProperties ffi_props;
     ffi_props.count = 2;
-    ::Property kvp[2];
+    ::LoonProperty kvp[2];
     // first is valid
     kvp[0].key = const_cast<char*>(PROPERTY_WRITER_BUFFER_SIZE);
     kvp[0].value = const_cast<char*>("3");
@@ -116,9 +116,9 @@ TEST_F(APIPropertiesTest, test_ffi_convert) {
 
   // Test FFI properties with invalid enum value
   {
-    ::Properties ffi_props;
+    ::LoonProperties ffi_props;
     ffi_props.count = 1;
-    ::Property kvp[1];
+    ::LoonProperty kvp[1];
     kvp[0].key = const_cast<char*>(PROPERTY_WRITER_COMPRESSION);
     kvp[0].value = const_cast<char*>("unknown_compression");
     ffi_props.properties = kvp;

--- a/cpp/test/ffi/bridge_test.cpp
+++ b/cpp/test/ffi/bridge_test.cpp
@@ -66,7 +66,7 @@ TEST_F(BridgeTest, ExportImportColumnGroups) {
   cgs.push_back(std::make_shared<ColumnGroup>(cg2));
 
   // test export and import
-  CColumnGroups* ccgs = nullptr;
+  LoonColumnGroups* ccgs = nullptr;
   ASSERT_STATUS_OK(export_column_groups(cgs, &ccgs));
 
   // verify export C struct
@@ -132,7 +132,7 @@ TEST_F(BridgeTest, ExportImportColumnGroups) {
       }
     }
   }
-  column_groups_destroy(ccgs);
+  loon_column_groups_destroy(ccgs);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -23,8 +23,8 @@
 
 #define TEST_ROOT_PATH "./"
 
-void create_filesystem_pp(Properties* pp) {
-  FFIResult rc;
+void create_filesystem_pp(LoonProperties* pp) {
+  LoonFFIResult rc;
   size_t test_pp_count;
   const char* test_key[] = {
       "fs.storage_type",
@@ -39,28 +39,28 @@ void create_filesystem_pp(Properties* pp) {
   test_pp_count = sizeof(test_key) / sizeof(test_key[0]);
   assert(test_pp_count == sizeof(test_val) / sizeof(test_val[0]));
 
-  rc = properties_create((const char* const*)test_key, (const char* const*)test_val, test_pp_count, pp);
-  ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+  rc = loon_properties_create((const char* const*)test_key, (const char* const*)test_val, test_pp_count, pp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 }
 
 static void test_filesystem_create_destroy(void) {
-  Properties pp;
-  FFIResult rc;
+  LoonProperties pp;
+  LoonFFIResult rc;
 
   create_filesystem_pp(&pp);
 
   FileSystemHandle fs_handle;
-  rc = filesystem_create(&pp, &fs_handle);
-  ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+  rc = loon_filesystem_create(&pp, &fs_handle);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   ck_assert(fs_handle != 0);
 
-  filesystem_destroy(fs_handle);
-  properties_free(&pp);
+  loon_filesystem_destroy(fs_handle);
+  loon_properties_free(&pp);
 }
 
 static void test_filesystem_write_and_read(void) {
-  Properties pp;
-  FFIResult rc;
+  LoonProperties pp;
+  LoonFFIResult rc;
 
   const char* file_path = "test_filesystem_write";
   const size_t test_buffer_len = 4096;
@@ -73,36 +73,36 @@ static void test_filesystem_write_and_read(void) {
   create_filesystem_pp(&pp);
 
   FileSystemHandle fs_handle;
-  rc = filesystem_create(&pp, &fs_handle);
-  ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+  rc = loon_filesystem_create(&pp, &fs_handle);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   ck_assert(fs_handle != 0);
 
   // test write
   {
     FileSystemWriterHandle write_handle;
-    rc = filesystem_open_writer(fs_handle, file_path, strlen(file_path), &write_handle);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_open_writer(fs_handle, file_path, strlen(file_path), &write_handle);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert(write_handle != 0);
 
-    rc = filesystem_writer_write(write_handle, test_buffer, test_buffer_len);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_writer_write(write_handle, test_buffer, test_buffer_len);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    rc = filesystem_writer_flush(write_handle);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_writer_flush(write_handle);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    rc = filesystem_writer_write(write_handle, test_buffer, test_buffer_len);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_writer_write(write_handle, test_buffer, test_buffer_len);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    rc = filesystem_writer_write(write_handle, test_buffer, test_buffer_len);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_writer_write(write_handle, test_buffer, test_buffer_len);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    rc = filesystem_writer_flush(write_handle);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_writer_flush(write_handle);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    rc = filesystem_writer_close(write_handle);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_writer_close(write_handle);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    filesystem_writer_destroy(write_handle);
+    loon_filesystem_writer_destroy(write_handle);
   }
 
   // test read
@@ -111,30 +111,30 @@ static void test_filesystem_write_and_read(void) {
     uint8_t read_buffer[test_buffer_len];
     size_t read_len;
 
-    rc = filesystem_open_reader(fs_handle, file_path, strlen(file_path), &reader_handle);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_open_reader(fs_handle, file_path, strlen(file_path), &reader_handle);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert(reader_handle != 0);
 
-    rc = filesystem_reader_readat(reader_handle, 0, test_buffer_len, read_buffer);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_reader_readat(reader_handle, 0, test_buffer_len, read_buffer);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert_int_eq(memcmp(read_buffer, test_buffer, test_buffer_len), 0);
 
-    rc = filesystem_reader_readat(reader_handle, test_buffer_len, test_buffer_len, read_buffer);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_reader_readat(reader_handle, test_buffer_len, test_buffer_len, read_buffer);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert_int_eq(memcmp(read_buffer, test_buffer, test_buffer_len), 0);
 
-    rc = filesystem_reader_readat(reader_handle, test_buffer_len * 2, test_buffer_len, read_buffer);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_reader_readat(reader_handle, test_buffer_len * 2, test_buffer_len, read_buffer);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert_int_eq(memcmp(read_buffer, test_buffer, test_buffer_len), 0);
 
-    rc = filesystem_reader_close(reader_handle);
-    ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+    rc = loon_filesystem_reader_close(reader_handle);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-    filesystem_reader_destroy(reader_handle);
+    loon_filesystem_reader_destroy(reader_handle);
   }
 
-  filesystem_destroy(fs_handle);
-  properties_free(&pp);
+  loon_filesystem_destroy(fs_handle);
+  loon_properties_free(&pp);
 }
 
 void run_filesystem_suite(void) {

--- a/cpp/test/ffi/ffi_property_test.c
+++ b/cpp/test/ffi/ffi_property_test.c
@@ -64,63 +64,63 @@ void free_properties_test_kvs(char** test_key, char** test_val) {
 static void test_basic(void) {
   const char* test_key = "key";
   const char* test_val = "val";
-  Properties rp;
-  FFIResult rc;
+  LoonProperties rp;
+  LoonFFIResult rc;
 
-  rc = properties_create(&test_key, &test_val, 1, &rp);
-  ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+  rc = loon_properties_create(&test_key, &test_val, 1, &rp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-  const char* test_val_got = properties_get(&rp, (const char*)test_key);
+  const char* test_val_got = loon_properties_get(&rp, (const char*)test_key);
   ck_assert(test_val_got != NULL && strcmp(test_val_got, test_val) == 0);
-  properties_free(&rp);
+  loon_properties_free(&rp);
 }
 
 static void test_properties_create_multi_kvs(void) {
-  FFIResult rc;
-  Properties rp;
+  LoonFFIResult rc;
+  LoonProperties rp;
   char** test_key = NULL;
   char** test_val = NULL;
   size_t test_count = PROPERTIES_TEST_COUNT;
 
   create_properties_test_kvs(&test_key, &test_val);
-  rc = properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
-  ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+  rc = loon_properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   for (int i = 0; i < test_count; i++) {
-    const char* test_val_got = properties_get(&rp, (const char*)test_key[i]);
+    const char* test_val_got = loon_properties_get(&rp, (const char*)test_key[i]);
     ck_assert(test_val_got != NULL && strcmp(test_val_got, test_val[i]) == 0);
   }
 
-  properties_free(&rp);
+  loon_properties_free(&rp);
   free_properties_test_kvs(test_key, test_val);
 }
 
 static void test_properties_create_null_kvs(void) {
-  FFIResult rc;
-  Properties rp;
+  LoonFFIResult rc;
+  LoonProperties rp;
   char** test_key = NULL;
   char** test_val = NULL;
   size_t test_count = PROPERTIES_TEST_COUNT;
 
   create_properties_test_kvs(&test_key, &test_val);
 
-  rc = properties_create(NULL, (const char* const*)test_val, test_count, &rp);
-  ck_assert(!IsSuccess(&rc));
-  // printf("rc message: %s\n", GetErrorMessage(&rc));
-  FreeFFIResult(&rc);
-  properties_free(&rp);
+  rc = loon_properties_create(NULL, (const char* const*)test_val, test_count, &rp);
+  ck_assert(!loon_ffi_is_success(&rc));
+  // printf("rc message: %s\n", loon_ffi_get_errmsg(&rc));
+  loon_ffi_free_result(&rc);
+  loon_properties_free(&rp);
 
-  rc = properties_create((const char* const*)test_key, NULL, test_count, &rp);
-  ck_assert(!IsSuccess(&rc));
-  // printf("rc message: %s\n", GetErrorMessage(&rc));
-  FreeFFIResult(&rc);
-  properties_free(&rp);
+  rc = loon_properties_create((const char* const*)test_key, NULL, test_count, &rp);
+  ck_assert(!loon_ffi_is_success(&rc));
+  // printf("rc message: %s\n", loon_ffi_get_errmsg(&rc));
+  loon_ffi_free_result(&rc);
+  loon_properties_free(&rp);
   free_properties_test_kvs(test_key, test_val);
 }
 
 static void test_properties_create_null_kv(void) {
-  FFIResult rc;
-  Properties rp;
+  LoonFFIResult rc;
+  LoonProperties rp;
   char** test_key = NULL;
   char** test_val = NULL;
   size_t test_count = PROPERTIES_TEST_COUNT;
@@ -131,10 +131,10 @@ static void test_properties_create_null_kv(void) {
   char* temp_key = test_key[test_count - 1];
   test_key[test_count - 1] = NULL;
 
-  rc = properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
-  ck_assert(!IsSuccess(&rc));
-  FreeFFIResult(&rc);
-  properties_free(&rp);
+  rc = loon_properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+  loon_properties_free(&rp);
 
   // restore the key
   test_key[test_count - 1] = temp_key;
@@ -143,10 +143,10 @@ static void test_properties_create_null_kv(void) {
   char* temp_val = test_val[test_count - 1];
   test_val[test_count - 1] = NULL;
 
-  rc = properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
-  ck_assert(!IsSuccess(&rc));
-  FreeFFIResult(&rc);
-  properties_free(&rp);
+  rc = loon_properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+  loon_properties_free(&rp);
 
   // restore the value
   test_val[test_count - 1] = temp_val;
@@ -154,34 +154,34 @@ static void test_properties_create_null_kv(void) {
 }
 
 static void test_properties_get(void) {
-  FFIResult rc;
-  Properties rp;
+  LoonFFIResult rc;
+  LoonProperties rp;
   char** test_key = NULL;
   char** test_val = NULL;
   size_t test_count = PROPERTIES_TEST_COUNT;
 
   create_properties_test_kvs(&test_key, &test_val);
 
-  rc = properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
-  ck_assert_msg(IsSuccess(&rc), "%s", GetErrorMessage(&rc));
+  rc = loon_properties_create((const char* const*)test_key, (const char* const*)test_val, test_count, &rp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-  const char* test_val_got = properties_get(&rp, (const char*)test_key[test_count - 1]);
+  const char* test_val_got = loon_properties_get(&rp, (const char*)test_key[test_count - 1]);
   ck_assert(test_val_got != NULL && strcmp(test_val_got, test_val[test_count - 1]) == 0);
   // memory ptr should not be the same
   ck_assert(test_val_got != test_val[test_count - 1]);
 
-  test_val_got = properties_get(&rp, "Invalid.Key");
+  test_val_got = loon_properties_get(&rp, "Invalid.Key");
   ck_assert(test_val_got == NULL);
 
-  properties_free(&rp);
+  loon_properties_free(&rp);
   free_properties_test_kvs(test_key, test_val);
 }
 
 static void test_properties_create_dup_kv(void) {
   const char** test_key;
   const char** test_val;
-  Properties rp;
-  FFIResult rc;
+  LoonProperties rp;
+  LoonFFIResult rc;
 
   test_key = (const char**)malloc(sizeof(char*) * 2);
   test_val = (const char**)malloc(sizeof(char*) * 2);
@@ -191,11 +191,11 @@ static void test_properties_create_dup_kv(void) {
   test_val[0] = "value1";
   test_val[1] = "value2";
 
-  rc = properties_create(test_key, test_val, 2, &rp);
-  ck_assert(!IsSuccess(&rc));
-  // printf("rc message: %s\n", GetErrorMessage(&rc));
-  FreeFFIResult(&rc);
-  properties_free(&rp);
+  rc = loon_properties_create(test_key, test_val, 2, &rp);
+  ck_assert(!loon_ffi_is_success(&rc));
+  // printf("rc message: %s\n", loon_ffi_get_errmsg(&rc));
+  loon_ffi_free_result(&rc);
+  loon_properties_free(&rp);
 
   free((void*)test_key);
   free((void*)test_val);

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -28,7 +28,7 @@ void run_external_suite(void);
 void run_filesystem_suite(void);
 
 int main(void) {
-  thread_pool_singleton(4);
+  loon_thread_pool_singleton(4);
   run_manifest_suite();
   run_properties_suite();
   run_writer_suite();
@@ -36,8 +36,8 @@ int main(void) {
   run_external_suite();
   run_filesystem_suite();
 
-  close_filesystems();
-  thread_pool_singleton_release();
+  loon_close_filesystems();
+  loon_thread_pool_singleton_release();
 
   printf("\nRan %d tests, %d failed.\n", global_tests_run, global_tests_failed);
   return (global_tests_failed == 0) ? 0 : 1;


### PR DESCRIPTION
Introducing `Loon` as a prefix is because FFI itself does not have a namespace, so a prefix is needed to prevent naming conflicts.

- For C Struct, the name rule is `Loon{struct_name}`
- For C function, the name rule is `loon_{function_name}`