### PR TITLE
enhance: add AWS Errow 412 and 409 as extend arrow status

### DIFF
--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -25,7 +25,10 @@
 namespace milvus_storage {
 enum class ExtendStatusCode : char {
   // arrow::StatusCode biggest is 45
-  NoSuchUpload = 101,
+  AwsErrorNoSuchUpload = 101,
+  AwsErrorConflict = 102,
+  AwsErrorPreConditionFailed = 103,
+
 };
 
 class ExtendStatusDetail : public arrow::StatusDetail {

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -39,7 +39,7 @@ std::string ExtendStatusDetail::extra_info() const { return extra_info_; }
 
 std::string ExtendStatusDetail::CodeAsString() const {
   switch (code()) {
-    case ExtendStatusCode::NoSuchUpload:
+    case ExtendStatusCode::AwsErrorNoSuchUpload:
       return "NoSuchUpload";
     default:
       return "Unknown";


### PR DESCRIPTION
The extend status `AwsErrorPreConditionFailed` and `AwsErrorConflict` can be used to distinguish whether an error in S3 filesystem caused by the condition write or another IOError.
