### PR TITLE
enhance: Implement file rolling for Writer

### DIFF
--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -124,6 +124,8 @@ struct PropertyInfo {
 #define PROPERTY_WRITER_SIZE_BASE_MCIG "writer.split.size_based.max_columns_in_group"
 #define PROPERTY_WRITER_BUFFER_SIZE "writer.buffer_size"
 
+#define PROPERTY_WRITER_FILE_ROLLING_SIZE "writer.file_rolling.size"
+
 #define PROPERTY_WRITER_COMPRESSION "writer.compression"
 #define PROPERTY_WRITER_COMPRESSION_LEVEL "writer.compression_level"
 #define PROPERTY_WRITER_ENABLE_DICTIONARY "writer.enable_dictionary"

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -137,7 +137,6 @@ arrow::Status ParquetFormatReader::open() {
 
   // create file reader
   ARROW_ASSIGN_OR_RAISE(file_reader_, create_parquet_file_reader(fs_, path_, key_retriever_, nullptr /* metadata */));
-
   // create row group infos
   assert(file_reader_->parquet_reader() && "arrow logical fault");
   ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(file_reader_->parquet_reader()->metadata()));

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -424,6 +424,15 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "The maximum number of connections for the filesystem storage service.",
                       uint32_t(100),
                       ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_MULTI_PART_UPLOAD_SIZE,
+                      PropertyType::INT64,
+                      "The multi-part upload size(Bytes) used in the writer.",
+                      int64_t(DEFAULT_MULTIPART_UPLOAD_PART_SIZE),  // 10 MB
+                      // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
+                      // the part numbers can be 5MB ~ 5GB
+                      // R2 limit is 10MB ~ 5GB
+                      ValidatePropertyType() + ValidatePropertyRange<int64_t>(MINIMAL_MULTIPART_UPLOAD_PART_SIZE,
+                                                                              MAXIMAL_MULTIPART_UPLOAD_PART_SIZE)),
     // --- writer properties define ---
     REGISTER_PROPERTY(PROPERTY_WRITER_POLICY,
                       PropertyType::STRING,
@@ -452,15 +461,14 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "The buffer size(Bytes) used in the writer.",
                       32 * 1024 * 1024,  // 32MB
                       ValidatePropertyType()),
-    REGISTER_PROPERTY(PROPERTY_FS_MULTI_PART_UPLOAD_SIZE,
-                      PropertyType::INT64,
-                      "The multi-part upload size(Bytes) used in the writer.",
-                      int64_t(DEFAULT_MULTIPART_UPLOAD_PART_SIZE),  // 10 MB
-                      // According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
-                      // the part numbers can be 5MB ~ 5GB
-                      // R2 limit is 10MB ~ 5GB
-                      ValidatePropertyType() + ValidatePropertyRange<int64_t>(MINIMAL_MULTIPART_UPLOAD_PART_SIZE,
-                                                                              MAXIMAL_MULTIPART_UPLOAD_PART_SIZE)),
+    REGISTER_PROPERTY(PROPERTY_WRITER_FILE_ROLLING_SIZE,
+                      PropertyType::UINT64,
+                      "The max size(Bytes) for each data file rolling. Current size is uncompressed data size. Default "
+                      "is 2GB. If the writer is configured with 2GB rolling size, and the writer has written 2GB data, "
+                      "it will roll the file and start a new file. But the file size in disk(or object store) may be "
+                      "smaller than 2GB, because of format writer may do the encoding or compression.",
+                      uint64_t(2ULL * 1024 * 1024 * 1024),  // 2GB
+                      ValidatePropertyType()),
     REGISTER_PROPERTY(PROPERTY_WRITER_COMPRESSION,
                       PropertyType::STRING,
                       "The compression type used in the writer.",

--- a/cpp/test/format/column_groups_wr_test.cpp
+++ b/cpp/test/format/column_groups_wr_test.cpp
@@ -350,6 +350,10 @@ TEST_P(ColumnGroupsWRTest, TestTake) {
     ASSERT_AND_ASSIGN(auto batch, do_take(take_reader, row_indices));
     verify_take_result(batch, expected_ids, row_indices);
   }
+
+  // reset
+  EXPECT_EQ(SetValue(properties_, PROPERTY_READER_VORTEX_CHUNK_ROWS, std::to_string(origin_chunk_rows).c_str()),
+            std::nullopt);
 }
 
 TEST_P(ColumnGroupsWRTest, TestFullProjection) {


### PR DESCRIPTION
In the storage, files generated from a single write operation without rolling. Even though a column-splitting logic already exists (different columns are stored in separate files). But for compactions triggered by Milvus, this can still lead to the creation of very large individual files (exceeding 2GB). This increases the likelihood of `import/export` failures when multi-part upload is not enabled.

This commit introduces a new property (PROPERTY_WRITER_FILE_ROLLING_SIZE, default 2GB). It allows a single write operation to split files based on the specified size limit of uncompressed data written.