### PR TITLE
enhance: add cpp codecoverage in CI

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -29,9 +29,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        id: rust-cache
+        uses: actions/cache@v4
         with:
-          workspaces: "cpp/src/format/bridge/rust -> target"
+          path: |
+            cpp/build/Release/cargo/build
+          key: storage-bridge-rust-${{ runner.os }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock') }}
+          restore-keys: storage-bridge-rust-
 
       - name: setup conan
         run: 
@@ -59,6 +63,7 @@ jobs:
             cpp/build/Release/test/Test_FFI
             cpp/build/Release/libs/
             cpp/build/Release/libmilvus-storage.so*
+            cpp/build/Release/**/*.gcno
 
   lint:
     runs-on: ubuntu-22.04
@@ -105,6 +110,10 @@ jobs:
           name: gtest-binary
           path: ./cpp/build/Release
 
+      - name: Install coverage tools
+        run: |
+          sudo apt-get update && sudo apt-get install -y lcov
+
       - name: Change mod of binary
         working-directory: ./cpp
         run: |
@@ -128,3 +137,32 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/build/Release:$(pwd)/build/Release/libs
           source ./scripts/minio_env.sh && ./build/Release/test/milvus_test
           
+      - name: coverage-report
+        working-directory: ./cpp
+        run: |
+          BUILD_TYPE=Release ./scripts/coverage-report.sh
+
+      - name: Upload coverage to Codecov
+        if: ${{ github.repository == 'milvus-io/milvus-storage' }}
+        uses: codecov/codecov-action@v4
+        id: storage-upload-cov
+        with:
+          files: cpp/coverage/coverage_filtered.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: storage-ubuntu-22.04-unittests
+          fail_ci_if_error: true
+          disable_safe_directory: true
+          verbose: true
+      - name: Retry Upload coverage to Codecov
+        if: ${{ failure() && github.repository == 'milvus-io/milvus-storage' }}
+        uses: codecov/codecov-action@v4
+        id: storage-retry-upload-cov
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: cpp/coverage/coverage_filtered.info
+          name: storage-ubuntu-22.04-unittests
+          fail_ci_if_error: true
+          disable_safe_directory: true
+          verbose: true
+
+

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        id: rust-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            cpp/build/Release/cargo/build
+          key: storage-bridge-rust-${{ runner.os }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock') }}
+          restore-keys: storage-bridge-rust-
+
       - name: Setup conan
         run:
           conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cpp/debug_build
 cpp/.vscode/*
 cpp/.cache/*
 cpp/.idea/*
+cpp/coverage/*
 cpp/conan.lock
 cpp/conaninfo.txt
 cpp/conanbuildinfo.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 0% #Allow the coverage to drop by threshold%, and posting a success status.
+    patch:
+      default:
+        target: 60%   #target of patch diff
+        threshold: 0%
+        if_ci_failed: error #success, failure, error, ignore
+
+ignore:
+  - "LICENSES"
+  - ".git"
+  - "*.yml"
+  - "*.md"
+  - "docs/.*"
+  - "**/*.pb.go"
+  - "**/*.proto"
+  - "cpp/test/**"
+  - "cpp/benchmark/**"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -93,6 +93,12 @@ if (WITH_PYTHON_BINDING)
 endif()
 
 if (WITH_UT)
+  # Enable code coverage instrumentation when ut is enabled
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+
   add_definitions(-DBUILD_GTEST)
   add_subdirectory(test)
 endif()

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -134,6 +134,3 @@ check-tidy:
 
 fix-tidy: 
 	python3 ./scripts/run-clang-tidy.py -fix -p build/Release
-
-proto: 
-	protoc -I="src/proto" --cpp_out="src/proto" src/proto/*.proto

--- a/cpp/scripts/coverage-report.sh
+++ b/cpp/scripts/coverage-report.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Configuration
+BUILD_TYPE=${BUILD_TYPE:-Release}
+
+# Detect LCOV version
+LCOV_VERSION=$(lcov --version | grep -oE '[0-9]+\.[0-9]+' | head -1)
+LCOV_MAJOR=$(echo $LCOV_VERSION | cut -d. -f1)
+
+# LCOV 2.0+ requires --ignore-errors for many common Clang/LLVM inconsistencies
+if [ "$LCOV_MAJOR" -ge 2 ]; then
+    LCOV_IGNORE_ERRORS="--ignore-errors mismatch,inconsistent,gcov,unused,deprecated,unsupported,format,count,category,empty,source"
+else
+    LCOV_IGNORE_ERRORS=""
+fi
+
+COVERAGE_BASE_DIR="coverage"
+COVERAGE_RAW_INFO="${COVERAGE_BASE_DIR}/coverage.info"
+COVERAGE_EXTRACTED_INFO="${COVERAGE_BASE_DIR}/coverage_extracted.info"
+COVERAGE_FILTERED_INFO="${COVERAGE_BASE_DIR}/coverage_filtered.info"
+
+echo "Generating coverage report..."
+rm -rf ${COVERAGE_BASE_DIR}
+mkdir -p ${COVERAGE_BASE_DIR}
+
+# Capture coverage data (without branch coverage to avoid LLVM issues)
+lcov --capture \
+    --directory build/"${BUILD_TYPE}" \
+    --output-file ${COVERAGE_RAW_INFO} \
+    ${LCOV_IGNORE_ERRORS}
+
+# Filter coverage data
+# 1. Extract production code areas (broader patterns to handle different CI layouts)
+lcov --extract ${COVERAGE_RAW_INFO} \
+    '*/milvus-storage/cpp/src/*' \
+    '*/milvus-storage/cpp/include/*' \
+    --output-file ${COVERAGE_EXTRACTED_INFO} \
+    ${LCOV_IGNORE_ERRORS}
+
+# 2. Explicitly remove unwanted directories (tests, benchmarks, build artifacts, system/vcpkg headers)
+lcov --remove ${COVERAGE_EXTRACTED_INFO} \
+    "/usr/*" \
+    "*/llvm/*" \
+    "*/src/pb/*" \
+    "*/src/core/bench/*" \
+    "*/unittest/*" \
+    "*/thirdparty/*" \
+    "*/3rdparty_download/*" \
+    "*/.conan/data/*" \
+    --output-file ${COVERAGE_FILTERED_INFO} \
+    ${LCOV_IGNORE_ERRORS}
+
+# Generate HTML report (without branch coverage for LLVM compatibility)
+genhtml ${COVERAGE_FILTERED_INFO} \
+    --output-directory ${COVERAGE_BASE_DIR}/html \
+    --title "Milvus Storage Coverage Report" \
+    --legend \
+    --highlight \
+    ${LCOV_IGNORE_ERRORS}
+
+echo ""
+echo "====================================="
+echo "Coverage report generated at: ${COVERAGE_BASE_DIR}/html/index.html"
+echo "====================================="
+
+# Print summary
+lcov --summary ${COVERAGE_FILTERED_INFO} ${LCOV_IGNORE_ERRORS}


### PR DESCRIPTION
Introduced codecoverage to check the current test coverage of storage, and integrated codecov in CI. Also modified the cargo compilation cache. Since `corrosion` is used to compile Rust bridge, the compilation path here is fixed to `cpp/build/{build_type}/cargo/build`.