### PR TITLE
enhance: extend Lance bridge with dataset-level Scan and Take operations

### DIFF
--- a/cpp/include/milvus-storage/format/lance/lance_common.h
+++ b/cpp/include/milvus-storage/format/lance/lance_common.h
@@ -1,0 +1,70 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <arrow/result.h>
+
+#include "lance_bridge.h"
+#include "milvus-storage/filesystem/fs.h"
+
+namespace milvus_storage::lance {
+
+/// Parse a Lance URI to extract the base path and fragment ID.
+/// URI format: {base_path}?fragment_id={fragment_id}
+///
+/// @param uri The full URI containing base path and fragment ID
+/// @return A pair of (base_path, fragment_id) or an error if the format is invalid
+arrow::Result<std::pair<std::string, uint64_t>> ParseLanceUri(const std::string& uri);
+
+/// Construct a Lance URI from a base path and fragment ID.
+///
+/// @param base_path The base path (e.g., "s3://bucket/path" or "/tmp/path")
+/// @param fragment_id The fragment ID to append
+/// @return The constructed URI in format: {base_path}?fragment_id={fragment_id}
+std::string MakeLanceUri(const std::string& base_path, uint64_t fragment_id);
+
+/// Build a Lance-compatible base URI from ArrowFileSystemConfig and a relative path.
+///
+/// For cloud storage, constructs URIs like:
+/// - AWS S3: s3://bucket/path
+/// - Azure: az://container/path
+/// - GCP: gs://bucket/path
+/// - Aliyun OSS: oss://bucket/path
+///
+/// For local storage, returns the absolute path.
+///
+/// Returns error for unsupported providers (Tencent, Huawei).
+///
+/// @param config The filesystem configuration containing storage type and bucket info
+/// @param relative_path The relative path within the bucket/filesystem
+/// @return The constructed base URI or an error
+arrow::Result<std::string> BuildLanceBaseUri(const ArrowFileSystemConfig& config, const std::string& relative_path);
+
+/// Convert ArrowFileSystemConfig to LanceStorageOptions for cloud storage access.
+/// Only populates options when storage_type is not "local".
+///
+/// Supported cloud providers:
+/// - AWS S3: aws_access_key_id, aws_secret_access_key, aws_region, aws_endpoint, allow_http
+/// - Azure: azure_storage_account_name, azure_storage_account_key, azure_endpoint, allow_http
+/// - GCP: credentials via environment/service account
+/// - Aliyun OSS: oss_access_key_id, oss_secret_access_key, oss_region, oss_endpoint
+///
+/// Throws LanceException for unsupported providers (Tencent, Huawei).
+LanceStorageOptions ToLanceStorageOptions(const ArrowFileSystemConfig& config);
+
+}  // namespace milvus_storage::lance

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -25,8 +25,6 @@ namespace milvus_storage::lance {
 
 class LanceTableReader final : public FormatReader, public std::enable_shared_from_this<LanceTableReader> {
   public:
-  static arrow::Result<std::pair<std::string, uint64_t>> parse_uri(const std::string& uri);
-
   LanceTableReader(const std::shared_ptr<BlockingDataset> dataset,
                    uint64_t fragment_id,
                    const std::shared_ptr<arrow::Schema>& schema,

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -5809,6 +5809,7 @@ dependencies = [
  "cxx-build",
  "futures",
  "lance",
+ "lance-encoding",
  "lance-index",
  "lance-io",
  "lance-table",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -28,10 +28,11 @@ vortex = "0.56.0"
 vortex-io = { version = "0.56.0", features = ["tokio"] }
 
 # Lance Ecosystem
-lance = "=1.0.0"
-lance-index = "=1.0.0"
-lance-io = "=1.0.0"
-lance-table = "=1.0.0"
+lance = "1.0.0"
+lance-encoding = "1.0.0"
+lance-index = "1.0.0"
+lance-io = "1.0.0"
+lance-table = "1.0.0"
 
 # CXX bridge
 cxx = "1.0.184"

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -19,6 +19,7 @@
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
+#include "milvus-storage/format/lance/lance_common.h"
 #include "milvus-storage/filesystem/fs.h"
 
 namespace milvus_storage {
@@ -49,7 +50,7 @@ arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
   } else if (format == LOON_FORMAT_LANCE_TABLE) {
     std::string base_path;
     uint64_t fragment_id;
-    ARROW_ASSIGN_OR_RAISE(std::tie(base_path, fragment_id), lance::LanceTableReader::parse_uri(file.path));
+    ARROW_ASSIGN_OR_RAISE(std::tie(base_path, fragment_id), lance::ParseLanceUri(file.path));
     format_reader = std::make_shared<lance::LanceTableReader>(base_path, fragment_id, schema, properties);
   } else {
     return arrow::Status::Invalid(fmt::format("Unknown file format: {}", format));

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -1,0 +1,207 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/format/lance/lance_common.h"
+
+#include <fmt/format.h>
+
+namespace milvus_storage::lance {
+
+static const std::string kLanceUriDelimiter = "?fragment_id=";
+
+//------------------------------------------------------------------------------
+// URI Parsing and Construction
+//------------------------------------------------------------------------------
+
+arrow::Result<std::pair<std::string, uint64_t>> ParseLanceUri(const std::string& uri) {
+  auto pos = uri.find(kLanceUriDelimiter);
+  if (pos == std::string::npos) {
+    return arrow::Status::Invalid("Invalid uri format: ", uri,
+                                  ". Expected format: {base_path}?fragment_id={fragment_id}");
+  }
+
+  uint64_t fragment_id = 0;
+  try {
+    fragment_id = std::stoull(uri.substr(pos + kLanceUriDelimiter.length()));
+  } catch (const std::exception& e) {
+    return arrow::Status::Invalid(fmt::format("Invalid fragment_id in uri: {}", uri));
+  }
+
+  auto base_path = uri.substr(0, pos);
+  return std::make_pair(base_path, fragment_id);
+}
+
+std::string MakeLanceUri(const std::string& base_path, uint64_t fragment_id) {
+  return base_path + kLanceUriDelimiter + std::to_string(fragment_id);
+}
+
+//------------------------------------------------------------------------------
+// Cloud Provider URI Scheme Mapping
+//------------------------------------------------------------------------------
+
+static arrow::Result<std::string> GetCloudUriScheme(const std::string& provider) {
+  if (provider == kCloudProviderAWS) {
+    return "s3";
+  }
+  if (provider == kCloudProviderAzure) {
+    return "az";
+  }
+  if (provider == kCloudProviderGCP) {
+    return "gs";
+  }
+  if (provider == kCloudProviderAliyun) {
+    return "oss";
+  }
+  if (provider == kCloudProviderTencent || provider == kCloudProviderHuawei) {
+    return arrow::Status::Invalid("Lance does not support cloud provider: " + provider);
+  }
+  return arrow::Status::Invalid("Unknown cloud provider: " + provider);
+}
+
+arrow::Result<std::string> BuildLanceBaseUri(const ArrowFileSystemConfig& config, const std::string& relative_path) {
+  if (config.storage_type == "local") {
+    return config.root_path + "/" + relative_path;
+  }
+
+  if (config.bucket_name.empty()) {
+    return arrow::Status::Invalid("Bucket name is required for cloud storage");
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto scheme, GetCloudUriScheme(config.cloud_provider));
+  return scheme + "://" + config.bucket_name + "/" + relative_path;
+}
+
+//------------------------------------------------------------------------------
+// Endpoint URL Helpers
+//------------------------------------------------------------------------------
+
+struct EndpointInfo {
+  std::string url;
+  bool allow_http = false;
+};
+
+static EndpointInfo BuildEndpointUrl(const std::string& address) {
+  if (address.empty()) {
+    return {};
+  }
+
+  // If already has scheme, check if it's http
+  if (address.find("://") != std::string::npos) {
+    bool is_http = (address.find("http://") == 0);
+    return {address, is_http};
+  }
+
+  // Default to HTTPS for cloud storage
+  return {"https://" + address, false};
+}
+
+static std::string BuildAzureEndpointAddress(const std::string& address, const std::string& account_name) {
+  std::string host = address;
+  std::string scheme_prefix;
+
+  // Extract scheme if present
+  size_t scheme_pos = host.find("://");
+  if (scheme_pos != std::string::npos) {
+    scheme_prefix = host.substr(0, scheme_pos + 3);
+    host = host.substr(scheme_pos + 3);
+  }
+
+  // Prepend account name if not already present
+  // Azure endpoint format: https://<account>.blob.core.windows.net
+  if (!account_name.empty() && host.find(account_name + ".") != 0) {
+    host = account_name + "." + host;
+  }
+
+  return scheme_prefix + host;
+}
+
+//------------------------------------------------------------------------------
+// Provider-Specific Storage Options
+//------------------------------------------------------------------------------
+
+static void SetOptionIfNotEmpty(LanceStorageOptions& options, const std::string& key, const std::string& value) {
+  if (!value.empty()) {
+    options[key] = value;
+  }
+}
+
+static void SetEndpointOptions(LanceStorageOptions& options,
+                               const std::string& endpoint_key,
+                               const std::string& address) {
+  if (address.empty()) {
+    return;
+  }
+
+  auto endpoint_info = BuildEndpointUrl(address);
+  options[endpoint_key] = endpoint_info.url;
+  if (endpoint_info.allow_http) {
+    options["allow_http"] = "true";
+  }
+}
+
+static void ConfigureAwsOptions(LanceStorageOptions& options, const ArrowFileSystemConfig& config) {
+  SetOptionIfNotEmpty(options, "aws_access_key_id", config.access_key_id);
+  SetOptionIfNotEmpty(options, "aws_secret_access_key", config.access_key_value);
+  SetOptionIfNotEmpty(options, "aws_region", config.region);
+  SetEndpointOptions(options, "aws_endpoint", config.address);
+}
+
+static void ConfigureAzureOptions(LanceStorageOptions& options, const ArrowFileSystemConfig& config) {
+  SetOptionIfNotEmpty(options, "azure_storage_account_name", config.access_key_id);
+  SetOptionIfNotEmpty(options, "azure_storage_account_key", config.access_key_value);
+
+  if (!config.address.empty()) {
+    auto azure_address = BuildAzureEndpointAddress(config.address, config.access_key_id);
+    SetEndpointOptions(options, "azure_endpoint", azure_address);
+  }
+}
+
+static void ConfigureAliyunOptions(LanceStorageOptions& options, const ArrowFileSystemConfig& config) {
+  SetOptionIfNotEmpty(options, "oss_access_key_id", config.access_key_id);
+  SetOptionIfNotEmpty(options, "oss_secret_access_key", config.access_key_value);
+  SetOptionIfNotEmpty(options, "oss_region", config.region);
+  SetEndpointOptions(options, "oss_endpoint", config.address);
+}
+
+//------------------------------------------------------------------------------
+// Main Conversion Function
+//------------------------------------------------------------------------------
+
+LanceStorageOptions ToLanceStorageOptions(const ArrowFileSystemConfig& config) {
+  LanceStorageOptions options;
+
+  if (config.storage_type == "local") {
+    return options;
+  }
+
+  const auto& provider = config.cloud_provider;
+
+  if (provider == kCloudProviderAWS) {
+    ConfigureAwsOptions(options, config);
+  } else if (provider == kCloudProviderAzure) {
+    ConfigureAzureOptions(options, config);
+  } else if (provider == kCloudProviderGCP) {
+    // GCP uses default credentials, no additional options needed
+  } else if (provider == kCloudProviderAliyun) {
+    ConfigureAliyunOptions(options, config);
+  } else if (provider == kCloudProviderTencent || provider == kCloudProviderHuawei) {
+    throw LanceException("Lance does not support cloud provider: " + provider);
+  } else {
+    throw LanceException("Unknown cloud provider: " + provider);
+  }
+
+  return options;
+}
+
+}  // namespace milvus_storage::lance


### PR DESCRIPTION
Previously the Lance bridge only supported local filesystem and fragment-level read. This extends it to support cloud storage (S3/GCS/Azure/Aliyun) and adds dataset-level Scan and Take operations.

Added LanceStorageOptions to pass cloud credentials and endpoint configuration to Lance. Also added helper functions in lance_common.h to build Lance-compatible URIs for different cloud providers.

Added BlockingScanner class and dataset_take() for dataset-level operations. These work on the entire dataset rather than individual fragments, which is more convenient for benchmarking and general use cases.

Updated LanceTableReader and LanceTableWriter to use the new cloud storage options so they work properly on S3 and other cloud backends.