### PR TITLE
enhance: remove WITH_VORTEX and WITH_LANCE build options

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         working-directory: ./cpp
         run: |
-          make build USE_ASAN=True BUILD_TYPE=Release WITH_VORTEX=True
+          make build USE_ASAN=True BUILD_TYPE=Release
 
       - name: Upload
         uses: actions/upload-artifact@v4
@@ -77,6 +77,19 @@ jobs:
         with:
           conan: 1.61.0
           cmake: true
+
+      - name: Setup Rust
+        id: rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: rust build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            cpp/build/Release/cargo/build
+          key: storage-bridge-rust-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
+          restore-keys: |
+            storage-bridge-rust-${{ runner.os }}-${{ steps.rust-toolchain.outputs.cachekey }}-
 
       - name: setup conan
         run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,6 @@ make build
 # Build variants
 BUILD_TYPE=Debug make build
 USE_ASAN=False make build
-WITH_VORTEX=True WITH_LANCE=True make build
 
 # Build for language bindings
 make python-lib    # Python FFI

--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ make test-all
 |--------|-------------|
 | `BUILD_TYPE=Debug/Release` | Build type |
 | `WITH_AZURE_FS=ON` | Azure filesystem support |
-| `WITH_VORTEX=ON` | Vortex format support |
-| `WITH_LANCE=ON` | Lance format support |
 | `WITH_JNI=ON` | Java JNI bindings |
 | `WITH_PYTHON_BINDING=ON` | Python bindings |
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -10,8 +10,6 @@ option(WITH_UT "Build the testing tree." OFF)
 option(WITH_ASAN "Build with address sanitizer." OFF)
 option(WITH_BENCHMARK "Build with micro benchmark." ON)
 option(WITH_AZURE_FS "Build with azure file system." ON)
-option(WITH_VORTEX "Build with vortex." OFF)
-option(WITH_LANCE "Build with lance." OFF)
 option(WITH_JNI "Build with JNI library." OFF)
 option(WITH_PYTHON_BINDING "Build for Python bindings with hidden symbols." OFF)
 
@@ -39,26 +37,12 @@ find_package(Protobuf REQUIRED)
 find_package(google-cloud-cpp REQUIRED)
 find_package(libavrocpp REQUIRED)
 
-set(BUILD_RUST_BRIDGE OFF)
-if(WITH_VORTEX OR WITH_LANCE)
-    set(BUILD_RUST_BRIDGE ON)
-endif()
+# Rust bridge for Vortex and Lance formats (always built)
+set(RUST_BRIDGE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/format/bridge/rust)
+add_subdirectory(${RUST_BRIDGE_PATH})
 
-if (BUILD_RUST_BRIDGE)
-  if (WITH_VORTEX)
-    add_definitions(-DBUILD_VORTEX_BRIDGE)
-  endif() # WITH_VORTEX
-
-  if (WITH_LANCE)
-    add_definitions(-DBUILD_LANCE_BRIDGE)
-  endif() # WITH_LANCE
-
-  set(RUST_BRIDGE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/format/bridge/rust)
-  add_subdirectory(${RUST_BRIDGE_PATH})
-
-  list(APPEND LINK_LIBS prsbridge)
-  list(APPEND INCLUDE_PATHS ${RUST_BRIDGE_PATH}/include/)
-endif()  # BUILD_RUST_BRIDGE
+list(APPEND LINK_LIBS prsbridge)
+list(APPEND INCLUDE_PATHS ${RUST_BRIDGE_PATH}/include/)
 
 file(GLOB_RECURSE ALL_SRC_FILES
     src/*.cpp

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -11,8 +11,6 @@ with_benchmark ?= True
 build_type ?= Release
 use_jni ?= False
 use_python_binding ?= False
-with_vortex ?= False
-with_lance ?= False
 
 ifdef USE_ASAN
 use_asan = $(USE_ASAN)
@@ -32,12 +30,6 @@ endif
 ifdef USE_PYTHON_BINDING
 use_python_binding = $(USE_PYTHON_BINDING)
 endif
-ifdef WITH_VORTEX
-with_vortex = $(WITH_VORTEX)
-endif
-ifdef WITH_LANCE
-with_lance = $(WITH_LANCE)
-endif
 
 libcxx_setting =
 uname_s := $(shell uname -s)
@@ -53,14 +45,11 @@ build: fix-format
 	@echo "build_type: ${build_type}"
 	@echo "use_jni: ${use_jni}"
 	@echo "use_python_binding: ${use_python_binding}"
-	@echo "with_vortex: ${with_vortex}"
-	@echo "with_lance: ${with_lance}"
 
 	mkdir -p build && cd build && \
 	conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update \
 	-o with_ut=${with_ut} -o with_benchmark=${with_benchmark} -o with_asan=${use_asan} \
-	-o with_jni=${use_jni} -o with_python_binding=${use_python_binding} \
-	-o with_vortex=${with_vortex} -o with_lance=${with_lance} && conan build ..
+	-o with_jni=${use_jni} -o with_python_binding=${use_python_binding} && conan build ..
 
 package: build
 	mkdir -p build && cd build && \
@@ -70,14 +59,14 @@ python-lib:
 	@echo "Building library for Python bindings with hidden symbols..."
 	mkdir -p build && cd build && \
 	conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update \
-	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=False -o with_jemalloc=False -o with_python_binding=True -o with_azure=False -o with_vortex=True -o with_lance=True && \
-	conan build .. 
+	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=False -o with_jemalloc=False -o with_python_binding=True -o with_azure=False && \
+	conan build ..
 
 java-lib:
 	@echo "Building library for Java/Scala dependencies..."
 	mkdir -p build && cd build && \
 	conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update \
-	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=True -o with_jemalloc=False -o with_python_binding=False -o with_azure=True -o with_vortex=True -o with_lance=True && \
+	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=True -o with_jemalloc=False -o with_python_binding=False -o with_azure=True && \
 	conan build .. 
 
 clean:

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -31,8 +31,6 @@ class StorageConan(ConanFile):
         "with_azure": [True, False],
         "with_jni": [True, False],
         "with_python_binding": [True, False],
-        "with_vortex": [True, False],
-        "with_lance": [True, False],
     }
     default_options = {
         "shared": True,
@@ -45,8 +43,6 @@ class StorageConan(ConanFile):
         "with_jemalloc": True,
         "with_jni": False,
         "with_python_binding": False,
-        "with_vortex": False,
-        "with_lance": False,
         "glog:with_gflags": True,
         "glog:shared": True,
         "aws-sdk-cpp:config": True,
@@ -200,8 +196,6 @@ class StorageConan(ConanFile):
         tc.variables["ARROW_WITH_JEMALLOC"] = self.options.with_jemalloc
         tc.variables["WITH_JNI"] = self.options.with_jni
         tc.variables["WITH_PYTHON_BINDING"] = self.options.with_python_binding
-        tc.variables["WITH_VORTEX"] = self.options.with_vortex
-        tc.variables["WITH_LANCE"] = self.options.with_lance
 
         # Set JAVA_HOME for JNI compilation
         if self.options.with_jni:

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_LANCE_BRIDGE
+
 #pragma once
 
 #include <memory>
@@ -71,4 +71,3 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
 };
 
 }  // namespace milvus_storage::lance
-#endif  // BUILD_LANCE_BRIDGE

--- a/cpp/include/milvus-storage/format/lance/lance_table_writer.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_writer.h
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef BUILD_LANCE_BRIDGE
+// The lance writer and reader are APIs for the dataset level.
+// The current lance writer is only for testing purposes,
+// so the inner table will not be written in lance format.
 #ifdef BUILD_GTEST
 
 #pragma once
@@ -58,4 +60,3 @@ class LanceTableWriter final : public FormatWriter {
 }  // namespace milvus_storage::lance
 
 #endif  // BUILD_GTEST
-#endif  // BUILD_LANCE_BRIDGE

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_VORTEX_BRIDGE
+
 #pragma once
 
 #include <arrow/chunked_array.h>
@@ -83,5 +83,3 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
 };
 
 }  // namespace milvus_storage::vortex
-
-#endif  // BUILD_VORTEX_BRIDGE

--- a/cpp/include/milvus-storage/format/vortex/vortex_writer.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_writer.h
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_VORTEX_BRIDGE
+
 #pragma once
 
 #include <memory>
@@ -54,4 +54,3 @@ class VortexFileWriter final : public FormatWriter {
   int64_t written_rows_ = 0;
 };
 }  // namespace milvus_storage::vortex
-#endif

--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -37,10 +37,7 @@
 #include "milvus-storage/transaction/transaction.h"
 
 using namespace milvus_storage::api;
-
-#ifdef BUILD_VORTEX_BRIDGE
 using namespace milvus_storage::vortex;
-#endif
 using namespace milvus_storage::api::transaction;
 
 struct ColumnGroupsExporter;
@@ -216,9 +213,7 @@ LoonFFIResult loon_exttable_get_file_info(const char* format,
       if (!close_status.ok()) {
         RETURN_ERROR(LOON_ARROW_ERROR, close_status.ToString());
       }
-    }
-#ifdef BUILD_VORTEX_BRIDGE
-    else if (format_str == LOON_FORMAT_VORTEX) {
+    } else if (format_str == LOON_FORMAT_VORTEX) {
       VortexFormatReader reader(fs, nullptr /* schema */, file_path, properties_map,
                                 std::vector<std::string>{} /* projection */);
       auto open_result = reader.open();
@@ -226,9 +221,7 @@ LoonFFIResult loon_exttable_get_file_info(const char* format,
         RETURN_ERROR(LOON_ARROW_ERROR, "Open failed. " + open_result.ToString());
       }
       *out_num_of_rows = reader.rows();
-    }
-#endif
-    else {
+    } else {
       RETURN_ERROR(LOON_INVALID_ARGS, "Unsupported format: " + format_str + ", file_path: " + file_path);
     }
 

--- a/cpp/src/format/column_group_writer.cpp
+++ b/cpp/src/format/column_group_writer.cpp
@@ -127,20 +127,15 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
       ARROW_ASSIGN_OR_RAISE(writer, parquet::ParquetFileWriter::Make(
                                         file_system, schema,
                                         std::move(get_data_filepath(base_path, column_group_id, format)), properties));
-    }
-#ifdef BUILD_VORTEX_BRIDGE
-    else if (format == LOON_FORMAT_VORTEX) {
+    } else if (format == LOON_FORMAT_VORTEX) {
       writer = std::make_unique<vortex::VortexFileWriter>(
           file_system, schema, std::move(get_data_filepath(base_path, column_group_id, format)), properties);
     }
-#endif  // BUILD_VORTEX_BRIDGE
-#ifdef BUILD_LANCE_BRIDGE
 #ifdef BUILD_GTEST
     else if (format == LOON_FORMAT_LANCE_TABLE) {
       writer = std::make_unique<lance::LanceTableWriter>(base_path, schema, properties);
     }
 #endif  // BUILD_GTEST
-#endif  // BUILD_LANCE_BRIDGE
     else {
       return arrow::Status::Invalid(fmt::format("Unknown file format: '{}'. [base_path={}, column_group_id={}]", format,
                                                 base_path, column_group_id));

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -42,23 +42,16 @@ arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
     format_reader = std::make_shared<parquet::ParquetFormatReader>(file_system, file.path, properties, needed_columns,
                                                                    key_retriever);
-  }
-#ifdef BUILD_VORTEX_BRIDGE
-  else if (format == LOON_FORMAT_VORTEX) {
+  } else if (format == LOON_FORMAT_VORTEX) {
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
     format_reader =
         std::make_shared<vortex::VortexFormatReader>(file_system, schema, file.path, properties, needed_columns);
-  }
-#endif  // BUILD_VORTEX_BRIDGE
-#ifdef BUILD_LANCE_BRIDGE
-  else if (format == LOON_FORMAT_LANCE_TABLE) {
+  } else if (format == LOON_FORMAT_LANCE_TABLE) {
     std::string base_path;
     uint64_t fragment_id;
     ARROW_ASSIGN_OR_RAISE(std::tie(base_path, fragment_id), lance::LanceTableReader::parse_uri(file.path));
     format_reader = std::make_shared<lance::LanceTableReader>(base_path, fragment_id, schema, properties);
-  }
-#endif  // BUILD_LANCE_BRIDGE
-  else {
+  } else {
     return arrow::Status::Invalid(fmt::format("Unknown file format: {}", format));
   }
 

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_LANCE_BRIDGE
+
 #include "milvus-storage/format/lance/lance_table_reader.h"
 
 #include <string>
@@ -205,4 +205,3 @@ arrow::Result<std::shared_ptr<FormatReader>> LanceTableReader::clone_reader() {
 }
 
 }  // namespace milvus_storage::lance
-#endif  // BUILD_LANCE_BRIDGE

--- a/cpp/src/format/lance/lance_table_writer.cpp
+++ b/cpp/src/format/lance/lance_table_writer.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_LANCE_BRIDGE
+
 #ifdef BUILD_GTEST
 
 #include "milvus-storage/format/lance/lance_table_writer.h"
@@ -157,4 +157,3 @@ arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
 }  // namespace milvus_storage::lance
 
 #endif  // BUILD_GTEST
-#endif  // BUILD_LANCE_BRIDGE

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_VORTEX_BRIDGE
+
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 #include "vortex_bridge.h"
 
@@ -267,5 +267,3 @@ uint64_t VortexFormatReader::total_mem_usage() {
 }
 
 }  // namespace milvus_storage::vortex
-
-#endif  // BUILD_VORTEX_BRIDGE

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_VORTEX_BRIDGE
 
 #include "milvus-storage/format/vortex/vortex_writer.h"
 #include <arrow/c/bridge.h>
@@ -84,4 +83,3 @@ arrow::Result<api::ColumnGroupFile> VortexFileWriter::Close() {
 }
 
 }  // namespace milvus_storage::vortex
-#endif

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -322,18 +322,10 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
     // --- global properties define ---
     REGISTER_PROPERTY(PROPERTY_FORMAT,
                       PropertyType::STRING,
-                      "The format of the storage. Options: parquet, vortex.",
+                      "The format of the storage. Options: parquet, vortex, lance_table.",
                       LOON_FORMAT_PARQUET,
-                      ValidatePropertyType() + ValidatePropertyEnum<std::string>(LOON_FORMAT_PARQUET
-#ifdef BUILD_VORTEX_BRIDGE
-                                                                                 ,
-                                                                                 LOON_FORMAT_VORTEX
-#endif
-#ifdef BUILD_LANCE_BRIDGE
-                                                                                 ,
-                                                                                 LOON_FORMAT_LANCE_TABLE
-#endif
-                                                                                 )),
+                      ValidatePropertyType() + ValidatePropertyEnum<std::string>(
+                                                   LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX, LOON_FORMAT_LANCE_TABLE)),
     // --- fs properties define ---
     REGISTER_PROPERTY(PROPERTY_FS_ADDRESS,
                       PropertyType::STRING,

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -1417,12 +1417,7 @@ TEST_P(APIWriterReaderTest, TestFileRolling) {
 
 INSTANTIATE_TEST_SUITE_P(APIWriterReaderTestP,
                          APIWriterReaderTest,
-#ifdef BUILD_VORTEX_BRIDGE
                          ::testing::Combine(::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX),
-                                            ::testing::Values(1, 4))
-#else
-                         ::testing::Combine(::testing::Values(LOON_FORMAT_PARQUET), ::testing::Values(1, 4))
-#endif
-);
+                                            ::testing::Values(1, 4)));
 
 }  // namespace milvus_storage::test

--- a/cpp/test/ffi/ffi_external_test.c
+++ b/cpp/test/ffi/ffi_external_test.c
@@ -258,11 +258,7 @@ static void test_exttable_get_file_info_single_file_parquet(void) {
   test_exttable_get_file_info_single_file("parquet");
 }
 
-static void test_exttable_get_file_info_single_file_vortex(void) {
-#ifdef BUILD_VORTEX_BRIDGE
-  test_exttable_get_file_info_single_file("vortex");
-#endif
-}
+static void test_exttable_get_file_info_single_file_vortex(void) { test_exttable_get_file_info_single_file("vortex"); }
 
 static void test_exttable_get_file_info_directory_error(const char* format) {
   LoonFFIResult rc;
@@ -300,9 +296,7 @@ static void test_exttable_get_file_info_directory_error_parquet(void) {
 }
 
 static void test_exttable_get_file_info_directory_error_vortex(void) {
-#ifdef BUILD_VORTEX_BRIDGE
   test_exttable_get_file_info_directory_error("vortex");
-#endif
 }
 
 static void test_exttable_get_file_info_invalid_format(void) {

--- a/cpp/test/format/column_groups_wr_test.cpp
+++ b/cpp/test/format/column_groups_wr_test.cpp
@@ -427,11 +427,6 @@ TEST_P(ColumnGroupsWRTest, TestProjection) {
 
 INSTANTIATE_TEST_SUITE_P(ColumnGroupsWRTestP,
                          ColumnGroupsWRTest,
-#ifdef BUILD_VORTEX_BRIDGE
                          ::testing::Combine(::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX),
-                                            ::testing::Values(1, 4))
-#else
-                         ::testing::Combine(::testing::Values(LOON_FORMAT_PARQUET), ::testing::Values(1, 4))
-#endif
-);
+                                            ::testing::Values(1, 4)));
 }  // namespace milvus_storage::test

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -169,6 +169,8 @@ TEST_P(FormatReaderTest, TestReadWithRange) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(FormatReaderTestP, FormatReaderTest, ::testing::ValuesIn(GenerateFormatTestPValuesIn()));
+INSTANTIATE_TEST_SUITE_P(FormatReaderTestP,
+                         FormatReaderTest,
+                         ::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX, LOON_FORMAT_LANCE_TABLE));
 
 }  // namespace milvus_storage::test

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifdef BUILD_LANCE_BRIDGE
+
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
@@ -54,10 +54,10 @@ class LanceBasicTest : public ::testing::Test {
       GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
     }
 
-    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    api::SetValue(properties_, PROPERTY_FS_ROOT_PATH, "/");
     ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
 
-    base_path_ = GetTestBasePath("lance-fragment-test");
+    base_path_ = GetTestBasePath("/tmp/lance-fragment-test");
     ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
     ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
 
@@ -68,7 +68,11 @@ class LanceBasicTest : public ::testing::Test {
     ASSERT_AND_ASSIGN(test_batch_, CreateTestData(schema_));
   }
 
-  void TearDown() override { ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_)); }
+  void TearDown() override {
+    if (!IsCloudEnv()) {
+      ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    }
+  }
 
   protected:
   std::shared_ptr<arrow::fs::FileSystem> fs_;
@@ -196,5 +200,3 @@ TEST_F(LanceBasicTest, TestRead) {
 }
 
 }  // namespace milvus_storage
-
-#endif  // BUILD_LANCE_BRIDGE

--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef BUILD_VORTEX_BRIDGE
-
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>
@@ -404,5 +402,3 @@ TEST_F(VortexBasicTest, TestBasicTake) {
 }
 
 }  // namespace milvus_storage
-
-#endif

--- a/cpp/test/include/test_env.h
+++ b/cpp/test/include/test_env.h
@@ -66,8 +66,6 @@ arrow::Status MoveTestBasePath(const milvus_storage::ArrowFileSystemPtr& fs,
                                const std::string& old_dir,
                                const std::string& new_dir);
 
-std::vector<std::string> GenerateFormatTestPValuesIn();
-
 arrow::Result<milvus_storage::ArrowFileSystemConfig> GetFileSystemConfig(const api::Properties& properties);
 arrow::Result<milvus_storage::ArrowFileSystemPtr> GetFileSystem(const api::Properties& properties);
 arrow::Status CreateTestDir(const milvus_storage::ArrowFileSystemPtr& fs, const std::string& path);

--- a/cpp/test/test_env.cpp
+++ b/cpp/test/test_env.cpp
@@ -40,22 +40,6 @@ bool IsCloudEnv() {
   return storage_type == "remote";
 }
 
-std::vector<std::string> GenerateFormatTestPValuesIn() {
-  std::vector<std::string> format_args;
-  format_args.emplace_back(LOON_FORMAT_PARQUET);
-
-#ifdef BUILD_VORTEX_BRIDGE
-  format_args.emplace_back(LOON_FORMAT_VORTEX);
-#endif
-#ifdef BUILD_LANCE_BRIDGE
-  if (!IsCloudEnv()) {
-    format_args.emplace_back(LOON_FORMAT_LANCE_TABLE);
-  }
-#endif
-
-  return format_args;
-}
-
 arrow::Status InitTestProperties(api::Properties& properties) {
   auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
 
@@ -71,8 +55,6 @@ arrow::Status InitTestProperties(api::Properties& properties) {
     api::SetValue(properties, PROPERTY_FS_ACCESS_KEY_VALUE,
                   GetEnvVar(ENV_VAR_ACCESS_KEY_VALUE).ValueOr("minioadmin").c_str());
     api::SetValue(properties, PROPERTY_FS_REGION, GetEnvVar(ENV_VAR_REGION).ValueOr("").c_str());
-    api::SetValue(properties, PROPERTY_FS_ROOT_PATH,
-                  GetEnvVar(ENV_VAR_ROOT_PATH).ValueOr("/milvus-storage-test").c_str());
   } else {
     return arrow::Status::Invalid("Unknown STORAGE_TYPE: " + storage_type);
   }


### PR DESCRIPTION
Remove optional build flags WITH_VORTEX, WITH_LANCE and related BUILD_RUST_BRIDGE, BUILD_VORTEX_BRIDGE, BUILD_LANCE_BRIDGE preprocessor definitions. Vortex and Lance format support is now always built.