### PR TITLE
fix: use calloc to zero-initialize ArrowArrayStream

### DIFF
--- a/cpp/src/jni/arrow_utils_jni.cpp
+++ b/cpp/src/jni/arrow_utils_jni.cpp
@@ -30,7 +30,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_ArrowUtilsNative_readNextBatch(JN
     }
 
     // Allocate ArrowArray for the next batch
-    ArrowArray* array = static_cast<ArrowArray*>(malloc(sizeof(ArrowArray)));
+    ArrowArray* array = static_cast<ArrowArray*>(calloc(1, sizeof(ArrowArray)));
     if (array == nullptr) {
       jclass exc_class = env->FindClass("java/lang/OutOfMemoryError");
       env->ThrowNew(exc_class, "Failed to allocate ArrowArray");

--- a/cpp/src/jni/chunk_reader_jni.cpp
+++ b/cpp/src/jni/chunk_reader_jni.cpp
@@ -75,7 +75,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageChunkReader_getChunk
   try {
     LoonChunkReaderHandle handle = static_cast<LoonChunkReaderHandle>(chunk_reader_handle);
 
-    ArrowArray* array = static_cast<ArrowArray*>(malloc(sizeof(ArrowArray)));
+    ArrowArray* array = static_cast<ArrowArray*>(calloc(1, sizeof(ArrowArray)));
     LoonFFIResult result = loon_get_chunk(handle, static_cast<int64_t>(chunk_index), array);
 
     if (!loon_ffi_is_success(&result)) {

--- a/cpp/src/jni/reader_jni.cpp
+++ b/cpp/src/jni/reader_jni.cpp
@@ -64,7 +64,7 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageReader_getRecordBatc
     LoonReaderHandle handle = static_cast<LoonReaderHandle>(reader_handle);
     const char* predicate_cstr = predicate ? env->GetStringUTFChars(predicate, nullptr) : nullptr;
 
-    ArrowArrayStream* stream = static_cast<ArrowArrayStream*>(malloc(sizeof(ArrowArrayStream)));
+    ArrowArrayStream* stream = static_cast<ArrowArrayStream*>(calloc(1, sizeof(ArrowArrayStream)));
     LoonFFIResult result = loon_get_record_batch_reader(handle, predicate_cstr, stream);
 
     if (predicate_cstr) {


### PR DESCRIPTION
malloc returns uninitialized memory. If get_record_batch_reader fails, the cleanup code checks stream->release and may call a garbage pointer, causing core dump. calloc zero-initializes memory, ensuring release is NULL and preventing the crash.