### PR TITLE
feat: integrate libfiu fault injection for IT Phase 2

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,6 +12,7 @@ option(WITH_BENCHMARK "Build with micro benchmark." ON)
 option(WITH_AZURE_FS "Build with azure file system." ON)
 option(WITH_JNI "Build with JNI library." OFF)
 option(WITH_PYTHON_BINDING "Build for Python bindings with hidden symbols." OFF)
+option(WITH_FIU "Build with fault injection support (libfiu)." OFF)
 
 # Disable Azure FS on macOS since the Arrow library is built without Azure support
 if(APPLE)
@@ -55,6 +56,38 @@ add_library(milvus-storage SHARED ${ALL_SRC_FILES})
 
 list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management google-cloud-cpp::storage libavrocpp::libavrocpp Folly::folly fmt::fmt-header-only)
 list(APPEND INCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Fault injection support using libfiu
+if (WITH_FIU)
+  # no conan package for libfiu
+  include(FetchContent)
+  FetchContent_Declare(
+    libfiu
+    GIT_REPOSITORY https://github.com/albertito/libfiu.git
+    GIT_TAG        1.1
+  )
+  FetchContent_GetProperties(libfiu)
+  if(NOT libfiu_POPULATED)
+    FetchContent_Populate(libfiu)
+  endif()
+
+  # Build libfiu as a static library (must be outside the POPULATED check)
+  set(FIU_SOURCE_DIR ${libfiu_SOURCE_DIR}/libfiu)
+  file(GLOB FIU_SOURCES ${FIU_SOURCE_DIR}/*.c)
+  add_library(fiu STATIC ${FIU_SOURCES})
+  target_include_directories(fiu PUBLIC ${FIU_SOURCE_DIR})
+  target_compile_definitions(fiu
+    PRIVATE DUMMY_BACKTRACE
+    PUBLIC FIU_ENABLE=1
+  )
+
+  add_definitions(-DBUILD_WITH_FIU)
+  list(APPEND LINK_LIBS fiu)
+  list(APPEND INCLUDE_PATHS ${FIU_SOURCE_DIR})
+  
+  message(STATUS "Fault injection enabled with libfiu")
+endif()
+
 
 target_link_libraries(milvus-storage PUBLIC ${LINK_LIBS})
 target_include_directories(milvus-storage PUBLIC ${INCLUDE_PATHS})

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test format python-lib
+.PHONY: build clean test format python-lib python-lib-fiu
 
 TEST_THREADS ?= 4
 ifneq ($(TIDY_THREADS),)
@@ -7,6 +7,7 @@ endif
 
 use_asan ?= True
 with_ut ?= True
+with_fiu ?= True
 with_benchmark ?= True
 build_type ?= Release
 use_jni ?= False
@@ -30,6 +31,9 @@ endif
 ifdef USE_PYTHON_BINDING
 use_python_binding = $(USE_PYTHON_BINDING)
 endif
+ifdef WITH_FIU
+with_fiu = $(WITH_FIU)
+endif
 
 libcxx_setting =
 uname_s := $(shell uname -s)
@@ -39,17 +43,19 @@ endif
 
 build: fix-format
 	# Example building debug mode: BUILD_TYPE=Debug WITH_UT=False make
+	# Example building with fault injection: WITH_FIU=True make
 	@echo "with_ut: ${with_ut}"
 	@echo "with_benchmark: ${with_benchmark}"
 	@echo "use_asan: ${use_asan}"
 	@echo "build_type: ${build_type}"
 	@echo "use_jni: ${use_jni}"
 	@echo "use_python_binding: ${use_python_binding}"
+	@echo "with_fiu: ${with_fiu}"
 
 	mkdir -p build && cd build && \
 	conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update \
 	-o with_ut=${with_ut} -o with_benchmark=${with_benchmark} -o with_asan=${use_asan} \
-	-o with_jni=${use_jni} -o with_python_binding=${use_python_binding} && conan build ..
+	-o with_jni=${use_jni} -o with_python_binding=${use_python_binding} -o with_fiu=${with_fiu} && conan build ..
 
 package: build
 	mkdir -p build && cd build && \
@@ -57,16 +63,17 @@ package: build
 
 python-lib:
 	@echo "Building library for Python bindings with hidden symbols..."
+	@echo "with_fiu: ${with_fiu}"
 	mkdir -p build && cd build && \
 	conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update \
-	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=False -o with_jemalloc=False -o with_python_binding=True -o with_azure=False && \
+	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=False -o with_jemalloc=False -o with_python_binding=True -o with_azure=False -o with_fiu=${with_fiu}  && \
 	conan build ..
 
 java-lib:
 	@echo "Building library for Java/Scala dependencies..."
 	mkdir -p build && cd build && \
 	conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update \
-	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=True -o with_jemalloc=False -o with_python_binding=False -o with_azure=True && \
+	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=True -o with_jemalloc=False -o with_python_binding=False -o with_azure=True -o with_fiu=False && \
 	conan build .. 
 
 clean:

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -31,6 +31,7 @@ class StorageConan(ConanFile):
         "with_azure": [True, False],
         "with_jni": [True, False],
         "with_python_binding": [True, False],
+        "with_fiu": [True, False],
     }
     default_options = {
         "shared": True,
@@ -43,6 +44,7 @@ class StorageConan(ConanFile):
         "with_jemalloc": True,
         "with_jni": False,
         "with_python_binding": False,
+        "with_fiu": False,
         "glog:with_gflags": True,
         "glog:shared": True,
         "aws-sdk-cpp:config": True,
@@ -196,6 +198,7 @@ class StorageConan(ConanFile):
         tc.variables["ARROW_WITH_JEMALLOC"] = self.options.with_jemalloc
         tc.variables["WITH_JNI"] = self.options.with_jni
         tc.variables["WITH_PYTHON_BINDING"] = self.options.with_python_binding
+        tc.variables["WITH_FIU"] = self.options.with_fiu
 
         # Set JAVA_HOME for JNI compilation
         if self.options.with_jni:

--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -143,6 +143,38 @@
     loon_filesystem_list_dir;
     loon_filesystem_free_file_info_list;
 
+    # Fault injection interface
+    loon_fiu_enable;
+    loon_fiu_disable;
+    loon_fiu_disable_all;
+    loon_fiu_is_enabled;
+
+    # Fault injection point names
+    # Writer
+    loon_fiukey_writer_write_fail;
+    loon_fiukey_writer_flush_fail;
+    loon_fiukey_writer_close_fail;
+    # Reader (low-level)
+    loon_fiukey_column_group_read_fail;
+    loon_fiukey_take_rows_fail;
+    loon_fiukey_chunk_reader_read_fail;
+    loon_fiukey_reader_open_fail;
+    # Transaction/Manifest
+    loon_fiukey_manifest_commit_fail;
+    loon_fiukey_manifest_read_fail;
+    loon_fiukey_manifest_write_fail;
+    # Filesystem
+    loon_fiukey_fs_open_output_fail;
+    loon_fiukey_fs_open_input_fail;
+    # S3 Filesystem
+    loon_fiukey_s3fs_create_upload_fail;
+    loon_fiukey_s3fs_part_upload_fail;
+    loon_fiukey_s3fs_complete_upload_fail;
+    loon_fiukey_s3fs_read_fail;
+    loon_fiukey_s3fs_readat_fail;
+    # ColumnGroup
+    loon_fiukey_column_group_write_fail;
+
   local:
     # Hide all other symbols
     *;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -140,3 +140,35 @@ _loon_filesystem_get_path_info
 _loon_filesystem_create_dir
 _loon_filesystem_list_dir
 _loon_filesystem_free_file_info_list
+
+# Fault injection interface
+_loon_fiu_enable
+_loon_fiu_disable
+_loon_fiu_disable_all
+_loon_fiu_is_enabled
+
+# Fault injection point names
+# Writer
+_loon_fiukey_writer_write_fail
+_loon_fiukey_writer_flush_fail
+_loon_fiukey_writer_close_fail
+# Reader (low-level)
+_loon_fiukey_column_group_read_fail
+_loon_fiukey_take_rows_fail
+_loon_fiukey_chunk_reader_read_fail
+_loon_fiukey_reader_open_fail
+# Transaction/Manifest
+_loon_fiukey_manifest_commit_fail
+_loon_fiukey_manifest_read_fail
+_loon_fiukey_manifest_write_fail
+# Filesystem
+_loon_fiukey_fs_open_output_fail
+_loon_fiukey_fs_open_input_fail
+# S3 Filesystem
+_loon_fiukey_s3fs_create_upload_fail
+_loon_fiukey_s3fs_part_upload_fail
+_loon_fiukey_s3fs_complete_upload_fail
+_loon_fiukey_s3fs_read_fail
+_loon_fiukey_s3fs_readat_fail
+# ColumnGroup
+_loon_fiukey_column_group_write_fail

--- a/cpp/include/milvus-storage/common/fiu_local.h
+++ b/cpp/include/milvus-storage/common/fiu_local.h
@@ -1,0 +1,121 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+/**
+ * @file fiu_local.h
+ * @brief Fault injection macros and key definitions for milvus-storage
+ *
+ * This header provides:
+ * 1. Fault injection point key definitions (constexpr strings)
+ * 2. Convenient macros for adding fault injection points
+ *
+ * When BUILD_WITH_FIU is defined:
+ *   - FIU_RETURN_ON: Returns specified value when fault point is triggered
+ *   - FIU_DO_ON: Executes code when fault point is triggered
+ *
+ * When BUILD_WITH_FIU is not defined:
+ *   - All macros compile to no-ops
+ *
+ * Usage:
+ *   FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, Status::IOError("fault"));
+ *   FIU_DO_ON(FIUKEY_FS_OPEN_OUTPUT_FAIL, { throw std::runtime_error("fault"); });
+ */
+
+// ==================== Fault Point Key Macros (Single Source of Truth) ====================
+// Use these macros directly in C++ code and FFI exports.
+
+// Writer fault points
+#define FIUKEY_WRITER_WRITE_FAIL "writer.write.fail"
+#define FIUKEY_WRITER_FLUSH_FAIL "writer.flush.fail"
+#define FIUKEY_WRITER_CLOSE_FAIL "writer.close.fail"
+
+// Reader fault points (low-level)
+#define FIUKEY_COLUMN_GROUP_READ_FAIL "column_group.read.fail"
+#define FIUKEY_TAKE_ROWS_FAIL "take_rows.fail"
+#define FIUKEY_CHUNK_READER_READ_FAIL "chunk_reader.read.fail"
+#define FIUKEY_READER_OPEN_FAIL "reader.open.fail"
+
+// Transaction/Manifest fault points
+#define FIUKEY_MANIFEST_COMMIT_FAIL "manifest.commit.fail"
+#define FIUKEY_MANIFEST_READ_FAIL "manifest.read.fail"
+#define FIUKEY_MANIFEST_WRITE_FAIL "manifest.write.fail"
+
+// Filesystem fault points
+#define FIUKEY_FS_OPEN_OUTPUT_FAIL "fs.open_output.fail"
+#define FIUKEY_FS_OPEN_INPUT_FAIL "fs.open_input.fail"
+
+// S3 Filesystem fault points
+#define FIUKEY_S3FS_CREATE_UPLOAD_FAIL "s3fs.create_upload.fail"
+#define FIUKEY_S3FS_PART_UPLOAD_FAIL "s3fs.part_upload.fail"
+#define FIUKEY_S3FS_COMPLETE_UPLOAD_FAIL "s3fs.complete_upload.fail"
+#define FIUKEY_S3FS_READ_FAIL "s3fs.read.fail"
+#define FIUKEY_S3FS_READAT_FAIL "s3fs.readat.fail"
+
+// ColumnGroup fault points
+#define FIUKEY_COLUMN_GROUP_WRITE_FAIL "column_group.write.fail"
+
+// ==================== Fault Injection Macros ====================
+
+#ifdef BUILD_WITH_FIU
+
+#include <fiu.h>
+#include <fiu-control.h>
+
+// Initialize fiu once (call in main or global init)
+#define FIU_INIT() fiu_init(0)
+
+// Return specified status when fault point is triggered
+// Usage: FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, Status::IOError("Injected fault"));
+#define FIU_RETURN_ON(name, retval) \
+  do {                              \
+    if (fiu_fail(name)) {           \
+      return (retval);              \
+    }                               \
+  } while (0)
+
+// Execute code block when fault point is triggered
+// Usage: FIU_DO_ON(FIUKEY_FS_OPEN_OUTPUT_FAIL, { throw std::runtime_error("Injected fault"); });
+#define FIU_DO_ON(name, action) \
+  do {                          \
+    if (fiu_fail(name)) {       \
+      action;                   \
+    }                           \
+  } while (0)
+
+// Enable a fault point once
+// Usage: FIU_ENABLE_FAULT_ONETIME(FIUKEY_WRITER_FLUSH_FAIL);
+#define FIU_ENABLE_FAULT_ONETIME(name) fiu_enable(name, -1, nullptr, FIU_ONETIME)
+
+// Enable a fault point forever (until disabled)
+// Usage: FIU_ENABLE_FAULT_ALWAYS(FIUKEY_WRITER_FLUSH_FAIL);
+#define FIU_ENABLE_FAULT_ALWAYS(name) fiu_enable(name, -1, nullptr, 0 /* without FIU_ONETIME */)
+
+// Disable a fault point
+// Usage: FIU_DISABLE_FAULT(FIUKEY_WRITER_FLUSH_FAIL);
+#define FIU_DISABLE_FAULT(name) fiu_disable(name)
+
+#else  // BUILD_WITH_FIU not defined
+
+// No-op implementations when FIU is disabled
+#define FIU_INIT() ((void)0)
+#define FIU_RETURN_ON(name, retval) ((void)0)
+#define FIU_DO_ON(name, action) ((void)0)
+
+#define FIU_ENABLE_FAULT_ONETIME(name) ((void)0)
+#define FIU_ENABLE_FAULT_ALWAYS(name) ((void)0)
+#define FIU_DISABLE_FAULT(name) ((void)0)
+
+#endif  // BUILD_WITH_FIU

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -40,7 +40,8 @@ extern "C" {
 #define LOON_GOT_EXCEPTION 5
 #define LOON_UNREACHABLE_ERROR 6
 #define LOON_INVALID_PROPERTIES 7
-#define LOON_ERRORCODE_MAX 8
+#define LOON_FAULT_INJECT_ERROR 8
+#define LOON_ERRORCODE_MAX 9
 
 // usage example(caller must free the message string):
 //

--- a/cpp/include/milvus-storage/ffi_fiu_c.h
+++ b/cpp/include/milvus-storage/ffi_fiu_c.h
@@ -1,0 +1,149 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LOON_FIU_C
+#define LOON_FIU_C
+
+#include "milvus-storage/ffi_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file ffi_fiu_c.h
+ * @brief Fault Injection FFI Interface
+ *
+ * This header provides FFI functions for fault injection using libfiu.
+ * Fault injection is used for testing error handling and recovery scenarios.
+ *
+ * Example usage (Python):
+ * @code
+ * # Enable fault point to fail once (one_time=1)
+ * loon_fiu_enable(loon_fiu_key_writer_flush_fail, len, 1)
+ *
+ * # The next flush will fail
+ * writer.flush()  # raises IOError
+ *
+ * # Retry should succeed (one_time auto-disables)
+ * writer.flush()  # succeeds
+ *
+ * # Disable all fault points
+ * loon_fiu_disable_all()
+ * @endcode
+ */
+
+// ==================== Fault Point Names ====================
+// Use these constants instead of hardcoding fault point names
+
+// --- Writer fault points ---
+/** Fault point: Fail during Writer write batch operation */
+FFI_EXPORT extern const char* loon_fiukey_writer_write_fail;
+
+/** Fault point: Fail during Writer flush operation */
+FFI_EXPORT extern const char* loon_fiukey_writer_flush_fail;
+
+/** Fault point: Fail during Writer close operation */
+FFI_EXPORT extern const char* loon_fiukey_writer_close_fail;
+
+// --- Reader fault points (low-level) ---
+/** Fault point: Fail during ColumnGroup read (get_chunk/get_chunks) */
+FFI_EXPORT extern const char* loon_fiukey_column_group_read_fail;
+
+/** Fault point: Fail during take rows operation */
+FFI_EXPORT extern const char* loon_fiukey_take_rows_fail;
+
+/** Fault point: Fail during ChunkReader read operation (FFI layer) */
+FFI_EXPORT extern const char* loon_fiukey_chunk_reader_read_fail;
+
+/** Fault point: Fail during Reader open operation (FFI layer) */
+FFI_EXPORT extern const char* loon_fiukey_reader_open_fail;
+
+// --- Transaction/Manifest fault points ---
+/** Fault point: Fail during Transaction/Manifest commit */
+FFI_EXPORT extern const char* loon_fiukey_manifest_commit_fail;
+
+/** Fault point: Fail during Manifest read operation */
+FFI_EXPORT extern const char* loon_fiukey_manifest_read_fail;
+
+/** Fault point: Fail during Manifest write/serialize operation */
+FFI_EXPORT extern const char* loon_fiukey_manifest_write_fail;
+
+// --- Filesystem fault points ---
+/** Fault point: Fail during FileSystem OpenOutputStream operation */
+FFI_EXPORT extern const char* loon_fiukey_fs_open_output_fail;
+
+/** Fault point: Fail during FileSystem OpenInputFile operation */
+FFI_EXPORT extern const char* loon_fiukey_fs_open_input_fail;
+
+// --- S3 Filesystem fault points ---
+/** Fault point: Fail during S3 CreateMultipartUpload operation */
+FFI_EXPORT extern const char* loon_fiukey_s3fs_create_upload_fail;
+
+/** Fault point: Fail during S3 multipart upload UploadPart operation */
+FFI_EXPORT extern const char* loon_fiukey_s3fs_part_upload_fail;
+
+/** Fault point: Fail during S3 multipart upload CompleteMultipartUpload operation */
+FFI_EXPORT extern const char* loon_fiukey_s3fs_complete_upload_fail;
+
+/** Fault point: Fail during S3 ObjectInputFile Read operation */
+FFI_EXPORT extern const char* loon_fiukey_s3fs_read_fail;
+
+/** Fault point: Fail during S3 ObjectInputFile ReadAt operation */
+FFI_EXPORT extern const char* loon_fiukey_s3fs_readat_fail;
+
+// --- ColumnGroup fault points ---
+/** Fault point: Fail during ColumnGroup write operation */
+FFI_EXPORT extern const char* loon_fiukey_column_group_write_fail;
+
+/**
+ * Enable a fault injection point.
+ *
+ * @param name The name of the fault point to enable.
+ * @param name_len The length of the fault point name.
+ * @param one_time If non-zero, the fault triggers only once (FIU_ONETIME).
+ *                 If zero, the fault triggers forever until disabled.
+ * @return result of FFI (success or error if FIU not enabled)
+ */
+FFI_EXPORT LoonFFIResult loon_fiu_enable(const char* name, uint32_t name_len, int one_time);
+
+/**
+ * Disable a specific fault injection point.
+ *
+ * @param name The name of the fault point to disable.
+ * @param name_len The length of the fault point name.
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_fiu_disable(const char* name, uint32_t name_len);
+
+/**
+ * Disable all active fault injection points.
+ *
+ * This should be called in test cleanup to ensure all fault points
+ * are disabled after a test completes.
+ */
+FFI_EXPORT void loon_fiu_disable_all(void);
+
+/**
+ * Check if fault injection support is compiled in.
+ *
+ * @return 1 if FIU is enabled, 0 otherwise.
+ */
+FFI_EXPORT int loon_fiu_is_enabled(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LOON_FIU_C

--- a/cpp/src/ffi/ffi_fiu_c.cpp
+++ b/cpp/src/ffi/ffi_fiu_c.cpp
@@ -1,0 +1,163 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_fiu_c.h"
+
+#include <mutex>
+#include <string>
+
+#include <fmt/core.h>
+
+#include "milvus-storage/ffi_internal/result.h"
+#include "milvus-storage/common/fiu_local.h"
+
+// ==================== Fault Point Name Definitions (C-linkage for FFI) ====================
+// These provide C-linkage symbols for external bindings (Python, Java, Rust).
+// String values are defined as FIUKEY_* macros in fiu_local.h (single source of truth).
+
+// Writer fault points
+const char* loon_fiukey_writer_write_fail = FIUKEY_WRITER_WRITE_FAIL;
+const char* loon_fiukey_writer_flush_fail = FIUKEY_WRITER_FLUSH_FAIL;
+const char* loon_fiukey_writer_close_fail = FIUKEY_WRITER_CLOSE_FAIL;
+
+// Reader fault points (low-level)
+const char* loon_fiukey_column_group_read_fail = FIUKEY_COLUMN_GROUP_READ_FAIL;
+const char* loon_fiukey_take_rows_fail = FIUKEY_TAKE_ROWS_FAIL;
+const char* loon_fiukey_chunk_reader_read_fail = FIUKEY_CHUNK_READER_READ_FAIL;
+const char* loon_fiukey_reader_open_fail = FIUKEY_READER_OPEN_FAIL;
+
+// Transaction/Manifest fault points
+const char* loon_fiukey_manifest_commit_fail = FIUKEY_MANIFEST_COMMIT_FAIL;
+const char* loon_fiukey_manifest_read_fail = FIUKEY_MANIFEST_READ_FAIL;
+const char* loon_fiukey_manifest_write_fail = FIUKEY_MANIFEST_WRITE_FAIL;
+
+// Filesystem fault points
+const char* loon_fiukey_fs_open_output_fail = FIUKEY_FS_OPEN_OUTPUT_FAIL;
+const char* loon_fiukey_fs_open_input_fail = FIUKEY_FS_OPEN_INPUT_FAIL;
+
+// S3 Filesystem fault points
+const char* loon_fiukey_s3fs_create_upload_fail = FIUKEY_S3FS_CREATE_UPLOAD_FAIL;
+const char* loon_fiukey_s3fs_part_upload_fail = FIUKEY_S3FS_PART_UPLOAD_FAIL;
+const char* loon_fiukey_s3fs_complete_upload_fail = FIUKEY_S3FS_COMPLETE_UPLOAD_FAIL;
+const char* loon_fiukey_s3fs_read_fail = FIUKEY_S3FS_READ_FAIL;
+const char* loon_fiukey_s3fs_readat_fail = FIUKEY_S3FS_READAT_FAIL;
+
+// ColumnGroup fault points
+const char* loon_fiukey_column_group_write_fail = FIUKEY_COLUMN_GROUP_WRITE_FAIL;
+
+#ifdef BUILD_WITH_FIU
+
+static std::once_flag fiu_init_flag;
+
+static inline void ensure_fiu_init() {
+  std::call_once(fiu_init_flag, []() {
+    int ret = FIU_INIT();
+    if (ret != 0) {
+      throw std::runtime_error(fmt::format("fiu_init failed with code: {}", ret));
+    }
+  });
+}
+
+LoonFFIResult loon_fiu_enable(const char* name, uint32_t name_len, int one_time) {
+  try {
+    if (name == nullptr || name_len == 0) {
+      RETURN_ERROR(LOON_INVALID_ARGS, "Fault point name cannot be empty");
+    }
+
+    ensure_fiu_init();
+
+    std::string fault_name(name, name_len);
+    int ret = one_time ? FIU_ENABLE_FAULT_ONETIME(fault_name.c_str()) : FIU_ENABLE_FAULT_ALWAYS(fault_name.c_str());
+    if (ret != 0) {
+      RETURN_ERROR(LOON_LOGICAL_ERROR, "Failed to enable fault point: " + fault_name);
+    }
+
+    RETURN_SUCCESS();
+  } catch (const std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+}
+
+LoonFFIResult loon_fiu_disable(const char* name, uint32_t name_len) {
+  try {
+    if (name == nullptr || name_len == 0) {
+      RETURN_ERROR(LOON_INVALID_ARGS, "Fault point name cannot be empty");
+    }
+
+    ensure_fiu_init();
+
+    std::string fault_name(name, name_len);
+
+    int ret = FIU_DISABLE_FAULT(fault_name.c_str());
+    if (ret != 0) {
+      // fiu_disable returns -1 if the point was not enabled, which is not an error
+      // Just ignore this case
+    }
+
+    RETURN_SUCCESS();
+  } catch (const std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+}
+
+void loon_fiu_disable_all(void) {
+  static const char* fault_points[] = {
+      // Writer
+      FIUKEY_WRITER_WRITE_FAIL,
+      FIUKEY_WRITER_FLUSH_FAIL,
+      FIUKEY_WRITER_CLOSE_FAIL,
+      // Reader (low-level)
+      FIUKEY_COLUMN_GROUP_READ_FAIL,
+      FIUKEY_TAKE_ROWS_FAIL,
+      FIUKEY_CHUNK_READER_READ_FAIL,
+      FIUKEY_READER_OPEN_FAIL,
+      // Transaction/Manifest
+      FIUKEY_MANIFEST_COMMIT_FAIL,
+      FIUKEY_MANIFEST_READ_FAIL,
+      FIUKEY_MANIFEST_WRITE_FAIL,
+      // Filesystem
+      FIUKEY_FS_OPEN_OUTPUT_FAIL,
+      FIUKEY_FS_OPEN_INPUT_FAIL,
+      // S3 Filesystem
+      FIUKEY_S3FS_CREATE_UPLOAD_FAIL,
+      FIUKEY_S3FS_PART_UPLOAD_FAIL,
+      FIUKEY_S3FS_COMPLETE_UPLOAD_FAIL,
+      FIUKEY_S3FS_READ_FAIL,
+      FIUKEY_S3FS_READAT_FAIL,
+      // ColumnGroup
+      FIUKEY_COLUMN_GROUP_WRITE_FAIL,
+  };
+
+  for (const auto* fp : fault_points) {
+    FIU_DISABLE_FAULT(fp);
+  }
+}
+
+int loon_fiu_is_enabled(void) { return 1; }
+
+#else  // !BUILD_WITH_FIU
+
+LoonFFIResult loon_fiu_enable(const char* /*name*/, uint32_t /*name_len*/, int /*one_time*/) {
+  RETURN_ERROR(LOON_LOGICAL_ERROR, "Fault injection is not enabled. Rebuild with -DWITH_FIU=ON");
+}
+
+LoonFFIResult loon_fiu_disable(const char* /*name*/, uint32_t /*name_len*/) {
+  RETURN_ERROR(LOON_LOGICAL_ERROR, "Fault injection is not enabled. Rebuild with -DWITH_FIU=ON");
+}
+
+void loon_fiu_disable_all() {}
+
+int loon_fiu_is_enabled() { return 0; }
+
+#endif  // BUILD_WITH_FIU

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -21,6 +21,7 @@
 #include <arrow/buffer.h>
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/util/key_value_metadata.h>
+#include <fmt/format.h>
 
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/ffi_c.h"
@@ -88,6 +89,7 @@ LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
                                           uint32_t num_of_meta,
                                           FileSystemWriterHandle* out_writer_ptr) {
   try {
+    // Note: fs.open.fail fault injection is in FileSystemProxy::OpenOutputStream
     if (!handle || !path_ptr || path_len == 0 || !out_writer_ptr) {
       RETURN_ERROR(LOON_INVALID_ARGS,
                    "Invalid arguments: handle, path_ptr, path_len, and out_writer_ptr must not be null");

--- a/cpp/src/ffi/result_c.cpp
+++ b/cpp/src/ffi/result_c.cpp
@@ -27,7 +27,8 @@ std::string error_to_string(int code) {
                                         "Logical error",             //
                                         "Got exception",             //
                                         "Unreachable code",          //
-                                        "Invalid properties"};
+                                        "Invalid properties",        //
+                                        "Fault injection error"};
   static_assert(sizeof(error_strings) / sizeof((error_strings)[0]) == LOON_ERRORCODE_MAX);
 
   if (code < LOON_SUCCESS || code >= LOON_ERRORCODE_MAX) {

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -34,6 +34,7 @@
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/macro.h"  // for UNLIKELY
+#include "milvus-storage/common/fiu_local.h"
 
 namespace milvus_storage::api {
 
@@ -134,6 +135,8 @@ static std::vector<std::vector<int64_t>> split_row_indices(const std::vector<int
 
 arrow::Result<std::shared_ptr<arrow::Table>> ColumnGroupLazyReaderImpl::take(const std::vector<int64_t>& row_indices,
                                                                              size_t parallelism) {
+  FIU_RETURN_ON(FIUKEY_TAKE_ROWS_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_TAKE_ROWS_FAIL)));
   std::vector<std::shared_ptr<arrow::Table>> result_tables;
   std::vector<std::packaged_task<arrow::Result<std::shared_ptr<arrow::Table>>()>> tasks;
   std::vector<std::future<arrow::Result<std::shared_ptr<arrow::Table>>>> futures;

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -32,6 +32,7 @@
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/fiu_local.h"
 
 namespace milvus_storage {
 
@@ -110,6 +111,10 @@ arrow::Status PackedRecordBatchWriter::init() {
 }
 
 arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::RecordBatch>& record) {
+  // Fault injection point for testing
+  FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
+
   if (!record) {
     return arrow::Status::OK();
   }
@@ -148,6 +153,10 @@ arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::Record
 }
 
 arrow::Status PackedRecordBatchWriter::Close() {
+  // Fault injection point for testing
+  FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
+
   // Check if already closed
   if (closed_) {
     return arrow::Status::OK();
@@ -167,6 +176,10 @@ arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, c
 }
 
 arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
+  // Fault injection point for testing
+  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
+
   if (closed_) {
     return arrow::Status::OK();
   }

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -28,6 +28,7 @@
 #include <arrow/filesystem/filesystem.h>
 #include <avro/Encoder.hh>
 #include <avro/Decoder.hh>
+
 #include <avro/Stream.hh>
 
 #include "milvus-storage/filesystem/fs.h"
@@ -36,6 +37,7 @@
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/layout.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/fiu_local.h"
 
 namespace milvus_storage::api::transaction {
 
@@ -322,6 +324,10 @@ Transaction::Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
       retry_limit_(retry_limit) {}
 
 arrow::Result<int64_t> Transaction::Commit() {
+  // Fault injection point for testing
+  FIU_RETURN_ON(FIUKEY_MANIFEST_COMMIT_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_COMMIT_FAIL)));
+
   assert(resolver_ != nullptr);
 
   // Fail if there are no updates
@@ -402,6 +408,10 @@ arrow::Result<std::shared_ptr<Manifest>> Transaction::GetManifest() {
 int64_t Transaction::GetReadVersion() const { return read_version_; }
 
 arrow::Result<std::shared_ptr<Manifest>> Transaction::read_manifest(int64_t version) {
+  // Fault injection point for testing
+  FIU_RETURN_ON(FIUKEY_MANIFEST_READ_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_READ_FAIL)));
+
   auto manifest = std::make_shared<Manifest>();
   // If version is 0 or less, return empty manifest (no manifests exist yet)
   if (version <= 0) {
@@ -481,6 +491,10 @@ arrow::Result<int64_t> Transaction::get_latest_version() {
 arrow::Status Transaction::write_manifest(const std::shared_ptr<Manifest>& manifest,
                                           int64_t old_version,
                                           int64_t new_version) {
+  // Fault injection point for testing
+  FIU_RETURN_ON(FIUKEY_MANIFEST_WRITE_FAIL,
+                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_WRITE_FAIL)));
+
   // Serialize new manifest to Avro
   std::ostringstream oss;
   ARROW_RETURN_NOT_OK(manifest->serialize(oss, base_path_));

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -31,6 +31,7 @@
 #include <fmt/format.h>
 
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/metadata.h"
@@ -304,6 +305,9 @@ class WriterImpl : public Writer {
    *       All batches written to the same writer should have consistent schemas.
    */
   arrow::Status write(const std::shared_ptr<arrow::RecordBatch>& batch) override {
+    FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
+                  arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
+
     if (closed_) {
       return arrow::Status::Invalid(fmt::format("Cannot write to closed writer. [base_path={}, schema={}]",
                                                 base_path_,  // NOLINT
@@ -338,6 +342,9 @@ class WriterImpl : public Writer {
    *       after flushing.
    */
   arrow::Status flush() override {
+    FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL,
+                  arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
+
     if (closed_) {
       return arrow::Status::Invalid(fmt::format("Cannot flush closed writer. [base_path={}, schema={}]",
                                                 base_path_,  // NOLINT
@@ -372,6 +379,9 @@ class WriterImpl : public Writer {
    */
   arrow::Result<std::shared_ptr<ColumnGroups>> close(const std::vector<std::string_view>& config_keys = {},
                                                      const std::vector<std::string_view>& config_values = {}) override {
+    FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
+                  arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
+
     if (closed_) {
       return arrow::Status::Invalid(fmt::format("Writer already closed. [base_path={}, schema={}]",
                                                 base_path_,  // NOLINT

--- a/cpp/test/ffi/ffi_fiu_test.c
+++ b/cpp/test/ffi/ffi_fiu_test.c
@@ -1,0 +1,223 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_fiu_c.h"
+#include "test_runner.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Test that loon_fiu_is_enabled returns correct value
+static void test_fiu_is_enabled(void) {
+  int enabled = loon_fiu_is_enabled();
+  // Should return 1 if built with FIU, 0 otherwise
+  // We just verify it returns a valid boolean value
+  ck_assert(enabled == 0 || enabled == 1);
+}
+
+// Test that fault point name constants are accessible and non-null
+static void test_fiu_key_constants(void) {
+  // Writer fault points
+  ck_assert(loon_fiukey_writer_write_fail != NULL);
+  ck_assert(strlen(loon_fiukey_writer_write_fail) > 0);
+
+  ck_assert(loon_fiukey_writer_flush_fail != NULL);
+  ck_assert(strlen(loon_fiukey_writer_flush_fail) > 0);
+
+  ck_assert(loon_fiukey_writer_close_fail != NULL);
+  ck_assert(strlen(loon_fiukey_writer_close_fail) > 0);
+
+  // Reader fault points
+  ck_assert(loon_fiukey_column_group_read_fail != NULL);
+  ck_assert(strlen(loon_fiukey_column_group_read_fail) > 0);
+
+  ck_assert(loon_fiukey_take_rows_fail != NULL);
+  ck_assert(strlen(loon_fiukey_take_rows_fail) > 0);
+
+  ck_assert(loon_fiukey_chunk_reader_read_fail != NULL);
+  ck_assert(strlen(loon_fiukey_chunk_reader_read_fail) > 0);
+
+  ck_assert(loon_fiukey_reader_open_fail != NULL);
+  ck_assert(strlen(loon_fiukey_reader_open_fail) > 0);
+
+  // Transaction/Manifest fault points
+  ck_assert(loon_fiukey_manifest_commit_fail != NULL);
+  ck_assert(strlen(loon_fiukey_manifest_commit_fail) > 0);
+
+  ck_assert(loon_fiukey_manifest_read_fail != NULL);
+  ck_assert(strlen(loon_fiukey_manifest_read_fail) > 0);
+
+  ck_assert(loon_fiukey_manifest_write_fail != NULL);
+  ck_assert(strlen(loon_fiukey_manifest_write_fail) > 0);
+
+  // Filesystem fault points
+  ck_assert(loon_fiukey_fs_open_output_fail != NULL);
+  ck_assert(strlen(loon_fiukey_fs_open_output_fail) > 0);
+
+  ck_assert(loon_fiukey_fs_open_input_fail != NULL);
+  ck_assert(strlen(loon_fiukey_fs_open_input_fail) > 0);
+
+  // S3 Filesystem fault points
+  ck_assert(loon_fiukey_s3fs_create_upload_fail != NULL);
+  ck_assert(strlen(loon_fiukey_s3fs_create_upload_fail) > 0);
+
+  ck_assert(loon_fiukey_s3fs_part_upload_fail != NULL);
+  ck_assert(strlen(loon_fiukey_s3fs_part_upload_fail) > 0);
+
+  ck_assert(loon_fiukey_s3fs_complete_upload_fail != NULL);
+  ck_assert(strlen(loon_fiukey_s3fs_complete_upload_fail) > 0);
+
+  ck_assert(loon_fiukey_s3fs_read_fail != NULL);
+  ck_assert(strlen(loon_fiukey_s3fs_read_fail) > 0);
+
+  ck_assert(loon_fiukey_s3fs_readat_fail != NULL);
+  ck_assert(strlen(loon_fiukey_s3fs_readat_fail) > 0);
+
+  // ColumnGroup fault points
+  ck_assert(loon_fiukey_column_group_write_fail != NULL);
+  ck_assert(strlen(loon_fiukey_column_group_write_fail) > 0);
+}
+
+// Test loon_fiu_enable with null name
+static void test_fiu_enable_null_name(void) {
+  LoonFFIResult rc = loon_fiu_enable(NULL, 0, 0);
+  // Should fail with invalid args
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+}
+
+// Test loon_fiu_enable with empty name
+static void test_fiu_enable_empty_name(void) {
+  LoonFFIResult rc = loon_fiu_enable("", 0, 0);
+  // Should fail with invalid args
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+}
+
+// Test loon_fiu_disable with null name
+static void test_fiu_disable_null_name(void) {
+  LoonFFIResult rc = loon_fiu_disable(NULL, 0);
+  // Should fail with invalid args
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+}
+
+// Test loon_fiu_disable with empty name
+static void test_fiu_disable_empty_name(void) {
+  LoonFFIResult rc = loon_fiu_disable("", 0);
+  // Should fail with invalid args
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+}
+
+// Test loon_fiu_enable and disable with valid fault point
+static void test_fiu_enable_disable_valid(void) {
+  if (!loon_fiu_is_enabled()) {
+    // If FIU is not enabled, enable should return error
+    const char* name = loon_fiukey_writer_write_fail;
+    LoonFFIResult rc = loon_fiu_enable(name, (uint32_t)strlen(name), 1);
+    ck_assert(!loon_ffi_is_success(&rc));
+    loon_ffi_free_result(&rc);
+    return;
+  }
+
+  // FIU is enabled, test enable/disable cycle
+  const char* name = loon_fiukey_writer_write_fail;
+  uint32_t name_len = (uint32_t)strlen(name);
+
+  // Enable fault point (one_time)
+  LoonFFIResult rc = loon_fiu_enable(name, name_len, 1);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  // Disable fault point
+  rc = loon_fiu_disable(name, name_len);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+}
+
+// Test loon_fiu_enable with one_time=0 (always)
+static void test_fiu_enable_always(void) {
+  if (!loon_fiu_is_enabled()) {
+    return;  // Skip if FIU not enabled
+  }
+
+  const char* name = loon_fiukey_writer_flush_fail;
+  uint32_t name_len = (uint32_t)strlen(name);
+
+  // Enable fault point (always)
+  LoonFFIResult rc = loon_fiu_enable(name, name_len, 0);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  // Disable fault point
+  rc = loon_fiu_disable(name, name_len);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+}
+
+// Test loon_fiu_disable_all
+static void test_fiu_disable_all(void) {
+  if (!loon_fiu_is_enabled()) {
+    // Should be a no-op when FIU is not enabled
+    loon_fiu_disable_all();
+    return;
+  }
+
+  // Enable multiple fault points
+  const char* names[] = {
+      loon_fiukey_writer_write_fail,
+      loon_fiukey_writer_flush_fail,
+      loon_fiukey_writer_close_fail,
+  };
+
+  for (int i = 0; i < 3; i++) {
+    LoonFFIResult rc = loon_fiu_enable(names[i], (uint32_t)strlen(names[i]), 0);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  }
+
+  // Disable all
+  loon_fiu_disable_all();
+
+  // Re-enabling should work (proves they were disabled)
+  for (int i = 0; i < 3; i++) {
+    LoonFFIResult rc = loon_fiu_enable(names[i], (uint32_t)strlen(names[i]), 1);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  }
+
+  // Clean up
+  loon_fiu_disable_all();
+}
+
+// Test that disabling a non-enabled fault point doesn't error
+static void test_fiu_disable_not_enabled(void) {
+  if (!loon_fiu_is_enabled()) {
+    return;  // Skip if FIU not enabled
+  }
+
+  // Disable a fault point that was never enabled
+  const char* name = loon_fiukey_manifest_commit_fail;
+  LoonFFIResult rc = loon_fiu_disable(name, (uint32_t)strlen(name));
+  // Should succeed (fiu_disable returns -1 for not enabled, but we ignore it)
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+}
+
+void run_fiu_suite(void) {
+  RUN_TEST(test_fiu_is_enabled);
+  RUN_TEST(test_fiu_key_constants);
+  RUN_TEST(test_fiu_enable_null_name);
+  RUN_TEST(test_fiu_enable_empty_name);
+  RUN_TEST(test_fiu_disable_null_name);
+  RUN_TEST(test_fiu_disable_empty_name);
+  RUN_TEST(test_fiu_enable_disable_valid);
+  RUN_TEST(test_fiu_enable_always);
+  RUN_TEST(test_fiu_disable_all);
+  RUN_TEST(test_fiu_disable_not_enabled);
+}

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -26,6 +26,7 @@ void run_reader_suite(void);
 void run_manifest_suite(void);
 void run_external_suite(void);
 void run_filesystem_suite(void);
+void run_fiu_suite(void);
 
 int main(void) {
   loon_thread_pool_singleton(4);
@@ -35,6 +36,7 @@ int main(void) {
   run_reader_suite();
   run_external_suite();
   run_filesystem_suite();
+  run_fiu_suite();
 
   loon_close_filesystems();
   loon_thread_pool_singleton_release();

--- a/cpp/test/fiu_test.cpp
+++ b/cpp/test/fiu_test.cpp
@@ -1,0 +1,296 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Only compile this test file when FIU is enabled
+#ifdef BUILD_WITH_FIU
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <arrow/api.h>
+#include <arrow/filesystem/localfs.h>
+
+#include "include/test_env.h"
+#include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/writer.h"
+#include "milvus-storage/reader.h"
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/format/column_group_reader.h"
+
+namespace milvus_storage::test {
+
+using namespace milvus_storage::api;
+
+static std::once_flag fiu_init_flag;
+
+class FaultInjectionTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // Initialize FIU once (thread-safe, only on first test run)
+    std::call_once(fiu_init_flag, []() { FIU_INIT(); });
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+
+    base_path_ = GetTestBasePath("fiu-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
+
+    ASSERT_AND_ASSIGN(schema_, CreateTestSchema());
+    ASSERT_AND_ASSIGN(test_batch_, CreateTestData(schema_));
+
+    ThreadPoolHolder::WithSingleton(4);
+  }
+
+  void TearDown() override {
+    // Disable all fault points
+    FIU_DISABLE_FAULT(FIUKEY_WRITER_WRITE_FAIL);
+    FIU_DISABLE_FAULT(FIUKEY_WRITER_FLUSH_FAIL);
+    FIU_DISABLE_FAULT(FIUKEY_WRITER_CLOSE_FAIL);
+    FIU_DISABLE_FAULT(FIUKEY_COLUMN_GROUP_READ_FAIL);
+    FIU_DISABLE_FAULT(FIUKEY_TAKE_ROWS_FAIL);
+    FIU_DISABLE_FAULT(FIUKEY_COLUMN_GROUP_WRITE_FAIL);
+
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    ThreadPoolHolder::Release();
+  }
+
+  // Helper to write test data and return column groups
+  arrow::Result<std::shared_ptr<ColumnGroups>> WriteTestData() {
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+    auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+    ARROW_RETURN_NOT_OK(writer->write(test_batch_));
+    return writer->close();
+  }
+
+  protected:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> schema_;
+  std::string base_path_;
+  std::shared_ptr<arrow::RecordBatch> test_batch_;
+  milvus_storage::api::Properties properties_;
+};
+
+TEST_F(FaultInjectionTest, WriterWriteFail) {
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_WRITER_WRITE_FAIL);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+
+  // First write should fail
+  auto status = writer->write(test_batch_);
+  ASSERT_FALSE(status.ok());
+  EXPECT_TRUE(status.ToString().find("Injected fault") != std::string::npos);
+
+  // Second write should succeed (FIU_ONETIME exhausted)
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+  EXPECT_EQ(cgs->size(), 1);
+}
+
+TEST_F(FaultInjectionTest, WriterFlushFail) {
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_WRITER_FLUSH_FAIL);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+
+  // First flush should fail
+  auto status = writer->flush();
+  ASSERT_FALSE(status.ok());
+  EXPECT_TRUE(status.ToString().find("Injected fault") != std::string::npos);
+
+  // Second flush should succeed
+  ASSERT_STATUS_OK(writer->flush());
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+  EXPECT_EQ(cgs->size(), 1);
+}
+
+TEST_F(FaultInjectionTest, WriterCloseFail) {
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_WRITER_CLOSE_FAIL);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+
+  // First close should fail
+  auto result = writer->close();
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().ToString().find("Injected fault") != std::string::npos);
+}
+
+TEST_F(FaultInjectionTest, ColumnGroupReadFail) {
+  // First write valid data
+  ASSERT_AND_ASSIGN(auto cgs, WriteTestData());
+
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(reader, nullptr);
+
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_COLUMN_GROUP_READ_FAIL);
+
+  // get_chunk_reader should succeed, but get_chunk should fail
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+
+  auto chunk_result = chunk_reader->get_chunk(0);
+  ASSERT_FALSE(chunk_result.ok());
+  EXPECT_TRUE(chunk_result.status().ToString().find("Injected fault") != std::string::npos);
+
+  // Second attempt should succeed (failnum=1 exhausted)
+  ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
+  EXPECT_GT(chunk->num_rows(), 0);
+}
+
+TEST_F(FaultInjectionTest, ColumnGroupReadFailMultiple) {
+  // First write valid data
+  ASSERT_AND_ASSIGN(auto cgs, WriteTestData());
+
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(reader, nullptr);
+
+  // Enable fault point with failnum=-1 (fail forever)
+  FIU_ENABLE_FAULT_ALWAYS(FIUKEY_COLUMN_GROUP_READ_FAIL);
+
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+
+  // Multiple reads should all fail
+  for (int i = 0; i < 3; ++i) {
+    auto chunk_result = chunk_reader->get_chunk(0);
+    ASSERT_FALSE(chunk_result.ok());
+  }
+
+  // Disable fault point and verify reads succeed
+  FIU_DISABLE_FAULT(FIUKEY_COLUMN_GROUP_READ_FAIL);
+  ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
+  EXPECT_GT(chunk->num_rows(), 0);
+}
+
+TEST_F(FaultInjectionTest, TakeRowsFail) {
+  // First write valid data
+  ASSERT_AND_ASSIGN(auto cgs, WriteTestData());
+
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(reader, nullptr);
+
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_TAKE_ROWS_FAIL);
+
+  std::vector<int64_t> row_indices = {0, 10, 50};
+
+  // First take should fail
+  auto result = reader->take(row_indices);
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().ToString().find("Injected fault") != std::string::npos);
+
+  // Second take should succeed
+  ASSERT_AND_ASSIGN(auto table, reader->take(row_indices));
+  ASSERT_AND_ASSIGN(auto batch, table->CombineChunksToBatch());
+  EXPECT_EQ(batch->num_rows(), row_indices.size());
+}
+
+TEST_F(FaultInjectionTest, ColumnGroupWriteFail) {
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_COLUMN_GROUP_WRITE_FAIL);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+
+  // Write should fail due to column group write failure
+  auto status = writer->write(test_batch_);
+  ASSERT_FALSE(status.ok());
+  EXPECT_TRUE(status.ToString().find("Injected fault") != std::string::npos);
+
+  // Second write should succeed
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+  EXPECT_EQ(cgs->size(), 1);
+}
+
+TEST_F(FaultInjectionTest, RecoveryAfterWriterFault) {
+  // Test that system recovers properly after writer fault injection
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_WRITER_WRITE_FAIL);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+  auto writer = Writer::create(base_path_ + "/recovery1", schema_, std::move(policy), properties_);
+
+  // First write fails
+  ASSERT_FALSE(writer->write(test_batch_).ok());
+
+  // But we can continue using the writer
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+
+  // And data is readable
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader());
+  ASSERT_AND_ASSIGN(auto table, batch_reader->ToTable());
+  EXPECT_EQ(table->num_rows(), test_batch_->num_rows());
+}
+
+TEST_F(FaultInjectionTest, RecoveryAfterReaderFault) {
+  // Write valid data first
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
+  auto writer = Writer::create(base_path_ + "/recovery2", schema_, std::move(policy), properties_);
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+
+  // Enable fault
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_COLUMN_GROUP_READ_FAIL);
+
+  // First read fails
+  ASSERT_FALSE(chunk_reader->get_chunk(0).ok());
+
+  // But retry succeeds
+  ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
+  EXPECT_EQ(chunk->num_rows(), test_batch_->num_rows());
+}
+
+TEST_F(FaultInjectionTest, GetChunksFail) {
+  // First write valid data
+  ASSERT_AND_ASSIGN(auto cgs, WriteTestData());
+
+  auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(reader, nullptr);
+
+  // Enable fault point
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_COLUMN_GROUP_READ_FAIL);
+
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+
+  // get_chunks should fail
+  std::vector<int64_t> chunk_indices = {0};
+  auto chunks_result = chunk_reader->get_chunks(chunk_indices);
+  ASSERT_FALSE(chunks_result.ok());
+  EXPECT_TRUE(chunks_result.status().ToString().find("Injected fault") != std::string::npos);
+
+  // Second attempt should succeed
+  ASSERT_AND_ASSIGN(auto chunks, chunk_reader->get_chunks(chunk_indices));
+  EXPECT_EQ(chunks.size(), 1);
+  EXPECT_GT(chunks[0]->num_rows(), 0);
+}
+
+}  // namespace milvus_storage::test
+
+#endif  // BUILD_WITH_FIU

--- a/python/milvus_storage/__init__.py
+++ b/python/milvus_storage/__init__.py
@@ -45,6 +45,7 @@ from .filesystem import (
     FilesystemSingleton,
     FilesystemWriter,
 )
+from .fiu import FaultInjector, is_fiu_enabled
 from .manifest import (
     ColumnGroup,
     ColumnGroupFile,
@@ -100,4 +101,7 @@ __all__ = [
     "ArrowError",
     "InvalidArgumentError",
     "ResourceError",
+    # Fault Injection
+    "FaultInjector",
+    "is_fiu_enabled",
 ]

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -471,6 +471,33 @@ _ffi.cdef("""
                                               LoonFilesystemMetricsSnapshot* out_metrics);
 
     LoonFFIResult loon_filesystem_reset_metrics(FileSystemHandle handle);
+
+    // ==================== Fault Injection C Interface (ffi_fiu_c.h) ====================
+    // Fault point key constants (exported from C library)
+    extern const char* loon_fiukey_writer_write_fail;
+    extern const char* loon_fiukey_writer_flush_fail;
+    extern const char* loon_fiukey_writer_close_fail;
+    extern const char* loon_fiukey_column_group_read_fail;
+    extern const char* loon_fiukey_take_rows_fail;
+    extern const char* loon_fiukey_chunk_reader_read_fail;
+    extern const char* loon_fiukey_reader_open_fail;
+    extern const char* loon_fiukey_manifest_commit_fail;
+    extern const char* loon_fiukey_manifest_read_fail;
+    extern const char* loon_fiukey_manifest_write_fail;
+    extern const char* loon_fiukey_fs_open_output_fail;
+    extern const char* loon_fiukey_fs_open_input_fail;
+    extern const char* loon_fiukey_s3fs_create_upload_fail;
+    extern const char* loon_fiukey_s3fs_part_upload_fail;
+    extern const char* loon_fiukey_s3fs_complete_upload_fail;
+    extern const char* loon_fiukey_s3fs_read_fail;
+    extern const char* loon_fiukey_s3fs_readat_fail;
+    extern const char* loon_fiukey_column_group_write_fail;
+
+    // Fault injection functions
+    LoonFFIResult loon_fiu_enable(const char* name, uint32_t name_len, int one_time);
+    LoonFFIResult loon_fiu_disable(const char* name, uint32_t name_len);
+    void loon_fiu_disable_all(void);
+    int loon_fiu_is_enabled(void);
 """)
 
 

--- a/python/milvus_storage/fiu.py
+++ b/python/milvus_storage/fiu.py
@@ -1,0 +1,231 @@
+"""
+Fault Injection Utilities for milvus-storage.
+
+This module provides Python wrappers for the libfiu-based fault injection
+functionality. Fault injection is used for testing error handling and
+recovery scenarios.
+
+Example usage:
+    from milvus_storage.fiu import FaultInjector
+
+    # Create injector
+    fiu = FaultInjector()
+
+    # Check if fault injection is enabled
+    if fiu.is_enabled():
+        # Enable a fault point to fail once
+        fiu.enable(FaultInjector.WRITER_FLUSH_FAIL, one_time=True)
+
+        # The next flush will fail
+        try:
+            writer.flush()
+        except IOError:
+            pass
+
+        # Retry should succeed (failnum exhausted)
+        writer.flush()
+
+        # Cleanup
+        fiu.disable_all()
+
+Available fault points (use FaultInjector class constants):
+    Writer fault points:
+    - FaultInjector.WRITER_WRITE_FAIL: Fail during Writer write batch operation
+    - FaultInjector.WRITER_FLUSH_FAIL: Fail during Writer flush
+    - FaultInjector.WRITER_CLOSE_FAIL: Fail during Writer close
+
+    Reader fault points (low-level):
+    - FaultInjector.COLUMN_GROUP_READ_FAIL: Fail during ColumnGroup get_chunk/get_chunks
+    - FaultInjector.TAKE_ROWS_FAIL: Fail during take rows operation
+    - FaultInjector.CHUNK_READER_READ_FAIL: Fail during ChunkReader read (FFI layer)
+    - FaultInjector.READER_OPEN_FAIL: Fail during Reader open (FFI layer)
+
+    Transaction/Manifest fault points:
+    - FaultInjector.MANIFEST_COMMIT_FAIL: Fail during Transaction commit
+    - FaultInjector.MANIFEST_READ_FAIL: Fail during manifest read
+    - FaultInjector.MANIFEST_WRITE_FAIL: Fail during manifest write/serialize
+
+    Filesystem fault points:
+    - FaultInjector.FS_OPEN_OUTPUT_FAIL: Fail during filesystem open output stream
+    - FaultInjector.FS_OPEN_INPUT_FAIL: Fail during filesystem open input file
+
+    S3 Filesystem fault points:
+    - FaultInjector.S3FS_CREATE_UPLOAD_FAIL: Fail during S3 CreateMultipartUpload
+    - FaultInjector.S3FS_PART_UPLOAD_FAIL: Fail during S3 multipart upload UploadPart
+    - FaultInjector.S3FS_COMPLETE_UPLOAD_FAIL: Fail during S3 CompleteMultipartUpload
+    - FaultInjector.S3FS_READ_FAIL: Fail during S3 ObjectInputFile Read
+    - FaultInjector.S3FS_READAT_FAIL: Fail during S3 ObjectInputFile ReadAt
+
+    ColumnGroup fault points:
+    - FaultInjector.COLUMN_GROUP_WRITE_FAIL: Fail during ColumnGroup write operation
+"""
+
+from ._ffi import _ffi, check_result, get_library
+
+
+def _get_fiu_key(lib, name: str) -> str:
+    """Get fault point key string from FFI library."""
+    ptr = getattr(lib, name)
+    return _ffi.string(ptr).decode("utf-8")
+
+
+class FaultInjector:
+    """
+    Fault injection controller for testing error handling.
+
+    This class provides methods to enable/disable fault injection points
+    in the milvus-storage C++ library. Fault injection must be enabled
+    at compile time with -DWITH_FIU=ON.
+    """
+
+    # Fault point keys are loaded from FFI library at class initialization time
+    _keys_loaded = False
+
+    # Writer fault points
+    WRITER_WRITE_FAIL: str = ""
+    WRITER_FLUSH_FAIL: str = ""
+    WRITER_CLOSE_FAIL: str = ""
+
+    # Reader fault points (low-level)
+    COLUMN_GROUP_READ_FAIL: str = ""
+    TAKE_ROWS_FAIL: str = ""
+    CHUNK_READER_READ_FAIL: str = ""
+    READER_OPEN_FAIL: str = ""
+
+    # Transaction/Manifest fault points
+    MANIFEST_COMMIT_FAIL: str = ""
+    MANIFEST_READ_FAIL: str = ""
+    MANIFEST_WRITE_FAIL: str = ""
+
+    # Filesystem fault points
+    FS_OPEN_OUTPUT_FAIL: str = ""
+    FS_OPEN_INPUT_FAIL: str = ""
+
+    # S3 Filesystem fault points
+    S3FS_CREATE_UPLOAD_FAIL: str = ""
+    S3FS_PART_UPLOAD_FAIL: str = ""
+    S3FS_COMPLETE_UPLOAD_FAIL: str = ""
+    S3FS_READ_FAIL: str = ""
+    S3FS_READAT_FAIL: str = ""
+
+    # ColumnGroup fault points
+    COLUMN_GROUP_WRITE_FAIL: str = ""
+
+    @classmethod
+    def _load_keys(cls) -> None:
+        """Load fault point keys from FFI library (called once)."""
+        if cls._keys_loaded:
+            return
+        lib = get_library()
+        # Writer fault points
+        cls.WRITER_WRITE_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_writer_write_fail")
+        cls.WRITER_FLUSH_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_writer_flush_fail")
+        cls.WRITER_CLOSE_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_writer_close_fail")
+        # Reader fault points
+        cls.COLUMN_GROUP_READ_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_column_group_read_fail")
+        cls.TAKE_ROWS_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_take_rows_fail")
+        cls.CHUNK_READER_READ_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_chunk_reader_read_fail")
+        cls.READER_OPEN_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_reader_open_fail")
+        # Transaction/Manifest fault points
+        cls.MANIFEST_COMMIT_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_manifest_commit_fail")
+        cls.MANIFEST_READ_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_manifest_read_fail")
+        cls.MANIFEST_WRITE_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_manifest_write_fail")
+        # Filesystem fault points
+        cls.FS_OPEN_OUTPUT_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_fs_open_output_fail")
+        cls.FS_OPEN_INPUT_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_fs_open_input_fail")
+        # S3 Filesystem fault points
+        cls.S3FS_CREATE_UPLOAD_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_s3fs_create_upload_fail")
+        cls.S3FS_PART_UPLOAD_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_s3fs_part_upload_fail")
+        cls.S3FS_COMPLETE_UPLOAD_FAIL = _get_fiu_key(
+            lib.lib, "loon_fiukey_s3fs_complete_upload_fail"
+        )
+        cls.S3FS_READ_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_s3fs_read_fail")
+        cls.S3FS_READAT_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_s3fs_readat_fail")
+        # ColumnGroup fault points
+        cls.COLUMN_GROUP_WRITE_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_column_group_write_fail")
+        cls._keys_loaded = True
+
+    def __init__(self):
+        """Initialize the fault injector."""
+        self._lib = get_library()
+        # Load fault point keys from FFI library
+        self._load_keys()
+
+    def is_enabled(self) -> bool:
+        """
+        Check if fault injection support is compiled in.
+
+        Returns:
+            True if FIU is enabled, False otherwise.
+        """
+        return bool(self._lib.lib.loon_fiu_is_enabled())
+
+    def enable(self, name: str, one_time: bool = True) -> None:
+        """
+        Enable a fault injection point.
+
+        Args:
+            name: The name of the fault point to enable.
+            one_time: If True, the fault triggers only once then auto-disables.
+                      If False, the fault triggers forever until explicitly disabled.
+
+        Raises:
+            RuntimeError: If FIU is not enabled or if enabling fails.
+        """
+        if not self.is_enabled():
+            raise RuntimeError(
+                "Fault injection is not enabled. " "Rebuild the C++ library with -DWITH_FIU=ON"
+            )
+
+        name_bytes = name.encode("utf-8")
+        result = self._lib.lib.loon_fiu_enable(name_bytes, len(name_bytes), 1 if one_time else 0)
+        check_result(result)
+
+    def disable(self, name: str) -> None:
+        """
+        Disable a specific fault injection point.
+
+        Args:
+            name: The name of the fault point to disable.
+
+        Raises:
+            RuntimeError: If FIU is not enabled or if disabling fails.
+        """
+        if not self.is_enabled():
+            raise RuntimeError(
+                "Fault injection is not enabled. " "Rebuild the C++ library with -DWITH_FIU=ON"
+            )
+
+        name_bytes = name.encode("utf-8")
+        result = self._lib.lib.loon_fiu_disable(name_bytes, len(name_bytes))
+        check_result(result)
+
+    def disable_all(self) -> None:
+        """
+        Disable all active fault injection points.
+
+        This should be called in test cleanup to ensure all fault points
+        are disabled after a test completes.
+        """
+        self._lib.lib.loon_fiu_disable_all()
+
+    def __enter__(self) -> "FaultInjector":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Context manager exit - disable all fault points."""
+        self.disable_all()
+        return None
+
+
+# Convenience function for quick access
+def is_fiu_enabled() -> bool:
+    """
+    Check if fault injection support is compiled in.
+
+    Returns:
+        True if FIU is enabled, False otherwise.
+    """
+    lib = get_library()
+    return bool(lib.lib.loon_fiu_is_enabled())


### PR DESCRIPTION
Brought in libfiu to simulate failures in tests — write errors, read errors, S3 going down, that sort of thing.

The key idea is that fiu_local.h is the single source of truth for all fault point names (FIUKEY_* macros). C++ code uses these macros directly, and Python reads the same strings via extern const char* through FFI, so no one can typo a fault point name.

On the C++ side, added FIU_RETURN_ON / FIU_DO_ON injection points in multi code(contains writer/reader and filesystem ...) . Also added a set of gtests (fiu_test.cpp) covering some fault scenarios. The FFI layer exposes four new functions: loon_fiu_enable/disable/disable_all/is_enabled. The enable function takes a one_time flag to choose between single-shot and always-on modes. Both Linux and macOS export maps are updated with all 4 functions and multi key symbols.

On the Python side, everything is wrapped in a FaultInjector class with context manager support. All keys are loaded dynamically from the C library at runtime — no hardcoded strings.

Build-wise, CMakeLists.txt pulls libfiu via FetchContent, gated behind WITH_FIU=ON. The Makefile got new build-fiu and test-fiu targets.