### PR TITLE
enhance: allow filesystem FFI to pass metadata when opening a writer

### DIFF
--- a/cpp/include/milvus-storage/ffi_filesystem_c.h
+++ b/cpp/include/milvus-storage/ffi_filesystem_c.h
@@ -50,12 +50,20 @@ void loon_filesystem_destroy(FileSystemHandle handle);
  * @param handle The filesystem instance.
  * @param path_ptr The path of the file to write.
  * @param path_len The length of the path.
+ * @param meta_keys The metadata keys.
+ * @param meta_values The metadata values.
+ * @param num_of_meta The number of metadata.
  * @param out_handle The output writer instance.
+ *
+ * The metadata will be passed into the `OpenOutputStream`.
  * @return result of FFI
  */
 LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
                                           const char* path_ptr,
                                           uint32_t path_len,
+                                          const char** meta_keys,
+                                          const char** meta_values,
+                                          uint32_t num_of_meta,
                                           FileSystemWriterHandle* out_handle);
 
 /**

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -80,7 +80,7 @@ static void test_filesystem_write_and_read(void) {
   // test write
   {
     FileSystemWriterHandle write_handle;
-    rc = loon_filesystem_open_writer(fs_handle, file_path, strlen(file_path), &write_handle);
+    rc = loon_filesystem_open_writer(fs_handle, file_path, strlen(file_path), NULL, NULL, 0, &write_handle);
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert(write_handle != 0);
 


### PR DESCRIPTION
`loon_filesystem_open_writer` can now attach metadata when opening an output stream. This metadata includes the object's own metadata as well as the header for conditional writes. The filesystem FFI had previously overlooked exposing this part.