### PR TITLE
docs: add CLAUDE.md and rewrite README for better project introduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Milvus Storage is a multi-language columnar storage engine built on Apache Arrow. The core is implemented in C++ with FFI bindings for Python, Java, and Rust. It supports Parquet, Vortex, and Lance (read-only) formats with cloud storage backends (AWS S3, GCS, Azure, Aliyun, Tencent, Huawei).
+
+## Build Commands
+
+All C++ commands run from `/cpp` directory:
+
+```bash
+# Build (Release with ASAN by default)
+make build
+
+# Build variants
+BUILD_TYPE=Debug make build
+USE_ASAN=False make build
+WITH_VORTEX=True WITH_LANCE=True make build
+
+# Build for language bindings
+make python-lib    # Python FFI
+make java-lib      # Java JNI
+
+# Run tests
+make test          # Unit tests
+make test-all      # Tests with MinIO
+
+# Cloud storage tests
+make test-cloud-storage        # All providers
+make test-cloud-storage aws    # Specific provider (aws/gcp/azure/aliyun/tencent/huawei)
+
+# Code quality
+make fix-format    # Apply clang-format
+make check-format  # Verify formatting
+make fix-tidy      # Apply clang-tidy fixes
+make check-tidy    # Run clang-tidy
+```
+
+Python (`/python`):
+```bash
+pip install -e ".[dev]"
+pytest tests/ -v
+```
+
+Rust (`/rust`):
+```bash
+cargo build --release
+cargo test
+cargo fmt && cargo clippy -- -D warnings
+```
+
+Java (`/java`):
+```bash
+sbt compile
+sbt test
+```
+
+## Architecture
+
+```
+Application Layer (Python/Java/Rust/C++) + Filesystem FFI
+                    │                           │
+                    ▼                           │
+            FFI Layer (extern "C")              │
+                    │                           │
+        ┌───────────┴───────────┐               │
+        ▼                       ▼               │
+   Writer API              Reader API           │
+        │                       │               │
+        └───────────┬───────────┘               │
+                    ▼                           │
+           Transaction Layer                    │
+    (Manifest/Conflict Resolution)              │
+                    │                           │
+        ┌───────────┴───────────┐               │
+        ▼                       ▼               │
+ Column Group Writer    Column Group Reader     │
+                    │                           │
+                    ▼                           │
+             Format Layer                       │
+      (Parquet/Vortex/Lance)                    │
+                    │                           │
+                    ▼                           ▼
+              Filesystem Layer
+    (Local/S3/GCS/Azure/Aliyun/Tencent/Huawei)
+```
+
+## Key Source Locations
+
+- **Public Headers**: `cpp/include/milvus-storage/`
+  - `writer.h`, `reader.h` - High-level APIs
+  - `transaction/transaction.h` - Transaction support
+  - `manifest.h`, `column_groups.h` - Metadata structures
+  - `properties.h` - Configuration properties
+  - `ffi_c.h`, `ffi_filesystem_c.h` - FFI interfaces
+
+- **Core Implementation**: `cpp/src/`
+  - `format/` - Parquet, Vortex format readers/writers
+  - `filesystem/` - Cloud storage backends (s3/, azure/)
+  - `packed/` - Column group management
+  - `ffi/` - FFI layer implementation
+  - `jni/` - Java JNI bindings
+
+- **Language Bindings**:
+  - `python/milvus_storage/_ffi.py` - Python FFI wrapper
+  - `rust/src/ffi.rs` - Rust FFI bindings
+  - `java/src/main/scala/` - Scala JNI wrappers
+
+- **Tests**: `cpp/test/`
+  - `api_writer_reader_test.cpp` - Core API tests
+  - `api_transaction_test.cpp` - Transaction tests
+  - `packed/packed_integration_test.cpp` - Cloud integration tests
+
+## Build Prerequisites
+
+- CMake >= 3.20.0
+- C++17 compiler (GCC 8+, Clang 6+)
+- Conan >= 1.60.0 and < 2.0.0
+
+Setup Conan remote before first build:
+```bash
+conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert 0
+```
+
+## Code Conventions
+
+- C++ follows Google style with 120 column limit (`.clang-format`)
+- Tests use Google Test framework
+- Arrow Status/Result pattern for error handling

--- a/README.md
+++ b/README.md
@@ -1,108 +1,157 @@
-# Design
+# Milvus Storage
 
-Packed storage is Milvus storage engine that uses Apache Arrow Parquet as the underlying data format. It is designed to optimize read and write performance by packing narrow columns into groups. There are three main advantages of packed storage:
+A high-performance columnar storage engine built on Apache Arrow, designed for vector databases and analytical workloads.
 
-1. Read and write memory can be controlled separately.
-2. Reduce the number of storage files.
-3. Support partial reading capability.
+[![C++ CI](https://github.com/milvus-io/milvus-storage/actions/workflows/cpp-ci.yml/badge.svg)](https://github.com/milvus-io/milvus-storage/actions/workflows/cpp-ci.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-![packed_design](./img/packed_design.png)
+## Architecture
 
-## Packed Writer
-The PackedWriter serves as the primary interface for the write path. Initialization requires specifying memory limit, table schema, file system source, write path, and Parquet writer properties.
+```
+┌───────────────────────────────────────────────────────────────┬─────────────┐
+│                       Application Layer                       │ Filesystem  │
+│                   (Python / Java / Rust / C++)                │ FFI (C ABI) │
+└───────────────────────────────────────────────────────────────┴──────┬──────┘
+                                      │                                │
+                                      ▼                                │
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         FFI Layer (extern "C")                              │
+│                    (Cross-language bindings via C ABI)                      │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                      │                                │
+                          ┌───────────┴───────────┐                    │
+                          ▼                       ▼                    │
+┌─────────────────────────────────────┐ ┌─────────────────────────────────────┐
+│            Writer API               │ │            Reader API               │
+│  ┌───────────────────────────────┐  │ │  ┌───────────────────────────────┐  │
+│  │    Column Group Policy        │  │ │  │   RecordBatchReader (Scan)    │  │
+│  │  (Single/Schema/Size Based)   │  │ │  │   ChunkReader (Random Access) │  │
+│  └───────────────────────────────┘  │ │  │   Take (Row Indices)          │  │
+└─────────────────────────────────────┘ └─────────────────────────────────────┘
+                          │                       │                    │
+                          └───────────┬───────────┘                    │
+                                      ▼                                │
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           Transaction Layer                                 │
+│         (Manifest Versioning / Conflict Resolution / Delta Logs)            │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                      │                                │
+                          ┌───────────┴───────────┐                    │
+                          ▼                       ▼                    │
+┌─────────────────────────────────────┐ ┌─────────────────────────────────────┐
+│       Column Group Writer           │ │        Column Group Reader          │
+│  ┌───────────────────────────────┐  │ │  ┌───────────────────────────────┐  │
+│  │  Buffer Management            │  │ │  │  Chunk Management             │  │
+│  │  Row Group Sizing             │  │ │  │  Column Projection            │  │
+│  │  File Rolling                 │  │ │  │  Predicate Pushdown           │  │
+│  └───────────────────────────────┘  │ │  └───────────────────────────────┘  │
+└─────────────────────────────────────┘ └─────────────────────────────────────┘
+                          │                       │                    │
+                          └───────────┬───────────┘                    │
+                                      ▼                                │
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            Format Layer                                     │
+│    ┌─────────────┐      ┌─────────────┐      ┌───────────────────────────┐ │
+│    │   Parquet   │      │   Vortex    │      │    Lance (Read Only)      │ │
+│    └─────────────┘      └─────────────┘      └───────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                      │                                │
+                                      ▼                                ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          Filesystem Layer                                   │
+│  ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌────────┐ ┌────────┐  │
+│  │ Local │ │AWS S3 │ │  GCS  │ │ Azure │ │Aliyun │ │Tencent │ │ Huawei │  │
+│  └───────┘ └───────┘ └───────┘ └───────┘ └───────┘ └────────┘ └────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
 
-During writing, half of the allocated memory is used as the first buffer for dividing columns into groups, initializing columnGroupWriter, and validating memory usage:
+## Features
 
-1. Column Group: When the buffer is full, sizedBasedSplitter divides columns into groups based on their sizes, recording the original column indices. Subsequent writes use indexBasedSplitter to divide columns by these indices.
-2. Initialize ColumnGroupWriter: After grouping, each group is assigned a ColumnGroupWriter, which wraps the Arrow file writer. Since the Arrow writer divides row groups based on row count (by default 1024 * 1024 rows) rather than size, the ColumnGroupWriter ensures that row groups are written based on size.
-3. Memory Validation and Calculation: S3 uploads use multipart uploads with part size requirements. For example, AWS S3 requires a minimum part size of 5MB. In Arrow, the part size is set to 10MB due to Cloudflare R2 constraints. Therefore, the minimum memory required is `column_group_num * (row_group_size + 10MB)`, and the maximum is `column_group_num * 20MB`.
-The subsequent memory buffer is constrained by the above calculation. For each incoming batch, if the total buffer exceeds the memory limit, the largest ColumnGroupWriter in the maxHeap will be flushed. Once space is available, the batch is split by IndexBasedSplitter and written to the corresponding columnGroupWriter.
-
-## Packed Reader
-The PackedReader is mainly responsible for reading and deserializing data from multiple Parquet files into recordBatch. Initialization requires providing the file system, file paths, schema, file and column positions for each column, the required columns, and a memory limit. PackedReader consists of two main parts: advanceBuffer and chunk manager.
-
-1. AdvanceBuffer: This component manages buffer size and reads as many row groups as possible from the file while updating memory usage. The reading logic involves extracting the smallest row offset from a minHeap as long as there is enough memory. It probes the next row group in the file and records the readable row group index. When memory is close to full, ParquetFileReader calls `ReadRowGroups(const std::vector<int>& row_groups, std::shared_ptr<::arrow::Table>* out)` to perform an I/O read for each file.
-
-2. ChunkManager: A chunk represents a contiguous memory unit in Parquet. To achieve zero-copy processing, chunk manager handles data read by advanceBuffer. It splits data into chunks based on the largest contiguous fragment size from multiple Arrow table queues, considering the offset of each column group. Depending on the chunk size and the current block's length and offset, it determines whether to read the current block entirely or move to the next. If all chunks are fully read, the table is marked for deletion to free memory. In extreme cases, offset differences might require a file to span multiple tables, so each file maintains a queue to track its records.
-
-3. ReadNext: This method checks if new data needs to be read. If so, it calls advanceBuffer and then uses chunkManager to determine the largest contiguous data block, deserializing the data and returning it as a recordBatch.
+- **Column Group Storage** - Organize columns into groups for optimal I/O and compression
+- **Multi-Format Support** - Parquet (primary), Vortex, and Lance formats
+- **Transaction Support** - ACID-like semantics with manifest versioning and conflict resolution
+- **Cloud Native** - Built-in support for major cloud storage providers
+- **Multi-Language SDKs** - Python, Java/Scala, Rust, and C++ bindings
+- **Encryption & Compression** - Data-at-rest encryption and configurable compression
 
 ## Cloud Storage Support
-We have validate with the following cloud object stroage services, please see `cpp/test/packed/packed_integration_test.cpp` for how to integrate packed reader and writer with these services:
-1. AWS S3
-2. Google Cloud Storage
-3. Aliyun OSS
-4. Tencent COS
 
-# Developement Guide
+| Provider | Status |
+|----------|--------|
+| AWS S3 | Supported (including S3-compatible: MinIO, Cloudflare R2) |
+| Google Cloud Storage | Supported |
+| Azure Blob Storage | Supported |
+| Aliyun OSS | Supported |
+| Tencent COS | Supported |
+| Huawei Cloud OBS | Supported |
 
-This document is a guide for developers who want to contribute to Milvus Storage. It provides information on the development environment, coding style, and testing process.
+## Language SDKs
 
-## Development Environment
+| Language | Status | Notes |
+|----------|--------|-------|
+| C++ | Primary | Core implementation |
+| Python | Supported | FFI bindings with PyArrow integration |
+| Java/Scala | Supported | JNI bindings |
+| Rust | Supported | DataFusion TableProvider integration |
+
+## Development
 
 ### Prerequisites
 
-- conan >= 1.54.0
-- Docker 19.03+
-- Docker Compose 1.25+
-- Git
+- CMake >= 3.20.0
+- C++17 compiler (GCC 8+, Clang 6+)
+- Conan >= 1.60.0 and <= 2.0.0
 
 
-### Setup
+### Build from Source (C++)
 
-To set up the development environment, follow these steps:
-
-1. Clone the repository:
-
-```    
-git clone https://github.com/milvus-io/milvus-stroage.git
-```
-
-2. Build the Milvus Docker image:
-
-```
+```bash
+git clone https://github.com/milvus-io/milvus-storage.git
 cd milvus-storage/cpp
-docker build -t milvus-storage:latest .
-```
 
-3. Start the Docker container:
+# Setup Conan remote
+conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert 0
 
-```
-docker run -it milvus-storage:latest bash
-```
-
-### Building
-check conan remote list, it should be the following sequence:
-```
-conan remote list
-
-default-conan-local: https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local [Verify SSL: True]
-conancenter: https://center.conan.io [Verify SSL: True]
-
-```
-You can modify the sequence by using `conan remote add` command.
-```
-conan remote remove default-conan-local
-conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert
-
-```
-Then, build the project by running the following command:
-
-```
+# Build
 make build
-```
 
-### Testing
-```
+# Test
 make test
+
+# Test with minio
+make test-all
 ```
 
-This will run all the tests in the `test` directory.
+#### Build Options
+
+| Option | Description |
+|--------|-------------|
+| `BUILD_TYPE=Debug/Release` | Build type |
+| `WITH_AZURE_FS=ON` | Azure filesystem support |
+| `WITH_VORTEX=ON` | Vortex format support |
+| `WITH_LANCE=ON` | Lance format support |
+| `WITH_JNI=ON` | Java JNI bindings |
+| `WITH_PYTHON_BINDING=ON` | Python bindings |
+
+## Quick Start
+
+See the [examples](python/examples/) directory for usage examples:
+- [basic_write.py](python/examples/basic_write.py) - Writing data
+- [basic_read.py](python/examples/basic_read.py) - Reading data
+
+For cloud storage integration, see [cpp/test/packed/packed_integration_test.cpp](cpp/test/packed/packed_integration_test.cpp).
 
 ### Code Style
 
-```
+```bash
 make fix-format
+make fix-tidy
 ```
 
-This will format the code using `clang-format` and fix any style issues.
+## Contributing
+
+Contributions are welcome. Please ensure code follows the project style and tests pass.
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Add CLAUDE.md to provide guidance for Claude Code AI assistant,including build commands, architecture overview, key source locations, and code conventions

Rewrite README.md from internal design document to user-facing project introduction with architecture diagram, features, cloud storage support matrix, language SDK status, and quick start guide