### PR TITLE
enhance: add comprehensive benchmark framework for multi-format comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ make test
 
 # Test with minio
 make test-all
+
+# Run benchmarks
+./build/Release/benchmark/benchmark --benchmark_filter="Typical/"
 ```
 
 #### Build Options
@@ -136,6 +139,8 @@ make test-all
 See [python/tests/test_write_read.py](python/tests/test_write_read.py) for Python usage examples.
 
 For old storage(packed interface) integration, see [cpp/test/packed/packed_integration_test.cpp](cpp/test/packed/packed_integration_test.cpp).
+
+For benchmarks, see [cpp/benchmark/benchmark.md](cpp/benchmark/benchmark.md) and [docs/multi-format-benchmark-design.md](docs/multi-format-benchmark-design.md).
 
 ### Code Style
 

--- a/cpp/benchmark/CMakeLists.txt
+++ b/cpp/benchmark/CMakeLists.txt
@@ -1,19 +1,43 @@
-
 find_package(benchmark REQUIRED)
 
-file(GLOB_RECURSE BUSTUB_BENCH_SOURCES "${PROJECT_SOURCE_DIR}/benchmark/*.cpp")
+# Core benchmark sources (always included)
+set(BENCHMARK_SOURCES
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_main.cpp
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_wr.cpp
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_footer_size.cpp
+)
 
-# Also include test helper implementation used by some benchmarks
-list(APPEND BUSTUB_BENCH_SOURCES "${PROJECT_SOURCE_DIR}/test/test_env.cpp")
+# Format Layer benchmarks (format availability checked at runtime)
+list(APPEND BENCHMARK_SOURCES
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_format_write.cpp
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_format_read.cpp
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_v2_v3.cpp
+)
+
+# Storage Layer benchmark
+list(APPEND BENCHMARK_SOURCES
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_storage_layer.cpp
+)
+
+# Data loader for configurable data sources (synthetic or Milvus segment)
+list(APPEND BENCHMARK_SOURCES
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_data_loader.cpp
+)
+
+# Include test helper implementation used by benchmarks
+list(APPEND BENCHMARK_SOURCES "${PROJECT_SOURCE_DIR}/test/test_env.cpp")
 
 add_executable(
   benchmark
-  ${BUSTUB_BENCH_SOURCES}
+  ${BENCHMARK_SOURCES}
 )
 
 target_link_libraries(
   benchmark milvus-storage benchmark::benchmark
 )
 
-# for test_env.h 
-target_include_directories(benchmark PUBLIC ${PROJECT_SOURCE_DIR}/test/include)
+# Include directories for benchmark headers and test helpers
+target_include_directories(benchmark PUBLIC
+  ${PROJECT_SOURCE_DIR}/benchmark
+  ${PROJECT_SOURCE_DIR}/test/include
+)

--- a/cpp/benchmark/benchmark.md
+++ b/cpp/benchmark/benchmark.md
@@ -1,0 +1,121 @@
+# Milvus Storage Benchmark
+
+Benchmark suite for testing Milvus Storage read/write performance.
+
+## Build
+
+```bash
+cd cpp
+make build
+```
+
+The benchmark executable is located at `build/Release/benchmark/benchmark`.
+
+## Run
+
+```bash
+# Run all benchmarks
+./build/Release/benchmark/benchmark
+
+# Filter by regex
+./build/Release/benchmark/benchmark --benchmark_filter="Typical/"
+
+# Multiple patterns (use | separator)
+./build/Release/benchmark/benchmark --benchmark_filter="MilvusStorage_Read|MilvusStorage_Take"
+
+# Exclude patterns (use - prefix)
+./build/Release/benchmark/benchmark --benchmark_filter="-Typical/"
+```
+
+## Benchmark Files
+
+### benchmark_format_read.cpp
+**Format Layer Read Performance**
+
+Tests read performance for different storage formats (Parquet, Vortex):
+
+| Benchmark | Description | Args |
+|-----------|-------------|------|
+| `ReadFullScan` | Full table scan, read all rows and columns | format, num_threads, memory_config |
+| `ReadProjection` | Column projection, read subset of columns | format, num_columns, num_threads, memory_config |
+| `ReadTake` | Random access by indices | format, take_count, distribution, num_threads, memory_config |
+
+**Format index**: 0=Parquet, 1=Vortex
+
+### benchmark_format_write.cpp
+**Format Layer Write Performance**
+
+| Benchmark | Description | Args |
+|-----------|-------------|------|
+| `WriteComparison` | Write performance comparison | format, data_config, memory_config |
+| `CompressionAnalysis` | Compression ratio analysis | format, data_config |
+
+**Data config index**: 0=Small(rK rows), 1=Medium(40K rows), 2=Large(409K rows), 3=HighDim, 4=LongString
+
+### benchmark_storage_layer.cpp
+**Storage Layer End-to-End Performance (with Transaction)**
+
+Compares MilvusStorage (Parquet/Vortex + Transaction) vs Lance Native:
+
+| Benchmark | Description | Args |
+|-----------|-------------|------|
+| `MilvusStorage_WriteCommit` | Write + transaction commit | format_type, data_config |
+| `MilvusStorage_WriteOnly` | Write only (no transaction) | format_type, data_config |
+| `MilvusStorage_OpenRead` | Open transaction + read | format_type, data_config, num_threads |
+| `MilvusStorage_Take` | Open transaction + take | format_type, take_count, num_threads |
+| `MilvusStorage_MultiReader` | Multi-reader concurrency test | format_type, num_readers, thread_pool_size |
+| `LanceNative_WriteCommit` | Lance write | data_config |
+| `LanceNative_OpenRead` | Lance read | data_config, num_threads |
+| `LanceNative_Take` | Lance take | take_count, num_threads |
+| `LanceNative_MultiReader` | Lance multi-reader concurrency | num_readers, thread_pool_size |
+
+**Format type index**: 0=Parquet, 1=Vortex, 2=Mixed(Parquet+Vortex)
+
+**Note**: Lance benchmarks require `BUILD_LANCE_BRIDGE` enabled at compile time.
+
+**TODO**: Lance S3 storage requires separate configuration (not using MilvusStorage's filesystem layer).
+
+### benchmark_v2_v3.cpp
+**V2 vs V3 API Performance Comparison**
+
+Compares low-level Packed API (V2) vs high-level Reader/Writer API (V3):
+
+| Benchmark | Description | Args |
+|-----------|-------------|------|
+| `V2_PackedRecordBatchReader` | Low-level PackedRecordBatchReader | data_config |
+| `V2_PackedRecordBatchWriter` | Low-level PackedRecordBatchWriter | data_config |
+| `V3_RecordBatchReader` | High-level Reader API (get_record_batch_reader) | data_config |
+| `V3_ChunkReader` | High-level Reader API (get_chunk_reader) | data_config |
+| `V3_Writer` | High-level Writer API | data_config |
+
+### benchmark_footer_size.cpp
+**Parquet Footer Size Analysis**
+
+Measures Parquet file footer size and its percentage of total file size:
+
+| Benchmark | Description | Args |
+|-----------|-------------|------|
+| `MeasureFooterSize` | Footer size measurement | num_rows, vector_dim, string_length |
+
+Output metrics: `footer_size_bytes`, `file_size_bytes`, `footer_percentage`
+
+### benchmark_wr.cpp
+**Basic Read/Write Performance**
+
+Simple read/write performance tests for quick validation:
+
+| Benchmark | Description | Args |
+|-----------|-------------|------|
+| `WriteDefaultConfig` | Default config write | loop_times |
+| `WriteSingleColumnConfig` | Single column write | loop_times, column_idx |
+| `ReadFullScanDefaultConfig` | Default config full scan | loop_times |
+| `ReadFullScanSingleColumnConfig` | Single column full scan | loop_times, column_idx |
+| `WriteRead768dimVector` | 768-dim vector large file test | target_size, target_dim |
+
+## Typical Benchmarks
+
+Benchmarks with `Typical/` prefix are representative tests with common parameter configurations, suitable for quick validation:
+
+```bash
+./build/Release/benchmark/benchmark --benchmark_filter="Typical/"
+```

--- a/cpp/benchmark/benchmark_data_loader.cpp
+++ b/cpp/benchmark/benchmark_data_loader.cpp
@@ -1,0 +1,300 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark_data_loader.h"
+
+#include <filesystem>
+#include <cstdlib>
+
+#include <arrow/io/file.h>
+#include <arrow/table.h>
+#include <parquet/arrow/reader.h>
+
+#include "test_env.h"
+
+namespace milvus_storage {
+namespace benchmark {
+
+//=============================================================================
+// SyntheticDataLoader Implementation
+//=============================================================================
+
+SyntheticDataLoader::SyntheticDataLoader(const SyntheticDataConfig& config) : config_(config) {}
+
+arrow::Status SyntheticDataLoader::Load() {
+  // Create schema using test helper
+  ARROW_ASSIGN_OR_RAISE(schema_, CreateTestSchema());
+
+  // Create test data
+  ARROW_ASSIGN_OR_RAISE(auto batch, CreateTestData(schema_, 0, config_.random_data, config_.num_rows,
+                                                   config_.vector_dim, config_.string_length));
+
+  // Convert to table
+  table_ = arrow::Table::Make(schema_, batch->columns(), batch->num_rows());
+
+  return arrow::Status::OK();
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> SyntheticDataLoader::GetRecordBatchReader() const {
+  if (!table_) {
+    return arrow::Status::Invalid("Data not loaded");
+  }
+  return std::make_shared<arrow::TableBatchReader>(*table_);
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> SyntheticDataLoader::GetRecordBatch() const {
+  if (!table_) {
+    return arrow::Status::Invalid("Data not loaded");
+  }
+  arrow::TableBatchReader reader(*table_);
+  reader.set_chunksize(table_->num_rows());
+  std::shared_ptr<arrow::RecordBatch> batch;
+  ARROW_RETURN_NOT_OK(reader.ReadNext(&batch));
+  return batch;
+}
+
+std::string SyntheticDataLoader::GetSchemaBasePatterns() const {
+  // Default synthetic schema: id, name, value, vector
+  // Group 1: id, name, value (scalar)
+  // Group 2: vector
+  return "id,name,value;vector";
+}
+
+int64_t SyntheticDataLoader::GetDataSize() const {
+  if (!table_)
+    return 0;
+  int64_t size = 0;
+  for (int i = 0; i < table_->num_columns(); ++i) {
+    for (const auto& chunk : table_->column(i)->chunks()) {
+      for (const auto& buffer : chunk->data()->buffers) {
+        if (buffer)
+          size += buffer->size();
+      }
+    }
+  }
+  return size;
+}
+
+std::shared_ptr<std::vector<std::string>> SyntheticDataLoader::GetScalarProjection() const {
+  auto projection = std::make_shared<std::vector<std::string>>();
+  projection->push_back("id");
+  projection->push_back("name");
+  projection->push_back("value");
+  return projection;
+}
+
+std::shared_ptr<std::vector<std::string>> SyntheticDataLoader::GetVectorProjection() const {
+  auto projection = std::make_shared<std::vector<std::string>>();
+  projection->push_back("vector");
+  return projection;
+}
+
+std::string SyntheticDataLoader::GetDescription() const {
+  return "synthetic/" + std::to_string(config_.num_rows) + "rows/" + std::to_string(config_.vector_dim) + "dim";
+}
+
+//=============================================================================
+// MilvusSegmentLoader Implementation
+//=============================================================================
+
+MilvusSegmentLoader::MilvusSegmentLoader(const std::string& segment_path) : segment_path_(segment_path) {}
+
+arrow::Status MilvusSegmentLoader::Load() {
+  namespace fs = std::filesystem;
+
+  if (!fs::exists(segment_path_)) {
+    return arrow::Status::IOError("Segment path does not exist: " + segment_path_);
+  }
+
+  // Iterate through column group directories
+  for (const auto& entry : fs::directory_iterator(segment_path_)) {
+    if (!entry.is_directory()) {
+      continue;
+    }
+
+    std::string dir_name = entry.path().filename().string();
+    int64_t group_id;
+    try {
+      group_id = std::stoll(dir_name);
+    } catch (...) {
+      continue;  // Skip non-numeric directories
+    }
+
+    // Find parquet file in this column group directory
+    for (const auto& file_entry : fs::directory_iterator(entry.path())) {
+      if (file_entry.is_regular_file()) {
+        std::string file_path = file_entry.path().string();
+        ARROW_RETURN_NOT_OK(LoadColumnGroup(group_id, file_path));
+        break;  // Only one file per column group
+      }
+    }
+  }
+
+  if (column_groups_.empty()) {
+    return arrow::Status::Invalid("No column groups found in segment: " + segment_path_);
+  }
+
+  // Build merged schema and table
+  ARROW_RETURN_NOT_OK(BuildMergedData());
+
+  return arrow::Status::OK();
+}
+
+arrow::Status MilvusSegmentLoader::LoadColumnGroup(int64_t group_id, const std::string& file_path) {
+  // Open parquet file
+  ARROW_ASSIGN_OR_RAISE(auto infile, arrow::io::ReadableFile::Open(file_path));
+
+  std::unique_ptr<parquet::arrow::FileReader> reader;
+  ARROW_RETURN_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+
+  // Read schema
+  std::shared_ptr<arrow::Schema> schema;
+  ARROW_RETURN_NOT_OK(reader->GetSchema(&schema));
+
+  // Read table
+  std::shared_ptr<arrow::Table> table;
+  ARROW_RETURN_NOT_OK(reader->ReadTable(&table));
+
+  column_groups_[group_id] = {group_id, file_path, schema, table};
+  return arrow::Status::OK();
+}
+
+arrow::Status MilvusSegmentLoader::BuildMergedData() {
+  // Collect all fields and columns
+  std::vector<std::shared_ptr<arrow::Field>> all_fields;
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> all_columns;
+
+  for (const auto& [group_id, info] : column_groups_) {
+    for (int i = 0; i < info.schema->num_fields(); ++i) {
+      all_fields.push_back(info.schema->field(i));
+      all_columns.push_back(info.table->column(i));
+    }
+  }
+
+  merged_schema_ = arrow::schema(all_fields);
+  merged_table_ = arrow::Table::Make(merged_schema_, all_columns);
+  return arrow::Status::OK();
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> MilvusSegmentLoader::GetRecordBatchReader() const {
+  if (!merged_table_) {
+    return arrow::Status::Invalid("Data not loaded");
+  }
+  return std::make_shared<arrow::TableBatchReader>(*merged_table_);
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> MilvusSegmentLoader::GetRecordBatch() const {
+  if (!merged_table_) {
+    return arrow::Status::Invalid("Data not loaded");
+  }
+  arrow::TableBatchReader reader(*merged_table_);
+  reader.set_chunksize(merged_table_->num_rows());
+  std::shared_ptr<arrow::RecordBatch> batch;
+  ARROW_RETURN_NOT_OK(reader.ReadNext(&batch));
+  return batch;
+}
+
+std::string MilvusSegmentLoader::GetSchemaBasePatterns() const {
+  // Pattern format: "col1|col2,col3|col4" where:
+  // - '|' separates columns within the same group
+  // - ',' separates different groups
+  std::string patterns;
+  for (const auto& [group_id, info] : column_groups_) {
+    if (!patterns.empty()) {
+      patterns += ",";
+    }
+    for (int i = 0; i < info.schema->num_fields(); ++i) {
+      if (i > 0) {
+        patterns += "|";
+      }
+      patterns += info.schema->field(i)->name();
+    }
+  }
+  return patterns;
+}
+
+int64_t MilvusSegmentLoader::GetDataSize() const {
+  if (!merged_table_)
+    return 0;
+  int64_t size = 0;
+  for (int i = 0; i < merged_table_->num_columns(); ++i) {
+    for (const auto& chunk : merged_table_->column(i)->chunks()) {
+      for (const auto& buffer : chunk->data()->buffers) {
+        if (buffer)
+          size += buffer->size();
+      }
+    }
+  }
+  return size;
+}
+
+std::shared_ptr<std::vector<std::string>> MilvusSegmentLoader::GetScalarProjection() const {
+  auto projection = std::make_shared<std::vector<std::string>>();
+  for (const auto& field : merged_schema_->fields()) {
+    // Skip system columns
+    if (field->name() == "RowID" || field->name() == "Timestamp") {
+      continue;
+    }
+    // Skip vector columns (fixed_size_binary or list<float>)
+    if (field->type()->id() == arrow::Type::FIXED_SIZE_BINARY || field->type()->id() == arrow::Type::LIST) {
+      continue;
+    }
+    projection->push_back(field->name());
+  }
+  return projection;
+}
+
+std::shared_ptr<std::vector<std::string>> MilvusSegmentLoader::GetVectorProjection() const {
+  auto projection = std::make_shared<std::vector<std::string>>();
+  for (const auto& field : merged_schema_->fields()) {
+    if (field->type()->id() == arrow::Type::FIXED_SIZE_BINARY || field->type()->id() == arrow::Type::LIST) {
+      projection->push_back(field->name());
+    }
+  }
+  return projection;
+}
+
+std::string MilvusSegmentLoader::GetDescription() const {
+  namespace fs = std::filesystem;
+  std::string segment_name = fs::path(segment_path_).filename().string();
+  return "milvus/" + segment_name + "/" + std::to_string(NumRows()) + "rows";
+}
+
+//=============================================================================
+// Factory Functions
+//=============================================================================
+
+std::unique_ptr<BenchmarkDataLoader> CreateDataLoader(DataLoaderType type,
+                                                      const std::string& path,
+                                                      const SyntheticDataConfig& config) {
+  switch (type) {
+    case DataLoaderType::SYNTHETIC:
+      return std::make_unique<SyntheticDataLoader>(config);
+    case DataLoaderType::MILVUS_SEGMENT:
+      return std::make_unique<MilvusSegmentLoader>(path);
+    default:
+      return std::make_unique<SyntheticDataLoader>(config);
+  }
+}
+
+std::unique_ptr<BenchmarkDataLoader> CreateDataLoaderFromEnv(const SyntheticDataConfig& fallback_config) {
+  const char* segment_path = std::getenv("CUSTOM_SEGMENT_PATH");
+  if (segment_path && segment_path[0] != '\0') {
+    return std::make_unique<MilvusSegmentLoader>(segment_path);
+  }
+  return std::make_unique<SyntheticDataLoader>(fallback_config);
+}
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_data_loader.h
+++ b/cpp/benchmark/benchmark_data_loader.h
@@ -1,0 +1,198 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <map>
+
+#include <arrow/api.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+namespace milvus_storage {
+namespace benchmark {
+
+//=============================================================================
+// Data Loader Type
+//=============================================================================
+
+enum class DataLoaderType {
+  SYNTHETIC = 0,  // Use CreateTestData/CreateTestSchema
+  MILVUS_SEGMENT  // Load from Milvus segment directory
+};
+
+//=============================================================================
+// BenchmarkDataLoader - Abstract interface for loading benchmark data
+//=============================================================================
+
+class BenchmarkDataLoader {
+  public:
+  virtual ~BenchmarkDataLoader() = default;
+
+  // Load data from source
+  virtual arrow::Status Load() = 0;
+
+  // Get merged schema (all columns)
+  virtual std::shared_ptr<arrow::Schema> GetSchema() const = 0;
+
+  // Get data as RecordBatchReader (for streaming reads)
+  virtual arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetRecordBatchReader() const = 0;
+
+  // Get data as Table (loads all data into memory - use with caution for large datasets)
+  virtual std::shared_ptr<arrow::Table> GetTable() const = 0;
+
+  // Get a single RecordBatch (convenience method, loads all data)
+  // For large datasets, prefer GetRecordBatchReader()
+  virtual arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetRecordBatch() const = 0;
+
+  // Get schema-based patterns string for Writer policy
+  // Format: "col1,col2;col3,col4" where each group is separated by semicolon
+  virtual std::string GetSchemaBasePatterns() const = 0;
+
+  // Get number of rows
+  virtual int64_t NumRows() const = 0;
+
+  // Get total data size in bytes (approximate)
+  virtual int64_t GetDataSize() const = 0;
+
+  // Get projection columns (scalar columns only)
+  virtual std::shared_ptr<std::vector<std::string>> GetScalarProjection() const = 0;
+
+  // Get projection columns (vector columns only)
+  virtual std::shared_ptr<std::vector<std::string>> GetVectorProjection() const = 0;
+
+  // Get data source description (for logging/labels)
+  virtual std::string GetDescription() const = 0;
+};
+
+//=============================================================================
+// SyntheticDataLoader - Generate synthetic test data
+//=============================================================================
+
+struct SyntheticDataConfig {
+  size_t num_rows = 40960;
+  size_t vector_dim = 128;
+  size_t string_length = 128;
+  bool random_data = true;
+
+  static SyntheticDataConfig Small() { return {4096, 128, 128, true}; }
+  static SyntheticDataConfig Medium() { return {40960, 128, 128, true}; }
+  static SyntheticDataConfig Large() { return {409600, 128, 128, true}; }
+};
+
+class SyntheticDataLoader : public BenchmarkDataLoader {
+  public:
+  explicit SyntheticDataLoader(const SyntheticDataConfig& config = SyntheticDataConfig::Medium());
+
+  arrow::Status Load() override;
+
+  std::shared_ptr<arrow::Schema> GetSchema() const override { return schema_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetRecordBatchReader() const override;
+
+  std::shared_ptr<arrow::Table> GetTable() const override { return table_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetRecordBatch() const override;
+
+  std::string GetSchemaBasePatterns() const override;
+
+  int64_t NumRows() const override { return table_ ? table_->num_rows() : 0; }
+
+  int64_t GetDataSize() const override;
+
+  std::shared_ptr<std::vector<std::string>> GetScalarProjection() const override;
+
+  std::shared_ptr<std::vector<std::string>> GetVectorProjection() const override;
+
+  std::string GetDescription() const override;
+
+  private:
+  SyntheticDataConfig config_;
+  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<arrow::Table> table_;
+};
+
+//=============================================================================
+// MilvusSegmentLoader - Load data from Milvus segment directory
+//=============================================================================
+
+class MilvusSegmentLoader : public BenchmarkDataLoader {
+  public:
+  struct ColumnGroupInfo {
+    int64_t group_id;
+    std::string file_path;
+    std::shared_ptr<arrow::Schema> schema;
+    std::shared_ptr<arrow::Table> table;
+  };
+
+  explicit MilvusSegmentLoader(const std::string& segment_path);
+
+  arrow::Status Load() override;
+
+  std::shared_ptr<arrow::Schema> GetSchema() const override { return merged_schema_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetRecordBatchReader() const override;
+
+  std::shared_ptr<arrow::Table> GetTable() const override { return merged_table_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetRecordBatch() const override;
+
+  std::string GetSchemaBasePatterns() const override;
+
+  int64_t NumRows() const override { return merged_table_ ? merged_table_->num_rows() : 0; }
+
+  int64_t GetDataSize() const override;
+
+  std::shared_ptr<std::vector<std::string>> GetScalarProjection() const override;
+
+  std::shared_ptr<std::vector<std::string>> GetVectorProjection() const override;
+
+  std::string GetDescription() const override;
+
+  // Get column group info (for advanced use)
+  const std::map<int64_t, ColumnGroupInfo>& GetColumnGroups() const { return column_groups_; }
+
+  private:
+  arrow::Status LoadColumnGroup(int64_t group_id, const std::string& file_path);
+  arrow::Status BuildMergedData();
+
+  std::string segment_path_;
+  std::map<int64_t, ColumnGroupInfo> column_groups_;
+  std::shared_ptr<arrow::Schema> merged_schema_;
+  std::shared_ptr<arrow::Table> merged_table_;
+};
+
+//=============================================================================
+// Factory function to create data loader
+//=============================================================================
+
+// Create data loader based on type
+// For SYNTHETIC: config should be SyntheticDataConfig (or use default)
+// For MILVUS_SEGMENT: path should be segment directory path
+std::unique_ptr<BenchmarkDataLoader> CreateDataLoader(
+    DataLoaderType type,
+    const std::string& path = "",
+    const SyntheticDataConfig& config = SyntheticDataConfig::Medium());
+
+// Create data loader from environment variable
+// If CUSTOM_SEGMENT_PATH is set, use MilvusSegmentLoader
+// Otherwise, use SyntheticDataLoader with specified config
+std::unique_ptr<BenchmarkDataLoader> CreateDataLoaderFromEnv(
+    const SyntheticDataConfig& fallback_config = SyntheticDataConfig::Medium());
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_format_common.h
+++ b/cpp/benchmark/benchmark_format_common.h
@@ -1,0 +1,575 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <array>
+#include <numeric>
+#include <random>
+#include <algorithm>
+#include <set>
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <sys/resource.h>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#elif defined(__linux__)
+#include <fstream>
+#endif
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/api.h>
+#include <arrow/memory_pool.h>
+
+#include "milvus-storage/properties.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/common/macro.h"
+#include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/writer.h"
+#include "milvus-storage/reader.h"
+#include "test_env.h"
+#include "benchmark_data_loader.h"
+
+namespace milvus_storage {
+namespace benchmark {
+
+//=============================================================================
+// Benchmark Assertion Macros
+//=============================================================================
+
+#define BENCH_ASSERT_STATUS_OK(status, st)             \
+  do {                                                 \
+    if (!(status).ok()) {                              \
+      (st).SkipWithError((status).ToString().c_str()); \
+      return;                                          \
+    }                                                  \
+  } while (false)
+
+#define BENCH_ASSERT_AND_ASSIGN_IMPL(status_name, lhs, rexpr, st) \
+  auto status_name = (rexpr);                                     \
+  BENCH_ASSERT_STATUS_OK(status_name.status(), st);               \
+  lhs = std::move(status_name).ValueOrDie();
+
+#define BENCH_ASSERT_AND_ASSIGN(lhs, rexpr, st) \
+  BENCH_ASSERT_AND_ASSIGN_IMPL(CONCAT(_tmp_value, __COUNTER__), lhs, rexpr, st)
+
+#define BENCH_ASSERT_NOT_NULL(ptr, st)               \
+  do {                                               \
+    if ((ptr) == nullptr) {                          \
+      (st).SkipWithError("Unexpected null pointer"); \
+      return;                                        \
+    }                                                \
+  } while (false)
+
+//=============================================================================
+// Benchmark Metrics Helpers
+//=============================================================================
+
+// Helper struct for formatted size with unit
+struct FormattedSize {
+  double value;
+  std::string unit;
+};
+
+// Format bytes to appropriate unit (B, KB, MB, GB, TB)
+inline FormattedSize FormatBytes(int64_t bytes) {
+  const char* units[] = {"B", "KB", "MB", "GB", "TB"};
+  int unit_idx = 0;
+  double value = static_cast<double>(bytes);
+
+  while (value >= 1024.0 && unit_idx < 4) {
+    value /= 1024.0;
+    unit_idx++;
+  }
+
+  return {value, units[unit_idx]};
+}
+
+// Report size with automatic unit selection
+// Key will be "{name}({unit})", e.g., "file_size(MB)"
+inline void ReportSize(::benchmark::State& st,
+                       const std::string& name,
+                       int64_t bytes,
+                       ::benchmark::Counter::Flags flags = ::benchmark::Counter::kAvgIterations) {
+  auto formatted = FormatBytes(bytes);
+  st.counters[name + "(" + formatted.unit + ")"] = ::benchmark::Counter(formatted.value, flags);
+}
+
+inline void ReportThroughput(::benchmark::State& st, int64_t bytes_processed, int64_t rows_processed) {
+  auto formatted = FormatBytes(bytes_processed);
+  st.counters["throughput(" + formatted.unit + "/s)"] =
+      ::benchmark::Counter(formatted.value, ::benchmark::Counter::kIsRate);
+  st.counters["rows/s"] = ::benchmark::Counter(static_cast<double>(rows_processed), ::benchmark::Counter::kIsRate);
+}
+
+inline void ReportCompressionRatio(::benchmark::State& st, int64_t raw_size, int64_t compressed_size) {
+  if (raw_size > 0) {
+    st.counters["compression_ratio"] = ::benchmark::Counter(
+        static_cast<double>(compressed_size) / static_cast<double>(raw_size), ::benchmark::Counter::kDefaults);
+  }
+}
+
+//=============================================================================
+// Data Configuration Structures
+//=============================================================================
+
+// Data size configurations as per design doc
+struct DataSizeConfig {
+  std::string name;
+  size_t num_rows;
+  size_t vector_dim;
+  size_t string_length;
+
+  static DataSizeConfig Small() { return {"Small", 4096, 128, 128}; }
+  static DataSizeConfig Medium() { return {"Medium", 40960, 128, 128}; }
+  static DataSizeConfig Large() { return {"Large", 409600, 128, 128}; }
+  static DataSizeConfig HighDim() { return {"HighDim", 4096, 768, 128}; }
+  static DataSizeConfig LongString() { return {"LongString", 4096, 128, 1024}; }
+
+  static std::vector<DataSizeConfig> All() { return {Small(), Medium(), Large(), HighDim(), LongString()}; }
+
+  static DataSizeConfig FromIndex(size_t idx) {
+    auto all = All();
+    return idx < all.size() ? all[idx] : Small();
+  }
+};
+
+// Memory configurations as per design doc
+struct MemoryConfig {
+  std::string name;
+  size_t buffer_size;
+  size_t batch_size;
+
+  static MemoryConfig Low() { return {"Low", 16ULL * 1024 * 1024, 1024}; }
+  static MemoryConfig Default() { return {"Default", 128ULL * 1024 * 1024, 16384}; }
+  static MemoryConfig High() { return {"High", 256ULL * 1024 * 1024, 32768}; }
+
+  static std::vector<MemoryConfig> All() { return {Low(), Default(), High()}; }
+
+  static MemoryConfig FromIndex(size_t idx) {
+    auto all = All();
+    return idx < all.size() ? all[idx] : Default();
+  }
+};
+
+//=============================================================================
+// Index Distribution Generators for Take Benchmarks
+//=============================================================================
+
+// Generate sequential indices starting from a given start position
+inline std::vector<int64_t> GenerateSequentialIndices(size_t count, int64_t start = 0) {
+  std::vector<int64_t> indices(count);
+  std::iota(indices.begin(), indices.end(), start);
+  return indices;
+}
+
+// Generate uniformly distributed random indices
+inline std::vector<int64_t> GenerateRandomIndices(size_t count, int64_t max_value, uint32_t seed = 42) {
+  std::vector<int64_t> indices;
+  std::set<int64_t> seen;
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int64_t> dist(0, max_value - 1);
+
+  while (indices.size() < count) {
+    int64_t idx = dist(gen);
+    if (seen.insert(idx).second) {
+      indices.push_back(idx);
+    }
+  }
+  std::sort(indices.begin(), indices.end());
+  return indices;
+}
+
+// Generate clustered indices (multiple small contiguous clusters)
+inline std::vector<int64_t> GenerateClusteredIndices(size_t count,
+                                                     int64_t max_value,
+                                                     size_t cluster_size = 5,
+                                                     uint32_t seed = 42) {
+  std::vector<int64_t> indices;
+  std::set<int64_t> seen;
+  size_t num_clusters = (count + cluster_size - 1) / cluster_size;
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int64_t> dist(0, max_value - static_cast<int64_t>(cluster_size));
+
+  while (indices.size() < count) {
+    int64_t start = dist(gen);
+    for (size_t j = 0; j < cluster_size && indices.size() < count; ++j) {
+      int64_t idx = start + static_cast<int64_t>(j);
+      if (idx < max_value && seen.insert(idx).second) {
+        indices.push_back(idx);
+      }
+    }
+  }
+  std::sort(indices.begin(), indices.end());
+  return indices;
+}
+
+// Distribution type enum
+enum class IndexDistribution { Sequential = 0, Random = 1, Clustered = 2 };
+
+inline std::vector<int64_t> GenerateIndices(IndexDistribution dist,
+                                            size_t count,
+                                            int64_t max_value,
+                                            uint32_t seed = 42) {
+  switch (dist) {
+    case IndexDistribution::Sequential:
+      return GenerateSequentialIndices(count, 0);
+    case IndexDistribution::Random:
+      return GenerateRandomIndices(count, max_value, seed);
+    case IndexDistribution::Clustered:
+      return GenerateClusteredIndices(count, max_value, 5, seed);
+    default:
+      return GenerateRandomIndices(count, max_value, seed);
+  }
+}
+
+inline const char* IndexDistributionName(IndexDistribution dist) {
+  switch (dist) {
+    case IndexDistribution::Sequential:
+      return "Sequential";
+    case IndexDistribution::Random:
+      return "Random";
+    case IndexDistribution::Clustered:
+      return "Clustered";
+    default:
+      return "Unknown";
+  }
+}
+
+//=============================================================================
+// Format Utilities
+//=============================================================================
+
+// Get list of available formats based on build configuration
+inline std::vector<std::string> GetAvailableFormats() { return {LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX}; }
+
+// Get format name by index
+inline std::string GetFormatByIndex(size_t idx) {
+  auto formats = GetAvailableFormats();
+  assert(idx < formats.size() && "Format index out of range");
+  return formats[idx];
+}
+
+// Check if a format is available
+inline bool IsFormatAvailable(const std::string& format) {
+  auto formats = GetAvailableFormats();
+  return std::find(formats.begin(), formats.end(), format) != formats.end();
+}
+
+//=============================================================================
+// Memory Tracking Utilities (System-level)
+//=============================================================================
+
+// Get max RSS (Resident Set Size) in bytes using getrusage
+// Note: ru_maxrss is the maximum RSS during the process lifetime
+inline int64_t GetMaxRSS() {
+  struct rusage usage;
+  if (getrusage(RUSAGE_SELF, &usage) == 0) {
+#ifdef __APPLE__
+    // macOS: ru_maxrss is in bytes
+    return static_cast<int64_t>(usage.ru_maxrss);
+#else
+    // Linux: ru_maxrss is in KB
+    return static_cast<int64_t>(usage.ru_maxrss) * 1024;
+#endif
+  }
+  return 0;
+}
+
+class MemoryTracker {
+  public:
+  MemoryTracker() = default;
+
+  void Reset() {}  // No-op, kept for API compatibility
+
+  // Returns the peak RSS (max resident set size) of the process
+  int64_t GetPeakMemory() const { return GetMaxRSS(); }
+
+  void ReportToState(::benchmark::State& st) const { ReportSize(st, "peak_memory", GetPeakMemory()); }
+};
+
+//=============================================================================
+// Thread Count Tracking Utilities
+//=============================================================================
+
+// Get current thread count for this process
+inline int GetCurrentThreadCount() {
+#ifdef __APPLE__
+  mach_port_t task = mach_task_self();
+  thread_act_array_t threads;
+  mach_msg_type_number_t thread_count;
+  if (task_threads(task, &threads, &thread_count) == KERN_SUCCESS) {
+    vm_deallocate(task, reinterpret_cast<vm_address_t>(threads), thread_count * sizeof(thread_act_t));
+    return static_cast<int>(thread_count);
+  }
+  return -1;
+#elif defined(__linux__)
+  std::ifstream status("/proc/self/status");
+  std::string line;
+  while (std::getline(status, line)) {
+    if (line.rfind("Threads:", 0) == 0) {
+      return std::stoi(line.substr(8));
+    }
+  }
+  return -1;
+#else
+  return -1;
+#endif
+}
+
+class ThreadTracker {
+  public:
+  ThreadTracker() : running_(false), peak_threads_(0) {}
+
+  ~ThreadTracker() { Stop(); }
+
+  void Start(std::chrono::milliseconds interval = std::chrono::milliseconds(1)) {
+    if (running_.exchange(true)) {
+      return;
+    }
+    peak_threads_ = GetCurrentThreadCount();
+    sampler_thread_ = std::thread([this, interval]() {
+      while (running_.load()) {
+        int current = GetCurrentThreadCount();
+        if (current > 0) {
+          int expected = peak_threads_.load();
+          while (current > expected && !peak_threads_.compare_exchange_weak(expected, current)) {
+          }
+        }
+        std::this_thread::sleep_for(interval);
+      }
+    });
+  }
+
+  void Stop() {
+    if (running_.exchange(false)) {
+      if (sampler_thread_.joinable()) {
+        sampler_thread_.join();
+      }
+    }
+  }
+
+  int GetPeakThreads() const { return peak_threads_.load(); }
+
+  void ReportToState(::benchmark::State& st) const {
+    st.counters["peak_threads"] =
+        ::benchmark::Counter(static_cast<double>(GetPeakThreads()), ::benchmark::Counter::kDefaults);
+  }
+
+  private:
+  std::atomic<bool> running_;
+  std::atomic<int> peak_threads_;
+  std::thread sampler_thread_;
+};
+
+//=============================================================================
+// Format Benchmark Fixture Base Class
+//=============================================================================
+
+template <bool EnableMemoryTracker = true, bool EnableThreadTracker = false>
+class FormatBenchFixtureBase : public ::benchmark::Fixture {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    // Initialize properties from environment
+    BENCH_ASSERT_STATUS_OK(InitTestProperties(properties_), st);
+
+    // Configure global properties for benchmarks
+    ConfigureGlobalProp();
+
+    // Get filesystem
+    BENCH_ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_), st);
+
+    // Setup base path
+    base_path_ = GetTestBasePath("format_benchmark");
+    BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_), st);
+    BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_), st);
+
+    // Get available formats
+    available_formats_ = GetAvailableFormats();
+
+    // Initialize data loader from environment
+    // If CUSTOM_SEGMENT_PATH is set, use MilvusSegmentLoader; otherwise use SyntheticDataLoader
+    data_loader_ = CreateDataLoaderFromEnv(SyntheticDataConfig::Medium());
+    auto load_status = data_loader_->Load();
+    if (!load_status.ok()) {
+      st.SkipWithError(("Failed to load benchmark data: " + load_status.ToString()).c_str());
+      return;
+    }
+
+    // Initialize trackers if enabled
+    if constexpr (EnableMemoryTracker) {
+      memory_tracker_.Reset();
+    }
+    if constexpr (EnableThreadTracker) {
+      thread_tracker_.Start();
+    }
+  }
+
+  void TearDown(::benchmark::State& st) override {
+    // Stop and report thread tracker if enabled
+    if constexpr (EnableThreadTracker) {
+      thread_tracker_.Stop();
+      thread_tracker_.ReportToState(st);
+    }
+
+    // Report memory metrics if enabled
+    if constexpr (EnableMemoryTracker) {
+      memory_tracker_.ReportToState(st);
+    }
+
+    // Release data loader to free loaded data
+    data_loader_.reset();
+
+    // Clean up test directory
+    auto status = DeleteTestDir(fs_, base_path_);
+    if (!status.ok()) {
+      // Log but don't fail on cleanup errors
+    }
+  }
+
+  protected:
+  // Configure global properties for all benchmarks
+  void ConfigureGlobalProp() { api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "32768"); }
+
+  // Configure memory settings based on MemoryConfig
+  void ConfigureMemory(const MemoryConfig& config) {
+    api::SetValue(properties_, PROPERTY_WRITER_BUFFER_SIZE, std::to_string(config.buffer_size).c_str());
+    api::SetValue(properties_, PROPERTY_READER_RECORD_BATCH_MAX_ROWS, std::to_string(config.batch_size).c_str());
+    api::SetValue(properties_, PROPERTY_READER_RECORD_BATCH_MAX_SIZE, std::to_string(config.buffer_size).c_str());
+  }
+
+  //-----------------------------------------------------------------------
+  // Data Loader Methods - Use data from configured source
+  //-----------------------------------------------------------------------
+
+  // Get data loader
+  BenchmarkDataLoader* GetDataLoader() const { return data_loader_.get(); }
+
+  // Get schema from data loader
+  std::shared_ptr<arrow::Schema> GetLoaderSchema() const { return data_loader_->GetSchema(); }
+
+  // Get record batch reader from data loader (for streaming reads, preferred for large datasets)
+  arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetLoaderBatchReader() const {
+    return data_loader_->GetRecordBatchReader();
+  }
+
+  // Get single record batch from data loader (loads all data into memory)
+  // Use GetLoaderBatchReader() for large datasets
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetLoaderBatch() const { return data_loader_->GetRecordBatch(); }
+
+  // Get schema-based patterns for Writer policy
+  std::string GetSchemaBasePatterns() const { return data_loader_->GetSchemaBasePatterns(); }
+
+  // Get scalar projection columns
+  std::shared_ptr<std::vector<std::string>> GetScalarProjection() const { return data_loader_->GetScalarProjection(); }
+
+  // Get vector projection columns
+  std::shared_ptr<std::vector<std::string>> GetVectorProjection() const { return data_loader_->GetVectorProjection(); }
+
+  // Get number of rows in loaded data
+  int64_t GetLoaderNumRows() const { return data_loader_->NumRows(); }
+
+  // Get data description for labels
+  std::string GetDataDescription() const { return data_loader_->GetDescription(); }
+
+  //-----------------------------------------------------------------------
+  // Legacy Methods - For backward compatibility (uses synthetic data)
+  //-----------------------------------------------------------------------
+
+  // Create schema for test data (legacy - uses CreateTestSchema directly)
+  arrow::Result<std::shared_ptr<arrow::Schema>> CreateSchema(std::array<bool, 4> needed_columns = {true, true, true,
+                                                                                                   true}) {
+    return CreateTestSchema(needed_columns);
+  }
+
+  // Create test data batch (legacy - uses CreateTestData directly)
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateBatch(std::shared_ptr<arrow::Schema> schema,
+                                                                 const DataSizeConfig& config,
+                                                                 bool random_data = true,
+                                                                 int64_t start_offset = 0) {
+    return CreateTestData(schema, start_offset, random_data, config.num_rows, config.vector_dim, config.string_length);
+  }
+
+  // Create policy for specific format
+  arrow::Result<std::unique_ptr<api::ColumnGroupPolicy>> CreatePolicyForFormat(
+      const std::string& format, const std::shared_ptr<arrow::Schema>& schema) {
+    return CreateSinglePolicy(format, schema);
+  }
+
+  // Get unique path for this benchmark iteration
+  std::string GetUniquePath(const std::string& suffix = "") const {
+    static std::atomic<uint64_t> counter{0};
+    std::string path = base_path_ + "/bench_" + std::to_string(counter++);
+    if (!suffix.empty()) {
+      path += "_" + suffix;
+    }
+    return path;
+  }
+
+  // Check if format is available and skip if not
+  bool CheckFormatAvailable(::benchmark::State& st, const std::string& format) {
+    if (!IsFormatAvailable(format)) {
+      st.SkipWithError(("Format not available: " + format).c_str());
+      return false;
+    }
+    return true;
+  }
+
+  // Calculate logical data size for a batch.
+  // Computes size from type layout and num_rows, consistent regardless of slicing.
+  static int64_t CalculateRawDataSize(const std::shared_ptr<arrow::RecordBatch>& batch) {
+    int64_t size = 0;
+    int64_t num_rows = batch->num_rows();
+    for (int i = 0; i < batch->num_columns(); ++i) {
+      auto type = batch->column(i)->type();
+      if (type->id() == arrow::Type::LIST) {
+        // list<T>: use offsets to get actual child element count
+        auto list_array = std::static_pointer_cast<arrow::ListArray>(batch->column(i));
+        int64_t total_values = list_array->value_offset(num_rows) - list_array->value_offset(0);
+        size += total_values * list_array->value_type()->byte_width();
+      } else if (arrow::is_fixed_width(*type)) {
+        size += num_rows * type->byte_width();
+      } else if (type->id() == arrow::Type::STRING || type->id() == arrow::Type::BINARY) {
+        // Variable-width (string/binary): use offsets
+        auto offsets = batch->column(i)->data()->buffers[1];
+        auto offset_base = batch->column(i)->offset();
+        auto off_ptr = reinterpret_cast<const int32_t*>(offsets->data());
+        size += off_ptr[offset_base + num_rows] - off_ptr[offset_base];
+      } else {
+        throw std::runtime_error("CalculateRawDataSize: unsupported type " + type->ToString());
+      }
+    }
+    return size;
+  }
+
+  protected:
+  api::Properties properties_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::string base_path_;
+  std::vector<std::string> available_formats_;
+  std::unique_ptr<BenchmarkDataLoader> data_loader_;
+  MemoryTracker memory_tracker_;
+  ThreadTracker thread_tracker_;
+};
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_format_read.cpp
+++ b/cpp/benchmark/benchmark_format_read.cpp
@@ -1,0 +1,342 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark_format_common.h"
+
+#include <thread>
+#include <arrow/table.h>
+#include "milvus-storage/thread_pool.h"
+
+namespace milvus_storage {
+namespace benchmark {
+
+using namespace milvus_storage::api;
+
+//=============================================================================
+// Read Performance Benchmark Base
+//=============================================================================
+
+class FormatReadBenchmark : public FormatBenchFixtureBase<> {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    FormatBenchFixtureBase<>::SetUp(st);
+
+    // Get schema from data loader
+    schema_ = GetLoaderSchema();
+  }
+
+  void TearDown(::benchmark::State& st) override {
+    // Clear schema to release memory
+    schema_.reset();
+    // Release thread pool before base teardown
+    ThreadPoolHolder::Release();
+    FormatBenchFixtureBase<>::TearDown(st);
+  }
+
+  protected:
+  // Prepare test data by writing to storage using streaming reader (memory-efficient)
+  arrow::Status PrepareTestData(const std::string& format,
+                                std::shared_ptr<ColumnGroups>& out_cgs,
+                                std::string& out_path) {
+    out_path = GetUniquePath(format + "_read_test");
+
+    // Use schema-based policy to preserve column groups
+    std::string patterns = GetSchemaBasePatterns();
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
+
+    auto writer = Writer::create(out_path, schema_, std::move(policy), properties_);
+    if (!writer) {
+      return arrow::Status::Invalid("Failed to create writer");
+    }
+
+    // Write using streaming reader (memory-efficient for large datasets)
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, GetLoaderBatchReader());
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
+      if (!batch)
+        break;
+      ARROW_RETURN_NOT_OK(writer->write(batch));
+    }
+
+    ARROW_ASSIGN_OR_RAISE(out_cgs, writer->close());
+
+    return arrow::Status::OK();
+  }
+
+  // Get projection columns based on count (from schema)
+  std::shared_ptr<std::vector<std::string>> GetProjection(size_t num_columns) {
+    auto projection = std::make_shared<std::vector<std::string>>();
+    for (size_t i = 0; i < std::min(num_columns, static_cast<size_t>(schema_->num_fields())); ++i) {
+      projection->push_back(schema_->field(i)->name());
+    }
+    return projection;
+  }
+
+  std::shared_ptr<arrow::Schema> schema_;
+};
+
+//=============================================================================
+// Full Scan Benchmark
+//=============================================================================
+
+// Full scan benchmark - read all rows and all columns
+// Args: [format_idx, num_threads, memory_config_idx]
+BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadFullScan)(::benchmark::State& st) {
+  size_t format_idx = static_cast<size_t>(st.range(0));
+  size_t num_threads = static_cast<size_t>(st.range(1));
+  size_t memory_config_idx = static_cast<size_t>(st.range(2));
+
+  std::string format = GetFormatByIndex(format_idx);
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+
+  MemoryConfig memory_config = MemoryConfig::FromIndex(memory_config_idx);
+
+  // Configure memory and thread pool
+  ConfigureMemory(memory_config);
+  ThreadPoolHolder::WithSingleton(static_cast<int>(num_threads));
+
+  // Prepare test data using data loader
+  std::shared_ptr<ColumnGroups> cgs;
+  std::string path;
+  BENCH_ASSERT_STATUS_OK(PrepareTestData(format, cgs, path), st);
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+
+  for (auto _ : st) {
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    BENCH_ASSERT_NOT_NULL(reader, st);
+
+    BENCH_ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader(), st);
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      BENCH_ASSERT_STATUS_OK(batch_reader->ReadNext(&batch), st);
+      if (batch == nullptr) {
+        break;
+      }
+      total_rows_read += batch->num_rows();
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+  }
+
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+  st.SetLabel(format + "/" + std::to_string(num_threads) + "T/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
+    ->ArgsProduct({
+        {0, 1},         // Format: parquet(0), vortex(1)
+        {1, 4, 8, 16},  // Threads: 1, 4, 8, 16
+        {1}             // MemoryConfig: Default(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Column Projection Benchmark
+//=============================================================================
+
+// Column projection benchmark - read subset of columns
+// Args: [format_idx, num_columns, num_threads, memory_config_idx]
+BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadProjection)(::benchmark::State& st) {
+  size_t format_idx = static_cast<size_t>(st.range(0));
+  size_t num_columns = static_cast<size_t>(st.range(1));
+  size_t num_threads = static_cast<size_t>(st.range(2));
+  size_t memory_config_idx = static_cast<size_t>(st.range(3));
+
+  std::string format = GetFormatByIndex(format_idx);
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+
+  MemoryConfig memory_config = MemoryConfig::FromIndex(memory_config_idx);
+
+  ConfigureMemory(memory_config);
+  ThreadPoolHolder::WithSingleton(static_cast<int>(num_threads));
+
+  // Prepare test data (write all columns)
+  std::shared_ptr<ColumnGroups> cgs;
+  std::string path;
+  BENCH_ASSERT_STATUS_OK(PrepareTestData(format, cgs, path), st);
+
+  // Get projection for specified number of columns
+  auto projection = GetProjection(num_columns);
+
+  // Create projected schema
+  std::vector<std::shared_ptr<arrow::Field>> projected_fields;
+  for (const auto& col_name : *projection) {
+    auto field = schema_->GetFieldByName(col_name);
+    if (field) {
+      projected_fields.push_back(field);
+    }
+  }
+  auto projected_schema = arrow::schema(projected_fields);
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+
+  for (auto _ : st) {
+    auto reader = Reader::create(cgs, projected_schema, projection, properties_);
+    BENCH_ASSERT_NOT_NULL(reader, st);
+
+    BENCH_ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader(), st);
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      BENCH_ASSERT_STATUS_OK(batch_reader->ReadNext(&batch), st);
+      if (batch == nullptr) {
+        break;
+      }
+      total_rows_read += batch->num_rows();
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+  }
+
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+  st.SetLabel(format + "/" + std::to_string(num_columns) + "cols/" + std::to_string(num_threads) + "T/" +
+              GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
+    ->ArgsProduct({
+        {0, 1},        // Format: parquet(0), vortex(1)
+        {1, 2, 3, 4},  // Number of columns: 1, 2, 3, 4
+        {1, 8},        // Threads: 1, 8
+        {1}            // MemoryConfig: Default(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Random Access (Take) Benchmark
+//=============================================================================
+
+// Random access benchmark - read specific rows by indices
+// Args: [format_idx, take_count, distribution, num_threads, memory_config_idx]
+BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadTake)(::benchmark::State& st) {
+  size_t format_idx = static_cast<size_t>(st.range(0));
+  size_t take_count = static_cast<size_t>(st.range(1));
+  int distribution = static_cast<int>(st.range(2));
+  size_t num_threads = static_cast<size_t>(st.range(3));
+  size_t memory_config_idx = static_cast<size_t>(st.range(4));
+
+  std::string format = GetFormatByIndex(format_idx);
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+
+  MemoryConfig memory_config = MemoryConfig::FromIndex(memory_config_idx);
+
+  ConfigureMemory(memory_config);
+  ThreadPoolHolder::WithSingleton(static_cast<int>(num_threads));
+
+  // Prepare test data
+  std::shared_ptr<ColumnGroups> cgs;
+  std::string path;
+  BENCH_ASSERT_STATUS_OK(PrepareTestData(format, cgs, path), st);
+
+  // Generate indices based on distribution
+  IndexDistribution dist = static_cast<IndexDistribution>(distribution);
+  auto indices = GenerateIndices(dist, take_count, GetLoaderNumRows());
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+
+  for (auto _ : st) {
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    BENCH_ASSERT_NOT_NULL(reader, st);
+
+    BENCH_ASSERT_AND_ASSIGN(auto table, reader->take(indices), st);
+
+    total_rows_read += table->num_rows();
+    // Estimate bytes read
+    arrow::TableBatchReader batch_reader(*table);
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      BENCH_ASSERT_STATUS_OK(batch_reader.ReadNext(&batch), st);
+      if (batch == nullptr) {
+        break;
+      }
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+  }
+
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+  st.counters["rows_taken"] = ::benchmark::Counter(static_cast<double>(take_count), ::benchmark::Counter::kDefaults);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+
+  st.SetLabel(format + "/" + std::to_string(take_count) + "rows/" + IndexDistributionName(dist) + "/" +
+              std::to_string(num_threads) + "T/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
+    ->ArgsProduct({
+        {0, 1},                  // Format: parquet(0), vortex(1)
+        {10, 100, 1000, 10000},  // Take count
+        {0, 1, 2},               // Distribution: sequential(0), random(1), clustered(2)
+        {1, 8},                  // Threads: 1, 8
+        {1}                      // MemoryConfig: Default(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Typical Benchmarks
+// Run with: --benchmark_filter="Typical/"
+//=============================================================================
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
+    ->Name("Typical/ReadFullScan_Parquet")
+    ->Args({0, 8, 1})  // Parquet + 8 threads + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
+    ->Name("Typical/ReadFullScan_Vortex")
+    ->Args({1, 8, 1})  // Vortex + 8 threads + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
+    ->Name("Typical/ReadProjection_Parquet")
+    ->Args({0, 1, 8, 1})  // Parquet + 1 col + 8 threads + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
+    ->Name("Typical/ReadProjection_Vortex")
+    ->Args({1, 1, 8, 1})  // Vortex + 1 col + 8 threads + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
+    ->Name("Typical/ReadTake_Parquet")
+    ->Args({0, 1000, 1, 8, 1})  // Parquet + 1000 rows + Random + 8 threads + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
+    ->Name("Typical/ReadTake_Vortex")
+    ->Args({1, 1000, 1, 8, 1})  // Vortex + 1000 rows + Random + 8 threads + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_format_write.cpp
+++ b/cpp/benchmark/benchmark_format_write.cpp
@@ -1,0 +1,284 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark_format_common.h"
+
+#include <arrow/filesystem/filesystem.h>
+
+namespace milvus_storage {
+namespace benchmark {
+
+using namespace milvus_storage::api;
+
+//=============================================================================
+// Write Performance Benchmark
+//=============================================================================
+
+class FormatWriteBenchmark : public FormatBenchFixtureBase<> {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    FormatBenchFixtureBase<>::SetUp(st);
+
+    // Get schema from data loader
+    schema_ = GetLoaderSchema();
+
+    // Pre-load all batches for write benchmarks (measure pure write performance)
+    auto reader_result = GetLoaderBatchReader();
+    if (!reader_result.ok()) {
+      st.SkipWithError(("Failed to get batch reader: " + reader_result.status().ToString()).c_str());
+      return;
+    }
+    auto batch_reader = *reader_result;
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      auto status = batch_reader->ReadNext(&batch);
+      if (!status.ok()) {
+        st.SkipWithError(("Failed to read batch: " + status.ToString()).c_str());
+        return;
+      }
+      if (!batch)
+        break;
+      batches_.push_back(batch);
+      total_bytes_ += CalculateRawDataSize(batch);
+      total_rows_ += batch->num_rows();
+    }
+  }
+
+  void TearDown(::benchmark::State& st) override {
+    // Clear pre-loaded batches to release memory
+    batches_.clear();
+    batches_.shrink_to_fit();
+    schema_.reset();
+    FormatBenchFixtureBase<>::TearDown(st);
+  }
+
+  protected:
+  std::shared_ptr<arrow::Schema> schema_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+  int64_t total_bytes_ = 0;
+  int64_t total_rows_ = 0;
+};
+
+// Write comparison benchmark across formats
+// Args: [format_idx, data_config_idx, memory_config_idx]
+BENCHMARK_DEFINE_F(FormatWriteBenchmark, WriteComparison)(::benchmark::State& st) {
+  size_t format_idx = static_cast<size_t>(st.range(0));
+  // data_config_idx is ignored - we use data from loader
+  size_t memory_config_idx = static_cast<size_t>(st.range(2));
+
+  std::string format = GetFormatByIndex(format_idx);
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+
+  MemoryConfig memory_config = MemoryConfig::FromIndex(memory_config_idx);
+
+  // Configure memory settings
+  ConfigureMemory(memory_config);
+
+  // Track total bytes and rows for throughput calculation
+  int64_t total_bytes_written = 0;
+  int64_t total_rows_written = 0;
+
+  for (auto _ : st) {
+    std::string path = GetUniquePath(format);
+
+    // Create policy using schema-based patterns from loader
+    std::string patterns = GetSchemaBasePatterns();
+    BENCH_ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns, format, schema_), st);
+
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    BENCH_ASSERT_NOT_NULL(writer, st);
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      BENCH_ASSERT_STATUS_OK(writer->write(batch), st);
+    }
+
+    // Close and get column groups
+    BENCH_ASSERT_AND_ASSIGN(auto cgs, writer->close(), st);
+
+    total_bytes_written += total_bytes_;
+    total_rows_written += total_rows_;
+  }
+
+  // Report metrics
+  ReportThroughput(st, total_bytes_written, total_rows_written);
+
+  // Add labels for better output readability
+  st.SetLabel(format + "/" + GetDataDescription());
+}
+
+// Register write benchmark with all combinations
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
+    ->ArgsProduct({
+        {0, 1},     // Format: parquet(0), vortex(1)
+        {0, 1, 2},  // DataConfig: Small(0), Medium(1), Large(2)
+        {1}         // MemoryConfig: Default(1) only for basic tests
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+// Extended write benchmark with all memory configurations (for detailed analysis)
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
+    ->Name("FormatWriteBenchmark/WriteComparisonExtended")
+    ->ArgsProduct({
+        {0, 1},    // Format: parquet(0), vortex(1)
+        {0},       // DataConfig: Small(0) only
+        {0, 1, 2}  // MemoryConfig: Low(0), Default(1), High(2)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+// High-dimensional vector write benchmark
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
+    ->Name("FormatWriteBenchmark/WriteHighDim")
+    ->ArgsProduct({
+        {0, 1},  // Format: parquet(0), vortex(1)
+        {3},     // DataConfig: HighDim(3)
+        {1}      // MemoryConfig: Default(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+// Long string write benchmark
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
+    ->Name("FormatWriteBenchmark/WriteLongString")
+    ->ArgsProduct({
+        {0, 1},  // Format: parquet(0), vortex(1)
+        {4},     // DataConfig: LongString(4)
+        {1}      // MemoryConfig: Default(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// File Size / Compression Analysis Benchmark
+//=============================================================================
+
+// Helper function to calculate total file size from column groups
+static arrow::Result<int64_t> CalculateFileSize(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                                const std::shared_ptr<api::ColumnGroups>& cgs) {
+  int64_t total_size = 0;
+  for (const auto& cg : *cgs) {
+    for (const auto& file : cg->files) {
+      ARROW_ASSIGN_OR_RAISE(auto file_info, fs->GetFileInfo(file.path));
+      total_size += file_info.size();
+    }
+  }
+  return total_size;
+}
+
+// This benchmark measures file size and compression ratio
+// The compression ratio is calculated by comparing file size against raw data size from loader
+// Args: [format_idx, data_config_idx]
+BENCHMARK_DEFINE_F(FormatWriteBenchmark, CompressionAnalysis)(::benchmark::State& st) {
+  size_t format_idx = static_cast<size_t>(st.range(0));
+  // data_config_idx is ignored - we use data from loader
+
+  std::string format = GetFormatByIndex(format_idx);
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+
+  std::string patterns = GetSchemaBasePatterns();
+
+  // Baseline is raw data size from loader (calculated in SetUp via CalculateRawDataSize)
+  int64_t baseline_size = total_bytes_;
+
+  // Write files with the target format and measure
+  int64_t total_file_size = 0;
+  int64_t iteration_count = 0;
+
+  for (auto _ : st) {
+    std::string path = GetUniquePath(format);
+
+    // Create policy and writer with target format (uses default zstd compression for parquet)
+    BENCH_ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns, format, schema_), st);
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    BENCH_ASSERT_NOT_NULL(writer, st);
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      BENCH_ASSERT_STATUS_OK(writer->write(batch), st);
+    }
+
+    // Close and get column groups
+    BENCH_ASSERT_AND_ASSIGN(auto cgs, writer->close(), st);
+
+    // Calculate file size
+    BENCH_ASSERT_AND_ASSIGN(auto file_size, CalculateFileSize(fs_, cgs), st);
+
+    total_file_size += file_size;
+    iteration_count++;
+  }
+
+  // Report compression metrics
+  if (iteration_count > 0) {
+    int64_t avg_file_size = total_file_size / iteration_count;
+
+    // Compression ratio = file_size / raw_data_size
+    // Values < 1.0 indicate good compression
+    ReportCompressionRatio(st, baseline_size, avg_file_size);
+
+    ReportSize(st, "file_size", avg_file_size);
+    ReportSize(st, "baseline_size", baseline_size);
+  }
+
+  st.SetLabel(format + "/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
+    ->ArgsProduct({
+        {0, 1},          // Format: parquet(0), vortex(1)
+        {0, 1, 2, 3, 4}  // All DataConfigs
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime()
+    ->Iterations(3);  // Few iterations since we're measuring file size
+
+//=============================================================================
+// Typical Benchmarks
+// Run with: --benchmark_filter="Typical/"
+//=============================================================================
+
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
+    ->Name("Typical/FormatWrite_Parquet")
+    ->Args({0, 1, 1})  // Parquet + Medium + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
+    ->Name("Typical/FormatWrite_Vortex")
+    ->Args({1, 1, 1})  // Vortex + Medium + Default
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
+    ->Name("Typical/Compression_Parquet")
+    ->Args({0, 1})  // Parquet + Medium
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime()
+    ->Iterations(3);
+
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
+    ->Name("Typical/Compression_Vortex")
+    ->Args({1, 1})  // Vortex + Medium
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime()
+    ->Iterations(3);
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_main.cpp
+++ b/cpp/benchmark/benchmark_main.cpp
@@ -14,9 +14,4 @@
 
 #include <benchmark/benchmark.h>
 
-int main(int argc, char** argv) {
-  benchmark::Initialize(&argc, argv);
-  benchmark::RunSpecifiedBenchmarks();
-  benchmark::Shutdown();
-  return 0;
-}
+BENCHMARK_MAIN();

--- a/cpp/benchmark/benchmark_storage_layer.cpp
+++ b/cpp/benchmark/benchmark_storage_layer.cpp
@@ -1,0 +1,930 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Storage Layer Benchmark (Phase 3)
+// Compare Milvus-Storage (Parquet/Vortex + Transaction) vs Lance Native.
+// Measures end-to-end performance including transaction overhead.
+
+#include "benchmark_format_common.h"
+
+#include <arrow/table.h>
+#include <arrow/record_batch.h>
+
+#include "milvus-storage/transaction/transaction.h"
+#include "milvus-storage/thread_pool.h"
+
+#include <arrow/c/bridge.h>
+#include "format/bridge/rust/include/lance_bridge.h"
+#include "milvus-storage/format/lance/lance_common.h"
+
+namespace milvus_storage {
+namespace benchmark {
+
+using namespace milvus_storage::api;
+using namespace milvus_storage::api::transaction;
+
+//=============================================================================
+// Storage Format Types
+//=============================================================================
+
+enum class StorageFormatType { PARQUET = 0, VORTEX = 1, MIXED = 2 };
+
+inline const char* StorageFormatTypeName(StorageFormatType type) {
+  switch (type) {
+    case StorageFormatType::PARQUET:
+      return "parquet";
+    case StorageFormatType::VORTEX:
+      return "vortex";
+    case StorageFormatType::MIXED:
+      return "mixed(pq+vtx)";
+    default:
+      return "unknown";
+  }
+}
+
+//=============================================================================
+// Helper: Project columns from a RecordBatch
+//=============================================================================
+
+inline std::shared_ptr<arrow::RecordBatch> ProjectColumns(const std::shared_ptr<arrow::RecordBatch>& batch,
+                                                          const std::vector<int>& column_indices) {
+  std::vector<std::shared_ptr<arrow::Array>> arrays;
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  for (int idx : column_indices) {
+    arrays.push_back(batch->column(idx));
+    fields.push_back(batch->schema()->field(idx));
+  }
+  return arrow::RecordBatch::Make(arrow::schema(fields), batch->num_rows(), arrays);
+}
+
+//=============================================================================
+// Storage Layer Benchmark Fixture
+//=============================================================================
+
+class StorageLayerFixture : public FormatBenchFixtureBase<> {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    FormatBenchFixtureBase<>::SetUp(st);
+
+    // Get schema from data loader
+    schema_ = GetLoaderSchema();
+
+    // Pre-load all batches for write benchmarks (measure pure write performance)
+    auto reader_result = GetLoaderBatchReader();
+    if (!reader_result.ok()) {
+      st.SkipWithError(("Failed to get batch reader: " + reader_result.status().ToString()).c_str());
+      return;
+    }
+    auto batch_reader = *reader_result;
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      auto status = batch_reader->ReadNext(&batch);
+      if (!status.ok()) {
+        st.SkipWithError(("Failed to read batch: " + status.ToString()).c_str());
+        return;
+      }
+      if (!batch)
+        break;
+      batches_.push_back(batch);
+      total_bytes_ += CalculateRawDataSize(batch);
+      total_rows_ += batch->num_rows();
+    }
+
+    // Thread pool will be configured per-benchmark
+  }
+
+  void TearDown(::benchmark::State& st) override {
+    // Clear pre-loaded batches to release memory
+    batches_.clear();
+    batches_.shrink_to_fit();
+    schema_.reset();
+    ThreadPoolHolder::Release();
+    FormatBenchFixtureBase<>::TearDown(st);
+  }
+
+  void ConfigureThreadPool(int num_threads) { ThreadPoolHolder::WithSingleton(num_threads); }
+
+  protected:
+  //-----------------------------------------------------------------------
+  // MilvusStorage: Write + Transaction Commit (using pre-loaded batches)
+  //-----------------------------------------------------------------------
+  arrow::Status WriteMilvusStorage(StorageFormatType format_type, const std::string& path) {
+    std::string format = (format_type == StorageFormatType::PARQUET) ? LOON_FORMAT_PARQUET : LOON_FORMAT_VORTEX;
+
+    // Use schema-based policy
+    std::string patterns = GetSchemaBasePatterns();
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
+
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    if (!writer)
+      return arrow::Status::Invalid("Failed to create writer");
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      ARROW_RETURN_NOT_OK(writer->write(batch));
+    }
+    ARROW_ASSIGN_OR_RAISE(auto cgs, writer->close());
+
+    ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs_, path));
+    txn->AppendFiles(*cgs);
+    ARROW_ASSIGN_OR_RAISE(auto version, txn->Commit());
+
+    return arrow::Status::OK();
+  }
+
+  //-----------------------------------------------------------------------
+  // MilvusStorage: Write Only (No Transaction, using pre-loaded batches)
+  //-----------------------------------------------------------------------
+  arrow::Status WriteMilvusStorageNoTxn(StorageFormatType format_type, const std::string& path) {
+    std::string format = (format_type == StorageFormatType::PARQUET) ? LOON_FORMAT_PARQUET : LOON_FORMAT_VORTEX;
+
+    // Use schema-based policy
+    std::string patterns = GetSchemaBasePatterns();
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
+
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    if (!writer)
+      return arrow::Status::Invalid("Failed to create writer");
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      ARROW_RETURN_NOT_OK(writer->write(batch));
+    }
+    ARROW_ASSIGN_OR_RAISE(auto cgs, writer->close());
+    // No transaction commit
+
+    return arrow::Status::OK();
+  }
+
+  //-----------------------------------------------------------------------
+  // MilvusStorage: Open Transaction + Read (with stats collection)
+  //-----------------------------------------------------------------------
+  arrow::Status ReadMilvusStorageWithStats(const std::string& path, int64_t& out_rows, int64_t& out_bytes) {
+    ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs_, path));
+    ARROW_ASSIGN_OR_RAISE(auto manifest, txn->GetManifest());
+    auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
+
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    if (!reader)
+      return arrow::Status::Invalid("Failed to create reader");
+
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader->get_record_batch_reader());
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
+      if (!batch)
+        break;
+      out_rows += batch->num_rows();
+      out_bytes += CalculateRawDataSize(batch);
+    }
+    return arrow::Status::OK();
+  }
+
+  //-----------------------------------------------------------------------
+  // MilvusStorage: Open Transaction + Read (no stats, for benchmark loop)
+  //-----------------------------------------------------------------------
+  arrow::Status ReadMilvusStorage(const std::string& path) {
+    ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs_, path));
+    ARROW_ASSIGN_OR_RAISE(auto manifest, txn->GetManifest());
+    auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
+
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    if (!reader)
+      return arrow::Status::Invalid("Failed to create reader");
+
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader->get_record_batch_reader());
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
+      if (!batch)
+        break;
+      // No stats collection in benchmark loop
+    }
+    return arrow::Status::OK();
+  }
+
+  //-----------------------------------------------------------------------
+  // MilvusStorage: Open Transaction + Take (with stats collection)
+  //-----------------------------------------------------------------------
+  arrow::Status TakeMilvusStorageWithStats(const std::string& path,
+                                           const std::vector<int64_t>& indices,
+                                           int64_t& out_rows,
+                                           int64_t& out_bytes) {
+    ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs_, path));
+    ARROW_ASSIGN_OR_RAISE(auto manifest, txn->GetManifest());
+    auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
+
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    if (!reader)
+      return arrow::Status::Invalid("Failed to create reader");
+
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->take(indices));
+    out_rows += table->num_rows();
+    for (int i = 0; i < table->num_columns(); ++i) {
+      for (const auto& chunk : table->column(i)->chunks()) {
+        for (const auto& buffer : chunk->data()->buffers) {
+          if (buffer)
+            out_bytes += buffer->size();
+        }
+      }
+    }
+    return arrow::Status::OK();
+  }
+
+  //-----------------------------------------------------------------------
+  // MilvusStorage: Open Transaction + Take (no stats, for benchmark loop)
+  //-----------------------------------------------------------------------
+  arrow::Status TakeMilvusStorage(const std::string& path, const std::vector<int64_t>& indices) {
+    ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs_, path));
+    ARROW_ASSIGN_OR_RAISE(auto manifest, txn->GetManifest());
+    auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
+
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    if (!reader)
+      return arrow::Status::Invalid("Failed to create reader");
+
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->take(indices));
+    // No stats collection in benchmark loop
+    return arrow::Status::OK();
+  }
+
+  //-----------------------------------------------------------------------
+  // Format availability check
+  //-----------------------------------------------------------------------
+  bool CheckStorageFormatAvailable(::benchmark::State& st, StorageFormatType format_type) {
+    if (format_type == StorageFormatType::VORTEX || format_type == StorageFormatType::MIXED) {
+      if (!IsFormatAvailable(LOON_FORMAT_VORTEX)) {
+        st.SkipWithError("Vortex format not available");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  //-----------------------------------------------------------------------
+  // Lance: Build URI and storage options for cloud storage support
+  //-----------------------------------------------------------------------
+  arrow::Result<std::string> BuildLanceUri(const std::string& relative_path) {
+    ArrowFileSystemConfig fs_config;
+    ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
+    return lance::BuildLanceBaseUri(fs_config, relative_path);
+  }
+
+  lance::LanceStorageOptions GetLanceStorageOptions() {
+    ArrowFileSystemConfig fs_config;
+    auto status = ArrowFileSystemConfig::create_file_system_config(properties_, fs_config);
+    if (!status.ok()) {
+      return {};
+    }
+    return lance::ToLanceStorageOptions(fs_config);
+  }
+
+  // Write test data to a lance dataset using pre-loaded batches
+  arrow::Status WriteLanceDataset(const std::string& lance_uri, const lance::LanceStorageOptions& storage_options) {
+    // Create a RecordBatchReader from pre-loaded batches
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, arrow::RecordBatchReader::Make(batches_, schema_));
+
+    ArrowArrayStream stream;
+    ARROW_RETURN_NOT_OK(arrow::ExportRecordBatchReader(batch_reader, &stream));
+
+    try {
+      auto dataset = lance::BlockingDataset::WriteDataset(lance_uri, &stream, storage_options);
+    } catch (const lance::LanceException& e) {
+      return arrow::Status::IOError("Lance write failed: ", e.what());
+    }
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<arrow::Schema> schema_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+  int64_t total_bytes_ = 0;
+  int64_t total_rows_ = 0;
+};
+
+//=============================================================================
+// MilvusStorage Write + Commit Benchmark
+//=============================================================================
+
+// Args: [format_type]
+BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_WriteCommit)(::benchmark::State& st) {
+  auto format_type = static_cast<StorageFormatType>(st.range(0));
+
+  if (!CheckStorageFormatAvailable(st, format_type))
+    return;
+
+  ConfigureThreadPool(1);
+
+  std::string path = GetUniquePath("ms_write");
+  BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, path), st);
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+
+  for (auto _ : st) {
+    BENCH_ASSERT_STATUS_OK(WriteMilvusStorage(format_type, path), st);
+  }
+
+  int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
+  int64_t total_rows = total_rows_ * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.SetLabel(std::string(StorageFormatTypeName(format_type)) + "/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
+    ->ArgsProduct({
+        {0, 1}  // FormatType: parquet(0), vortex(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// MilvusStorage Write Only (No Transaction) Benchmark
+//=============================================================================
+
+// Args: [format_type]
+BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_WriteOnly)(::benchmark::State& st) {
+  auto format_type = static_cast<StorageFormatType>(st.range(0));
+
+  if (!CheckStorageFormatAvailable(st, format_type))
+    return;
+
+  ConfigureThreadPool(1);
+
+  std::string path = GetUniquePath("ms_write_only");
+
+  BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, path), st);
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+
+  for (auto _ : st) {
+    BENCH_ASSERT_STATUS_OK(WriteMilvusStorageNoTxn(format_type, path), st);
+  }
+
+  int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
+  int64_t total_rows = total_rows_ * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.SetLabel(std::string(StorageFormatTypeName(format_type)) + "/" + GetDataDescription() + "/no-txn");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteOnly)
+    ->ArgsProduct({
+        {0, 1}  // FormatType: parquet(0), vortex(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// MilvusStorage Open + Read Benchmark
+//=============================================================================
+
+// Args: [format_type, num_threads]
+BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_OpenRead)(::benchmark::State& st) {
+  auto format_type = static_cast<StorageFormatType>(st.range(0));
+  int num_threads = static_cast<int>(st.range(1));
+
+  if (!CheckStorageFormatAvailable(st, format_type))
+    return;
+
+  ConfigureThreadPool(num_threads);
+
+  std::string path = GetUniquePath("ms_read");
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+  BENCH_ASSERT_STATUS_OK(WriteMilvusStorage(format_type, path), st);
+
+  // Collect stats once before benchmark loop
+  int64_t rows_per_iter = 0;
+  int64_t bytes_per_iter = 0;
+  BENCH_ASSERT_STATUS_OK(ReadMilvusStorageWithStats(path, rows_per_iter, bytes_per_iter), st);
+
+  for (auto _ : st) {
+    BENCH_ASSERT_STATUS_OK(ReadMilvusStorage(path), st);
+  }
+
+  // Calculate totals using iteration count
+  int64_t total_rows = rows_per_iter * static_cast<int64_t>(st.iterations());
+  int64_t total_bytes = bytes_per_iter * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+  st.SetLabel(std::string(StorageFormatTypeName(format_type)) + "/" + GetDataDescription() + "/" +
+              std::to_string(num_threads) + "T");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
+    ->ArgsProduct({
+        {0, 1},        // FormatType: parquet(0), vortex(1)
+        {1, 4, 8, 16}  // Threads: 1, 4, 8, 16
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// MilvusStorage Take Benchmark
+//=============================================================================
+
+// Args: [format_type, take_count, num_threads]
+BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_Take)(::benchmark::State& st) {
+  auto format_type = static_cast<StorageFormatType>(st.range(0));
+  size_t take_count = static_cast<size_t>(st.range(1));
+  int num_threads = static_cast<int>(st.range(2));
+
+  if (!CheckStorageFormatAvailable(st, format_type))
+    return;
+
+  ConfigureThreadPool(num_threads);
+
+  std::string path = GetUniquePath("ms_take");
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+  BENCH_ASSERT_STATUS_OK(WriteMilvusStorage(format_type, path), st);
+
+  auto indices = GenerateRandomIndices(take_count, GetLoaderNumRows());
+
+  // Collect stats once before benchmark loop
+  int64_t rows_per_iter = 0;
+  int64_t bytes_per_iter = 0;
+  BENCH_ASSERT_STATUS_OK(TakeMilvusStorageWithStats(path, indices, rows_per_iter, bytes_per_iter), st);
+
+  for (auto _ : st) {
+    BENCH_ASSERT_STATUS_OK(TakeMilvusStorage(path, indices), st);
+  }
+
+  // Calculate totals using iteration count
+  int64_t total_rows = rows_per_iter * static_cast<int64_t>(st.iterations());
+  int64_t total_bytes = bytes_per_iter * static_cast<int64_t>(st.iterations());
+
+  ReportThroughput(st, total_bytes, total_rows);
+  st.counters["rows_taken"] = ::benchmark::Counter(static_cast<double>(take_count), ::benchmark::Counter::kDefaults);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+  st.SetLabel(std::string(StorageFormatTypeName(format_type)) + "/" + std::to_string(take_count) + "rows/" +
+              std::to_string(num_threads) + "T");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
+    ->ArgsProduct({
+        {0, 1},                 // FormatType: parquet(0), vortex(1)
+        {100, 200, 500, 1000},  // Take count
+        {1, 4, 8, 16}           // Threads: 1, 4, 8, 16
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Lance Native Benchmarks
+//=============================================================================
+
+BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_WriteCommit)(::benchmark::State& st) {
+  ConfigureThreadPool(1);
+
+  std::string path = GetUniquePath("lance_write");
+  BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, path), st);
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+
+  // Build Lance URI and get storage options for cloud storage support
+  BENCH_ASSERT_AND_ASSIGN(auto lance_uri, BuildLanceUri(path), st);
+  auto storage_options = GetLanceStorageOptions();
+
+  for (auto _ : st) {
+    BENCH_ASSERT_STATUS_OK(WriteLanceDataset(lance_uri, storage_options), st);
+  }
+
+  int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
+  int64_t total_rows = total_rows_ * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.SetLabel("lance/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_WriteCommit)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+//=============================================================================
+// Lance Native Open + Read Benchmark
+//=============================================================================
+
+// Args: [num_threads]
+BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_OpenRead)(::benchmark::State& st) {
+  int num_threads = static_cast<int>(st.range(0));
+
+  lance::ReplaceLanceRuntime(static_cast<uint32_t>(num_threads));
+
+  std::string path = GetUniquePath("lance_read");
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+
+  // Build Lance URI and get storage options for cloud storage support
+  BENCH_ASSERT_AND_ASSIGN(auto lance_uri, BuildLanceUri(path), st);
+  auto storage_options = GetLanceStorageOptions();
+
+  BENCH_ASSERT_STATUS_OK(WriteLanceDataset(lance_uri, storage_options), st);
+
+  // Lambda to read lance dataset
+  auto read_lance = [&](bool collect_stats, int64_t& out_rows, int64_t& out_bytes) -> arrow::Status {
+    auto dataset = lance::BlockingDataset::Open(lance_uri, storage_options);
+
+    ArrowSchema c_schema;
+    ARROW_RETURN_NOT_OK(arrow::ExportSchema(*schema_, &c_schema));
+
+    auto scanner = dataset->Scan(c_schema, 8192);
+    auto stream = scanner->OpenStream();
+
+    ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
+
+    std::shared_ptr<arrow::RecordBatch> rb;
+    while (true) {
+      ARROW_RETURN_NOT_OK(reader->ReadNext(&rb));
+      if (!rb)
+        break;
+      if (collect_stats) {
+        out_rows += rb->num_rows();
+        out_bytes += CalculateRawDataSize(rb);
+      }
+    }
+    return arrow::Status::OK();
+  };
+
+  // Collect stats once before benchmark loop
+  int64_t rows_per_iter = 0;
+  int64_t bytes_per_iter = 0;
+  BENCH_ASSERT_STATUS_OK(read_lance(true, rows_per_iter, bytes_per_iter), st);
+
+  for (auto _ : st) {
+    int64_t dummy_rows = 0, dummy_bytes = 0;
+    BENCH_ASSERT_STATUS_OK(read_lance(false, dummy_rows, dummy_bytes), st);
+  }
+
+  // Calculate totals using iteration count
+  int64_t total_rows = rows_per_iter * static_cast<int64_t>(st.iterations());
+  int64_t total_bytes = bytes_per_iter * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+  st.SetLabel("lance/" + GetDataDescription() + "/" + std::to_string(num_threads) + "T");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_OpenRead)
+    ->ArgsProduct({
+        {1, 4, 8, 16}  // Threads: 1, 4, 8, 16
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Lance Native Take Benchmark
+//=============================================================================
+
+// Args: [take_count, num_threads]
+BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_Take)(::benchmark::State& st) {
+  size_t take_count = static_cast<size_t>(st.range(0));
+  int num_threads = static_cast<int>(st.range(1));
+
+  lance::ReplaceLanceRuntime(static_cast<uint32_t>(num_threads));
+
+  std::string path = GetUniquePath("lance_take");
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+
+  // Build Lance URI and get storage options for cloud storage support
+  BENCH_ASSERT_AND_ASSIGN(auto lance_uri, BuildLanceUri(path), st);
+  auto storage_options = GetLanceStorageOptions();
+
+  BENCH_ASSERT_STATUS_OK(WriteLanceDataset(lance_uri, storage_options), st);
+
+  auto indices = GenerateRandomIndices(take_count, GetLoaderNumRows());
+
+  // Lambda to take from lance dataset
+  auto take_lance = [&](bool collect_stats, int64_t& out_rows, int64_t& out_bytes) -> arrow::Status {
+    auto dataset = lance::BlockingDataset::Open(lance_uri, storage_options);
+
+    ArrowSchema c_schema;
+    ARROW_RETURN_NOT_OK(arrow::ExportSchema(*schema_, &c_schema));
+
+    auto stream = dataset->Take(indices, c_schema);
+
+    ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
+
+    std::shared_ptr<arrow::RecordBatch> rb;
+    while (true) {
+      ARROW_RETURN_NOT_OK(reader->ReadNext(&rb));
+      if (!rb)
+        break;
+      if (collect_stats) {
+        out_rows += rb->num_rows();
+        out_bytes += CalculateRawDataSize(rb);
+      }
+    }
+    return arrow::Status::OK();
+  };
+
+  // Collect stats once before benchmark loop
+  int64_t rows_per_iter = 0;
+  int64_t bytes_per_iter = 0;
+  BENCH_ASSERT_STATUS_OK(take_lance(true, rows_per_iter, bytes_per_iter), st);
+
+  for (auto _ : st) {
+    int64_t dummy_rows = 0, dummy_bytes = 0;
+    BENCH_ASSERT_STATUS_OK(take_lance(false, dummy_rows, dummy_bytes), st);
+  }
+
+  // Calculate totals using iteration count
+  int64_t total_rows = rows_per_iter * static_cast<int64_t>(st.iterations());
+  int64_t total_bytes = bytes_per_iter * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.counters["rows_taken"] = ::benchmark::Counter(static_cast<double>(take_count), ::benchmark::Counter::kDefaults);
+  st.counters["threads"] = ::benchmark::Counter(static_cast<double>(num_threads), ::benchmark::Counter::kDefaults);
+  st.SetLabel("lance/" + std::to_string(take_count) + "rows/" + std::to_string(num_threads) + "T");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_Take)
+    ->ArgsProduct({
+        {100, 200, 500, 1000},  // Take count
+        {1, 4, 8, 16}           // Threads: 1, 4, 8, 16
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+// Typical: Lance benchmarks
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_WriteCommit)
+    ->Name("Typical/Lance_Write")
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_OpenRead)
+    ->Name("Typical/Lance_Read")
+    ->Args({8})  // 8 threads
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_Take)
+    ->Name("Typical/Lance_Take")
+    ->Args({1000, 8})  // 1000 rows + 8 threads
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Lance Multi-Reader Concurrency Benchmark
+//=============================================================================
+
+// Args: [num_readers, thread_pool_size]
+BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_MultiReader)(::benchmark::State& st) {
+  int num_readers = static_cast<int>(st.range(0));
+  int thread_pool_size = static_cast<int>(st.range(1));
+
+  lance::ReplaceLanceRuntime(static_cast<uint32_t>(thread_pool_size));
+
+  std::string path = GetUniquePath("lance_multi_reader");
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+
+  // Build Lance URI and get storage options for cloud storage support
+  BENCH_ASSERT_AND_ASSIGN(auto lance_uri, BuildLanceUri(path), st);
+  auto storage_options = GetLanceStorageOptions();
+
+  BENCH_ASSERT_STATUS_OK(WriteLanceDataset(lance_uri, storage_options), st);
+
+  // Start thread tracker
+  ThreadTracker thread_tracker;
+  thread_tracker.Start(std::chrono::milliseconds(1));
+
+  int64_t total_rows = 0;
+  int64_t total_bytes = 0;
+
+  for (auto _ : st) {
+    std::vector<std::thread> reader_threads;
+    std::atomic<int64_t> rows_read{0};
+    std::atomic<int64_t> bytes_read{0};
+    std::atomic<bool> has_error{false};
+
+    // Launch N reader threads
+    for (int i = 0; i < num_readers; ++i) {
+      reader_threads.emplace_back([&, i]() {
+        auto read_all = [&]() -> arrow::Status {
+          auto dataset = lance::BlockingDataset::Open(lance_uri, storage_options);
+
+          ArrowSchema c_schema;
+          ARROW_RETURN_NOT_OK(arrow::ExportSchema(*schema_, &c_schema));
+
+          auto scanner = dataset->Scan(c_schema, 8192);
+          auto stream = scanner->OpenStream();
+
+          ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
+
+          std::shared_ptr<arrow::RecordBatch> rb;
+          while (true) {
+            ARROW_RETURN_NOT_OK(reader->ReadNext(&rb));
+            if (!rb)
+              break;
+            rows_read += rb->num_rows();
+            bytes_read += CalculateRawDataSize(rb);
+          }
+          return arrow::Status::OK();
+        };
+
+        if (!read_all().ok()) {
+          has_error = true;
+        }
+      });
+    }
+
+    // Wait for all readers to complete
+    for (auto& t : reader_threads) {
+      t.join();
+    }
+
+    if (has_error) {
+      st.SkipWithError("Reader error in concurrent read");
+      return;
+    }
+
+    total_rows += rows_read.load();
+    total_bytes += bytes_read.load();
+  }
+
+  thread_tracker.Stop();
+
+  ReportThroughput(st, total_bytes, total_rows);
+  thread_tracker.ReportToState(st);
+  st.counters["num_readers"] = ::benchmark::Counter(static_cast<double>(num_readers), ::benchmark::Counter::kDefaults);
+  st.counters["pool_size"] =
+      ::benchmark::Counter(static_cast<double>(thread_pool_size), ::benchmark::Counter::kDefaults);
+  st.SetLabel("lance/" + std::to_string(num_readers) + "readers/" + std::to_string(thread_pool_size) + "pool");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_MultiReader)
+    ->ArgsProduct({
+        {1, 16, 64, 256},  // NumReaders: 1, 16, 64, 256
+        {1, 8, 16, 32}     // ThreadPoolSize: 1, 8, 16, 32
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Multi-Reader Concurrency Benchmark
+// Measures memory usage and thread count with N concurrent readers
+//=============================================================================
+
+// Args: [format_type, num_readers, thread_pool_size]
+BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_MultiReader)(::benchmark::State& st) {
+  auto format_type = static_cast<StorageFormatType>(st.range(0));
+  int num_readers = static_cast<int>(st.range(1));
+  int thread_pool_size = static_cast<int>(st.range(2));
+
+  if (!CheckStorageFormatAvailable(st, format_type))
+    return;
+
+  ConfigureThreadPool(thread_pool_size);
+
+  std::string path = GetUniquePath("ms_multi_reader");
+  BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, path), st);
+  BENCH_ASSERT_STATUS_OK(WriteMilvusStorage(format_type, path), st);
+
+  // Start thread tracker
+  ThreadTracker thread_tracker;
+  thread_tracker.Start(std::chrono::milliseconds(1));
+
+  int64_t total_rows = 0;
+  int64_t total_bytes = 0;
+
+  for (auto _ : st) {
+    std::vector<std::thread> reader_threads;
+    std::atomic<int64_t> rows_read{0};
+    std::atomic<int64_t> bytes_read{0};
+    std::atomic<bool> has_error{false};
+
+    // Launch N reader threads, each opens its own transaction
+    for (int i = 0; i < num_readers; ++i) {
+      reader_threads.emplace_back([&, i]() {
+        auto read_all = [&]() -> arrow::Status {
+          ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs_, path));
+          ARROW_ASSIGN_OR_RAISE(auto manifest, txn->GetManifest());
+          auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
+
+          auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+          if (!reader)
+            return arrow::Status::Invalid("Failed to create reader");
+
+          ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader->get_record_batch_reader());
+
+          std::shared_ptr<arrow::RecordBatch> rb;
+          while (true) {
+            ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&rb));
+            if (!rb)
+              break;
+            rows_read += rb->num_rows();
+            bytes_read += CalculateRawDataSize(rb);
+          }
+          return arrow::Status::OK();
+        };
+
+        if (!read_all().ok()) {
+          has_error = true;
+        }
+      });
+    }
+
+    // Wait for all readers to complete
+    for (auto& t : reader_threads) {
+      t.join();
+    }
+
+    if (has_error) {
+      st.SkipWithError("Reader error in concurrent read");
+      return;
+    }
+
+    total_rows += rows_read.load();
+    total_bytes += bytes_read.load();
+  }
+
+  thread_tracker.Stop();
+
+  ReportThroughput(st, total_bytes, total_rows);
+  thread_tracker.ReportToState(st);
+  st.counters["num_readers"] = ::benchmark::Counter(static_cast<double>(num_readers), ::benchmark::Counter::kDefaults);
+  st.counters["pool_size"] =
+      ::benchmark::Counter(static_cast<double>(thread_pool_size), ::benchmark::Counter::kDefaults);
+  st.SetLabel(std::string(StorageFormatTypeName(format_type)) + "/" + std::to_string(num_readers) + "readers/" +
+              std::to_string(thread_pool_size) + "pool");
+}
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_MultiReader)
+    ->ArgsProduct({
+        {0, 1},            // FormatType: parquet(0), vortex(1)
+        {1, 16, 64, 256},  // NumReaders: 1, 16, 64, 256
+        {1, 8, 16, 32}     // ThreadPoolSize: 1, 8, 16, 32
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// Typical Benchmarks (Quick validation with representative parameters)
+// Run with: --benchmark_filter="Typical/"
+//=============================================================================
+
+// Typical: MilvusStorage Parquet
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
+    ->Name("Typical/MilvusStorage_Write_Parquet")
+    ->Args({0})  // Parquet
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
+    ->Name("Typical/MilvusStorage_Read_Parquet_1T")
+    ->Args({0, 1})  // Parquet + 1 thread
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
+    ->Name("Typical/MilvusStorage_Read_Parquet_8T")
+    ->Args({0, 8})  // Parquet + 8 threads
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
+    ->Name("Typical/MilvusStorage_Take_Parquet_1T")
+    ->Args({0, 1000, 1})  // Parquet + 1000 rows + 1 thread
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
+    ->Name("Typical/MilvusStorage_Take_Parquet")
+    ->Args({0, 1000, 8})  // Parquet + 1000 rows + 8 threads
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+// Typical: MilvusStorage Vortex
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
+    ->Name("Typical/MilvusStorage_Write_Vortex")
+    ->Args({1})  // Vortex
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
+    ->Name("Typical/MilvusStorage_Read_Vortex_1T")
+    ->Args({1, 1})  // Vortex + 1 thread
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
+    ->Name("Typical/MilvusStorage_Read_Vortex_8T")
+    ->Args({1, 8})  // Vortex + 8 threads
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
+    ->Name("Typical/MilvusStorage_Take_Vortex_1T")
+    ->Args({1, 1000, 1})  // Vortex + 1000 rows + 1 thread
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
+    ->Name("Typical/MilvusStorage_Take_Vortex_8T")
+    ->Args({1, 1000, 8})  // Vortex + 1000 rows + 8 threads
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_v2_v3.cpp
+++ b/cpp/benchmark/benchmark_v2_v3.cpp
@@ -1,0 +1,349 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// V2 vs V3 Reader Benchmark
+// Compare performance between packed/ low-level reader (V2: PackedRecordBatchReader)
+// and top-level Reader API (V3: get_record_batch_reader / get_chunk_reader).
+// V2 uses PackedRecordBatchWriter + PackedRecordBatchReader directly.
+// V3 uses the high-level Writer + Reader API.
+
+#include "benchmark_format_common.h"
+
+#include <arrow/table.h>
+
+#include "milvus-storage/packed/writer.h"
+#include "milvus-storage/packed/reader.h"
+#include "milvus-storage/thread_pool.h"
+
+namespace milvus_storage {
+namespace benchmark {
+
+using namespace milvus_storage::api;
+
+//=============================================================================
+// V2 vs V3 Benchmark Fixture
+//=============================================================================
+
+inline size_t ComputeNumBatches(size_t num_rows) {
+  return std::max<size_t>(1, num_rows / 1000);  // ~1000 rows per batch
+}
+
+class V2V3BenchFixture : public FormatBenchFixtureBase<> {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    FormatBenchFixtureBase<>::SetUp(st);
+
+    if (!CheckFormatAvailable(st, LOON_FORMAT_PARQUET)) {
+      return;
+    }
+
+    // Get schema from data loader
+    schema_ = GetLoaderSchema();
+
+    // Pre-load all batches for write benchmarks
+    auto reader_result = GetLoaderBatchReader();
+    if (!reader_result.ok()) {
+      st.SkipWithError(("Failed to get batch reader: " + reader_result.status().ToString()).c_str());
+      return;
+    }
+    auto batch_reader = *reader_result;
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      auto status = batch_reader->ReadNext(&batch);
+      if (!status.ok()) {
+        st.SkipWithError(("Failed to read batch: " + status.ToString()).c_str());
+        return;
+      }
+      if (!batch)
+        break;
+      batches_.push_back(batch);
+      total_bytes_ += CalculateRawDataSize(batch);
+      total_rows_ += batch->num_rows();
+    }
+
+    ThreadPoolHolder::WithSingleton(1);
+  }
+
+  void TearDown(::benchmark::State& st) override {
+    // Clear pre-loaded batches to release memory
+    batches_.clear();
+    batches_.shrink_to_fit();
+    schema_.reset();
+    ThreadPoolHolder::Release();
+    FormatBenchFixtureBase<>::TearDown(st);
+  }
+
+  protected:
+  // Write data using PackedRecordBatchWriter (V2 path) and return the file path
+  arrow::Status PrepareV2Data(std::string& out_path) {
+    out_path = GetUniquePath("v2_test") + "/data.parquet";
+    std::vector<std::string> paths = {out_path};
+
+    // Build column groups based on schema
+    std::vector<std::vector<int>> column_groups;
+    std::vector<int> all_cols;
+    for (int i = 0; i < schema_->num_fields(); ++i) {
+      all_cols.push_back(i);
+    }
+    column_groups.push_back(all_cols);
+
+    StorageConfig storage_config;
+
+    ARROW_ASSIGN_OR_RAISE(auto writer, PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config, column_groups,
+                                                                     DEFAULT_WRITE_BUFFER_SIZE));
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      ARROW_RETURN_NOT_OK(writer->Write(batch));
+    }
+    auto result = writer->Close();
+
+    return arrow::Status::OK();
+  }
+
+  // Write data using Writer API (V3 path) and return column groups
+  arrow::Status PrepareV3Data(std::shared_ptr<ColumnGroups>& out_cgs) {
+    std::string path = GetUniquePath("v3_test");
+
+    // Use schema-based policy
+    std::string patterns = GetSchemaBasePatterns();
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSchemaBasePolicy(patterns, LOON_FORMAT_PARQUET, schema_));
+
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    if (!writer) {
+      return arrow::Status::Invalid("Failed to create writer");
+    }
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      ARROW_RETURN_NOT_OK(writer->write(batch));
+    }
+    ARROW_ASSIGN_OR_RAISE(out_cgs, writer->close());
+
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<arrow::Schema> schema_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+  int64_t total_bytes_ = 0;
+  int64_t total_rows_ = 0;
+};
+
+//=============================================================================
+// V2: PackedRecordBatchReader Benchmark (Low-level)
+//=============================================================================
+
+BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchReader)(::benchmark::State& st) {
+  // Write data using packed writer
+  std::string path;
+  BENCH_ASSERT_STATUS_OK(PrepareV2Data(path), st);
+
+  std::vector<std::string> paths = {path};
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+
+  for (auto _ : st) {
+    PackedRecordBatchReader reader(fs_, paths, schema_, DEFAULT_READ_BUFFER_SIZE);
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      BENCH_ASSERT_STATUS_OK(reader.ReadNext(&batch), st);
+      if (batch == nullptr)
+        break;
+      total_rows_read += batch->num_rows();
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+    BENCH_ASSERT_STATUS_OK(reader.Close(), st);
+  }
+
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+  st.SetLabel("v2/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchReader)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+//=============================================================================
+// V3: Reader::get_record_batch_reader Benchmark (Top-level)
+//=============================================================================
+
+BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_RecordBatchReader)(::benchmark::State& st) {
+  // Write data using Writer API
+  std::shared_ptr<ColumnGroups> cgs;
+  BENCH_ASSERT_STATUS_OK(PrepareV3Data(cgs), st);
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+
+  for (auto _ : st) {
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    BENCH_ASSERT_NOT_NULL(reader, st);
+
+    BENCH_ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader(), st);
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      BENCH_ASSERT_STATUS_OK(batch_reader->ReadNext(&batch), st);
+      if (batch == nullptr) {
+        break;
+      }
+      total_rows_read += batch->num_rows();
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+  }
+
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+  st.SetLabel("v3-rb/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_RecordBatchReader)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+//=============================================================================
+// V3: Reader::get_chunk_reader Benchmark (Top-level Chunk Access)
+//=============================================================================
+
+// Args: [config_idx]
+BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_ChunkReader)(::benchmark::State& st) {
+  // Write data using Writer API
+  std::shared_ptr<ColumnGroups> cgs;
+  BENCH_ASSERT_STATUS_OK(PrepareV3Data(cgs), st);
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+
+  for (auto _ : st) {
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    BENCH_ASSERT_NOT_NULL(reader, st);
+
+    BENCH_ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0), st);
+
+    size_t total_chunks = chunk_reader->total_number_of_chunks();
+    for (size_t i = 0; i < total_chunks; ++i) {
+      BENCH_ASSERT_AND_ASSIGN(auto batch, chunk_reader->get_chunk(i), st);
+      total_rows_read += batch->num_rows();
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+  }
+
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+  st.SetLabel("v3-chunk/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_ChunkReader)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+//=============================================================================
+// V2: PackedRecordBatchWriter Benchmark (Low-level)
+//=============================================================================
+
+BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)(::benchmark::State& st) {
+  std::string base_path = GetUniquePath("v2_write_bench");
+
+  // Build column groups based on schema
+  std::vector<std::vector<int>> column_groups;
+  std::vector<int> all_cols;
+  for (int i = 0; i < schema_->num_fields(); ++i) {
+    all_cols.push_back(i);
+  }
+  column_groups.push_back(all_cols);
+
+  for (auto _ : st) {
+    std::string path = base_path + "/data.parquet";
+    std::vector<std::string> paths = {path};
+    StorageConfig storage_config;
+
+    BENCH_ASSERT_AND_ASSIGN(
+        auto writer,
+        PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config, column_groups, DEFAULT_WRITE_BUFFER_SIZE),
+        st);
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      BENCH_ASSERT_STATUS_OK(writer->Write(batch), st);
+    }
+    auto result = writer->Close();
+
+    // Cleanup for next iteration
+    BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path), st);
+    BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path), st);
+  }
+
+  int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
+  int64_t total_rows = total_rows_ * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.SetLabel("v2-writer/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+//=============================================================================
+// V3: Writer API Benchmark (Top-level)
+//=============================================================================
+
+BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_Writer)(::benchmark::State& st) {
+  std::string base_path = GetUniquePath("v3_write_bench");
+
+  for (auto _ : st) {
+    // Use schema-based policy
+    std::string patterns = GetSchemaBasePatterns();
+    BENCH_ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns, LOON_FORMAT_PARQUET, schema_), st);
+    auto writer = Writer::create(base_path, schema_, std::move(policy), properties_);
+    BENCH_ASSERT_NOT_NULL(writer, st);
+
+    // Write all pre-loaded batches
+    for (const auto& batch : batches_) {
+      BENCH_ASSERT_STATUS_OK(writer->write(batch), st);
+    }
+    BENCH_ASSERT_AND_ASSIGN(auto cgs, writer->close(), st);
+
+    // Cleanup for next iteration
+    BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path), st);
+    BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path), st);
+  }
+
+  int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
+  int64_t total_rows = total_rows_ * static_cast<int64_t>(st.iterations());
+  ReportThroughput(st, total_bytes, total_rows);
+  st.SetLabel("v3-writer/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_Writer)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+//=============================================================================
+// Typical Benchmarks
+// Run with: --benchmark_filter="Typical/"
+//=============================================================================
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchReader)
+    ->Name("Typical/V2_Reader")
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_RecordBatchReader)
+    ->Name("Typical/V3_Reader")
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)
+    ->Name("Typical/V2_Writer")
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_Writer)
+    ->Name("Typical/V3_Writer")
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+}  // namespace benchmark
+}  // namespace milvus_storage

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -133,7 +133,8 @@ class StorageConan(ConanFile):
         self.requires("google-cloud-cpp/2.5.0@milvus/2.4#c5591ab30b26b53ea6068af6f07128d3")
         self.requires("googleapis/cci.20221108#65604e1b3b9a6b363044da625b201a2a")
         if self.options.with_benchmark:
-            self.requires("benchmark/1.7.0")
+            # don't use 1.7.0 which have core when `--help`.
+            self.requires("benchmark/1.8.3")
         if self.options.with_ut:
             self.requires("gtest/1.13.0")
         if self.settings.os == "Macos":


### PR DESCRIPTION
This adds a benchmark framework to compare Parquet, Vortex, and Lance formats.

The benchmarks cover the following dimensions:

1. Format layer write performance and compression analysis
2. Format layer read including full scan, column projection, and random access (take)
3. V2 packed API vs V3 high-level API for both read and write
4. Storage layer with transactions comparing MilvusStorage (Parquet/Vortex) against Lance native API
5. Multi-reader concurrency under different thread pool sizes

The benchmarks report throughput (MB/s and rows/s), compression ratio, file size, and peak memory usage. Also for the `Multi-reader concurrency`, the benchark report the number of thread to make sure resource is under control.

Added a "Typical" benchmark suite with representative parameters for quick validation. Use --benchmark_filter="Typical/" to run a fast sanity check instead of the full matrix.