### PR TITLE
 feature: add text column support with LOB storage

### DIFF
--- a/cpp/include/milvus-storage/common/arrow_util.h
+++ b/cpp/include/milvus-storage/common/arrow_util.h
@@ -15,13 +15,32 @@
 #pragma once
 #include <memory>
 #include <cstdint>
+#include <string>
 
 #include <arrow/table.h>
 #include <arrow/result.h>
+#include <arrow/util/key_value_metadata.h>
 #include <parquet/arrow/reader.h>
 #include <arrow/filesystem/filesystem.h>
 
+#include "milvus-storage/common/constants.h"
+
 namespace milvus_storage {
+
+// Extract field_id from Arrow field.
+// Tries PARQUET:field_id metadata first, falls back to parsing field name as integer.
+inline int64_t GetFieldId(const std::shared_ptr<arrow::Field>& field) {
+  auto metadata = field->metadata();
+  if (metadata && metadata->Contains(ARROW_FIELD_ID_KEY)) {
+    return std::stoll(metadata->Get(ARROW_FIELD_ID_KEY).ValueOrDie());
+  }
+  try {
+    return std::stoll(field->name());
+  } catch (...) {
+    return -1;
+  }
+}
+
 arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> MakeArrowFileReader(arrow::fs::FileSystem& fs,
                                                                                  const std::string& file_path);
 

--- a/cpp/include/milvus-storage/common/layout.h
+++ b/cpp/include/milvus-storage/common/layout.h
@@ -58,6 +58,9 @@ inline const std::string kDataPath = kDataDir + kSep;
 inline const std::string kDeltaPath = kDeltaDir + kSep;
 inline const std::string kStatsPath = kStatsDir + kSep;
 inline const std::string kIndexPath = kIndexDir + kSep;
+// LOB files live at partition level (sibling to {seg_id}/), so from the segment
+// base_path ({partition}/{seg_id}) we go up one level: {partition}/{seg_id}/../lobs/
+inline const std::string kLobPath = std::string("..") + kSep + "lobs" + kSep;
 
 std::string get_manifest_path(const std::string& base_path);
 std::string get_manifest_filename(const size_t& version);

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -220,6 +220,26 @@ typedef struct LoonStatsLog {
 } LoonStatsLog;
 
 /**
+ * @brief C structure representing a single LOB file info
+ * Used for TEXT column compaction strategy decision (hole ratio calculation)
+ */
+typedef struct LoonLobFileInfo {
+  const char* path;         ///< Relative path to the LOB file
+  int64_t field_id;         ///< Field ID this LOB file belongs to
+  int64_t total_rows;       ///< Total number of rows in the LOB file
+  int64_t valid_rows;       ///< Number of valid (non-deleted) rows
+  int64_t file_size_bytes;  ///< Size of the LOB file in bytes
+} LoonLobFileInfo;
+
+/**
+ * @brief C structure representing LOB files in manifest
+ */
+typedef struct LoonLobFiles {
+  LoonLobFileInfo* files;  ///< Array of LOB file info
+  uint32_t num_files;      ///< Number of LOB files
+} LoonLobFiles;
+
+/**
  * @brief C structure representing a Manifest
  */
 typedef struct LoonManifest {
@@ -231,6 +251,9 @@ typedef struct LoonManifest {
 
   // Stats
   LoonStatsLog stats;
+
+  // LOB files (TEXT column metadata)
+  LoonLobFiles lob_files;
 } LoonManifest;
 
 /**
@@ -714,6 +737,16 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
                                                       const char* const* metadata_values,
                                                       size_t metadata_len);
 
+/**
+ * @brief Add a LOB file info to the transaction updates
+ * Used during compaction REUSE_ALL mode to merge LOB file references
+ *
+ * @param handle Transaction handle
+ * @param lob_file LOB file info to add
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_transaction_add_lob_file(LoonTransactionHandle handle, const LoonLobFileInfo* lob_file);
+
 // ==================== End of Manifest C Interface ====================
 
 // ==================== Test-only Interface ====================
@@ -726,6 +759,205 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
  */
 void loon_reset_context(void);
 #endif  // BUILD_GTEST
+
+// ==================== SegmentWriter C Interface ====================
+
+/// opaque handle for SegmentWriter
+typedef uintptr_t LoonSegmentWriterHandle;
+
+/// configuration for TEXT column
+typedef struct LoonLobColumnConfig {
+  const char* lob_base_path;      // base path for LOB files
+  int64_t field_id;               // field ID
+  int64_t inline_threshold;       // threshold for inline storage (bytes)
+  int64_t max_lob_file_bytes;     // max size per LOB file
+  int64_t flush_threshold_bytes;  // flush threshold
+  bool rewrite_mode;              // true = input is LOB references, decode & rewrite
+} LoonLobColumnConfig;
+
+/// configuration for SegmentWriter
+typedef struct LoonSegmentWriterConfig {
+  const char* segment_path;          // segment path for manifest and data
+  LoonLobColumnConfig* lob_columns;  // TEXT column configurations
+  size_t num_lob_columns;            // number of TEXT columns
+} LoonSegmentWriterConfig;
+
+/// output of SegmentWriter close — contains column groups + LOB file info
+/// caller is responsible for committing these via Transaction
+typedef struct LoonSegmentWriteOutput {
+  LoonColumnGroups* column_groups;  // parquet column group metadata
+  LoonLobFileInfo* lob_files;       // LOB file metadata array (caller must free)
+  size_t num_lob_files;             // number of LOB files
+  int64_t rows_written;             // number of rows written
+} LoonSegmentWriteOutput;
+
+/**
+ * @brief Creates a new SegmentWriter
+ *
+ * @param schema Arrow schema handle
+ * @param config Writer configuration
+ * @param properties Storage properties
+ * @param out_handle Output writer handle
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_writer_new(struct ArrowSchema* schema,
+                                                 const LoonSegmentWriterConfig* config,
+                                                 const LoonProperties* properties,
+                                                 LoonSegmentWriterHandle* out_handle);
+
+/**
+ * @brief Writes a record batch to the segment
+ *
+ * @param handle SegmentWriter handle
+ * @param array Arrow array representing the record batch
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_writer_write(LoonSegmentWriterHandle handle, struct ArrowArray* array);
+
+/**
+ * @brief Flushes pending data to storage
+ *
+ * @param handle SegmentWriter handle
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_writer_flush(LoonSegmentWriterHandle handle);
+
+/**
+ * @brief Closes the writer and returns write output (does NOT commit manifest)
+ *
+ * Returns ColumnGroups + LOB file metadata. Caller must commit via Transaction.
+ *
+ * @param handle SegmentWriter handle
+ * @param out_output Output containing column groups and LOB file info
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_writer_close(LoonSegmentWriterHandle handle, LoonSegmentWriteOutput* out_output);
+
+/**
+ * @brief Destroys a SegmentWriter handle
+ *
+ * @param handle SegmentWriter handle to destroy
+ */
+FFI_EXPORT void loon_segment_writer_destroy(LoonSegmentWriterHandle handle);
+
+/**
+ * @brief Frees a SegmentWriteOutput
+ *
+ * @param output Output to free
+ */
+FFI_EXPORT void loon_segment_write_output_free(LoonSegmentWriteOutput* output);
+
+// ==================== End of SegmentWriter C Interface ====================
+
+// ==================== SegmentReader C Interface ====================
+
+/// opaque handle for SegmentReader
+typedef uintptr_t LoonSegmentReaderHandle;
+
+/// configuration for SegmentReader
+typedef struct LoonSegmentReaderConfig {
+  LoonLobColumnConfig* lob_columns;  ///< TEXT column configurations (reuses SegmentWriter's struct)
+  size_t num_lob_columns;            ///< number of TEXT columns
+  int64_t read_buffer_size;          ///< read buffer size (0 = default 64MB)
+} LoonSegmentReaderConfig;
+
+/**
+ * @brief Opens a SegmentReader from manifest path
+ *
+ * TEXT columns are automatically resolved: LOBReferences in parquet are decoded
+ * to actual text strings in the returned RecordBatches.
+ *
+ * @param segment_path Base path where manifest and data files are stored
+ * @param version Manifest version to read (-1 = latest)
+ * @param schema Arrow schema with TEXT columns as utf8() type
+ * @param needed_columns Column names to read (NULL = all columns)
+ * @param num_columns Number of needed columns
+ * @param config Reader configuration with TEXT column LOB paths
+ * @param properties Storage properties
+ * @param out_handle Output reader handle
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_reader_open(const char* segment_path,
+                                                  int64_t version,
+                                                  struct ArrowSchema* schema,
+                                                  const char** needed_columns,
+                                                  int64_t num_columns,
+                                                  const LoonSegmentReaderConfig* config,
+                                                  const LoonProperties* properties,
+                                                  LoonSegmentReaderHandle* out_handle);
+
+/**
+ * @brief Gets an ArrowArrayStream from the SegmentReader
+ *
+ * TEXT columns are returned as utf8 strings (LOBReferences auto-resolved).
+ *
+ * @param handle SegmentReader handle
+ * @param out_stream Output ArrowArrayStream
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_reader_get_stream(LoonSegmentReaderHandle handle,
+                                                        struct ArrowArrayStream* out_stream);
+
+/**
+ * @brief Random access: extract specific rows by indices
+ *
+ * TEXT columns are automatically resolved (LOBReferences decoded to utf8).
+ * Returns result as an ArrowArrayStream containing the selected rows.
+ *
+ * @param handle SegmentReader handle
+ * @param row_indices Array of global row indices (0-based)
+ * @param num_indices Number of row indices
+ * @param parallelism Number of parallel I/O threads (0 = default 1)
+ * @param out_stream Output ArrowArrayStream with selected rows
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_reader_take(LoonSegmentReaderHandle handle,
+                                                  const int64_t* row_indices,
+                                                  int64_t num_indices,
+                                                  int64_t parallelism,
+                                                  struct ArrowArrayStream* out_stream);
+
+/**
+ * @brief Gets a filtered ArrowArrayStream with predicate support
+ *
+ * TEXT columns are automatically resolved (LOBReferences decoded to utf8).
+ *
+ * @param handle SegmentReader handle
+ * @param predicate Filter expression string (NULL or empty = no filtering)
+ * @param out_stream Output ArrowArrayStream
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_reader_get_filtered_stream(LoonSegmentReaderHandle handle,
+                                                                 const char* predicate,
+                                                                 struct ArrowArrayStream* out_stream);
+
+/**
+ * @brief Gets a ChunkReader for a specific column group from the SegmentReader
+ *
+ * NOTE: chunk-level data is NOT LOB-resolved. TEXT columns remain as binary LOBReferences.
+ * This is intended for segment load / mmap scenarios where raw storage format is needed.
+ *
+ * @param handle SegmentReader handle
+ * @param column_group_index Index of the column group
+ * @param needed_columns Optional column names to read (NULL = all)
+ * @param num_columns Number of column names
+ * @param out_handle Output ChunkReader handle
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_segment_reader_get_chunk_reader(LoonSegmentReaderHandle handle,
+                                                              int64_t column_group_index,
+                                                              const char* const* needed_columns,
+                                                              size_t num_columns,
+                                                              LoonChunkReaderHandle* out_handle);
+
+/**
+ * @brief Destroys a SegmentReader handle
+ *
+ * @param handle SegmentReader handle to destroy
+ */
+FFI_EXPORT void loon_segment_reader_destroy(LoonSegmentReaderHandle handle);
+
+// ==================== End of SegmentReader C Interface ====================
 
 #endif  // LOON_FFI_C
 

--- a/cpp/include/milvus-storage/ffi_jni.h
+++ b/cpp/include/milvus-storage/ffi_jni.h
@@ -420,6 +420,83 @@ JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transacti
                                                                                           jobject obj,
                                                                                           jlong transaction_handle);
 
+// ==================== JNI SegmentWriter Interface ====================
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterNew(JNIEnv* env,
+                                                                                    jobject obj,
+                                                                                    jlong schema_ptr,
+                                                                                    jstring segment_path,
+                                                                                    jlongArray lob_field_ids,
+                                                                                    jobjectArray lob_base_paths,
+                                                                                    jlongArray lob_inline_thresholds,
+                                                                                    jlongArray lob_max_file_bytes,
+                                                                                    jlongArray lob_flush_thresholds,
+                                                                                    jlong properties_ptr);
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterWrite(JNIEnv* env,
+                                                                                     jobject obj,
+                                                                                     jlong handle,
+                                                                                     jlong array_ptr);
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterFlush(JNIEnv* env,
+                                                                                     jobject obj,
+                                                                                     jlong handle);
+
+// Returns LoonSegmentWriteOutput as two values: columnGroupsPtr and lobFilesJson
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterClose(JNIEnv* env,
+                                                                                      jobject obj,
+                                                                                      jlong handle,
+                                                                                      jlongArray out_lob_field_ids,
+                                                                                      jobjectArray out_lob_paths,
+                                                                                      jlongArray out_lob_total_rows,
+                                                                                      jlongArray out_lob_valid_rows,
+                                                                                      jlongArray out_lob_file_sizes);
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterDestroy(JNIEnv* env,
+                                                                                       jobject obj,
+                                                                                       jlong handle);
+
+// ==================== JNI SegmentReader Interface ====================
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderOpen(JNIEnv* env,
+                                                                                     jobject obj,
+                                                                                     jstring segment_path,
+                                                                                     jlong version,
+                                                                                     jlong schema_ptr,
+                                                                                     jobjectArray needed_columns,
+                                                                                     jlongArray lob_field_ids,
+                                                                                     jobjectArray lob_base_paths,
+                                                                                     jlongArray lob_inline_thresholds,
+                                                                                     jlongArray lob_max_file_bytes,
+                                                                                     jlongArray lob_flush_thresholds,
+                                                                                     jlong properties_ptr);
+
+// Returns ArrowArrayStream pointer. TEXT columns are auto-decoded to utf8 strings.
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderGetStream(JNIEnv* env,
+                                                                                          jobject obj,
+                                                                                          jlong handle);
+
+// Random access: extract specific rows by indices. Returns ArrowArrayStream pointer.
+// TEXT columns are auto-decoded to utf8 strings.
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderTake(
+    JNIEnv* env, jobject obj, jlong handle, jlongArray row_indices, jint parallelism);
+
+// Sequential read with predicate filtering. Returns ArrowArrayStream pointer.
+// TEXT columns are auto-decoded to utf8 strings.
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderGetFilteredStream(JNIEnv* env,
+                                                                                                  jobject obj,
+                                                                                                  jlong handle,
+                                                                                                  jstring predicate);
+
+// Get ChunkReader for a specific column group. Returns ChunkReader handle.
+// NOTE: chunk data is NOT LOB-resolved (TEXT columns remain as binary refs).
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderGetChunkReader(
+    JNIEnv* env, jobject obj, jlong handle, jlong column_group_index, jobjectArray needed_columns);
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderDestroy(JNIEnv* env,
+                                                                                       jobject obj,
+                                                                                       jlong handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpp/include/milvus-storage/lob_column/lob_column_manager.h
+++ b/cpp/include/milvus-storage/lob_column/lob_column_manager.h
@@ -1,0 +1,111 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/status.h>
+#include <arrow/result.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "milvus-storage/properties.h"
+
+namespace milvus_storage::lob_column {
+
+class LobColumnWriter;
+class LobColumnReader;
+
+// data type stored in the LOB column
+enum class LobDataType {
+  kText,    // UTF-8 text
+  kBinary,  // arbitrary bytes
+};
+
+// configuration for a single LOB column (TEXT or BINARY)
+struct LobColumnConfig {
+  // data type determines Arrow type and field name in Vortex files
+  LobDataType data_type = LobDataType::kText;
+
+  // lob base path: {partition_path}/lobs/{field_id}
+  // Go layer constructs the full path and passes it to C++
+  std::string lob_base_path;
+
+  // field id of the LOB column
+  int64_t field_id = 0;
+
+  // inline threshold in bytes (data smaller than this is stored inline)
+  // inline data is variable length, no maximum limit
+  // default: 64KB
+  size_t inline_threshold = 64 * 1024;
+
+  // maximum bytes per LOB file before rolling to a new file
+  // default: 512MB
+  size_t max_lob_file_bytes = 512 * 1024 * 1024;
+
+  // flush threshold: when buffered LOB data exceeds this size, flush to file
+  // this prevents memory buildup during batch writes
+  // default: 64MB
+  size_t flush_threshold_bytes = 64 * 1024 * 1024;
+
+  // rewrite mode: when true, Write() input contains encoded LOB references (binary)
+  // that must be decoded (via LobColumnReader) before re-encoding as new LOB data.
+  // Used during compaction REWRITE_ALL to reclaim space from deleted rows.
+  // When false (default), Write() input is raw text/binary data.
+  bool rewrite_mode = false;
+
+  // storage properties (filesystem config, compression, etc.)
+  api::Properties properties;
+};
+
+// manager for a single LOB column (TEXT or BINARY)
+// each LOB field in a collection should have its own manager instance
+//
+// usage:
+//   auto manager = LobColumnManager::Create(fs, config);
+//   auto writer = manager->CreateWriter();
+//   auto refs = writer->WriteBatch(texts);  // or WriteData() for binary
+//   writer->Close();
+//
+//   auto reader = manager->CreateReader();
+//   auto texts = reader->ReadBatch(encoded_refs);  // or ReadData() for binary
+class LobColumnManager {
+  public:
+  virtual ~LobColumnManager() = default;
+
+  // create a new manager for the specified LOB column
+  static arrow::Result<std::unique_ptr<LobColumnManager>> Create(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                 const LobColumnConfig& config);
+
+  // create a writer for this LOB column
+  // the writer manages LOB file lifecycle and generates LOBReferences
+  virtual arrow::Result<std::unique_ptr<LobColumnWriter>> CreateWriter() = 0;
+
+  // create a reader for this LOB column
+  // the reader can resolve LOBReferences and read data from LOB files
+  virtual arrow::Result<std::unique_ptr<LobColumnReader>> CreateReader() = 0;
+
+  // get the configuration
+  virtual const LobColumnConfig& GetConfig() const = 0;
+
+  // get the filesystem
+  virtual std::shared_ptr<arrow::fs::FileSystem> GetFileSystem() const = 0;
+
+  protected:
+  LobColumnManager() = default;
+};
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/include/milvus-storage/lob_column/lob_column_reader.h
+++ b/cpp/include/milvus-storage/lob_column/lob_column_reader.h
@@ -1,0 +1,124 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/table.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "milvus-storage/lob_column/lob_reference.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+
+namespace milvus_storage::lob_column {
+
+// encoded reference with size information
+// needed because inline data is variable length
+struct EncodedRef {
+  const uint8_t* data;
+  size_t size;
+};
+
+// reader for a single LOB column (TEXT or BINARY)
+// resolves encoded references and reads data from LOB files
+//
+// the reader handles both inline and LOB references:
+//   - inline (flag=0x00): data is directly in the reference, variable length
+//   - LOB (flag=0x01): data is in a Vortex LOB file, fixed 24 bytes
+//
+// for batch reads, the reader optimizes by:
+//   1. grouping references by file_id_str (UUID string)
+//   2. using Vortex take() API for efficient random access
+//   3. caching open file handles
+//
+// thread safety: not thread-safe, use one reader per thread
+class LobColumnReader {
+  public:
+  virtual ~LobColumnReader() = default;
+
+  // --- generic data interface (works for both text and binary) ---
+
+  // read a single entry from an encoded reference
+  // handles both inline (variable length) and LOB (24 bytes) references
+  virtual arrow::Result<std::vector<uint8_t>> ReadData(const uint8_t* encoded_ref, size_t ref_size) = 0;
+
+  // read multiple entries from encoded references
+  // more efficient than calling ReadData() repeatedly as it groups reads by file_id
+  virtual arrow::Result<std::vector<std::vector<uint8_t>>> ReadBatchData(
+      const std::vector<EncodedRef>& encoded_refs) = 0;
+
+  // read data from a BinaryArray of encoded references
+  // returns a BinaryArray with the decoded data
+  virtual arrow::Result<std::shared_ptr<arrow::BinaryArray>> ReadArrowArray(
+      const std::shared_ptr<arrow::BinaryArray>& encoded_refs) = 0;
+
+  // take entries by row indices from a specific LOB file
+  // returns data in the order of row_offsets
+  virtual arrow::Result<std::vector<std::vector<uint8_t>>> TakeData(const std::string& file_id_str,
+                                                                    const std::vector<int32_t>& row_offsets) = 0;
+
+  // testonly: production code uses ReadData() directly
+  arrow::Result<std::string> ReadText(const uint8_t* encoded_ref, size_t ref_size) {
+    ARROW_ASSIGN_OR_RAISE(auto data, ReadData(encoded_ref, ref_size));
+    return std::string(reinterpret_cast<const char*>(data.data()), data.size());
+  }
+
+  // testonly: production code uses ReadBatchData() directly
+  arrow::Result<std::vector<std::string>> ReadBatch(const std::vector<EncodedRef>& encoded_refs) {
+    ARROW_ASSIGN_OR_RAISE(auto data_vec, ReadBatchData(encoded_refs));
+    std::vector<std::string> results;
+    results.reserve(data_vec.size());
+    for (const auto& d : data_vec) {
+      results.emplace_back(reinterpret_cast<const char*>(d.data()), d.size());
+    }
+    return results;
+  }
+
+  arrow::Result<std::vector<std::string>> Take(const std::string& file_id_str,
+                                               const std::vector<int32_t>& row_offsets) {
+    ARROW_ASSIGN_OR_RAISE(auto data_vec, TakeData(file_id_str, row_offsets));
+    std::vector<std::string> results;
+    results.reserve(data_vec.size());
+    for (const auto& d : data_vec) {
+      results.emplace_back(reinterpret_cast<const char*>(d.data()), d.size());
+    }
+    return results;
+  }
+
+  // --- lifecycle methods ---
+
+  // close the reader and release resources
+  virtual arrow::Status Close() = 0;
+
+  // check if the reader is closed
+  virtual bool IsClosed() const = 0;
+
+  // clear the file handle cache
+  virtual void ClearCache() = 0;
+
+  protected:
+  LobColumnReader() = default;
+};
+
+// factory function to create LobColumnReader
+arrow::Result<std::unique_ptr<LobColumnReader>> CreateLobColumnReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                      const LobColumnConfig& config);
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/include/milvus-storage/lob_column/lob_column_writer.h
+++ b/cpp/include/milvus-storage/lob_column/lob_column_writer.h
@@ -1,0 +1,130 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "milvus-storage/lob_column/lob_column_manager.h"
+
+namespace milvus_storage::lob_column {
+
+// statistics for LOB column writer
+struct LobColumnWriterStats {
+  int64_t total_entries = 0;      // total number of entries written
+  int64_t inline_entries = 0;     // number of entries stored inline
+  int64_t lob_entries = 0;        // number of entries stored as LOB
+  int64_t total_bytes = 0;        // total bytes of data
+  int64_t lob_files_created = 0;  // number of LOB files created
+};
+
+// result for a single LOB file created by LobColumnWriter
+struct LobFileResult {
+  std::string path;         // file path
+  int64_t total_rows;       // total number of rows in this file
+  int64_t valid_rows;       // number of valid (non-deleted) rows
+  int64_t file_size_bytes;  // size of the file in bytes
+};
+
+// writer for a single LOB column (TEXT or BINARY)
+// handles the decision of inline vs LOB storage and generates LOBReferences
+//
+// the writer outputs encoded references (24 bytes each for LOB, variable for inline)
+// that should be stored in the segment's reference binlog (parquet format)
+//
+// lifecycle:
+//   1. create writer via LobColumnManager::CreateWriter()
+//   2. call WriteData()/WriteText() or WriteBatchData()/WriteBatch() to write data
+//   3. call Flush() periodically if needed
+//   4. call Close() to finalize and close LOB files
+//   5. use the returned references to write reference binlog
+//
+// thread safety: not thread-safe, use one writer per thread
+class LobColumnWriter {
+  public:
+  virtual ~LobColumnWriter() = default;
+
+  // --- generic data interface (works for both text and binary) ---
+
+  // write a single data entry and return the encoded reference
+  // the reference is either:
+  //   - inline data (flag=0x00): data stored directly, size = 1 + data_size
+  //   - LOB reference (flag=0x01): pointer to data in a Vortex LOB file, fixed 24 bytes
+  virtual arrow::Result<std::vector<uint8_t>> WriteData(const uint8_t* data, size_t data_size) = 0;
+
+  // write multiple data entries and return encoded references
+  // more efficient than calling WriteData() repeatedly as it can batch writes
+  virtual arrow::Result<std::vector<std::vector<uint8_t>>> WriteBatchData(
+      const std::vector<std::pair<const uint8_t*, size_t>>& items) = 0;
+
+  // write data from an Arrow BinaryArray
+  // returns encoded references as a BinaryArray
+  virtual arrow::Result<std::shared_ptr<arrow::BinaryArray>> WriteArrowArray(
+      const std::shared_ptr<arrow::BinaryArray>& data) = 0;
+
+  // testonly: production code uses WriteData() directly
+  arrow::Result<std::vector<uint8_t>> WriteText(const std::string& text) {
+    return WriteData(reinterpret_cast<const uint8_t*>(text.data()), text.size());
+  }
+
+  // testonly: production code uses WriteBatchData() directly
+  arrow::Result<std::vector<std::vector<uint8_t>>> WriteBatch(const std::vector<std::string>& texts) {
+    std::vector<std::pair<const uint8_t*, size_t>> items;
+    items.reserve(texts.size());
+    for (const auto& t : texts) {
+      items.emplace_back(reinterpret_cast<const uint8_t*>(t.data()), t.size());
+    }
+    return WriteBatchData(items);
+  }
+
+  // --- lifecycle methods ---
+
+  // flush buffered data to storage (does not close the current LOB file)
+  virtual arrow::Status Flush() = 0;
+
+  // close the writer and finalize all LOB files
+  // after calling this, the writer cannot be used anymore
+  // returns the list of LOB file results with metadata
+  virtual arrow::Result<std::vector<LobFileResult>> Close() = 0;
+
+  // abort the writer and discard all written data
+  // this will delete any LOB files that were created
+  virtual arrow::Status Abort() = 0;
+
+  // get the number of rows written so far
+  virtual int64_t WrittenRows() const = 0;
+
+  // get writer statistics
+  virtual LobColumnWriterStats GetStats() const = 0;
+
+  // check if the writer is closed
+  virtual bool IsClosed() const = 0;
+
+  protected:
+  LobColumnWriter() = default;
+};
+
+// factory function to create LobColumnWriter
+arrow::Result<std::unique_ptr<LobColumnWriter>> CreateLobColumnWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                      const LobColumnConfig& config);
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/include/milvus-storage/lob_column/lob_reference.h
+++ b/cpp/include/milvus-storage/lob_column/lob_reference.h
@@ -1,0 +1,169 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace milvus_storage::lob_column {
+
+// encoding format:
+//
+// 1. inline data (variable length):
+//    [flag=0x00 (1 byte)] [payload bytes...]
+//    total size = 1 + payload.length()
+//    payload can be text (UTF-8) or binary data; the caller determines the type.
+//
+// 2. LOB reference (fixed 24 bytes, 4-byte aligned):
+//    [flag=0x01 (1 byte)] [padding (3 bytes)] [file_id (16 bytes)] [row_offset (4 bytes)]
+//    total size = 1 + 3 + 16 + 4 = 24 bytes
+//
+//    file_id is stored as binary UUID (16 bytes).
+//    Converted to string format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) when building file paths.
+//
+//    ┌─────────┬─────────┬──────────────────┬────────────────┐
+//    │ Flag    │ Padding │ File ID (binary) │ Offset in File │
+//    │ (1B)    │ (3B)    │ (16B)            │ (4B)           │
+//    │ 0x01    │ 0x00    │ UUID bytes       │ int32          │
+//    └─────────┴─────────┴──────────────────┴────────────────┘
+
+// flag values
+constexpr uint8_t FLAG_INLINE_DATA = 0x00;
+constexpr uint8_t FLAG_LOB_REFERENCE = 0x01;
+
+// UUID binary size (16 bytes)
+constexpr size_t UUID_BINARY_SIZE = 16;
+
+// UUID string length (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+constexpr size_t UUID_STRING_SIZE = 36;
+
+// LOB reference size (fixed): flag + padding + file_id_binary + row_offset = 1 + 3 + 16 + 4 = 24 bytes
+constexpr size_t LOB_REFERENCE_SIZE = 24;
+
+// fixed-size encoded LOB reference (24 bytes, lives entirely on the stack)
+struct EncodedLOBRef {
+  std::array<uint8_t, LOB_REFERENCE_SIZE> bytes = {};
+
+  const uint8_t* data() const { return bytes.data(); }
+  size_t size() const { return LOB_REFERENCE_SIZE; }
+  uint8_t& operator[](size_t i) { return bytes[i]; }
+  uint8_t operator[](size_t i) const { return bytes[i]; }
+
+  operator std::vector<uint8_t>() const { return {bytes.begin(), bytes.end()}; }
+};
+
+struct LOBReference {
+  std::string file_id;
+  int32_t row_offset;
+};
+
+// --- generic inline data encode/decode (works for both text and binary) ---
+
+/**
+ * @brief encode inline data (variable length)
+ * @param payload raw bytes to encode
+ * @param size number of bytes in payload
+ * @return encoded bytes: [0x00] + [payload bytes], length = 1 + size
+ */
+std::vector<uint8_t> EncodeInlineData(const uint8_t* payload, size_t size);
+
+/**
+ * @brief decode inline data from encoded bytes (zero-copy)
+ * @param data encoded bytes starting with flag
+ * @param data_size total size of the encoded data
+ * @param out_payload output: pointer to the payload within data (after flag byte)
+ * @param out_size output: size of the payload
+ */
+void DecodeInlineData(const uint8_t* data, size_t data_size, const uint8_t** out_payload, size_t* out_size);
+
+// --- text convenience wrappers ---
+
+/**
+ * @brief encode inline text (variable length), convenience wrapper over EncodeInlineData
+ * @param text the text string to encode
+ * @return encoded bytes: [0x00] + [text bytes], length = 1 + text.size()
+ */
+inline std::vector<uint8_t> EncodeInlineText(const std::string& text) {
+  return EncodeInlineData(reinterpret_cast<const uint8_t*>(text.data()), text.size());
+}
+
+/**
+ * @brief decode inline text from encoded data, convenience wrapper over DecodeInlineData
+ * @param data encoded bytes starting with flag
+ * @param data_size total size of the encoded data
+ * @return decoded text string (without the flag byte)
+ */
+inline std::string DecodeInlineText(const uint8_t* data, size_t data_size) {
+  const uint8_t* payload;
+  size_t payload_size;
+  DecodeInlineData(data, data_size, &payload, &payload_size);
+  return std::string(reinterpret_cast<const char*>(payload), payload_size);
+}
+
+// --- LOB reference encode/decode ---
+
+/**
+ * @brief encode LOB reference (fixed 24 bytes)
+ * @param file_id binary UUID of the LOB file (16 bytes)
+ * @param row_offset row offset in the Vortex file
+ * @return stack-allocated 24-byte encoded reference
+ */
+EncodedLOBRef EncodeLOBReference(const uint8_t* file_id, int32_t row_offset);
+
+/**
+ * @brief decode LOB reference from encoded data
+ * @param data encoded bytes (must be at least 24 bytes)
+ * @return LOBReference with file_id (UUID string, 36 chars) and row_offset
+ */
+LOBReference DecodeLOBReference(const uint8_t* data);
+
+/**
+ * @brief check if data is a LOB reference (flag == 0x01)
+ * @param data encoded bytes
+ * @return true if it's a LOB reference
+ */
+inline bool IsLOBReference(const uint8_t* data) { return data[0] == FLAG_LOB_REFERENCE; }
+
+/**
+ * @brief check if data is inline data (flag == 0x00)
+ * @param data encoded bytes
+ * @return true if it's inline data
+ */
+inline bool IsInlineData(const uint8_t* data) { return data[0] == FLAG_INLINE_DATA; };
+
+/**
+ * @brief build LOB file path from file_id UUID string
+ * @param lob_base_path base path for LOB files (e.g., {partition}/lobs/{field_id})
+ * @param file_id_str UUID string of the LOB file (36 chars)
+ * @return full path to the LOB file (e.g., {lob_base_path}/_data/{uuid}.vx)
+ */
+std::string BuildLOBFilePath(const std::string& lob_base_path, const std::string& file_id_str);
+
+/**
+ * @brief generate a random UUID v4 as binary
+ * @param out output buffer (must be at least 16 bytes)
+ */
+void GenerateUUIDBinary(uint8_t* out);
+
+/**
+ * @brief convert binary UUID to string format
+ * @param uuid binary UUID (16 bytes)
+ * @return UUID string (36 chars: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+ */
+std::string UUIDToString(const uint8_t* uuid);
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -36,7 +36,32 @@ namespace milvus_storage::api {
 // - Version 2: Added indexes field for index metadata support
 // - Version 3: Changed stats from map<string, vector<string>> to map<string, Statistics>
 // - Version 4: Changed ColumnGroupFile fields (metadata) to properties map
-constexpr int32_t MANIFEST_VERSION = 4;
+// - Version 5: Added lob_files field for LOB (Large Object) file metadata
+constexpr int32_t MANIFEST_VERSION = 5;
+
+/**
+ * @brief Metadata for a single LOB (Large Object) file
+ *
+ * LOB files store large text/binary data separately from the main columnar storage.
+ * This structure tracks the file location and row statistics for garbage collection
+ * and query optimization.
+ */
+struct LobFileInfo {
+  std::string path;         ///< Relative path to the LOB file
+  int64_t field_id;         ///< Field ID this LOB file belongs to
+  int64_t total_rows;       ///< Total number of rows in the LOB file
+  int64_t valid_rows;       ///< Number of valid (non-deleted) rows
+  int64_t file_size_bytes;  ///< Size of the LOB file in bytes
+
+  LobFileInfo() : field_id(0), total_rows(0), valid_rows(0), file_size_bytes(0) {}
+  LobFileInfo(std::string p, int64_t fid, int64_t total, int64_t valid, int64_t size)
+      : path(std::move(p)), field_id(fid), total_rows(total), valid_rows(valid), file_size_bytes(size) {}
+
+  bool operator==(const LobFileInfo& other) const {
+    return path == other.path && field_id == other.field_id && total_rows == other.total_rows &&
+           valid_rows == other.valid_rows && file_size_bytes == other.file_size_bytes;
+  }
+};
 
 /**
  * @brief Type of delta log entry
@@ -95,6 +120,7 @@ class Manifest final {
                     const std::vector<DeltaLog>& delta_logs = {},
                     const std::map<std::string, Statistics>& stats = {},
                     const std::vector<Index>& indexes = {},
+                    const std::vector<LobFileInfo>& lob_files = {},
                     uint32_t version = MANIFEST_VERSION);
 
   Manifest(const Manifest&);
@@ -142,6 +168,29 @@ class Manifest final {
   [[nodiscard]] const Index* getIndex(const std::string& column_name, const std::string& index_type) const;
 
   /**
+   * @brief Get all LOB file info entries
+   */
+  [[nodiscard]] std::vector<LobFileInfo>& lobFiles() { return lob_files_; }
+
+  /**
+   * @brief Get all LOB file info entries (const)
+   */
+  [[nodiscard]] const std::vector<LobFileInfo>& lobFiles() const { return lob_files_; }
+
+  /**
+   * @brief Get LOB files for a specific field ID
+   */
+  [[nodiscard]] std::vector<LobFileInfo> getLobFilesForField(int64_t field_id) const {
+    std::vector<LobFileInfo> result;
+    for (const auto& file : lob_files_) {
+      if (file.field_id == field_id) {
+        result.push_back(file);
+      }
+    }
+    return result;
+  }
+
+  /**
    * @brief Get the manifest format version
    */
   [[nodiscard]] int32_t version() const { return version_; }
@@ -186,6 +235,7 @@ class Manifest final {
   std::vector<DeltaLog> delta_logs_;         ///< Delta log entries
   std::map<std::string, Statistics> stats_;  ///< Stats entries keyed by stat name
   std::vector<Index> indexes_;               ///< Index entries for columns
+  std::vector<LobFileInfo> lob_files_;       ///< LOB file metadata for TEXT/BLOB columns
 
   static milvus_storage::LRUCache<std::string, std::shared_ptr<Manifest>>& getCache();
 };

--- a/cpp/include/milvus-storage/segment/segment_reader.h
+++ b/cpp/include/milvus-storage/segment/segment_reader.h
@@ -1,0 +1,145 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/table.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/manifest.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/reader.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+
+namespace milvus_storage::segment {
+
+// configuration for SegmentReader
+struct SegmentReaderConfig {
+  // TEXT column field IDs and their configurations
+  // used to create LobColumnReader for resolving LOBReferences
+  std::map<int64_t, lob_column::LobColumnConfig> lob_columns;
+
+  // read buffer size for underlying readers
+  size_t read_buffer_size = 64U * 1024U * 1024U;  // 64MB default
+
+  // storage properties
+  api::Properties properties;
+};
+
+// SegmentReader reads row data from storage with optional column selection
+// - supports extracting specific columns from segment data
+// - LOBReferences are automatically resolved to TEXT
+// - supports both sequential read and random row access (Take)
+//
+// usage (read all columns):
+//   auto reader = SegmentReader::Open(fs, manifest, schema, {}, config);
+//   std::shared_ptr<arrow::RecordBatch> batch;
+//   while (reader->ReadNext(&batch).ok() && batch) {
+//     // process batch
+//   }
+//   reader->Close();
+//
+// usage (read specific columns):
+//   std::vector<std::string> columns = {"id", "content", "value"};
+//   auto reader = SegmentReader::Open(fs, manifest, schema, columns, config);
+//
+// usage (random access):
+//   auto reader = SegmentReader::Open(fs, manifest, schema, columns, config);
+//   std::vector<int64_t> row_indices = {0, 5, 10, 15};
+//   auto table = reader->Take(row_indices);
+//
+// thread safety: not thread-safe, use one reader per thread
+class SegmentReader : public arrow::RecordBatchReader {
+  public:
+  virtual ~SegmentReader() = default;
+
+  // create a SegmentReader from ColumnGroups (directly)
+  // column_groups: the ColumnGroups containing column group metadata
+  // schema: the original schema with TEXT columns as utf8() type
+  // columns: list of column names to extract (empty = all columns)
+  static arrow::Result<std::unique_ptr<SegmentReader>> Create(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                              const std::shared_ptr<api::ColumnGroups>& column_groups,
+                                                              const std::shared_ptr<arrow::Schema>& schema,
+                                                              const std::vector<std::string>& columns,
+                                                              const SegmentReaderConfig& config);
+
+  // open a SegmentReader from a manifest
+  // manifest: the manifest containing column group metadata (caller is responsible for transaction handling)
+  // schema: the original schema with TEXT columns as utf8() type
+  // columns: list of column names to extract (empty = all columns)
+  static arrow::Result<std::unique_ptr<SegmentReader>> Open(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                            const std::shared_ptr<api::Manifest>& manifest,
+                                                            const std::shared_ptr<arrow::Schema>& schema,
+                                                            const std::vector<std::string>& columns,
+                                                            const SegmentReaderConfig& config);
+
+  // read the next RecordBatch with selected columns
+  // LOBReferences are automatically resolved to TEXT
+  // returns nullptr when no more data
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override = 0;
+
+  // extract specific rows by indices (random access)
+  // row_indices: global row indices to extract (0-based)
+  // parallelism: number of parallel I/O threads
+  // returns Table containing only selected rows and columns
+  virtual arrow::Result<std::shared_ptr<arrow::Table>> Take(const std::vector<int64_t>& row_indices,
+                                                            size_t parallelism = 1) = 0;
+
+  // get the schema of extracted columns only
+  std::shared_ptr<arrow::Schema> schema() const override = 0;
+
+  // get the original full schema
+  virtual std::shared_ptr<arrow::Schema> GetOriginalSchema() const = 0;
+
+  // get the list of extracted column names
+  virtual const std::vector<std::string>& GetExtractedColumns() const = 0;
+
+  // get total number of rows read so far
+  virtual int64_t GetTotalRows() const = 0;
+
+  // close the reader and release resources
+  arrow::Status Close() override = 0;
+
+  // check if the reader is closed
+  virtual bool IsClosed() const = 0;
+
+  // get a sequential stream with optional predicate filtering
+  // TEXT columns are automatically resolved (LOBReferences decoded to utf8)
+  // predicate: filter expression string (empty = no filtering)
+  virtual arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetStream(const std::string& predicate = "") = 0;
+
+  // get a chunk reader for a specific column group (transparent passthrough to api::Reader)
+  // NOTE: chunk-level data is NOT LOB-resolved — TEXT columns remain as binary LOBReferences
+  // this is intended for segment load / mmap scenarios where raw storage format is needed
+  virtual arrow::Result<std::unique_ptr<api::ChunkReader>> GetChunkReader(
+      int64_t column_group_index, const std::shared_ptr<std::vector<std::string>>& needed_columns = nullptr) = 0;
+
+  // get the underlying column groups metadata
+  virtual std::shared_ptr<api::ColumnGroups> GetColumnGroups() const = 0;
+
+  protected:
+  SegmentReader() = default;
+};
+
+}  // namespace milvus_storage::segment

--- a/cpp/include/milvus-storage/segment/segment_writer.h
+++ b/cpp/include/milvus-storage/segment/segment_writer.h
@@ -1,0 +1,174 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+#include "milvus-storage/manifest.h"
+
+namespace milvus_storage::segment {
+
+// configuration for SegmentWriter
+struct SegmentWriterConfig {
+  // segment base path - this is where manifest and parquet data files are stored
+  // e.g., "/data/partitions/segments/seg-001"
+  // manifest: {segment_path}/_metadata/manifest-{version}.avro
+  // data:     {segment_path}/_data/cg{N}_{uuid}.parquet
+  std::string segment_path;
+
+  // TEXT column field IDs and their configurations
+  // Each LobColumnConfig has its own lob_base_path ({partition}/lobs/{field_id})
+  // The caller (Go layer) is responsible for constructing the full path
+  std::map<int64_t, lob_column::LobColumnConfig> lob_columns;
+
+  // storage properties (filesystem config, compression, column group policy, etc.)
+  // must include PROPERTY_WRITER_POLICY and PROPERTY_FORMAT for ColumnGroupPolicy
+  // see writer.h for available policy options:
+  //   - LOON_COLUMN_GROUP_POLICY_SINGLE: all columns in one group
+  //   - LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED: group by column name patterns
+  //   - LOON_COLUMN_GROUP_POLICY_SIZE_BASED: group by column sizes
+  api::Properties properties;
+};
+
+// output returned by SegmentWriter::Close()
+// contains column groups (parquet metadata) and LOB file info
+// the caller is responsible for committing these via Transaction
+struct SegmentWriteOutput {
+  // column groups containing parquet file metadata
+  std::shared_ptr<api::ColumnGroups> column_groups;
+
+  // LOB file metadata for TEXT columns
+  std::vector<api::LobFileInfo> lob_files;
+
+  // total number of rows written
+  int64_t rows_written = 0;
+};
+
+// legacy result (kept for backward compatibility with callers that manage Transaction externally)
+struct SegmentWriterResult {
+  // full path to the committed manifest file
+  // format: {segment_path}/_metadata/manifest-{version}.avro
+  std::string manifest_path;
+
+  // committed version number
+  int64_t committed_version = 0;
+
+  // total number of rows written
+  int64_t rows_written = 0;
+};
+
+// statistics for segment writer
+struct SegmentWriterStats {
+  int64_t total_rows = 0;             // total number of rows written
+  int64_t total_bytes = 0;            // total bytes written (approximate)
+  int64_t parquet_files_created = 0;  // number of parquet files created
+  int64_t lob_files_created = 0;      // number of LOB files created
+};
+
+// SegmentWriter writes complete row data to storage
+// - TEXT columns are stored in Vortex LOB files (via LobColumnManager)
+// - Regular columns are stored in Parquet files (via PackedRecordBatchWriter)
+// - Does NOT manage Transaction — caller is responsible for committing
+//
+// Usage:
+//   auto writer = SegmentWriter::Create(fs, schema, config);
+//   writer->Write(batch1);
+//   writer->Write(batch2);
+//   auto output = writer->Close();  // returns ColumnGroups + LobFileInfo, does NOT commit
+//
+//   // caller commits via Transaction:
+//   auto txn = Transaction::Open(fs, segment_path, read_version, ...);
+//   txn->AppendFiles(*output.column_groups);
+//   for (auto& lob : output.lob_files) txn->AddLobFile(lob);
+//   auto version = txn->Commit();
+//
+// File layout after Close() + Transaction commit:
+//   partition_path/
+//   ├── {segment_id}/                          <- segment_path points here
+//   │   ├── _metadata/
+//   │   │   └── manifest-{version}.avro        <- manifest at segment level
+//   │   └── _data/
+//   │       └── cg{N}_{uuid}.parquet           <- parquet files for regular columns
+//   └── lobs/
+//       └── {field_id}/                        <- LobColumnConfig.lob_base_path points here
+//           └── _data/
+//               └── {uuid}.vx                  <- LOB files for TEXT columns (partition level)
+//
+// Thread safety: not thread-safe, use one writer per thread
+class SegmentWriter {
+  public:
+  virtual ~SegmentWriter() = default;
+
+  // create a SegmentWriter
+  // schema: the original schema with TEXT columns as utf8() type
+  // the writer will convert TEXT columns to binary() for storage
+  static arrow::Result<std::unique_ptr<SegmentWriter>> Create(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                              const std::shared_ptr<arrow::Schema>& schema,
+                                                              const SegmentWriterConfig& config);
+
+  // write a RecordBatch
+  // TEXT columns are automatically extracted and written to LOB files
+  // the LOBReferences are stored in the Parquet files
+  virtual arrow::Status Write(const std::shared_ptr<arrow::RecordBatch>& batch) = 0;
+
+  // flush all buffered data to storage
+  // this does not close the writer or commit the transaction
+  virtual arrow::Status Flush() = 0;
+
+  // close the writer and return write output
+  // returns SegmentWriteOutput containing:
+  //   - column_groups: parquet file metadata
+  //   - lob_files: LOB file metadata for TEXT columns
+  //   - rows_written: total rows written
+  // does NOT commit manifest — caller must use Transaction to commit
+  virtual arrow::Result<SegmentWriteOutput> Close() = 0;
+
+  // abort the writer and clean up all created files
+  // this will delete any LOB files and Parquet files that were created
+  // does NOT commit the transaction
+  virtual arrow::Status Abort() = 0;
+
+  // get the number of rows written so far
+  virtual int64_t WrittenRows() const = 0;
+
+  // get writer statistics
+  virtual SegmentWriterStats GetStats() const = 0;
+
+  // get the storage schema (TEXT columns converted to BINARY)
+  virtual std::shared_ptr<arrow::Schema> GetStorageSchema() const = 0;
+
+  // get the original schema
+  virtual std::shared_ptr<arrow::Schema> GetOriginalSchema() const = 0;
+
+  // check if the writer is closed
+  virtual bool IsClosed() const = 0;
+
+  protected:
+  SegmentWriter() = default;
+};
+
+}  // namespace milvus_storage::segment

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -54,12 +54,14 @@ class Updates {
   void UpdateStat(const std::string& key, const Statistics& stat);
   void AddIndex(const Index& index);
   void DropIndex(const std::string& column_name, const std::string& index_type);
+  void AddLobFile(const LobFileInfo& lob_file);
   [[nodiscard]] const std::vector<std::shared_ptr<ColumnGroup>>& GetAddedColumnGroups() const;
   [[nodiscard]] const std::vector<std::vector<std::shared_ptr<ColumnGroup>>>& GetAppendedFiles() const;
   [[nodiscard]] const std::vector<DeltaLog>& GetAddedDeltaLogs() const;
   [[nodiscard]] const std::map<std::string, Statistics>& GetAddedStats() const;
   [[nodiscard]] const std::vector<Index>& GetAddedIndexes() const;
   [[nodiscard]] const std::vector<std::pair<std::string, std::string>>& GetDroppedIndexes() const;
+  [[nodiscard]] const std::vector<LobFileInfo>& GetAddedLobFiles() const;
 
   private:
   // Column group changes
@@ -75,6 +77,9 @@ class Updates {
   // Index changes
   std::vector<Index> added_indexes_;                                  // Indexes to add or replace
   std::vector<std::pair<std::string, std::string>> dropped_indexes_;  // (column_name, index_type) to drop
+
+  // LOB file changes
+  std::vector<LobFileInfo> added_lob_files_;  // New LOB files to add
 };
 
 /**
@@ -210,6 +215,13 @@ class Transaction {
    * @return Reference to this transaction for method chaining
    */
   Transaction& DropIndex(const std::string& column_name, const std::string& index_type);
+
+  /**
+   * @brief Add a LOB file to the transaction updates
+   * @param lob_file LOB file info to add
+   * @return Reference to this transaction for method chaining
+   */
+  Transaction& AddLobFile(const LobFileInfo& lob_file);
 
   private:
   // Private constructor - use Open() factory method instead

--- a/cpp/src/ffi/bridge.cpp
+++ b/cpp/src/ffi/bridge.cpp
@@ -195,6 +195,8 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
     (*out_cmanifest)->stats.stat_metadata_values = nullptr;
     (*out_cmanifest)->stats.stat_metadata_counts = nullptr;
     (*out_cmanifest)->stats.num_stats = 0;
+    (*out_cmanifest)->lob_files.files = nullptr;
+    (*out_cmanifest)->lob_files.num_files = 0;
 
     // Export column groups directly into embedded structure
     const auto& cgs = manifest->columnGroups();
@@ -282,6 +284,31 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
         }
         (*out_cmanifest)->stats.stat_metadata_counts[idx] = num_metadata;
         idx++;
+      }
+    }
+
+    // Export LOB files
+    const auto& lob_files = manifest->lobFiles();
+    if (!lob_files.empty()) {
+      size_t num_lob_files = lob_files.size();
+      (*out_cmanifest)->lob_files.files = new LoonLobFileInfo[num_lob_files]{};
+      (*out_cmanifest)->lob_files.num_files = static_cast<uint32_t>(num_lob_files);
+
+      for (size_t i = 0; i < num_lob_files; i++) {
+        const auto& lob_file = lob_files[i];
+        auto& out_lob = (*out_cmanifest)->lob_files.files[i];
+
+        // Copy path
+        size_t path_len = lob_file.path.length();
+        char* path_str = new char[path_len + 1];
+        std::memcpy(path_str, lob_file.path.c_str(), path_len);
+        path_str[path_len] = '\0';
+        out_lob.path = path_str;
+
+        out_lob.field_id = lob_file.field_id;
+        out_lob.total_rows = lob_file.total_rows;
+        out_lob.valid_rows = lob_file.valid_rows;
+        out_lob.file_size_bytes = lob_file.file_size_bytes;
       }
     }
 

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -271,6 +271,30 @@ LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle handle,
   RETURN_UNREACHABLE();
 }
 
+LoonFFIResult loon_transaction_add_lob_file(LoonTransactionHandle handle, const LoonLobFileInfo* lob_file) {
+  if (!handle || !lob_file) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and lob_file must not be null");
+  }
+  try {
+    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
+
+    // Convert C struct to C++ struct
+    LobFileInfo cpp_lob_file;
+    cpp_lob_file.path = lob_file->path ? lob_file->path : "";
+    cpp_lob_file.field_id = lob_file->field_id;
+    cpp_lob_file.total_rows = lob_file->total_rows;
+    cpp_lob_file.valid_rows = lob_file->valid_rows;
+    cpp_lob_file.file_size_bytes = lob_file->file_size_bytes;
+
+    cpp_transaction->AddLobFile(cpp_lob_file);
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
 void loon_manifest_destroy(LoonManifest* cmanifest) {
   if (!cmanifest) {
     return;
@@ -347,6 +371,16 @@ void loon_manifest_destroy(LoonManifest* cmanifest) {
     cmanifest->stats.stat_metadata_counts = nullptr;
   }
   cmanifest->stats.num_stats = 0;
+
+  // Destroy LOB files
+  if (cmanifest->lob_files.files) {
+    for (uint32_t i = 0; i < cmanifest->lob_files.num_files; i++) {
+      delete[] const_cast<char*>(cmanifest->lob_files.files[i].path);
+    }
+    delete[] cmanifest->lob_files.files;
+    cmanifest->lob_files.files = nullptr;
+  }
+  cmanifest->lob_files.num_files = 0;
 
   // Free the structure itself
   delete cmanifest;

--- a/cpp/src/ffi/segment_reader_c.cpp
+++ b/cpp/src/ffi/segment_reader_c.cpp
@@ -1,0 +1,266 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_internal/bridge.h"
+#include "milvus-storage/ffi_internal/result.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/segment/segment_reader.h"
+#include "milvus-storage/transaction/transaction.h"
+
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+
+using namespace milvus_storage;
+using namespace milvus_storage::api;
+using namespace milvus_storage::segment;
+
+static arrow::Result<SegmentReaderConfig> ConvertReaderConfig(const LoonSegmentReaderConfig* config,
+                                                              const api::Properties& properties) {
+  SegmentReaderConfig cpp_config;
+  cpp_config.properties = properties;
+
+  if (config->read_buffer_size > 0) {
+    cpp_config.read_buffer_size = static_cast<size_t>(config->read_buffer_size);
+  }
+
+  for (size_t i = 0; i < config->num_lob_columns; i++) {
+    const auto& tc = config->lob_columns[i];
+    lob_column::LobColumnConfig lob_config;
+    lob_config.field_id = tc.field_id;
+    if (tc.lob_base_path) {
+      lob_config.lob_base_path = tc.lob_base_path;
+    }
+    lob_config.properties = properties;
+    cpp_config.lob_columns[tc.field_id] = lob_config;
+  }
+
+  return cpp_config;
+}
+
+LoonFFIResult loon_segment_reader_open(const char* segment_path,
+                                       int64_t version,
+                                       ArrowSchema* schema_raw,
+                                       const char** needed_columns,
+                                       int64_t num_columns,
+                                       const LoonSegmentReaderConfig* config,
+                                       const LoonProperties* properties,
+                                       LoonSegmentReaderHandle* out_handle) {
+  if (!segment_path || !schema_raw || !config || !properties || !out_handle) {
+    RETURN_ERROR(LOON_INVALID_ARGS,
+                 "Invalid arguments: segment_path, schema_raw, config, properties, and out_handle must not be null");
+  }
+
+  try {
+    // convert properties
+    api::Properties props_map;
+    auto opt = ConvertFFIProperties(props_map, properties);
+    if (opt != std::nullopt) {
+      RETURN_ERROR(LOON_INVALID_PROPERTIES, "Failed to parse properties: ", opt->c_str());
+    }
+
+    // import arrow schema
+    auto schema_result = arrow::ImportSchema(schema_raw);
+    if (!schema_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
+    }
+    auto schema = schema_result.ValueOrDie();
+
+    // convert config
+    auto config_result = ConvertReaderConfig(config, props_map);
+    if (!config_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, config_result.status().ToString());
+    }
+    auto cpp_config = config_result.ValueOrDie();
+
+    // build needed columns
+    std::vector<std::string> columns;
+    if (needed_columns && num_columns > 0) {
+      for (int64_t i = 0; i < num_columns; i++) {
+        columns.push_back(needed_columns[i]);
+      }
+    }
+
+    // get filesystem
+    auto fs = ArrowFileSystemSingleton::GetInstance().GetArrowFileSystem();
+    if (!fs) {
+      RETURN_ERROR(LOON_LOGICAL_ERROR, "Filesystem not initialized");
+    }
+
+    // open transaction to read manifest
+    auto txn_result = api::transaction::Transaction::Open(fs, segment_path, version,
+                                                          api::transaction::FailResolver, 1);
+    if (!txn_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, txn_result.status().ToString());
+    }
+    auto txn = std::move(txn_result).ValueOrDie();
+
+    auto manifest_result = txn->GetManifest();
+    if (!manifest_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, manifest_result.status().ToString());
+    }
+    auto manifest = std::move(manifest_result).ValueOrDie();
+
+    // open reader from manifest
+    auto reader_result = SegmentReader::Open(fs, manifest, schema, columns, cpp_config);
+    if (!reader_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, reader_result.status().ToString());
+    }
+
+    auto reader = std::move(reader_result).ValueOrDie();
+    *out_handle = reinterpret_cast<LoonSegmentReaderHandle>(reader.release());
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_reader_get_stream(LoonSegmentReaderHandle handle, ArrowArrayStream* out_stream) {
+  if (!handle || !out_stream) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_stream must not be null");
+  }
+
+  try {
+    auto* reader = reinterpret_cast<SegmentReader*>(handle);
+
+    // SegmentReader implements arrow::RecordBatchReader, export as stream.
+    // Use a no-op destructor since the handle is owned externally (destroyed via loon_segment_reader_destroy).
+    auto status = arrow::ExportRecordBatchReader(
+        std::shared_ptr<arrow::RecordBatchReader>(reader, [](arrow::RecordBatchReader*) {}), out_stream);
+    if (!status.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+    }
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_reader_take(LoonSegmentReaderHandle handle,
+                                       const int64_t* row_indices,
+                                       int64_t num_indices,
+                                       int64_t parallelism,
+                                       ArrowArrayStream* out_stream) {
+  if (!handle || !out_stream) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_stream must not be null");
+  }
+
+  if (!row_indices || num_indices <= 0) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: row_indices must not be null and num_indices must be > 0");
+  }
+
+  try {
+    auto* reader = reinterpret_cast<SegmentReader*>(handle);
+
+    std::vector<int64_t> indices(row_indices, row_indices + num_indices);
+    size_t par = parallelism > 0 ? static_cast<size_t>(parallelism) : 1;
+
+    auto result = reader->Take(indices, par);
+    if (!result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+    }
+    auto table = std::move(result).ValueOrDie();
+
+    // Convert Table to RecordBatchReader, then export as ArrowArrayStream
+    auto batch_reader = std::make_shared<arrow::TableBatchReader>(*table);
+    auto status = arrow::ExportRecordBatchReader(batch_reader, out_stream);
+    if (!status.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+    }
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_reader_get_filtered_stream(LoonSegmentReaderHandle handle,
+                                                      const char* predicate,
+                                                      ArrowArrayStream* out_stream) {
+  if (!handle || !out_stream) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_stream must not be null");
+  }
+
+  try {
+    auto* reader = reinterpret_cast<SegmentReader*>(handle);
+    std::string pred = predicate ? predicate : "";
+
+    auto result = reader->GetStream(pred);
+    if (!result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+    }
+    auto batch_reader = std::move(result).ValueOrDie();
+
+    auto status = arrow::ExportRecordBatchReader(batch_reader, out_stream);
+    if (!status.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+    }
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_reader_get_chunk_reader(LoonSegmentReaderHandle handle,
+                                                   int64_t column_group_index,
+                                                   const char* const* needed_columns,
+                                                   size_t num_columns,
+                                                   LoonChunkReaderHandle* out_handle) {
+  if (!handle || !out_handle) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_handle must not be null");
+  }
+
+  try {
+    auto* reader = reinterpret_cast<SegmentReader*>(handle);
+
+    std::shared_ptr<std::vector<std::string>> columns;
+    if (needed_columns && num_columns > 0) {
+      columns = std::make_shared<std::vector<std::string>>();
+      for (size_t i = 0; i < num_columns; i++) {
+        columns->push_back(needed_columns[i]);
+      }
+    }
+
+    auto result = reader->GetChunkReader(column_group_index, columns);
+    if (!result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+    }
+
+    auto chunk_reader = std::move(result).ValueOrDie();
+    *out_handle = reinterpret_cast<LoonChunkReaderHandle>(chunk_reader.release());
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+void loon_segment_reader_destroy(LoonSegmentReaderHandle handle) {
+  if (handle) {
+    delete reinterpret_cast<SegmentReader*>(handle);
+  }
+}

--- a/cpp/src/ffi/segment_writer_c.cpp
+++ b/cpp/src/ffi/segment_writer_c.cpp
@@ -1,0 +1,224 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_internal/bridge.h"
+#include "milvus-storage/ffi_internal/result.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/segment/segment_writer.h"
+
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
+#include <cstring>
+
+using namespace milvus_storage;
+using namespace milvus_storage::api;
+using namespace milvus_storage::segment;
+
+// helper to convert FFI config to C++ config
+static arrow::Result<SegmentWriterConfig> ConvertWriterConfig(const LoonSegmentWriterConfig* config,
+                                                              const api::Properties& properties) {
+  SegmentWriterConfig cpp_config;
+
+  if (!config->segment_path) {
+    return arrow::Status::Invalid("segment_path is required");
+  }
+  cpp_config.segment_path = config->segment_path;
+  cpp_config.properties = properties;
+
+  // convert TEXT column configs
+  for (size_t i = 0; i < config->num_lob_columns; i++) {
+    const auto& tc = config->lob_columns[i];
+    lob_column::LobColumnConfig text_config;
+    text_config.field_id = tc.field_id;
+    if (tc.lob_base_path) {
+      text_config.lob_base_path = tc.lob_base_path;
+    }
+    text_config.inline_threshold = tc.inline_threshold > 0 ? tc.inline_threshold : 256;
+    text_config.max_lob_file_bytes = tc.max_lob_file_bytes > 0 ? tc.max_lob_file_bytes : 64 * 1024 * 1024;
+    text_config.flush_threshold_bytes = tc.flush_threshold_bytes > 0 ? tc.flush_threshold_bytes : 16 * 1024 * 1024;
+    text_config.rewrite_mode = tc.rewrite_mode;
+    text_config.properties = properties;
+
+    cpp_config.lob_columns[tc.field_id] = text_config;
+  }
+
+  return cpp_config;
+}
+
+LoonFFIResult loon_segment_writer_new(ArrowSchema* schema_raw,
+                                      const LoonSegmentWriterConfig* config,
+                                      const LoonProperties* properties,
+                                      LoonSegmentWriterHandle* out_handle) {
+  if (!schema_raw || !config || !properties || !out_handle) {
+    RETURN_ERROR(LOON_INVALID_ARGS,
+                 "Invalid arguments: schema_raw, config, properties, and out_handle must not be null");
+  }
+
+  try {
+    // convert properties
+    api::Properties props_map;
+    auto opt = ConvertFFIProperties(props_map, properties);
+    if (opt != std::nullopt) {
+      RETURN_ERROR(LOON_INVALID_PROPERTIES, "Failed to parse properties: ", opt->c_str());
+    }
+
+    // import arrow schema
+    auto schema_result = arrow::ImportSchema(schema_raw);
+    if (!schema_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
+    }
+    auto schema = schema_result.ValueOrDie();
+
+    // convert config
+    auto config_result = ConvertWriterConfig(config, props_map);
+    if (!config_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, config_result.status().ToString());
+    }
+    auto cpp_config = config_result.ValueOrDie();
+
+    // get filesystem from singleton
+    auto fs = ArrowFileSystemSingleton::GetInstance().GetArrowFileSystem();
+    if (!fs) {
+      RETURN_ERROR(LOON_LOGICAL_ERROR, "Filesystem not initialized");
+    }
+
+    // create segment writer
+    auto writer_result = SegmentWriter::Create(fs, schema, cpp_config);
+    if (!writer_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, writer_result.status().ToString());
+    }
+
+    auto writer = std::move(writer_result).ValueOrDie();
+    *out_handle = reinterpret_cast<LoonSegmentWriterHandle>(writer.release());
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_writer_write(LoonSegmentWriterHandle handle, ArrowArray* array) {
+  if (!handle || !array) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and array must not be null");
+  }
+
+  try {
+    auto* writer = reinterpret_cast<SegmentWriter*>(handle);
+
+    auto rb_result = arrow::ImportRecordBatch(array, writer->GetOriginalSchema());
+    if (!rb_result.ok()) {
+      array->release(array);
+      RETURN_ERROR(LOON_ARROW_ERROR, rb_result.status().ToString());
+    }
+    auto batch = rb_result.ValueOrDie();
+
+    auto status = writer->Write(batch);
+    if (!status.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+    }
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_writer_flush(LoonSegmentWriterHandle handle) {
+  if (!handle) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
+  }
+
+  try {
+    auto* writer = reinterpret_cast<SegmentWriter*>(handle);
+    auto status = writer->Flush();
+    if (!status.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+    }
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+LoonFFIResult loon_segment_writer_close(LoonSegmentWriterHandle handle, LoonSegmentWriteOutput* out_output) {
+  if (!handle || !out_output) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_output must not be null");
+  }
+
+  try {
+    auto* writer = reinterpret_cast<SegmentWriter*>(handle);
+    auto result = writer->Close();
+    if (!result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+    }
+
+    auto output = std::move(result).ValueOrDie();
+
+    auto cgs = output.column_groups;
+    auto export_st = milvus_storage::column_groups_export(*cgs, &out_output->column_groups);
+    if (!export_st.ok()) {
+      RETURN_ERROR(LOON_LOGICAL_ERROR, export_st.ToString());
+    }
+    out_output->rows_written = output.rows_written;
+
+    out_output->num_lob_files = output.lob_files.size();
+    if (!output.lob_files.empty()) {
+      out_output->lob_files = static_cast<LoonLobFileInfo*>(malloc(sizeof(LoonLobFileInfo) * output.lob_files.size()));
+      for (size_t i = 0; i < output.lob_files.size(); i++) {
+        out_output->lob_files[i].path = strdup(output.lob_files[i].path.c_str());
+        out_output->lob_files[i].field_id = output.lob_files[i].field_id;
+        out_output->lob_files[i].total_rows = output.lob_files[i].total_rows;
+        out_output->lob_files[i].valid_rows = output.lob_files[i].valid_rows;
+        out_output->lob_files[i].file_size_bytes = output.lob_files[i].file_size_bytes;
+      }
+    } else {
+      out_output->lob_files = nullptr;
+    }
+
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_ERROR(LOON_GOT_EXCEPTION, e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+void loon_segment_write_output_free(LoonSegmentWriteOutput* output) {
+  if (output) {
+    if (output->lob_files) {
+      for (size_t i = 0; i < output->num_lob_files; i++) {
+        free(const_cast<char*>(output->lob_files[i].path));
+      }
+      free(output->lob_files);
+      output->lob_files = nullptr;
+    }
+  }
+}
+
+void loon_segment_writer_destroy(LoonSegmentWriterHandle handle) {
+  if (handle) {
+    delete reinterpret_cast<SegmentWriter*>(handle);
+  }
+}

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -127,7 +127,11 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     std::vector<std::shared_ptr<arrow::Field>> fields;
     for (const auto& col_name : filtered_columns) {
       auto field = schema->GetFieldByName(col_name);
-      assert(field);
+      if (!field) {
+        return arrow::Status::Invalid(
+            "ColumnGroupReader: column '" + col_name +
+            "' found in column_group but not in schema. Schema fields: " + schema->ToString());
+      }
       fields.emplace_back(field);
     }
     out_schema = std::make_shared<arrow::Schema>(fields);

--- a/cpp/src/jni/segment_reader_jni.cpp
+++ b/cpp/src/jni/segment_reader_jni.cpp
@@ -1,0 +1,210 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_jni.h"
+#include "milvus-storage/ffi_c.h"
+#include <arrow/c/abi.h>
+#include <string>
+#include <vector>
+
+// ==================== JNI SegmentReader Implementation ====================
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderOpen(JNIEnv* env,
+                                                                                     jobject obj,
+                                                                                     jstring segment_path,
+                                                                                     jlong version,
+                                                                                     jlong schema_ptr,
+                                                                                     jobjectArray needed_columns,
+                                                                                     jlongArray lob_field_ids,
+                                                                                     jobjectArray lob_base_paths,
+                                                                                     jlongArray lob_inline_thresholds,
+                                                                                     jlongArray lob_max_file_bytes,
+                                                                                     jlongArray lob_flush_thresholds,
+                                                                                     jlong properties_ptr) {
+  try {
+    const char* seg_path = env->GetStringUTFChars(segment_path, nullptr);
+    auto* schema = reinterpret_cast<ArrowSchema*>(schema_ptr);
+    auto* properties = reinterpret_cast<LoonProperties*>(properties_ptr);
+
+    // Convert needed columns
+    size_t num_columns = 0;
+    const char** columns = ConvertFromJavaStringArray(env, needed_columns, &num_columns);
+
+    // Build LOB configs
+    std::vector<LoonLobColumnConfig> lob_configs;
+    if (lob_field_ids) {
+      jsize n = env->GetArrayLength(lob_field_ids);
+      jlong* fids = env->GetLongArrayElements(lob_field_ids, nullptr);
+      jlong* inlines = lob_inline_thresholds ? env->GetLongArrayElements(lob_inline_thresholds, nullptr) : nullptr;
+      jlong* maxfiles = lob_max_file_bytes ? env->GetLongArrayElements(lob_max_file_bytes, nullptr) : nullptr;
+      jlong* flushes = lob_flush_thresholds ? env->GetLongArrayElements(lob_flush_thresholds, nullptr) : nullptr;
+
+      lob_configs.resize(n);
+      for (jsize i = 0; i < n; i++) {
+        lob_configs[i].field_id = fids[i];
+        auto path = (jstring)env->GetObjectArrayElement(lob_base_paths, i);
+        lob_configs[i].lob_base_path = env->GetStringUTFChars(path, nullptr);
+        lob_configs[i].inline_threshold = inlines ? inlines[i] : 256;
+        lob_configs[i].max_lob_file_bytes = maxfiles ? maxfiles[i] : 64 * 1024 * 1024;
+        lob_configs[i].flush_threshold_bytes = flushes ? flushes[i] : 16 * 1024 * 1024;
+        lob_configs[i].rewrite_mode = false;
+      }
+
+      env->ReleaseLongArrayElements(lob_field_ids, fids, JNI_ABORT);
+      if (inlines)
+        env->ReleaseLongArrayElements(lob_inline_thresholds, inlines, JNI_ABORT);
+      if (maxfiles)
+        env->ReleaseLongArrayElements(lob_max_file_bytes, maxfiles, JNI_ABORT);
+      if (flushes)
+        env->ReleaseLongArrayElements(lob_flush_thresholds, flushes, JNI_ABORT);
+    }
+
+    LoonSegmentReaderConfig config;
+    config.lob_columns = lob_configs.empty() ? nullptr : lob_configs.data();
+    config.num_lob_columns = lob_configs.size();
+    config.read_buffer_size = 0;  // use default
+
+    LoonSegmentReaderHandle handle;
+    LoonFFIResult result = loon_segment_reader_open(seg_path, version, schema, columns,
+                                                    static_cast<int64_t>(num_columns), &config, properties, &handle);
+
+    // Cleanup
+    env->ReleaseStringUTFChars(segment_path, seg_path);
+    FreeStringArray(env, columns, num_columns);
+    for (jsize i = 0; i < static_cast<jsize>(lob_configs.size()); i++) {
+      auto path = (jstring)env->GetObjectArrayElement(lob_base_paths, i);
+      env->ReleaseStringUTFChars(path, lob_configs[i].lob_base_path);
+    }
+
+    if (!loon_ffi_is_success(&result)) {
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+    return static_cast<jlong>(handle);
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderGetStream(JNIEnv* env,
+                                                                                          jobject obj,
+                                                                                          jlong handle) {
+  try {
+    ArrowArrayStream* stream = static_cast<ArrowArrayStream*>(calloc(1, sizeof(ArrowArrayStream)));
+    LoonFFIResult result = loon_segment_reader_get_stream(static_cast<LoonSegmentReaderHandle>(handle), stream);
+
+    if (!loon_ffi_is_success(&result)) {
+      free(stream);
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+    return reinterpret_cast<jlong>(stream);
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderTake(
+    JNIEnv* env, jobject obj, jlong handle, jlongArray row_indices, jint parallelism) {
+  try {
+    if (!row_indices) {
+      env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), "row_indices must not be null");
+      return -1;
+    }
+
+    jsize n = env->GetArrayLength(row_indices);
+    jlong* indices = env->GetLongArrayElements(row_indices, nullptr);
+
+    ArrowArrayStream* stream = static_cast<ArrowArrayStream*>(calloc(1, sizeof(ArrowArrayStream)));
+    LoonFFIResult result = loon_segment_reader_take(static_cast<LoonSegmentReaderHandle>(handle),
+                                                    reinterpret_cast<const int64_t*>(indices), static_cast<int64_t>(n),
+                                                    static_cast<int64_t>(parallelism > 0 ? parallelism : 1), stream);
+
+    env->ReleaseLongArrayElements(row_indices, indices, JNI_ABORT);
+
+    if (!loon_ffi_is_success(&result)) {
+      free(stream);
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+    return reinterpret_cast<jlong>(stream);
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderGetFilteredStream(JNIEnv* env,
+                                                                                                  jobject obj,
+                                                                                                  jlong handle,
+                                                                                                  jstring predicate) {
+  try {
+    const char* pred = predicate ? env->GetStringUTFChars(predicate, nullptr) : nullptr;
+
+    ArrowArrayStream* stream = static_cast<ArrowArrayStream*>(calloc(1, sizeof(ArrowArrayStream)));
+    LoonFFIResult result =
+        loon_segment_reader_get_filtered_stream(static_cast<LoonSegmentReaderHandle>(handle), pred, stream);
+
+    if (pred) {
+      env->ReleaseStringUTFChars(predicate, pred);
+    }
+
+    if (!loon_ffi_is_success(&result)) {
+      free(stream);
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+    return reinterpret_cast<jlong>(stream);
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderGetChunkReader(
+    JNIEnv* env, jobject obj, jlong handle, jlong column_group_index, jobjectArray needed_columns) {
+  try {
+    size_t num_columns = 0;
+    const char** columns = ConvertFromJavaStringArray(env, needed_columns, &num_columns);
+
+    LoonChunkReaderHandle chunk_handle;
+    LoonFFIResult result = loon_segment_reader_get_chunk_reader(static_cast<LoonSegmentReaderHandle>(handle),
+                                                                static_cast<int64_t>(column_group_index), columns,
+                                                                num_columns, &chunk_handle);
+
+    FreeStringArray(env, columns, num_columns);
+
+    if (!loon_ffi_is_success(&result)) {
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+    return static_cast<jlong>(chunk_handle);
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentReader_segmentReaderDestroy(JNIEnv* env,
+                                                                                       jobject obj,
+                                                                                       jlong handle) {
+  loon_segment_reader_destroy(static_cast<LoonSegmentReaderHandle>(handle));
+}

--- a/cpp/src/jni/segment_writer_jni.cpp
+++ b/cpp/src/jni/segment_writer_jni.cpp
@@ -1,0 +1,200 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_jni.h"
+#include "milvus-storage/ffi_c.h"
+#include <arrow/c/abi.h>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// ==================== JNI SegmentWriter Implementation ====================
+
+// Helper: build LoonLobColumnConfig array from parallel Java arrays.
+// Caller must call FreeLobConfigs() after use.
+static std::vector<LoonLobColumnConfig> BuildLobConfigs(JNIEnv* env,
+                                                        jlongArray field_ids,
+                                                        jobjectArray base_paths,
+                                                        jlongArray inline_thresholds,
+                                                        jlongArray max_file_bytes,
+                                                        jlongArray flush_thresholds) {
+  std::vector<LoonLobColumnConfig> configs;
+  if (!field_ids)
+    return configs;
+
+  jsize n = env->GetArrayLength(field_ids);
+  if (n == 0)
+    return configs;
+
+  jlong* fids = env->GetLongArrayElements(field_ids, nullptr);
+  jlong* inlines = inline_thresholds ? env->GetLongArrayElements(inline_thresholds, nullptr) : nullptr;
+  jlong* maxfiles = max_file_bytes ? env->GetLongArrayElements(max_file_bytes, nullptr) : nullptr;
+  jlong* flushes = flush_thresholds ? env->GetLongArrayElements(flush_thresholds, nullptr) : nullptr;
+
+  configs.resize(n);
+  for (jsize i = 0; i < n; i++) {
+    configs[i].field_id = fids[i];
+    auto path = (jstring)env->GetObjectArrayElement(base_paths, i);
+    configs[i].lob_base_path = env->GetStringUTFChars(path, nullptr);
+    configs[i].inline_threshold = inlines ? inlines[i] : 256;
+    configs[i].max_lob_file_bytes = maxfiles ? maxfiles[i] : 64 * 1024 * 1024;
+    configs[i].flush_threshold_bytes = flushes ? flushes[i] : 16 * 1024 * 1024;
+    configs[i].rewrite_mode = false;
+  }
+
+  env->ReleaseLongArrayElements(field_ids, fids, JNI_ABORT);
+  if (inlines)
+    env->ReleaseLongArrayElements(inline_thresholds, inlines, JNI_ABORT);
+  if (maxfiles)
+    env->ReleaseLongArrayElements(max_file_bytes, maxfiles, JNI_ABORT);
+  if (flushes)
+    env->ReleaseLongArrayElements(flush_thresholds, flushes, JNI_ABORT);
+
+  return configs;
+}
+
+static void FreeLobConfigs(JNIEnv* env, std::vector<LoonLobColumnConfig>& configs, jobjectArray base_paths) {
+  for (jsize i = 0; i < static_cast<jsize>(configs.size()); i++) {
+    auto path = (jstring)env->GetObjectArrayElement(base_paths, i);
+    env->ReleaseStringUTFChars(path, configs[i].lob_base_path);
+  }
+}
+
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterNew(JNIEnv* env,
+                                                                                    jobject obj,
+                                                                                    jlong schema_ptr,
+                                                                                    jstring segment_path,
+                                                                                    jlongArray lob_field_ids,
+                                                                                    jobjectArray lob_base_paths,
+                                                                                    jlongArray lob_inline_thresholds,
+                                                                                    jlongArray lob_max_file_bytes,
+                                                                                    jlongArray lob_flush_thresholds,
+                                                                                    jlong properties_ptr) {
+  try {
+    auto* schema = reinterpret_cast<ArrowSchema*>(schema_ptr);
+    auto* properties = reinterpret_cast<LoonProperties*>(properties_ptr);
+    const char* seg_path = env->GetStringUTFChars(segment_path, nullptr);
+
+    auto lob_configs = BuildLobConfigs(env, lob_field_ids, lob_base_paths, lob_inline_thresholds, lob_max_file_bytes,
+                                       lob_flush_thresholds);
+
+    LoonSegmentWriterConfig config;
+    config.segment_path = seg_path;
+    config.lob_columns = lob_configs.empty() ? nullptr : lob_configs.data();
+    config.num_lob_columns = lob_configs.size();
+
+    LoonSegmentWriterHandle handle;
+    LoonFFIResult result = loon_segment_writer_new(schema, &config, properties, &handle);
+
+    env->ReleaseStringUTFChars(segment_path, seg_path);
+    if (!lob_configs.empty())
+      FreeLobConfigs(env, lob_configs, lob_base_paths);
+
+    if (!loon_ffi_is_success(&result)) {
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+    return static_cast<jlong>(handle);
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterWrite(JNIEnv* env,
+                                                                                     jobject obj,
+                                                                                     jlong handle,
+                                                                                     jlong array_ptr) {
+  try {
+    auto* array = reinterpret_cast<ArrowArray*>(array_ptr);
+    LoonFFIResult result = loon_segment_writer_write(static_cast<LoonSegmentWriterHandle>(handle), array);
+    if (!loon_ffi_is_success(&result)) {
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+    }
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+  }
+}
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterFlush(JNIEnv* env,
+                                                                                     jobject obj,
+                                                                                     jlong handle) {
+  try {
+    LoonFFIResult result = loon_segment_writer_flush(static_cast<LoonSegmentWriterHandle>(handle));
+    if (!loon_ffi_is_success(&result)) {
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+    }
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+  }
+}
+
+// Close returns columnGroupsPtr. LOB file info is returned via output arrays.
+JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterClose(JNIEnv* env,
+                                                                                      jobject obj,
+                                                                                      jlong handle,
+                                                                                      jlongArray out_lob_field_ids,
+                                                                                      jobjectArray out_lob_paths,
+                                                                                      jlongArray out_lob_total_rows,
+                                                                                      jlongArray out_lob_valid_rows,
+                                                                                      jlongArray out_lob_file_sizes) {
+  try {
+    LoonSegmentWriteOutput output;
+    memset(&output, 0, sizeof(output));
+    LoonFFIResult result = loon_segment_writer_close(static_cast<LoonSegmentWriterHandle>(handle), &output);
+    if (!loon_ffi_is_success(&result)) {
+      ThrowJavaExceptionFromFFIResult(env, &result);
+      loon_ffi_free_result(&result);
+      return -1;
+    }
+
+    // Fill LOB file info into output arrays if provided and there are LOB files
+    if (output.num_lob_files > 0 && out_lob_field_ids && out_lob_paths) {
+      jsize n = static_cast<jsize>(output.num_lob_files);
+      std::vector<jlong> field_ids(n), total_rows(n), valid_rows(n), file_sizes(n);
+      for (jsize i = 0; i < n; i++) {
+        field_ids[i] = output.lob_files[i].field_id;
+        total_rows[i] = output.lob_files[i].total_rows;
+        valid_rows[i] = output.lob_files[i].valid_rows;
+        file_sizes[i] = output.lob_files[i].file_size_bytes;
+
+        jstring path = env->NewStringUTF(output.lob_files[i].path);
+        env->SetObjectArrayElement(out_lob_paths, i, path);
+      }
+      env->SetLongArrayRegion(out_lob_field_ids, 0, n, field_ids.data());
+      if (out_lob_total_rows)
+        env->SetLongArrayRegion(out_lob_total_rows, 0, n, total_rows.data());
+      if (out_lob_valid_rows)
+        env->SetLongArrayRegion(out_lob_valid_rows, 0, n, valid_rows.data());
+      if (out_lob_file_sizes)
+        env->SetLongArrayRegion(out_lob_file_sizes, 0, n, file_sizes.data());
+    }
+
+    jlong cg_ptr = reinterpret_cast<jlong>(output.column_groups);
+    loon_segment_write_output_free(&output);
+    return cg_ptr;
+  } catch (const std::exception& e) {
+    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    return -1;
+  }
+}
+
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusSegmentWriter_segmentWriterDestroy(JNIEnv* env,
+                                                                                       jobject obj,
+                                                                                       jlong handle) {
+  loon_segment_writer_destroy(static_cast<LoonSegmentWriterHandle>(handle));
+}

--- a/cpp/src/lob_column/lob_column_manager.cpp
+++ b/cpp/src/lob_column/lob_column_manager.cpp
@@ -1,0 +1,75 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/lob_column/lob_column_manager.h"
+
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/lob_column/lob_column_writer.h"
+
+namespace milvus_storage::lob_column {
+
+// implementation of LobColumnManager
+class LobColumnManagerImpl : public LobColumnManager {
+  public:
+  LobColumnManagerImpl(std::shared_ptr<arrow::fs::FileSystem> fs, LobColumnConfig config)
+      : fs_(std::move(fs)), config_(std::move(config)) {}
+
+  arrow::Result<std::unique_ptr<LobColumnWriter>> CreateWriter() override {
+    return CreateLobColumnWriter(fs_, config_);
+  }
+
+  arrow::Result<std::unique_ptr<LobColumnReader>> CreateReader() override {
+    return CreateLobColumnReader(fs_, config_);
+  }
+
+  const LobColumnConfig& GetConfig() const override { return config_; }
+
+  std::shared_ptr<arrow::fs::FileSystem> GetFileSystem() const override { return fs_; }
+
+  private:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  LobColumnConfig config_;
+};
+
+// static factory method
+arrow::Result<std::unique_ptr<LobColumnManager>> LobColumnManager::Create(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                          const LobColumnConfig& config) {
+  if (!fs) {
+    return arrow::Status::Invalid("filesystem is null");
+  }
+
+  if (config.lob_base_path.empty()) {
+    return arrow::Status::Invalid("lob_base_path is empty");
+  }
+
+  if (config.inline_threshold == 0) {
+    return arrow::Status::Invalid("inline_threshold must be greater than 0");
+  }
+
+  if (config.max_lob_file_bytes == 0) {
+    return arrow::Status::Invalid("max_lob_file_bytes must be greater than 0");
+  }
+
+  if (config.flush_threshold_bytes == 0) {
+    return arrow::Status::Invalid("flush_threshold_bytes must be greater than 0");
+  }
+
+  if (config.flush_threshold_bytes > config.max_lob_file_bytes) {
+    return arrow::Status::Invalid("flush_threshold_bytes should not exceed max_lob_file_bytes");
+  }
+
+  return std::make_unique<LobColumnManagerImpl>(std::move(fs), config);
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/src/lob_column/lob_column_reader.cpp
+++ b/cpp/src/lob_column/lob_column_reader.cpp
@@ -1,0 +1,372 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/lob_column/lob_column_reader.h"
+
+#include <arrow/array/builder_binary.h>
+#include <arrow/table.h>
+
+#include <algorithm>
+#include <cstring>
+#include <map>
+#include <unordered_map>
+
+#include "milvus-storage/format/vortex/vortex_format_reader.h"
+
+namespace milvus_storage::lob_column {
+
+namespace {
+
+// zero-copy view into an Arrow buffer
+struct DataView {
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+};
+
+// extract raw bytes from a BinaryArray chunk at the given index
+std::vector<uint8_t> GetBinaryValue(const std::shared_ptr<arrow::BinaryArray>& array, int64_t index) {
+  int32_t length;
+  const uint8_t* value = array->GetValue(index, &length);
+  return std::vector<uint8_t>(value, value + length);
+}
+
+}  // namespace
+
+// implementation of LobColumnReader using Vortex format
+class LobColumnReaderImpl : public LobColumnReader {
+  public:
+  LobColumnReaderImpl(std::shared_ptr<arrow::fs::FileSystem> fs, const LobColumnConfig& config)
+      : fs_(std::move(fs)), config_(config), closed_(false) {}
+
+  ~LobColumnReaderImpl() override {
+    if (!closed_) {
+      // best effort close, ignore errors in destructor
+      (void)Close();
+    }
+  }
+
+  arrow::Result<std::vector<uint8_t>> ReadData(const uint8_t* encoded_ref, size_t ref_size) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    if (ref_size == 0 || encoded_ref == nullptr) {
+      return arrow::Status::Invalid("invalid encoded reference");
+    }
+
+    // check if inline or LOB reference
+    if (IsInlineData(encoded_ref)) {
+      const uint8_t* payload;
+      size_t payload_size;
+      DecodeInlineData(encoded_ref, ref_size, &payload, &payload_size);
+      if (payload == nullptr) {
+        return std::vector<uint8_t>{};
+      }
+      return std::vector<uint8_t>(payload, payload + payload_size);
+    }
+
+    if (ref_size != LOB_REFERENCE_SIZE) {
+      return arrow::Status::Invalid("invalid LOB reference size: ", ref_size, ", expected: ", LOB_REFERENCE_SIZE);
+    }
+
+    auto [file_id_str, row_offset] = DecodeLOBReference(encoded_ref);
+
+    // get or open the vortex reader for this file
+    ARROW_ASSIGN_OR_RAISE(auto reader, GetOrOpenReader(file_id_str));
+
+    // read using take API
+    std::vector<int64_t> indices = {static_cast<int64_t>(row_offset)};
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->take(indices));
+
+    if (table->num_rows() == 0) {
+      return arrow::Status::IndexError("row offset out of range: ", row_offset);
+    }
+
+    auto lob_column = table->column(0);
+    if (lob_column->num_chunks() == 0 || lob_column->chunk(0)->length() == 0) {
+      return arrow::Status::IndexError("no data at row offset: ", row_offset);
+    }
+
+    auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(lob_column->chunk(0));
+    return GetBinaryValue(binary_array, 0);
+  }
+
+  arrow::Result<std::vector<std::vector<uint8_t>>> ReadBatchData(const std::vector<EncodedRef>& encoded_refs) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    std::vector<std::vector<uint8_t>> results(encoded_refs.size());
+
+    // group LOB references by file_id for efficient batch reading
+    // key: file_id (as string), value: vector of (original_index, row_offset)
+    std::map<std::string, std::vector<std::pair<size_t, int32_t>>> file_groups;
+
+    for (size_t i = 0; i < encoded_refs.size(); i++) {
+      const auto& ref = encoded_refs[i];
+
+      if (ref.data == nullptr || ref.size == 0) {
+        results[i] = {};
+        continue;
+      }
+
+      if (IsInlineData(ref.data)) {
+        const uint8_t* payload;
+        size_t payload_size;
+        DecodeInlineData(ref.data, ref.size, &payload, &payload_size);
+        if (payload != nullptr) {
+          results[i] = std::vector<uint8_t>(payload, payload + payload_size);
+        }
+      } else {
+        if (ref.size != LOB_REFERENCE_SIZE) {
+          return arrow::Status::Invalid("invalid LOB reference size at index ", i);
+        }
+
+        auto [file_id_str, row_offset] = DecodeLOBReference(ref.data);
+        file_groups[file_id_str].emplace_back(i, row_offset);
+      }
+    }
+
+    // process each file group
+    for (auto& [file_id_str, idx_offsets] : file_groups) {
+      ARROW_ASSIGN_OR_RAISE(auto reader, GetOrOpenReader(file_id_str));
+
+      // collect row indices and sort for efficient access
+      std::vector<std::pair<int32_t, size_t>> sorted_offsets;  // (row_offset, original_group_index)
+      sorted_offsets.reserve(idx_offsets.size());
+      for (size_t j = 0; j < idx_offsets.size(); j++) {
+        sorted_offsets.emplace_back(idx_offsets[j].second, j);
+      }
+      std::sort(sorted_offsets.begin(), sorted_offsets.end());
+
+      // build row indices array for take
+      std::vector<int64_t> row_indices;
+      row_indices.reserve(sorted_offsets.size());
+      for (const auto& [offset, _] : sorted_offsets) {
+        row_indices.push_back(static_cast<int64_t>(offset));
+      }
+
+      // batch read using take API
+      ARROW_ASSIGN_OR_RAISE(auto table, reader->take(row_indices));
+
+      // extract data and map back to original order
+      auto lob_column = table->column(0);
+      size_t data_idx = 0;
+
+      for (int chunk_idx = 0; chunk_idx < lob_column->num_chunks(); chunk_idx++) {
+        auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(lob_column->chunk(chunk_idx));
+        for (int64_t k = 0; k < binary_array->length(); k++) {
+          if (data_idx < sorted_offsets.size()) {
+            size_t group_idx = sorted_offsets[data_idx].second;
+            size_t original_idx = idx_offsets[group_idx].first;
+            results[original_idx] = GetBinaryValue(binary_array, k);
+            data_idx++;
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::BinaryArray>> ReadArrowArray(
+      const std::shared_ptr<arrow::BinaryArray>& encoded_refs) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    const int64_t n = encoded_refs->length();
+
+    std::vector<DataView> views(n);
+    // vortex tables must stay alive until the builder copies their data
+    std::vector<std::shared_ptr<arrow::Table>> keep_alive;
+
+    // group LOB references by file_id for batch reading
+    std::map<std::string, std::vector<std::pair<int64_t, int32_t>>> file_groups;
+
+    size_t total_bytes = 0;
+    for (int64_t i = 0; i < n; i++) {
+      if (encoded_refs->IsNull(i)) {
+        continue;
+      }
+
+      int32_t length;
+      const uint8_t* raw = encoded_refs->GetValue(i, &length);
+
+      if (IsInlineData(raw)) {
+        const uint8_t* payload;
+        size_t payload_size;
+        DecodeInlineData(raw, static_cast<size_t>(length), &payload, &payload_size);
+        views[i] = {payload, payload_size};
+        total_bytes += payload_size;
+      } else {
+        if (static_cast<size_t>(length) != LOB_REFERENCE_SIZE) {
+          return arrow::Status::Invalid("invalid LOB reference size at index ", i);
+        }
+        auto ref = DecodeLOBReference(raw);
+        file_groups[ref.file_id].emplace_back(i, ref.row_offset);
+      }
+    }
+
+    // batch read each file's LOB entries via vortex take()
+    for (auto& [file_id_str, idx_offsets] : file_groups) {
+      ARROW_ASSIGN_OR_RAISE(auto reader, GetOrOpenReader(file_id_str));
+
+      // sort by row_offset for sequential I/O
+      std::vector<std::pair<int32_t, size_t>> sorted;
+      sorted.reserve(idx_offsets.size());
+      for (size_t j = 0; j < idx_offsets.size(); j++) {
+        sorted.emplace_back(idx_offsets[j].second, j);
+      }
+      std::sort(sorted.begin(), sorted.end());
+
+      std::vector<int64_t> row_indices;
+      row_indices.reserve(sorted.size());
+      for (const auto& [offset, _] : sorted) {
+        row_indices.push_back(static_cast<int64_t>(offset));
+      }
+
+      ARROW_ASSIGN_OR_RAISE(auto table, reader->take(row_indices));
+      keep_alive.push_back(table);
+
+      // populate views with zero-copy pointers into the table's chunks
+      auto lob_col = table->column(0);
+      size_t data_idx = 0;
+      for (int c = 0; c < lob_col->num_chunks(); c++) {
+        auto chunk = std::static_pointer_cast<arrow::BinaryArray>(lob_col->chunk(c));
+        for (int64_t k = 0; k < chunk->length() && data_idx < sorted.size(); k++, data_idx++) {
+          size_t group_idx = sorted[data_idx].second;
+          int64_t original_idx = idx_offsets[group_idx].first;
+
+          int32_t val_len;
+          const uint8_t* val_data = chunk->GetValue(k, &val_len);
+          views[original_idx] = {val_data, static_cast<size_t>(val_len)};
+          total_bytes += val_len;
+        }
+      }
+    }
+
+    // single copy: views → BinaryBuilder
+    arrow::BinaryBuilder builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(n));
+    ARROW_RETURN_NOT_OK(builder.ReserveData(static_cast<int64_t>(total_bytes)));
+
+    for (int64_t i = 0; i < n; i++) {
+      if (encoded_refs->IsNull(i)) {
+        ARROW_RETURN_NOT_OK(builder.AppendNull());
+      } else {
+        ARROW_RETURN_NOT_OK(builder.Append(views[i].data, views[i].size));
+      }
+    }
+
+    std::shared_ptr<arrow::BinaryArray> result;
+    ARROW_RETURN_NOT_OK(builder.Finish(&result));
+    return result;
+  }
+
+  arrow::Result<std::vector<std::vector<uint8_t>>> TakeData(const std::string& file_id_str,
+                                                            const std::vector<int32_t>& row_offsets) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto reader, GetOrOpenReader(file_id_str));
+
+    // convert to int64_t for take API
+    std::vector<int64_t> indices;
+    indices.reserve(row_offsets.size());
+    for (auto offset : row_offsets) {
+      indices.push_back(static_cast<int64_t>(offset));
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->take(indices));
+
+    std::vector<std::vector<uint8_t>> results;
+    results.reserve(row_offsets.size());
+
+    auto lob_column = table->column(0);
+    for (int chunk_idx = 0; chunk_idx < lob_column->num_chunks(); chunk_idx++) {
+      auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(lob_column->chunk(chunk_idx));
+      for (int64_t k = 0; k < binary_array->length(); k++) {
+        results.push_back(GetBinaryValue(binary_array, k));
+      }
+    }
+
+    return results;
+  }
+
+  arrow::Status Close() override {
+    if (closed_) {
+      return arrow::Status::OK();
+    }
+
+    reader_cache_.clear();
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  bool IsClosed() const override { return closed_; }
+
+  void ClearCache() override { reader_cache_.clear(); }
+
+  private:
+  std::shared_ptr<arrow::DataType> ArrowType() const {
+    return config_.data_type == LobDataType::kText ? arrow::utf8() : arrow::binary();
+  }
+
+  std::string FieldName() const { return config_.data_type == LobDataType::kText ? "text_data" : "binary_data"; }
+
+  // get or open a vortex reader for the given file_id_str (UUID string)
+  arrow::Result<std::shared_ptr<vortex::VortexFormatReader>> GetOrOpenReader(const std::string& file_id_str) {
+    // check cache
+    auto it = reader_cache_.find(file_id_str);
+    if (it != reader_cache_.end()) {
+      return it->second;
+    }
+
+    // build file path using the function from lob_reference.h
+    auto file_path = BuildLOBFilePath(config_.lob_base_path, file_id_str);
+
+    auto field_name = FieldName();
+    auto schema = arrow::schema({
+        arrow::field(field_name, ArrowType(), false),
+    });
+
+    // create and open reader
+    auto reader = std::make_shared<vortex::VortexFormatReader>(fs_, schema, file_path, config_.properties,
+                                                               std::vector<std::string>{field_name});
+
+    ARROW_RETURN_NOT_OK(reader->open());
+
+    // cache the reader
+    reader_cache_[file_id_str] = reader;
+    return reader;
+  }
+
+  private:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  LobColumnConfig config_;
+  bool closed_;
+
+  // cache of open vortex readers, keyed by file_id
+  std::unordered_map<std::string, std::shared_ptr<vortex::VortexFormatReader>> reader_cache_;
+};
+
+// factory function to create LobColumnReader
+arrow::Result<std::unique_ptr<LobColumnReader>> CreateLobColumnReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                      const LobColumnConfig& config) {
+  return std::make_unique<LobColumnReaderImpl>(std::move(fs), config);
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/src/lob_column/lob_column_writer.cpp
+++ b/cpp/src/lob_column/lob_column_writer.cpp
@@ -1,0 +1,334 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/lob_column/lob_column_writer.h"
+
+#include <arrow/array/builder_binary.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
+#include <numeric>
+
+#include "milvus-storage/lob_column/lob_reference.h"
+#include "milvus-storage/filesystem/fs.h"
+
+#include "milvus-storage/format/vortex/vortex_writer.h"
+
+namespace milvus_storage::lob_column {
+
+// implementation of LobColumnWriter using Vortex format
+class LobColumnWriterImpl : public LobColumnWriter {
+  public:
+  LobColumnWriterImpl(std::shared_ptr<arrow::fs::FileSystem> fs, const LobColumnConfig& config)
+      : fs_(std::move(fs)),
+        config_(config),
+        closed_(false),
+        written_rows_(0),
+        current_file_rows_(0),
+        current_file_bytes_(0),
+        pending_bytes_(0) {
+    // generate binary UUID for the first LOB file
+    GenerateUUIDBinary(current_file_id_);
+  }
+
+  ~LobColumnWriterImpl() override {
+    if (!closed_) {
+      // best effort abort, ignore errors in destructor
+      (void)Abort();
+    }
+  }
+
+  arrow::Result<std::vector<uint8_t>> WriteData(const uint8_t* data, size_t data_size) override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is closed");
+    }
+
+    // check if data should be stored inline
+    if (data_size < config_.inline_threshold) {
+      stats_.inline_entries++;
+      stats_.total_entries++;
+      stats_.total_bytes += data_size;
+      written_rows_++;
+      return EncodeInlineData(data, data_size);
+    }
+
+    // data is too large, store as LOB
+    ARROW_RETURN_NOT_OK(EnsureVortexWriter());
+
+    // get current row offset in the LOB file
+    int32_t row_offset = static_cast<int32_t>(current_file_rows_);
+
+    // append directly to Arrow builder (single copy, no intermediate buffer)
+    ARROW_RETURN_NOT_OK(pending_builder_.Append(data, static_cast<int32_t>(data_size)));
+    pending_bytes_ += data_size;
+    current_file_rows_++;
+
+    // encode LOB reference
+    auto ref = EncodeLOBReference(current_file_id_, row_offset);
+
+    stats_.lob_entries++;
+    stats_.total_entries++;
+    stats_.total_bytes += data_size;
+    written_rows_++;
+
+    if (pending_bytes_ >= config_.flush_threshold_bytes) {
+      ARROW_RETURN_NOT_OK(FlushPending());
+      ARROW_RETURN_NOT_OK(MaybeRollFile());
+    }
+
+    return ref;
+  }
+
+  arrow::Result<std::vector<std::vector<uint8_t>>> WriteBatchData(
+      const std::vector<std::pair<const uint8_t*, size_t>>& items) override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is closed");
+    }
+
+    std::vector<std::vector<uint8_t>> results;
+    results.reserve(items.size());
+
+    for (const auto& [data, data_size] : items) {
+      if (data_size < config_.inline_threshold) {
+        results.push_back(EncodeInlineData(data, data_size));
+        stats_.inline_entries++;
+      } else {
+        ARROW_RETURN_NOT_OK(EnsureVortexWriter());
+
+        int32_t row_offset = static_cast<int32_t>(current_file_rows_);
+        ARROW_RETURN_NOT_OK(pending_builder_.Append(data, static_cast<int32_t>(data_size)));
+        pending_bytes_ += data_size;
+        current_file_rows_++;
+
+        results.push_back(EncodeLOBReference(current_file_id_, row_offset));
+        stats_.lob_entries++;
+
+        if (pending_bytes_ >= config_.flush_threshold_bytes) {
+          ARROW_RETURN_NOT_OK(FlushPending());
+          ARROW_RETURN_NOT_OK(MaybeRollFile());
+        }
+      }
+
+      stats_.total_entries++;
+      stats_.total_bytes += data_size;
+    }
+
+    written_rows_ += items.size();
+    return results;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::BinaryArray>> WriteArrowArray(
+      const std::shared_ptr<arrow::BinaryArray>& data_array) override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is closed");
+    }
+
+    arrow::BinaryBuilder builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(data_array->length()));
+
+    for (int64_t i = 0; i < data_array->length(); i++) {
+      if (data_array->IsNull(i)) {
+        ARROW_RETURN_NOT_OK(builder.AppendNull());
+        stats_.total_entries++;
+        written_rows_++;
+      } else {
+        int32_t length;
+        const uint8_t* value = data_array->GetValue(i, &length);
+        ARROW_ASSIGN_OR_RAISE(auto ref, WriteData(value, static_cast<size_t>(length)));
+        ARROW_RETURN_NOT_OK(builder.Append(ref.data(), ref.size()));
+      }
+    }
+
+    std::shared_ptr<arrow::BinaryArray> result;
+    ARROW_RETURN_NOT_OK(builder.Finish(&result));
+    return result;
+  }
+
+  arrow::Status Flush() override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is closed");
+    }
+
+    ARROW_RETURN_NOT_OK(FlushPending());
+    ARROW_RETURN_NOT_OK(MaybeRollFile());
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<std::vector<LobFileResult>> Close() override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is already closed");
+    }
+
+    ARROW_RETURN_NOT_OK(FlushPending());
+    ARROW_RETURN_NOT_OK(CloseCurrentFile());
+
+    closed_ = true;
+    return created_files_;
+  }
+
+  arrow::Status Abort() override {
+    if (closed_) {
+      return arrow::Status::OK();
+    }
+
+    // discard pending data
+    pending_builder_.Reset();
+
+    // close vortex writer without committing
+    if (vortex_writer_) {
+      vortex_writer_.reset();
+    }
+
+    // delete created files (best effort, ignore errors)
+    for (const auto& file_result : created_files_) {
+      (void)fs_->DeleteFile(file_result.path);
+    }
+
+    created_files_.clear();
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  int64_t WrittenRows() const override { return written_rows_; }
+
+  LobColumnWriterStats GetStats() const override { return stats_; }
+
+  bool IsClosed() const override { return closed_; }
+
+  private:
+  std::shared_ptr<arrow::DataType> ArrowType() const {
+    return config_.data_type == LobDataType::kText ? arrow::utf8() : arrow::binary();
+  }
+
+  std::string FieldName() const { return config_.data_type == LobDataType::kText ? "text_data" : "binary_data"; }
+
+  // ensure vortex writer is initialized
+  arrow::Status EnsureVortexWriter() {
+    if (vortex_writer_) {
+      return arrow::Status::OK();
+    }
+
+    auto schema = arrow::schema({
+        arrow::field(FieldName(), ArrowType(), false),
+    });
+
+    // build file path (convert binary UUID to string for path)
+    auto file_path = BuildLOBFilePath(config_.lob_base_path, UUIDToString(current_file_id_));
+
+    // ensure parent directory exists (only needed for local filesystem;
+    // remote/S3 filesystems auto-create parent paths on put)
+    if (IsLocalFileSystem(fs_)) {
+      auto parent_dir = file_path.substr(0, file_path.rfind('/'));
+      ARROW_RETURN_NOT_OK(fs_->CreateDir(parent_dir, true));
+    }
+
+    // create vortex writer
+    vortex_writer_ = std::make_unique<vortex::VortexFileWriter>(fs_, schema, file_path, config_.properties);
+
+    // add placeholder entry - will be updated with actual stats when file is closed
+    created_files_.push_back(LobFileResult{file_path, 0, 0, 0});
+    stats_.lob_files_created++;
+
+    return arrow::Status::OK();
+  }
+
+  // flush pending data to the current vortex file
+  arrow::Status FlushPending() {
+    if (pending_builder_.length() == 0) {
+      return arrow::Status::OK();
+    }
+
+    std::shared_ptr<arrow::Array> array;
+    ARROW_RETURN_NOT_OK(pending_builder_.Finish(&array));
+
+    auto schema = arrow::schema({
+        arrow::field(FieldName(), ArrowType(), false),
+    });
+    auto batch = arrow::RecordBatch::Make(schema, array->length(), {array});
+
+    ARROW_RETURN_NOT_OK(vortex_writer_->Write(batch));
+    ARROW_RETURN_NOT_OK(vortex_writer_->Flush());
+
+    current_file_bytes_ += pending_bytes_;
+    pending_bytes_ = 0;
+
+    return arrow::Status::OK();
+  }
+
+  // close the current vortex file and finalize its metadata
+  arrow::Status CloseCurrentFile() {
+    if (!vortex_writer_) {
+      return arrow::Status::OK();
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto cgfile, vortex_writer_->Close());
+    (void)cgfile;
+
+    if (!created_files_.empty()) {
+      auto& last_file = created_files_.back();
+      last_file.total_rows = current_file_rows_;
+      last_file.valid_rows = current_file_rows_;
+      last_file.file_size_bytes = static_cast<int64_t>(current_file_bytes_);
+    }
+
+    vortex_writer_.reset();
+    return arrow::Status::OK();
+  }
+
+  // if the current file exceeds max size, close it and prepare for a new one
+  arrow::Status MaybeRollFile() {
+    if (current_file_bytes_ < config_.max_lob_file_bytes) {
+      return arrow::Status::OK();
+    }
+
+    ARROW_RETURN_NOT_OK(CloseCurrentFile());
+
+    GenerateUUIDBinary(current_file_id_);
+    current_file_rows_ = 0;
+    current_file_bytes_ = 0;
+
+    return arrow::Status::OK();
+  }
+
+  private:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  LobColumnConfig config_;
+  bool closed_;
+  int64_t written_rows_;
+
+  // current LOB file state
+  uint8_t current_file_id_[UUID_BINARY_SIZE];  // binary UUID (16 bytes)
+  int64_t current_file_rows_;
+  size_t current_file_bytes_;  // bytes written to current file
+  std::unique_ptr<vortex::VortexFileWriter> vortex_writer_;
+
+  // pending data accumulates directly in Arrow builder to avoid double-copy.
+  // BinaryBuilder works for both text (utf8 is binary-compatible) and binary data.
+  arrow::BinaryBuilder pending_builder_;
+  size_t pending_bytes_;
+
+  // created file results (for cleanup on abort and return on close)
+  std::vector<LobFileResult> created_files_;
+
+  // statistics
+  LobColumnWriterStats stats_;
+};
+
+// factory function to create LobColumnWriter
+arrow::Result<std::unique_ptr<LobColumnWriter>> CreateLobColumnWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                      const LobColumnConfig& config) {
+  return std::make_unique<LobColumnWriterImpl>(std::move(fs), config);
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/src/lob_column/lob_reference.cpp
+++ b/cpp/src/lob_column/lob_reference.cpp
@@ -1,0 +1,79 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/lob_column/lob_reference.h"
+
+#include <cstring>
+#include <filesystem>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace milvus_storage::lob_column {
+
+std::vector<uint8_t> EncodeInlineData(const uint8_t* payload, size_t size) {
+  std::vector<uint8_t> data(1 + size);
+  data[0] = FLAG_INLINE_DATA;
+  if (size > 0) {
+    std::memcpy(&data[1], payload, size);
+  }
+  return data;
+}
+
+void DecodeInlineData(const uint8_t* data, size_t data_size, const uint8_t** out_payload, size_t* out_size) {
+  if (data_size <= 1) {
+    *out_payload = nullptr;
+    *out_size = 0;
+    return;
+  }
+  *out_payload = data + 1;
+  *out_size = data_size - 1;
+}
+
+EncodedLOBRef EncodeLOBReference(const uint8_t* file_id, int32_t row_offset) {
+  EncodedLOBRef ref;  // zero-initialized by default
+  ref[0] = FLAG_LOB_REFERENCE;
+  std::memcpy(&ref[4], file_id, UUID_BINARY_SIZE);
+  std::memcpy(&ref[20], &row_offset, sizeof(int32_t));
+  return ref;
+}
+
+LOBReference DecodeLOBReference(const uint8_t* data) {
+  LOBReference ref;
+  ref.file_id = UUIDToString(data + 4);
+  std::memcpy(&ref.row_offset, data + 20, sizeof(int32_t));
+  return ref;
+}
+
+void GenerateUUIDBinary(uint8_t* out) {
+  // use boost::uuids for consistent UUID generation with the rest of the project
+  static thread_local boost::uuids::random_generator gen;
+  boost::uuids::uuid boost_uuid = gen();
+  std::memcpy(out, boost_uuid.data, UUID_BINARY_SIZE);
+}
+
+std::string UUIDToString(const uint8_t* uuid) {
+  // convert binary UUID to string format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  boost::uuids::uuid boost_uuid;
+  std::memcpy(boost_uuid.data, uuid, UUID_BINARY_SIZE);
+  return boost::uuids::to_string(boost_uuid);
+}
+
+std::string BuildLOBFilePath(const std::string& lob_base_path, const std::string& file_id_str) {
+  std::filesystem::path path = std::filesystem::path(lob_base_path) / "_data" / (file_id_str + ".vx");
+  return path.string();
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -169,12 +169,32 @@ struct codec_traits<milvus_storage::api::Statistics> {
 };
 
 template <>
+struct codec_traits<milvus_storage::api::LobFileInfo> {
+  static void encode(Encoder& e, const milvus_storage::api::LobFileInfo& lob_file) {
+    avro::encode(e, lob_file.path);
+    avro::encode(e, lob_file.field_id);
+    avro::encode(e, lob_file.total_rows);
+    avro::encode(e, lob_file.valid_rows);
+    avro::encode(e, lob_file.file_size_bytes);
+  }
+
+  static void decode(Decoder& d, milvus_storage::api::LobFileInfo& lob_file) {
+    avro::decode(d, lob_file.path);
+    avro::decode(d, lob_file.field_id);
+    avro::decode(d, lob_file.total_rows);
+    avro::decode(d, lob_file.valid_rows);
+    avro::decode(d, lob_file.file_size_bytes);
+  }
+};
+
+template <>
 struct codec_traits<milvus_storage::api::Manifest> {
   static void encode(Encoder& e, const milvus_storage::api::Manifest& m) {
     avro::encode(e, m.columnGroups());
     avro::encode(e, m.deltaLogs());
     avro::encode(e, m.stats());
     avro::encode(e, m.indexes());
+    avro::encode(e, m.lobFiles());
   }
 
   static void decode(Decoder& d, milvus_storage::api::Manifest& m) {
@@ -182,6 +202,7 @@ struct codec_traits<milvus_storage::api::Manifest> {
     avro::decode(d, m.deltaLogs());
     avro::decode(d, m.stats());
     avro::decode(d, m.indexes());
+    avro::decode(d, m.lobFiles());
   }
 };
 
@@ -232,6 +253,15 @@ static const char* const MANIFEST_SCHEMA_JSON = R"({
         {"name": "index_type", "type": "string"},
         {"name": "path", "type": "string"},
         {"name": "properties", "type": {"type": "map", "values": "string"}, "default": {}}
+      ]
+    }}, "default": []},
+    {"name": "lob_files", "type": {"type": "array", "items": {
+      "type": "record", "name": "LobFileInfo", "fields": [
+        {"name": "path", "type": "string"},
+        {"name": "field_id", "type": "long"},
+        {"name": "total_rows", "type": "long"},
+        {"name": "valid_rows", "type": "long"},
+        {"name": "file_size_bytes", "type": "long"}
       ]
     }}, "default": []}
   ]
@@ -288,19 +318,22 @@ Manifest::Manifest(ColumnGroups column_groups,
                    const std::vector<DeltaLog>& delta_logs,
                    const std::map<std::string, Statistics>& stats,
                    const std::vector<Index>& indexes,
+                   const std::vector<LobFileInfo>& lob_files,
                    uint32_t version)
     : version_(version),
       column_groups_(std::move(column_groups)),
       delta_logs_(delta_logs),
       stats_(stats),
-      indexes_(indexes) {}
+      indexes_(indexes),
+      lob_files_(lob_files) {}
 
 Manifest::Manifest(const Manifest& other)
     : version_(other.version_),
       column_groups_(copy_column_groups(other.column_groups_)),
       delta_logs_(other.delta_logs_),
       stats_(other.stats_),
-      indexes_(other.indexes_) {}
+      indexes_(other.indexes_),
+      lob_files_(other.lob_files_) {}
 
 Manifest& Manifest::operator=(const Manifest& other) {
   if (this != &other) {
@@ -309,6 +342,7 @@ Manifest& Manifest::operator=(const Manifest& other) {
     delta_logs_ = other.delta_logs_;
     stats_ = other.stats_;
     indexes_ = other.indexes_;
+    lob_files_ = other.lob_files_;
   }
   return *this;
 }
@@ -337,6 +371,7 @@ arrow::Status Manifest::deserialize(std::istream& input_stream) {
     delta_logs_.clear();
     stats_.clear();
     indexes_.clear();
+    lob_files_.clear();
     return arrow::Status::Invalid(msg);
   };
 
@@ -432,6 +467,12 @@ void Manifest::deserializeLegacy(std::istream& input_stream) {
   } else {
     indexes_.clear();
   }
+
+  if (version >= 5) {
+    avro::decode(*decoder, lob_files_);
+  } else {
+    lob_files_.clear();
+  }
 }
 
 std::shared_ptr<ColumnGroup> Manifest::getColumnGroup(const std::string& column_name) const {
@@ -480,6 +521,12 @@ Manifest Manifest::toRelativePaths(const std::string& base_path) const {
     idx.path = ToRelative(idx.path, std::optional<std::string>(base_path), milvus_storage::kIndexPath);
   }
 
+  // normalize LOB file paths (convert absolute to relative)
+  // LOB files live at partition level ({partition}/lobs/{field_id}/_data/), use kLobPath to resolve
+  for (auto& lob_file : copy_manifest.lob_files_) {
+    lob_file.path = ToRelative(lob_file.path, std::optional<std::string>(base_path), milvus_storage::kLobPath);
+  }
+
   return copy_manifest;
 }
 
@@ -505,6 +552,11 @@ void Manifest::ToAbsolutePaths(const std::string& base_path) {
   // denormalize index paths (convert relative to absolute)
   for (auto& idx : indexes_) {
     idx.path = ToAbsolute(idx.path, std::optional<std::string>(base_path), milvus_storage::kIndexPath);
+  }
+
+  // denormalize LOB file paths (convert relative to absolute)
+  for (auto& lob_file : lob_files_) {
+    lob_file.path = ToAbsolute(lob_file.path, std::optional<std::string>(base_path), milvus_storage::kLobPath);
   }
 }
 

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -14,6 +14,7 @@
 
 #include "milvus-storage/reader.h"
 
+#include <cstdio>
 #include <memory>
 #include <numeric>
 #include <algorithm>
@@ -287,6 +288,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
     }
 
     current_offset_ += min_rows;
+
     *out_batch = arrow::RecordBatch::Make(out_schema_, min_rows, out_arrays);
 
     return arrow::Status::OK();

--- a/cpp/src/segment/segment_reader.cpp
+++ b/cpp/src/segment/segment_reader.cpp
@@ -1,0 +1,432 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/segment/segment_reader.h"
+
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/reader.h"
+
+namespace milvus_storage::segment {
+
+// wrapper that auto-resolves LOB references (TEXT or BINARY) in each batch
+class LobResolvingRecordBatchReader : public arrow::RecordBatchReader {
+  public:
+  LobResolvingRecordBatchReader(
+      std::shared_ptr<arrow::RecordBatchReader> inner,
+      std::shared_ptr<arrow::Schema> resolved_schema,
+      const std::unordered_map<int, std::unique_ptr<lob_column::LobColumnReader>>& lob_readers)
+      : inner_(std::move(inner)), resolved_schema_(std::move(resolved_schema)), lob_readers_(lob_readers) {}
+
+  std::shared_ptr<arrow::Schema> schema() const override { return resolved_schema_; }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+    std::shared_ptr<arrow::RecordBatch> storage_batch;
+    ARROW_RETURN_NOT_OK(inner_->ReadNext(&storage_batch));
+
+    if (!storage_batch) {
+      *batch = nullptr;
+      return arrow::Status::OK();
+    }
+
+    std::vector<std::shared_ptr<arrow::Array>> columns;
+    columns.reserve(storage_batch->num_columns());
+
+    for (int i = 0; i < storage_batch->num_columns(); i++) {
+      auto it = lob_readers_.find(i);
+      if (it != lob_readers_.end()) {
+        auto ref_array = std::dynamic_pointer_cast<arrow::BinaryArray>(storage_batch->column(i));
+        if (!ref_array) {
+          return arrow::Status::Invalid("expected BinaryArray for LOB column reference");
+        }
+        ARROW_ASSIGN_OR_RAISE(auto resolved_array, it->second->ReadArrowArray(ref_array));
+        columns.push_back(std::static_pointer_cast<arrow::Array>(resolved_array));
+      } else {
+        columns.push_back(storage_batch->column(i));
+      }
+    }
+
+    *batch = arrow::RecordBatch::Make(resolved_schema_, storage_batch->num_rows(), columns);
+    return arrow::Status::OK();
+  }
+
+  private:
+  std::shared_ptr<arrow::RecordBatchReader> inner_;
+  std::shared_ptr<arrow::Schema> resolved_schema_;
+  const std::unordered_map<int, std::unique_ptr<lob_column::LobColumnReader>>& lob_readers_;
+};
+
+// implementation of SegmentReader
+class SegmentReaderImpl : public SegmentReader {
+  public:
+  SegmentReaderImpl(std::shared_ptr<arrow::fs::FileSystem> fs,
+                    std::shared_ptr<arrow::Schema> original_schema,
+                    std::shared_ptr<arrow::Schema> extracted_schema,
+                    std::shared_ptr<arrow::Schema> storage_schema,
+                    std::vector<std::string> extracted_columns,
+                    const SegmentReaderConfig& config,
+                    std::vector<int> lob_column_indices)
+      : fs_(std::move(fs)),
+        original_schema_(std::move(original_schema)),
+        extracted_schema_(std::move(extracted_schema)),
+        storage_schema_(std::move(storage_schema)),
+        extracted_columns_(std::move(extracted_columns)),
+        config_(config),
+        lob_column_indices_(std::move(lob_column_indices)),
+        closed_(false),
+        total_rows_(0) {}
+
+  ~SegmentReaderImpl() override {
+    if (!closed_) {
+      (void)Close();
+    }
+  }
+
+  arrow::Status Init(const std::shared_ptr<api::ColumnGroups>& column_groups) {
+    column_groups_ = column_groups;
+
+    // create api::Reader with needed columns (storage schema column names)
+    std::vector<std::string> storage_column_names;
+    for (int i = 0; i < storage_schema_->num_fields(); i++) {
+      storage_column_names.push_back(storage_schema_->field(i)->name());
+    }
+
+    auto needed_columns = std::make_shared<std::vector<std::string>>(storage_column_names);
+    reader_ = api::Reader::create(column_groups_, storage_schema_, needed_columns, config_.properties);
+
+    // create LobColumnReaders for each TEXT column in extracted columns
+    for (int extracted_idx : lob_column_indices_) {
+      auto field = extracted_schema_->field(extracted_idx);
+      auto field_id = GetFieldId(field);
+      if (field_id < 0) {
+        return arrow::Status::Invalid("TEXT column must have a valid field_id in metadata");
+      }
+
+      auto it = config_.lob_columns.find(field_id);
+      if (it == config_.lob_columns.end()) {
+        return arrow::Status::Invalid("TEXT column config not found for field_id: " + std::to_string(field_id));
+      }
+
+      ARROW_ASSIGN_OR_RAISE(auto text_reader, lob_column::CreateLobColumnReader(fs_, it->second));
+      lob_readers_[extracted_idx] = std::move(text_reader);
+    }
+
+    // get record batch reader for sequential access
+    ARROW_ASSIGN_OR_RAISE(batch_reader_, reader_->get_record_batch_reader());
+
+    return arrow::Status::OK();
+  }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    // read from underlying reader
+    std::shared_ptr<arrow::RecordBatch> storage_batch;
+    ARROW_RETURN_NOT_OK(batch_reader_->ReadNext(&storage_batch));
+
+    if (!storage_batch) {
+      *batch = nullptr;
+      return arrow::Status::OK();
+    }
+
+    total_rows_ += storage_batch->num_rows();
+
+    // resolve TEXT columns
+    ARROW_ASSIGN_OR_RAISE(*batch, ResolveLobColumns(storage_batch));
+
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<std::shared_ptr<arrow::Table>> Take(const std::vector<int64_t>& row_indices,
+                                                    size_t parallelism) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    if (row_indices.empty()) {
+      // return empty table with correct schema
+      return arrow::Table::MakeEmpty(extracted_schema_);
+    }
+
+    // use api::Reader's take method
+    ARROW_ASSIGN_OR_RAISE(auto storage_table, reader_->take(row_indices, parallelism));
+
+    // convert table to batches, resolve TEXT, then convert back
+    arrow::TableBatchReader table_reader(*storage_table);
+    std::vector<std::shared_ptr<arrow::RecordBatch>> resolved_batches;
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(table_reader.ReadNext(&batch));
+      if (!batch) {
+        break;
+      }
+      ARROW_ASSIGN_OR_RAISE(auto resolved_batch, ResolveLobColumns(batch));
+      resolved_batches.push_back(resolved_batch);
+    }
+
+    if (resolved_batches.empty()) {
+      return arrow::Table::MakeEmpty(extracted_schema_);
+    }
+
+    return arrow::Table::FromRecordBatches(extracted_schema_, resolved_batches);
+  }
+
+  std::shared_ptr<arrow::Schema> schema() const override { return extracted_schema_; }
+
+  std::shared_ptr<arrow::Schema> GetOriginalSchema() const override { return original_schema_; }
+
+  const std::vector<std::string>& GetExtractedColumns() const override { return extracted_columns_; }
+
+  int64_t GetTotalRows() const override { return total_rows_; }
+
+  arrow::Status Close() override {
+    if (closed_) {
+      return arrow::Status::OK();
+    }
+
+    // close LobColumnReaders
+    for (auto& [idx, reader] : lob_readers_) {
+      ARROW_RETURN_NOT_OK(reader->Close());
+    }
+
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  bool IsClosed() const override { return closed_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetStream(const std::string& predicate) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto inner, reader_->get_record_batch_reader(predicate));
+
+    if (lob_readers_.empty()) {
+      // no TEXT columns, return inner reader directly
+      return inner;
+    }
+
+    // wrap with LOB-resolving reader
+    return std::make_shared<LobResolvingRecordBatchReader>(std::move(inner), extracted_schema_, lob_readers_);
+  }
+
+  arrow::Result<std::unique_ptr<api::ChunkReader>> GetChunkReader(
+      int64_t column_group_index, const std::shared_ptr<std::vector<std::string>>& needed_columns) override {
+    if (closed_) {
+      return arrow::Status::Invalid("reader is closed");
+    }
+    return reader_->get_chunk_reader(column_group_index, needed_columns);
+  }
+
+  std::shared_ptr<api::ColumnGroups> GetColumnGroups() const override { return column_groups_; }
+
+  private:
+  // resolve LOB columns (TEXT or BINARY) from LOBReferences to actual data
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> ResolveLobColumns(
+      const std::shared_ptr<arrow::RecordBatch>& storage_batch) {
+    if (lob_readers_.empty()) {
+      // no LOB columns, return as-is but with extracted schema
+      return arrow::RecordBatch::Make(extracted_schema_, storage_batch->num_rows(), storage_batch->columns());
+    }
+
+    std::vector<std::shared_ptr<arrow::Array>> columns;
+    columns.reserve(storage_batch->num_columns());
+
+    for (int i = 0; i < storage_batch->num_columns(); i++) {
+      auto it = lob_readers_.find(i);
+      if (it != lob_readers_.end()) {
+        // LOB column: resolve LOBReference to actual data (utf8 text or binary)
+        auto ref_array = std::dynamic_pointer_cast<arrow::BinaryArray>(storage_batch->column(i));
+        if (!ref_array) {
+          return arrow::Status::Invalid("expected BinaryArray for LOB column reference");
+        }
+        ARROW_ASSIGN_OR_RAISE(auto resolved_array, it->second->ReadArrowArray(ref_array));
+        columns.push_back(std::static_pointer_cast<arrow::Array>(resolved_array));
+      } else {
+        // regular column: use directly
+        columns.push_back(storage_batch->column(i));
+      }
+    }
+
+    return arrow::RecordBatch::Make(extracted_schema_, storage_batch->num_rows(), columns);
+  }
+
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> original_schema_;
+  std::shared_ptr<arrow::Schema> extracted_schema_;
+  std::shared_ptr<arrow::Schema> storage_schema_;
+  std::vector<std::string> extracted_columns_;
+  SegmentReaderConfig config_;
+  std::vector<int> lob_column_indices_;
+
+  bool closed_;
+  int64_t total_rows_;
+
+  std::shared_ptr<api::ColumnGroups> column_groups_;
+  std::unique_ptr<api::Reader> reader_;
+  std::shared_ptr<arrow::RecordBatchReader> batch_reader_;
+
+  // LOB column readers (TEXT or BINARY), keyed by index in extracted schema
+  std::unordered_map<int, std::unique_ptr<lob_column::LobColumnReader>> lob_readers_;
+};
+
+// helper function to build schemas and identify LOB columns for extraction
+static arrow::Result<std::tuple<std::shared_ptr<arrow::Schema>,  // extracted_schema (user-facing: utf8 for TEXT, binary
+                                                                 // for BINARY LOB)
+                                std::shared_ptr<arrow::Schema>,  // storage_schema (always binary for LOB columns)
+                                std::vector<int>>>               // lob_column_indices in extracted_schema
+BuildSchemasForExtraction(const std::shared_ptr<arrow::Schema>& original_schema,
+                          const std::vector<std::string>& columns,
+                          const std::map<int64_t, lob_column::LobColumnConfig>& lob_columns) {
+  // build column name set for quick lookup
+  std::unordered_set<std::string> column_set(columns.begin(), columns.end());
+  bool extract_all = columns.empty();
+
+  std::vector<std::shared_ptr<arrow::Field>> extracted_fields;
+  std::vector<std::shared_ptr<arrow::Field>> storage_fields;
+  std::vector<int> lob_column_indices;
+
+  int extracted_idx = 0;
+  for (int i = 0; i < original_schema->num_fields(); i++) {
+    auto field = original_schema->field(i);
+
+    // check if this column should be extracted
+    if (!extract_all && column_set.find(field->name()) == column_set.end()) {
+      continue;
+    }
+
+    if (lob_columns.count(GetFieldId(field)) > 0) {
+      // LOB column: extracted schema keeps original type (utf8 for TEXT, binary for BINARY LOB),
+      // storage schema always uses binary for LOBReferences
+      extracted_fields.push_back(field);  // keep original type
+      auto storage_field = arrow::field(field->name(), arrow::binary(), field->nullable(), field->metadata()->Copy());
+      storage_fields.push_back(storage_field);
+      lob_column_indices.push_back(extracted_idx);
+    } else {
+      // regular column: same in both schemas
+      extracted_fields.push_back(field);
+      storage_fields.push_back(field);
+    }
+    extracted_idx++;
+  }
+
+  if (extracted_fields.empty()) {
+    return arrow::Status::Invalid("no columns to extract");
+  }
+
+  auto extracted_schema = arrow::schema(extracted_fields);
+  auto storage_schema = arrow::schema(storage_fields);
+
+  return std::make_tuple(extracted_schema, storage_schema, lob_column_indices);
+}
+
+// factory function - create from ColumnGroups
+arrow::Result<std::unique_ptr<SegmentReader>> SegmentReader::Create(
+    std::shared_ptr<arrow::fs::FileSystem> fs,
+    const std::shared_ptr<api::ColumnGroups>& column_groups,
+    const std::shared_ptr<arrow::Schema>& schema,
+    const std::vector<std::string>& columns,
+    const SegmentReaderConfig& config) {
+  if (!fs) {
+    return arrow::Status::Invalid("filesystem is null");
+  }
+
+  if (!schema) {
+    return arrow::Status::Invalid("schema is null");
+  }
+
+  if (!column_groups) {
+    return arrow::Status::Invalid("column_groups is null");
+  }
+
+  // build extracted columns list
+  std::vector<std::string> extracted_columns;
+  if (columns.empty()) {
+    // extract all columns
+    for (int i = 0; i < schema->num_fields(); i++) {
+      extracted_columns.push_back(schema->field(i)->name());
+    }
+  } else {
+    extracted_columns = columns;
+  }
+
+  // build schemas
+  ARROW_ASSIGN_OR_RAISE(auto schema_info, BuildSchemasForExtraction(schema, extracted_columns, config.lob_columns));
+  auto& [extracted_schema, storage_schema, lob_column_indices] = schema_info;
+
+  auto reader = std::make_unique<SegmentReaderImpl>(std::move(fs), schema, extracted_schema, storage_schema,
+                                                    std::move(extracted_columns), config, std::move(lob_column_indices));
+
+  ARROW_RETURN_NOT_OK(reader->Init(column_groups));
+
+  return reader;
+}
+
+// factory function - open from manifest
+arrow::Result<std::unique_ptr<SegmentReader>> SegmentReader::Open(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                  const std::shared_ptr<api::Manifest>& manifest,
+                                                                  const std::shared_ptr<arrow::Schema>& schema,
+                                                                  const std::vector<std::string>& columns,
+                                                                  const SegmentReaderConfig& config) {
+  if (!fs) {
+    return arrow::Status::Invalid("filesystem is null");
+  }
+
+  if (!schema) {
+    return arrow::Status::Invalid("schema is null");
+  }
+
+  if (!manifest) {
+    return arrow::Status::Invalid("manifest is null");
+  }
+
+  auto column_groups = std::make_shared<api::ColumnGroups>(manifest->columnGroups());
+
+  // build extracted columns list
+  std::vector<std::string> extracted_columns;
+  if (columns.empty()) {
+    for (int i = 0; i < schema->num_fields(); i++) {
+      extracted_columns.push_back(schema->field(i)->name());
+    }
+  } else {
+    extracted_columns = columns;
+  }
+
+  // build schemas
+  ARROW_ASSIGN_OR_RAISE(auto schema_info, BuildSchemasForExtraction(schema, extracted_columns, config.lob_columns));
+  auto& [extracted_schema, storage_schema, lob_column_indices] = schema_info;
+
+  auto reader = std::make_unique<SegmentReaderImpl>(std::move(fs), schema, extracted_schema, storage_schema,
+                                                    std::move(extracted_columns), config, std::move(lob_column_indices));
+
+  ARROW_RETURN_NOT_OK(reader->Init(column_groups));
+
+  return reader;
+}
+
+}  // namespace milvus_storage::segment

--- a/cpp/src/segment/segment_writer.cpp
+++ b/cpp/src/segment/segment_writer.cpp
@@ -1,0 +1,335 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/segment/segment_writer.h"
+
+#include <arrow/array/builder_binary.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/layout.h"
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/lob_column/lob_column_writer.h"
+#include "milvus-storage/lob_column/lob_reference.h"
+#include "milvus-storage/writer.h"
+
+namespace milvus_storage::segment {
+
+// implementation of SegmentWriter using api::Writer for regular columns
+class SegmentWriterImpl : public SegmentWriter {
+  public:
+  SegmentWriterImpl(std::shared_ptr<arrow::fs::FileSystem> fs,
+                    std::shared_ptr<arrow::Schema> original_schema,
+                    std::shared_ptr<arrow::Schema> storage_schema,
+                    const SegmentWriterConfig& config,
+                    std::vector<int> lob_column_indices)
+      : fs_(std::move(fs)),
+        original_schema_(std::move(original_schema)),
+        storage_schema_(std::move(storage_schema)),
+        config_(config),
+        lob_column_indices_(std::move(lob_column_indices)),
+        closed_(false),
+        written_rows_(0) {}
+
+  ~SegmentWriterImpl() override {
+    if (!closed_) {
+      // best effort abort, ignore errors in destructor
+      (void)Abort();
+    }
+  }
+
+  arrow::Status Init() {
+    // create LobColumnWriters for each LOB column (TEXT or BINARY)
+    for (int col_idx : lob_column_indices_) {
+      auto field = original_schema_->field(col_idx);
+      auto field_id = GetFieldId(field);
+      if (field_id < 0) {
+        return arrow::Status::Invalid("LOB column must have a valid field_id in metadata");
+      }
+
+      auto it = config_.lob_columns.find(field_id);
+      if (it == config_.lob_columns.end()) {
+        return arrow::Status::Invalid("LOB column config not found for field_id: " + std::to_string(field_id));
+      }
+
+      ARROW_ASSIGN_OR_RAISE(auto writer, lob_column::CreateLobColumnWriter(fs_, it->second));
+      lob_writers_[col_idx] = std::move(writer);
+
+      // if rewrite_mode, also create a reader to decode old LOB references
+      if (it->second.rewrite_mode) {
+        ARROW_ASSIGN_OR_RAISE(auto reader, lob_column::CreateLobColumnReader(fs_, it->second));
+        lob_readers_[col_idx] = std::move(reader);
+        rewrite_columns_.insert(col_idx);
+      }
+    }
+
+    // create api::Writer for regular columns using ColumnGroupPolicy
+    ARROW_ASSIGN_OR_RAISE(auto policy,
+                          api::ColumnGroupPolicy::create_column_group_policy(config_.properties, storage_schema_));
+
+    writer_ = api::Writer::create(config_.segment_path, storage_schema_, std::move(policy), config_.properties);
+
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Write(const std::shared_ptr<arrow::RecordBatch>& batch) override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is closed");
+    }
+
+    if (!batch || batch->num_rows() == 0) {
+      return arrow::Status::OK();
+    }
+
+    // validate schema — in rewrite mode, TEXT columns may arrive as binary instead of utf8
+    if (!rewrite_columns_.empty()) {
+      // relaxed check: verify field count matches
+      if (batch->num_columns() != original_schema_->num_fields()) {
+        return arrow::Status::Invalid("batch column count does not match writer schema");
+      }
+    } else {
+      if (!batch->schema()->Equals(original_schema_)) {
+        return arrow::Status::Invalid("batch schema does not match writer schema");
+      }
+    }
+
+    // process each column
+    std::vector<std::shared_ptr<arrow::Array>> columns;
+    columns.reserve(batch->num_columns());
+
+    for (int i = 0; i < batch->num_columns(); i++) {
+      auto it = lob_writers_.find(i);
+      if (it != lob_writers_.end()) {
+        if (rewrite_columns_.count(i) > 0) {
+          // REWRITE mode: input is BinaryArray of LOB references
+          // decode references → get raw text → re-encode via writer
+          auto ref_array = std::static_pointer_cast<arrow::BinaryArray>(batch->column(i));
+          auto reader_it = lob_readers_.find(i);
+
+          // decode all references in batch via reader
+          ARROW_ASSIGN_OR_RAISE(auto decoded_array, reader_it->second->ReadArrowArray(ref_array));
+
+          // re-encode decoded data via writer (WriteArrowArray accepts BinaryArray)
+          ARROW_ASSIGN_OR_RAISE(auto new_ref_array, it->second->WriteArrowArray(decoded_array));
+          columns.push_back(new_ref_array);
+        } else {
+          // Normal mode: input is raw data (utf8 for TEXT, binary for BINARY LOB)
+          auto data_array = std::static_pointer_cast<arrow::BinaryArray>(batch->column(i));
+          ARROW_ASSIGN_OR_RAISE(auto ref_array, it->second->WriteArrowArray(data_array));
+          columns.push_back(ref_array);
+        }
+      } else {
+        // regular column: use directly
+        columns.push_back(batch->column(i));
+      }
+    }
+
+    // create storage batch with LOBReferences
+    auto storage_batch = arrow::RecordBatch::Make(storage_schema_, batch->num_rows(), columns);
+
+    // write to api::Writer
+    ARROW_RETURN_NOT_OK(writer_->write(storage_batch));
+
+    written_rows_ += batch->num_rows();
+    stats_.total_rows = written_rows_;
+
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is closed");
+    }
+
+    // flush all TEXT column writers
+    for (auto& [col_idx, writer] : lob_writers_) {
+      ARROW_RETURN_NOT_OK(writer->Flush());
+    }
+
+    // flush api::Writer
+    ARROW_RETURN_NOT_OK(writer_->flush());
+
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<SegmentWriteOutput> Close() override {
+    if (closed_) {
+      return arrow::Status::Invalid("writer is already closed");
+    }
+
+    // flush pending data
+    ARROW_RETURN_NOT_OK(Flush());
+
+    // close all TEXT column writers and collect LOB file results
+    for (auto& [col_idx, writer] : lob_writers_) {
+      ARROW_ASSIGN_OR_RAISE(auto lob_files, writer->Close());
+      lob_file_results_[col_idx] = std::move(lob_files);
+
+      auto text_stats = writer->GetStats();
+      stats_.lob_files_created += text_stats.lob_files_created;
+    }
+
+    // close LOB readers (rewrite mode)
+    for (auto& [col_idx, reader] : lob_readers_) {
+      ARROW_RETURN_NOT_OK(reader->Close());
+    }
+
+    // close api::Writer and get ColumnGroups
+    ARROW_ASSIGN_OR_RAISE(auto column_groups, writer_->close());
+    stats_.parquet_files_created = column_groups->size();
+
+    // build LOB file info list from results
+    std::vector<api::LobFileInfo> lob_file_infos;
+    for (const auto& [col_idx, lob_files] : lob_file_results_) {
+      auto field = original_schema_->field(col_idx);
+      auto field_id = GetFieldId(field);
+
+      for (const auto& lob_result : lob_files) {
+        api::LobFileInfo lob_info;
+        lob_info.path = lob_result.path;
+        lob_info.field_id = field_id;
+        lob_info.total_rows = lob_result.total_rows;
+        lob_info.valid_rows = lob_result.valid_rows;
+        lob_info.file_size_bytes = lob_result.file_size_bytes;
+        lob_file_infos.push_back(std::move(lob_info));
+      }
+    }
+
+    closed_ = true;
+
+    SegmentWriteOutput output;
+    output.column_groups = column_groups;
+    output.lob_files = std::move(lob_file_infos);
+    output.rows_written = written_rows_;
+
+    return output;
+  }
+
+  arrow::Status Abort() override {
+    if (closed_) {
+      return arrow::Status::OK();
+    }
+
+    // abort all TEXT column writers (they will delete their LOB files)
+    for (auto& [col_idx, writer] : lob_writers_) {
+      // best effort abort, continue on error
+      (void)writer->Abort();
+    }
+
+    // close LOB readers (rewrite mode)
+    for (auto& [col_idx, reader] : lob_readers_) {
+      (void)reader->Close();
+    }
+
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  int64_t WrittenRows() const override { return written_rows_; }
+
+  SegmentWriterStats GetStats() const override { return stats_; }
+
+  std::shared_ptr<arrow::Schema> GetStorageSchema() const override { return storage_schema_; }
+
+  std::shared_ptr<arrow::Schema> GetOriginalSchema() const override { return original_schema_; }
+
+  bool IsClosed() const override { return closed_; }
+
+  private:
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> original_schema_;
+  std::shared_ptr<arrow::Schema> storage_schema_;
+  SegmentWriterConfig config_;
+  std::vector<int> lob_column_indices_;
+
+  bool closed_;
+  int64_t written_rows_;
+
+  // LOB column writers (TEXT or BINARY), keyed by column index
+  std::unordered_map<int, std::unique_ptr<lob_column::LobColumnWriter>> lob_writers_;
+
+  // LOB column readers for rewrite mode — used to decode old LOB references
+  std::unordered_map<int, std::unique_ptr<lob_column::LobColumnReader>> lob_readers_;
+
+  // column indices that are in rewrite mode
+  std::unordered_set<int> rewrite_columns_;
+
+  // api::Writer for regular columns (Parquet/Vortex/Lance based on policy)
+  std::unique_ptr<api::Writer> writer_;
+
+  // LOB file results, keyed by column index
+  std::unordered_map<int, std::vector<lob_column::LobFileResult>> lob_file_results_;
+
+  // statistics
+  SegmentWriterStats stats_;
+};
+
+// factory function
+arrow::Result<std::unique_ptr<SegmentWriter>> SegmentWriter::Create(std::shared_ptr<arrow::fs::FileSystem> fs,
+                                                                    const std::shared_ptr<arrow::Schema>& schema,
+                                                                    const SegmentWriterConfig& config) {
+  if (!fs) {
+    return arrow::Status::Invalid("filesystem is null");
+  }
+
+  if (!schema) {
+    return arrow::Status::Invalid("schema is null");
+  }
+
+  if (config.segment_path.empty()) {
+    return arrow::Status::Invalid("segment_path is empty");
+  }
+
+  // validate required properties for ColumnGroupPolicy
+  if (config.properties.find(PROPERTY_WRITER_POLICY) == config.properties.end()) {
+    return arrow::Status::Invalid("properties must contain " + std::string(PROPERTY_WRITER_POLICY));
+  }
+
+  // identify LOB columns (TEXT or BINARY) and build storage schema
+  std::vector<std::shared_ptr<arrow::Field>> storage_fields;
+  std::vector<int> lob_column_indices;
+
+  for (int i = 0; i < schema->num_fields(); i++) {
+    auto field = schema->field(i);
+
+    if (config.lob_columns.count(GetFieldId(field)) > 0) {
+      // LOB column: storage always uses binary for LOBReferences
+      // (input may be utf8 for TEXT or binary for BINARY LOB)
+      auto storage_field = arrow::field(field->name(), arrow::binary(), field->nullable(), field->metadata()->Copy());
+      storage_fields.push_back(storage_field);
+      lob_column_indices.push_back(i);
+    } else {
+      // regular column: keep as-is
+      storage_fields.push_back(field);
+    }
+  }
+
+  auto storage_schema = arrow::schema(storage_fields);
+
+  // create writer implementation
+  auto writer =
+      std::make_unique<SegmentWriterImpl>(std::move(fs), schema, storage_schema, config, std::move(lob_column_indices));
+
+  ARROW_RETURN_NOT_OK(writer->Init());
+
+  return writer;
+}
+
+}  // namespace milvus_storage::segment

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -37,7 +37,7 @@ Updates::~Updates() = default;
 
 bool Updates::hasChanges() const {
   return !added_column_groups_.empty() || !appended_files_.empty() || !added_delta_logs_.empty() ||
-         !added_stats_.empty() || !added_indexes_.empty() || !dropped_indexes_.empty();
+         !added_stats_.empty() || !added_indexes_.empty() || !dropped_indexes_.empty() || !added_lob_files_.empty();
 }
 
 void Updates::AddColumnGroup(const std::shared_ptr<ColumnGroup>& cg) { added_column_groups_.push_back(cg); }
@@ -47,6 +47,8 @@ void Updates::AppendFiles(const ColumnGroups& cgs) { appended_files_.push_back(c
 void Updates::AddDeltaLog(const DeltaLog& delta_log) { added_delta_logs_.push_back(delta_log); }
 
 void Updates::UpdateStat(const std::string& key, const Statistics& stat) { added_stats_[key] = stat; }
+
+void Updates::AddLobFile(const LobFileInfo& lob_file) { added_lob_files_.push_back(lob_file); }
 
 const ColumnGroups& Updates::GetAddedColumnGroups() const { return added_column_groups_; }
 
@@ -66,6 +68,8 @@ const std::vector<Index>& Updates::GetAddedIndexes() const { return added_indexe
 
 const std::vector<std::pair<std::string, std::string>>& Updates::GetDroppedIndexes() const { return dropped_indexes_; }
 
+const std::vector<LobFileInfo>& Updates::GetAddedLobFiles() const { return added_lob_files_; }
+
 // ==================== Helper Functions ====================
 
 arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Manifest>& manifest,
@@ -77,6 +81,7 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
   auto& delta_logs = base->deltaLogs();
   auto& stats = base->stats();
   auto& indexes = base->indexes();
+  auto& lob_files = base->lobFiles();
 
   // Validate: Check if adding column groups has existing column names
   for (const auto& new_cg : updates.GetAddedColumnGroups()) {
@@ -183,6 +188,11 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
   // Apply stats (new values override)
   for (const auto& [key, stat] : updates.GetAddedStats()) {
     stats[key] = stat;
+  }
+
+  // Apply LOB files
+  for (const auto& lob_file : updates.GetAddedLobFiles()) {
+    lob_files.push_back(lob_file);
   }
 
   // Apply append files
@@ -426,6 +436,11 @@ Transaction& Transaction::AddIndex(const Index& index) {
 
 Transaction& Transaction::DropIndex(const std::string& column_name, const std::string& index_type) {
   updates_.DropIndex(column_name, index_type);
+  return *this;
+}
+
+Transaction& Transaction::AddLobFile(const LobFileInfo& lob_file) {
+  updates_.AddLobFile(lob_file);
   return *this;
 }
 

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -46,8 +46,11 @@ class TransactionTest : public ::testing::Test {
     milvus_storage::api::Manifest::CleanCache();
     ASSERT_STATUS_OK(milvus_storage::InitTestProperties(properties_));
     ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
-    base_path_ = GetTestBasePath("transaction-test");
-    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    // Use a path structure that simulates real {partition}/{seg_id} layout
+    // so that kLobPath (../lobs/) can correctly resolve LOB file paths
+    partition_path_ = GetTestBasePath("transaction-test-partition");
+    base_path_ = partition_path_ + "/seg-001";
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, partition_path_));
     ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
 
     schema_ = arrow::schema(
@@ -83,6 +86,7 @@ class TransactionTest : public ::testing::Test {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   api::Properties properties_;
   std::shared_ptr<arrow::Schema> schema_;
+  std::string partition_path_;
   std::string base_path_;
 };
 
@@ -710,6 +714,123 @@ TEST_F(TransactionTest, IndexMultipleColumnsDeprecationTest) {
     ASSERT_EQ(manifest->getIndex("id", "hnsw"), nullptr);        // Deprecated
     ASSERT_NE(manifest->getIndex("vector", "ivf-pq"), nullptr);  // Still exists
   }
+}
+
+// ==================== LOB Files Tests ====================
+
+TEST_F(TransactionTest, AddLobFile) {
+  // Create initial transaction to set up manifest
+  ASSERT_AND_ASSIGN(auto txn1, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+  ASSERT_AND_ASSIGN(auto manifest1, CreateSampleManifest("/dummy1.parquet"));
+  txn1->AddColumnGroup(manifest1->columnGroups()[0]);
+
+  // Add LOB file with absolute path (simulating real SegmentWriter behavior)
+  // LOB files live at {partition}/lobs/{field_id}/_data/{uuid}.vx
+  std::string lob_path = partition_path_ + "/lobs/101/_data/field101_001.vortex";
+  LobFileInfo lob1{lob_path, 101, 1000, 900, 1048576};
+  txn1->AddLobFile(lob1);
+
+  ASSERT_AND_ASSIGN(auto version1, txn1->Commit());
+  ASSERT_EQ(version1, 1);
+
+  // Read back and verify - path should be restored to absolute via kLobPath
+  ASSERT_AND_ASSIGN(auto txn2, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+  ASSERT_AND_ASSIGN(auto read_manifest, txn2->GetManifest());
+
+  ASSERT_EQ(read_manifest->lobFiles().size(), 1);
+  EXPECT_EQ(read_manifest->lobFiles()[0].path, lob_path);
+  EXPECT_EQ(read_manifest->lobFiles()[0].field_id, 101);
+  EXPECT_EQ(read_manifest->lobFiles()[0].total_rows, 1000);
+  EXPECT_EQ(read_manifest->lobFiles()[0].valid_rows, 900);
+  EXPECT_EQ(read_manifest->lobFiles()[0].file_size_bytes, 1048576);
+}
+
+TEST_F(TransactionTest, AddMultipleLobFiles) {
+  // Create initial transaction
+  ASSERT_AND_ASSIGN(auto txn1, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+  ASSERT_AND_ASSIGN(auto manifest1, CreateSampleManifest("/dummy1.parquet"));
+  txn1->AddColumnGroup(manifest1->columnGroups()[0]);
+
+  // Add multiple LOB files with absolute paths
+  txn1->AddLobFile({partition_path_ + "/lobs/101/_data/field101_001.vortex", 101, 1000, 900, 1048576});
+  txn1->AddLobFile({partition_path_ + "/lobs/101/_data/field101_002.vortex", 101, 2000, 1800, 2097152});
+  txn1->AddLobFile({partition_path_ + "/lobs/102/_data/field102_001.vortex", 102, 500, 450, 524288});
+
+  ASSERT_AND_ASSIGN(auto version1, txn1->Commit());
+  ASSERT_EQ(version1, 1);
+
+  // Read back and verify
+  ASSERT_AND_ASSIGN(auto txn2, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+  ASSERT_AND_ASSIGN(auto read_manifest, txn2->GetManifest());
+
+  ASSERT_EQ(read_manifest->lobFiles().size(), 3);
+
+  // Test getLobFilesForField
+  auto field101_files = read_manifest->getLobFilesForField(101);
+  ASSERT_EQ(field101_files.size(), 2);
+
+  auto field102_files = read_manifest->getLobFilesForField(102);
+  ASSERT_EQ(field102_files.size(), 1);
+
+  auto field999_files = read_manifest->getLobFilesForField(999);
+  ASSERT_TRUE(field999_files.empty());
+}
+
+TEST_F(TransactionTest, LobFilesPreservedAcrossTransactions) {
+  // Transaction 1: Add column groups and LOB files
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy1.parquet"));
+    txn->AddColumnGroup(manifest->columnGroups()[0]);
+    txn->AddLobFile({partition_path_ + "/lobs/101/_data/field101_001.vortex", 101, 1000, 900, 1048576});
+    ASSERT_AND_ASSIGN(auto version, txn->Commit());
+    ASSERT_EQ(version, 1);
+  }
+
+  // Transaction 2: Add more LOB files
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy2.parquet"));
+    txn->AppendFiles(manifest->columnGroups());
+    txn->AddLobFile({partition_path_ + "/lobs/101/_data/field101_002.vortex", 101, 2000, 1800, 2097152});
+    ASSERT_AND_ASSIGN(auto version, txn->Commit());
+    ASSERT_EQ(version, 2);
+  }
+
+  // Verify both LOB files are present
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+    ASSERT_AND_ASSIGN(auto manifest, txn->GetManifest());
+
+    ASSERT_EQ(manifest->lobFiles().size(), 2);
+    EXPECT_EQ(manifest->lobFiles()[0].total_rows, 1000);
+    EXPECT_EQ(manifest->lobFiles()[1].total_rows, 2000);
+  }
+}
+
+TEST_F(TransactionTest, EmptyLobFiles) {
+  // Create transaction without LOB files
+  ASSERT_AND_ASSIGN(auto txn1, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+  ASSERT_AND_ASSIGN(auto manifest1, CreateSampleManifest("/dummy1.parquet"));
+  txn1->AddColumnGroup(manifest1->columnGroups()[0]);
+
+  ASSERT_AND_ASSIGN(auto version1, txn1->Commit());
+  ASSERT_EQ(version1, 1);
+
+  // Read back and verify empty LOB files
+  ASSERT_AND_ASSIGN(auto txn2, Transaction::Open(fs_, base_path_, LATEST, MergeResolver));
+  ASSERT_AND_ASSIGN(auto read_manifest, txn2->GetManifest());
+
+  ASSERT_TRUE(read_manifest->lobFiles().empty());
+}
+
+TEST_F(TransactionTest, LobFileInfoEquality) {
+  LobFileInfo file1{"path.vortex", 101, 1000, 900, 1048576};
+  LobFileInfo file2{"path.vortex", 101, 1000, 900, 1048576};
+  LobFileInfo file3{"different.vortex", 101, 1000, 900, 1048576};
+
+  EXPECT_EQ(file1, file2);
+  EXPECT_FALSE(file1 == file3);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/lob_column/lob_column_cloud_test.cpp
+++ b/cpp/test/lob_column/lob_column_cloud_test.cpp
@@ -1,0 +1,495 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+#include "milvus-storage/lob_column/lob_column_writer.h"
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/lob_column/lob_reference.h"
+
+namespace milvus_storage::lob_column {
+
+// Integration tests for text column on cloud storage (S3/MinIO)
+// These tests are skipped in local environment
+class LobColumnCloudTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    if (!IsCloudEnv()) {
+      GTEST_SKIP() << "Cloud storage tests skipped in local environment";
+    }
+
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+
+    // create test base path
+    test_base_path_ = GetTestBasePath("text-column-cloud-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, test_base_path_));
+    ASSERT_STATUS_OK(CreateTestDir(fs_, test_base_path_));
+
+    // create config
+    config_.lob_base_path = test_base_path_ + "/lobs/100";
+    config_.field_id = 100;
+    config_.inline_threshold = 20;
+    config_.max_lob_file_bytes = 1024 * 1024;   // 1MB
+    config_.flush_threshold_bytes = 64 * 1024;  // 64KB
+    config_.properties = properties_;
+  }
+
+  void TearDown() override {
+    if (IsCloudEnv()) {
+      ASSERT_STATUS_OK(DeleteTestDir(fs_, test_base_path_));
+    }
+  }
+
+  std::string GenerateRandomString(size_t length) {
+    static const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, sizeof(charset) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+      result.push_back(charset[dis(gen)]);
+    }
+    return result;
+  }
+
+  protected:
+  api::Properties properties_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::string test_base_path_;
+  LobColumnConfig config_;
+};
+
+// ==================== Basic Cloud Storage Tests ====================
+
+// test basic write and read on cloud storage
+TEST_F(LobColumnCloudTest, BasicWriteAndRead) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok()) << manager_result.status().message();
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // prepare test data - mix of inline and LOB
+  std::vector<std::string> texts = {
+      "short1",                   // inline
+      GenerateRandomString(50),   // LOB
+      "short2",                   // inline
+      GenerateRandomString(100),  // LOB
+      "short3",                   // inline
+  };
+
+  // write
+  std::vector<std::vector<uint8_t>> refs;
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok()) << writer_result.status().message();
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto refs_result = writer->WriteBatch(texts);
+    ASSERT_TRUE(refs_result.ok()) << refs_result.status().message();
+    refs = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+  }
+
+  // read
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    for (size_t i = 0; i < texts.size(); i++) {
+      auto read_result = reader->ReadText(refs[i].data(), refs[i].size());
+      ASSERT_TRUE(read_result.ok()) << "index " << i << ": " << read_result.status().message();
+      ASSERT_EQ(read_result.ValueOrDie(), texts[i]);
+    }
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test batch write and read on cloud storage
+TEST_F(LobColumnCloudTest, BatchWriteAndRead) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // prepare larger batch
+  std::vector<std::string> texts;
+  for (int i = 0; i < 100; i++) {
+    if (i % 3 == 0) {
+      texts.push_back("inline_" + std::to_string(i));
+    } else {
+      texts.push_back(GenerateRandomString(50 + i % 50));
+    }
+  }
+
+  // write
+  std::vector<std::vector<uint8_t>> refs;
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto refs_result = writer->WriteBatch(texts);
+    ASSERT_TRUE(refs_result.ok());
+    refs = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+
+  // batch read
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    std::vector<EncodedRef> encoded_refs;
+    for (const auto& ref : refs) {
+      encoded_refs.push_back({ref.data(), ref.size()});
+    }
+
+    auto read_result = reader->ReadBatch(encoded_refs);
+    ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+    auto read_texts = std::move(read_result).ValueOrDie();
+
+    ASSERT_EQ(read_texts.size(), texts.size());
+    for (size_t i = 0; i < texts.size(); i++) {
+      ASSERT_EQ(read_texts[i], texts[i]) << "mismatch at index " << i;
+    }
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test file rolling on cloud storage
+TEST_F(LobColumnCloudTest, FileRolling) {
+  // use small max bytes to trigger rolling
+  config_.max_lob_file_bytes = 1024;    // 1KB per file
+  config_.flush_threshold_bytes = 512;  // flush at 512 bytes
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // write texts that will exceed max_lob_file_bytes
+  std::vector<std::string> texts;
+  std::vector<std::vector<uint8_t>> refs;
+
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    // each text is 100 bytes, write 25 = 2500 bytes total
+    // should create at least 2 files
+    for (int i = 0; i < 25; i++) {
+      texts.push_back(GenerateRandomString(100));
+    }
+
+    auto refs_result = writer->WriteBatch(texts);
+    ASSERT_TRUE(refs_result.ok());
+    refs = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto files = std::move(close_result).ValueOrDie();
+
+    // should have created multiple files
+    ASSERT_GE(files.size(), 2);
+  }
+
+  // verify we can still read all texts
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    std::vector<EncodedRef> encoded_refs;
+    for (const auto& ref : refs) {
+      encoded_refs.push_back({ref.data(), ref.size()});
+    }
+
+    auto read_result = reader->ReadBatch(encoded_refs);
+    ASSERT_TRUE(read_result.ok());
+    auto read_texts = std::move(read_result).ValueOrDie();
+
+    ASSERT_EQ(read_texts.size(), texts.size());
+    for (size_t i = 0; i < texts.size(); i++) {
+      ASSERT_EQ(read_texts[i], texts[i]);
+    }
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test cross-file batch read (reads from multiple LOB files)
+TEST_F(LobColumnCloudTest, CrossFileBatchRead) {
+  // use small max bytes to create multiple files
+  config_.max_lob_file_bytes = 512;
+  config_.flush_threshold_bytes = 256;
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  std::vector<std::string> texts;
+  std::vector<std::vector<uint8_t>> refs;
+
+  // write texts that will span multiple files
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    for (int i = 0; i < 20; i++) {
+      texts.push_back(GenerateRandomString(100));
+    }
+
+    auto refs_result = writer->WriteBatch(texts);
+    ASSERT_TRUE(refs_result.ok());
+    refs = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    ASSERT_GE(close_result.ValueOrDie().size(), 2);  // at least 2 files
+  }
+
+  // read in random order (should still work with cross-file reads)
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    // shuffle indices
+    std::vector<size_t> indices(refs.size());
+    std::iota(indices.begin(), indices.end(), 0);
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(indices.begin(), indices.end(), g);
+
+    // read in shuffled order
+    std::vector<EncodedRef> shuffled_refs;
+    for (size_t idx : indices) {
+      shuffled_refs.push_back({refs[idx].data(), refs[idx].size()});
+    }
+
+    auto read_result = reader->ReadBatch(shuffled_refs);
+    ASSERT_TRUE(read_result.ok());
+    auto read_texts = std::move(read_result).ValueOrDie();
+
+    ASSERT_EQ(read_texts.size(), texts.size());
+    for (size_t i = 0; i < indices.size(); i++) {
+      ASSERT_EQ(read_texts[i], texts[indices[i]]);
+    }
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test large text on cloud storage
+TEST_F(LobColumnCloudTest, LargeText) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // 5MB text
+  std::string large_text = GenerateRandomString(5 * 1024 * 1024);
+  std::vector<uint8_t> ref;
+
+  // write
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto ref_result = writer->WriteText(large_text);
+    ASSERT_TRUE(ref_result.ok()) << ref_result.status().message();
+    ref = std::move(ref_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+
+  // read
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    auto read_result = reader->ReadText(ref.data(), ref.size());
+    ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+    ASSERT_EQ(read_result.ValueOrDie(), large_text);
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test abort on cloud storage
+TEST_F(LobColumnCloudTest, AbortCleansUpFiles) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    // write some LOB texts
+    for (int i = 0; i < 5; i++) {
+      auto ref = writer->WriteText(GenerateRandomString(100));
+      ASSERT_TRUE(ref.ok());
+    }
+
+    // abort
+    ASSERT_STATUS_OK(writer->Abort());
+  }
+
+  // verify LOB data directory is empty or doesn't exist
+  auto lob_data_path = config_.lob_base_path + "/_data";
+  arrow::fs::FileSelector selector;
+  selector.base_dir = lob_data_path;
+  selector.recursive = false;
+
+  auto files_result = fs_->GetFileInfo(selector);
+  if (files_result.ok()) {
+    // directory exists - should be empty
+    ASSERT_TRUE(files_result.ValueOrDie().empty());
+  }
+  // if directory doesn't exist, that's also OK
+}
+
+// test Arrow array interface on cloud storage
+TEST_F(LobColumnCloudTest, ArrowArrayInterface) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // prepare string array
+  arrow::StringBuilder builder;
+  ASSERT_STATUS_OK(builder.Append("inline1"));
+  ASSERT_STATUS_OK(builder.Append(GenerateRandomString(50)));
+  ASSERT_STATUS_OK(builder.AppendNull());
+  ASSERT_STATUS_OK(builder.Append("inline2"));
+  ASSERT_STATUS_OK(builder.Append(GenerateRandomString(100)));
+
+  std::shared_ptr<arrow::StringArray> input_array;
+  ASSERT_STATUS_OK(builder.Finish(&input_array));
+
+  // write
+  std::shared_ptr<arrow::BinaryArray> refs_array;
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto refs_result = writer->WriteArrowArray(input_array);
+    ASSERT_TRUE(refs_result.ok()) << refs_result.status().message();
+    refs_array = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+
+  // read
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    auto output_result = reader->ReadArrowArray(refs_array);
+    ASSERT_TRUE(output_result.ok()) << output_result.status().message();
+    auto output_array = std::move(output_result).ValueOrDie();
+
+    ASSERT_EQ(output_array->length(), input_array->length());
+
+    for (int64_t i = 0; i < input_array->length(); i++) {
+      if (input_array->IsNull(i)) {
+        ASSERT_TRUE(output_array->IsNull(i));
+      } else {
+        ASSERT_FALSE(output_array->IsNull(i));
+        ASSERT_EQ(output_array->GetString(i), input_array->GetString(i));
+      }
+    }
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test Take API on cloud storage
+TEST_F(LobColumnCloudTest, TakeAPI) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  std::vector<std::string> texts;
+  std::vector<std::vector<uint8_t>> refs;
+
+  // write
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    for (int i = 0; i < 20; i++) {
+      texts.push_back(GenerateRandomString(50));
+    }
+
+    auto refs_result = writer->WriteBatch(texts);
+    ASSERT_TRUE(refs_result.ok());
+    refs = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+
+  // extract file_id from first ref
+  auto [file_id_str, row_offset] = DecodeLOBReference(refs[0].data());
+
+  // read using Take
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    std::vector<int32_t> take_indices = {0, 5, 10, 15, 19};
+    auto take_result = reader->Take(file_id_str, take_indices);
+    ASSERT_TRUE(take_result.ok()) << take_result.status().message();
+    auto taken_texts = std::move(take_result).ValueOrDie();
+
+    ASSERT_EQ(taken_texts.size(), take_indices.size());
+    for (size_t i = 0; i < take_indices.size(); i++) {
+      ASSERT_EQ(taken_texts[i], texts[take_indices[i]]);
+    }
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/test/lob_column/lob_column_manager_test.cpp
+++ b/cpp/test/lob_column/lob_column_manager_test.cpp
@@ -1,0 +1,475 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/filesystem/localfs.h>
+#include <boost/filesystem.hpp>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+#include "milvus-storage/lob_column/lob_column_writer.h"
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/lob_column/lob_reference.h"
+
+namespace milvus_storage::lob_column {
+
+class LobColumnManagerTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // create test directory
+    test_dir_ = "/tmp/lob_column_test_" + std::to_string(std::random_device{}());
+    boost::filesystem::create_directories(test_dir_);
+
+    // create filesystem
+    fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+
+    // create config with small thresholds for testing
+    config_.lob_base_path = test_dir_ + "/lobs/100";
+    config_.field_id = 100;
+    config_.inline_threshold = 20;              // small threshold for testing inline vs LOB
+    config_.max_lob_file_bytes = 1024 * 1024;   // 1MB for testing
+    config_.flush_threshold_bytes = 64 * 1024;  // 64KB for testing
+
+    ASSERT_STATUS_OK(InitTestProperties(config_.properties));
+  }
+
+  void TearDown() override {
+    // cleanup test directory
+    boost::filesystem::remove_all(test_dir_);
+  }
+
+  std::string GenerateRandomString(size_t length) {
+    static const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, sizeof(charset) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+      result.push_back(charset[dis(gen)]);
+    }
+    return result;
+  }
+
+  protected:
+  std::string test_dir_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  LobColumnConfig config_;
+};
+
+// test manager creation
+TEST_F(LobColumnManagerTest, CreateManager) {
+  auto result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto manager = std::move(result).ValueOrDie();
+  ASSERT_NE(manager, nullptr);
+  ASSERT_EQ(manager->GetConfig().field_id, 100);
+  ASSERT_EQ(manager->GetConfig().lob_base_path, config_.lob_base_path);
+}
+
+// test manager creation with invalid config
+TEST_F(LobColumnManagerTest, CreateManagerInvalidConfig) {
+  // null filesystem
+  auto result1 = LobColumnManager::Create(nullptr, config_);
+  ASSERT_FALSE(result1.ok());
+
+  // empty lob_base_path
+  LobColumnConfig invalid_config = config_;
+  invalid_config.lob_base_path = "";
+  auto result2 = LobColumnManager::Create(fs_, invalid_config);
+  ASSERT_FALSE(result2.ok());
+
+  // zero inline threshold
+  invalid_config = config_;
+  invalid_config.inline_threshold = 0;
+  auto result3 = LobColumnManager::Create(fs_, invalid_config);
+  ASSERT_FALSE(result3.ok());
+}
+
+// test writing inline text
+TEST_F(LobColumnManagerTest, WriteInlineText) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write short text (should be inline)
+  std::string short_text = "hello";
+  auto ref_result = writer->WriteText(short_text);
+  ASSERT_TRUE(ref_result.ok()) << ref_result.status().message();
+
+  auto ref = std::move(ref_result).ValueOrDie();
+  // inline text: flag (1 byte) + text bytes
+  ASSERT_EQ(ref.size(), 1 + short_text.size());
+  ASSERT_TRUE(IsInlineData(ref.data()));
+  ASSERT_EQ(DecodeInlineText(ref.data(), ref.size()), short_text);
+
+  // check stats
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.total_entries, 1);
+  ASSERT_EQ(stats.inline_entries, 1);
+  ASSERT_EQ(stats.lob_entries, 0);
+
+  // close writer
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+  auto files = std::move(close_result).ValueOrDie();
+  ASSERT_EQ(files.size(), 0);  // no LOB files created for inline text
+}
+
+// test writing LOB text
+TEST_F(LobColumnManagerTest, WriteLOBText) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write long text (should be LOB)
+  std::string long_text = GenerateRandomString(100);
+  auto ref_result = writer->WriteText(long_text);
+  ASSERT_TRUE(ref_result.ok()) << ref_result.status().message();
+
+  auto ref = std::move(ref_result).ValueOrDie();
+  // LOB reference is fixed 24 bytes (with padding)
+  ASSERT_EQ(ref.size(), LOB_REFERENCE_SIZE);
+  ASSERT_TRUE(IsLOBReference(ref.data()));
+
+  // check stats
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.total_entries, 1);
+  ASSERT_EQ(stats.inline_entries, 0);
+  ASSERT_EQ(stats.lob_entries, 1);
+
+  // close writer
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+  auto files = std::move(close_result).ValueOrDie();
+  ASSERT_EQ(files.size(), 1);  // one LOB file created
+}
+
+// test batch write
+TEST_F(LobColumnManagerTest, WriteBatch) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // prepare mixed texts (some inline, some LOB)
+  std::vector<std::string> texts = {
+      "short1",                   // inline (6 bytes < 20)
+      GenerateRandomString(100),  // LOB
+      "short2",                   // inline
+      GenerateRandomString(200),  // LOB
+      "short3",                   // inline
+  };
+
+  auto refs_result = writer->WriteBatch(texts);
+  ASSERT_TRUE(refs_result.ok()) << refs_result.status().message();
+
+  auto refs = std::move(refs_result).ValueOrDie();
+  ASSERT_EQ(refs.size(), 5);
+
+  // verify inline vs LOB
+  ASSERT_TRUE(IsInlineData(refs[0].data()));
+  ASSERT_TRUE(IsLOBReference(refs[1].data()));
+  ASSERT_TRUE(IsInlineData(refs[2].data()));
+  ASSERT_TRUE(IsLOBReference(refs[3].data()));
+  ASSERT_TRUE(IsInlineData(refs[4].data()));
+
+  // verify inline text sizes (flag + text length)
+  ASSERT_EQ(refs[0].size(), 1 + texts[0].size());
+  ASSERT_EQ(refs[2].size(), 1 + texts[2].size());
+  ASSERT_EQ(refs[4].size(), 1 + texts[4].size());
+
+  // verify LOB reference sizes (fixed 24 bytes with padding)
+  ASSERT_EQ(refs[1].size(), LOB_REFERENCE_SIZE);
+  ASSERT_EQ(refs[3].size(), LOB_REFERENCE_SIZE);
+
+  // check stats
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.total_entries, 5);
+  ASSERT_EQ(stats.inline_entries, 3);
+  ASSERT_EQ(stats.lob_entries, 2);
+
+  // close writer
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+// test write and read round trip
+TEST_F(LobColumnManagerTest, WriteAndRead) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // prepare test texts
+  std::vector<std::string> texts = {
+      "inline1",                  // inline
+      GenerateRandomString(50),   // LOB
+      "inline2",                  // inline
+      GenerateRandomString(100),  // LOB
+      GenerateRandomString(150),  // LOB
+  };
+
+  // write texts
+  std::vector<std::vector<uint8_t>> refs;
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto refs_result = writer->WriteBatch(texts);
+    ASSERT_TRUE(refs_result.ok());
+    refs = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+
+  // read texts back
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    // read one by one
+    for (size_t i = 0; i < texts.size(); i++) {
+      auto text_result = reader->ReadText(refs[i].data(), refs[i].size());
+      ASSERT_TRUE(text_result.ok()) << "failed to read text " << i << ": " << text_result.status().message();
+      ASSERT_EQ(text_result.ValueOrDie(), texts[i]);
+    }
+
+    // read in batch
+    std::vector<EncodedRef> encoded_refs;
+    for (const auto& ref : refs) {
+      encoded_refs.push_back({ref.data(), ref.size()});
+    }
+
+    auto batch_result = reader->ReadBatch(encoded_refs);
+    ASSERT_TRUE(batch_result.ok()) << batch_result.status().message();
+    auto read_texts = std::move(batch_result).ValueOrDie();
+
+    ASSERT_EQ(read_texts.size(), texts.size());
+    for (size_t i = 0; i < texts.size(); i++) {
+      ASSERT_EQ(read_texts[i], texts[i]);
+    }
+
+    auto close_result = reader->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+}
+
+// test file rolling based on bytes
+TEST_F(LobColumnManagerTest, FileRolling) {
+  // set small max bytes to trigger rolling
+  config_.max_lob_file_bytes = 1024;    // 1KB per file
+  config_.flush_threshold_bytes = 512;  // flush at 512 bytes
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write texts that will exceed max_lob_file_bytes
+  std::vector<std::string> texts;
+  std::vector<std::vector<uint8_t>> refs;
+
+  // each text is 100 bytes, write 25 = 2500 bytes total
+  // should create at least 2 files (2500 / 1024 = ~2.4)
+  for (int i = 0; i < 25; i++) {
+    texts.push_back(GenerateRandomString(100));  // all LOB
+  }
+
+  auto refs_result = writer->WriteBatch(texts);
+  ASSERT_TRUE(refs_result.ok());
+  refs = std::move(refs_result).ValueOrDie();
+
+  // close writer
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+  auto files = std::move(close_result).ValueOrDie();
+
+  // should have created multiple files
+  ASSERT_GE(files.size(), 2);
+
+  // verify we can still read all texts
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  std::vector<EncodedRef> encoded_refs;
+  for (const auto& ref : refs) {
+    encoded_refs.push_back({ref.data(), ref.size()});
+  }
+
+  auto batch_result = reader->ReadBatch(encoded_refs);
+  ASSERT_TRUE(batch_result.ok());
+  auto read_texts = std::move(batch_result).ValueOrDie();
+
+  ASSERT_EQ(read_texts.size(), texts.size());
+  for (size_t i = 0; i < texts.size(); i++) {
+    ASSERT_EQ(read_texts[i], texts[i]);
+  }
+}
+
+// test abort
+TEST_F(LobColumnManagerTest, WriterAbort) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write some LOB texts
+  std::vector<std::string> texts;
+  for (int i = 0; i < 5; i++) {
+    texts.push_back(GenerateRandomString(50));
+  }
+
+  auto refs_result = writer->WriteBatch(texts);
+  ASSERT_TRUE(refs_result.ok());
+
+  // abort instead of close
+  auto abort_result = writer->Abort();
+  ASSERT_TRUE(abort_result.ok());
+  ASSERT_TRUE(writer->IsClosed());
+
+  // verify no files remain
+  auto lob_data_dir = config_.lob_base_path + "/_data";
+  if (boost::filesystem::exists(lob_data_dir)) {
+    ASSERT_TRUE(boost::filesystem::is_empty(lob_data_dir));
+  }
+}
+
+// test Arrow array interface
+TEST_F(LobColumnManagerTest, ArrowArrayInterface) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // prepare string array
+  arrow::StringBuilder builder;
+  ASSERT_TRUE(builder.Append("inline1").ok());
+  ASSERT_TRUE(builder.Append(GenerateRandomString(50)).ok());
+  ASSERT_TRUE(builder.Append("inline2").ok());
+  ASSERT_TRUE(builder.AppendNull().ok());  // null value
+  ASSERT_TRUE(builder.Append(GenerateRandomString(100)).ok());
+
+  std::shared_ptr<arrow::StringArray> input_array;
+  ASSERT_TRUE(builder.Finish(&input_array).ok());
+
+  // write using Arrow interface
+  std::shared_ptr<arrow::BinaryArray> refs_array;
+  {
+    auto writer_result = manager->CreateWriter();
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto refs_result = writer->WriteArrowArray(input_array);
+    ASSERT_TRUE(refs_result.ok()) << refs_result.status().message();
+    refs_array = std::move(refs_result).ValueOrDie();
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+
+  ASSERT_EQ(refs_array->length(), input_array->length());
+
+  // read using Arrow interface
+  {
+    auto reader_result = manager->CreateReader();
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    auto output_result = reader->ReadArrowArray(refs_array);
+    ASSERT_TRUE(output_result.ok()) << output_result.status().message();
+    auto output_array = std::move(output_result).ValueOrDie();
+
+    ASSERT_EQ(output_array->length(), input_array->length());
+
+    // verify values
+    for (int64_t i = 0; i < input_array->length(); i++) {
+      if (input_array->IsNull(i)) {
+        ASSERT_TRUE(output_array->IsNull(i));
+      } else {
+        ASSERT_FALSE(output_array->IsNull(i));
+        ASSERT_EQ(output_array->GetString(i), input_array->GetString(i));
+      }
+    }
+
+    auto close_result = reader->Close();
+    ASSERT_TRUE(close_result.ok());
+  }
+}
+
+// test inline text with various sizes
+TEST_F(LobColumnManagerTest, InlineTextVariableSizes) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // test various inline text sizes
+  std::vector<std::string> texts = {
+      "",                    // empty
+      "a",                   // 1 byte
+      "ab",                  // 2 bytes
+      "hello world!",        // 12 bytes
+      "19 bytes of text!!",  // 19 bytes (just under threshold)
+  };
+
+  auto refs_result = writer->WriteBatch(texts);
+  ASSERT_TRUE(refs_result.ok());
+  auto refs = std::move(refs_result).ValueOrDie();
+
+  // all should be inline
+  for (size_t i = 0; i < refs.size(); i++) {
+    ASSERT_TRUE(IsInlineData(refs[i].data())) << "text " << i << " should be inline";
+    ASSERT_EQ(refs[i].size(), 1 + texts[i].size()) << "text " << i << " has wrong size";
+    ASSERT_EQ(DecodeInlineText(refs[i].data(), refs[i].size()), texts[i]) << "text " << i << " decoded incorrectly";
+  }
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/test/lob_column/lob_column_reader_test.cpp
+++ b/cpp/test/lob_column/lob_column_reader_test.cpp
@@ -1,0 +1,579 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/filesystem/localfs.h>
+#include <boost/filesystem.hpp>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+#include "milvus-storage/lob_column/lob_column_writer.h"
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/lob_column/lob_reference.h"
+
+namespace milvus_storage::lob_column {
+
+class LobColumnReaderTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // create test directory
+    test_dir_ = "/tmp/lob_column_reader_test_" + std::to_string(std::random_device{}());
+    boost::filesystem::create_directories(test_dir_);
+
+    // create filesystem
+    fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+
+    // create config with small thresholds for testing
+    config_.lob_base_path = test_dir_ + "/lobs/100";
+    config_.field_id = 100;
+    config_.inline_threshold = 20;              // small threshold for testing inline vs LOB
+    config_.max_lob_file_bytes = 1024 * 1024;   // 1MB for testing
+    config_.flush_threshold_bytes = 64 * 1024;  // 64KB for testing
+
+    ASSERT_STATUS_OK(InitTestProperties(config_.properties));
+  }
+
+  void TearDown() override {
+    // cleanup test directory
+    boost::filesystem::remove_all(test_dir_);
+  }
+
+  std::string GenerateRandomString(size_t length) {
+    static const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, sizeof(charset) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+      result.push_back(charset[dis(gen)]);
+    }
+    return result;
+  }
+
+  // helper to write test data and return references
+  std::vector<std::vector<uint8_t>> WriteTestData(const std::vector<std::string>& texts) {
+    auto manager_result = LobColumnManager::Create(fs_, config_);
+    EXPECT_TRUE(manager_result.ok());
+    auto manager = std::move(manager_result).ValueOrDie();
+
+    auto writer_result = manager->CreateWriter();
+    EXPECT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto refs_result = writer->WriteBatch(texts);
+    EXPECT_TRUE(refs_result.ok());
+
+    auto close_result = writer->Close();
+    EXPECT_TRUE(close_result.ok());
+
+    return std::move(refs_result).ValueOrDie();
+  }
+
+  protected:
+  std::string test_dir_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  LobColumnConfig config_;
+};
+
+// ==================== ReadText Tests ====================
+
+// test reading single inline text
+TEST_F(LobColumnReaderTest, ReadSingleInlineText) {
+  std::string text = "short";
+  auto refs = WriteTestData({text});
+  ASSERT_EQ(refs.size(), 1);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read_result = reader->ReadText(refs[0].data(), refs[0].size());
+  ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+  ASSERT_EQ(read_result.ValueOrDie(), text);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading single LOB text
+TEST_F(LobColumnReaderTest, ReadSingleLOBText) {
+  std::string text = GenerateRandomString(100);  // larger than inline threshold
+  auto refs = WriteTestData({text});
+  ASSERT_EQ(refs.size(), 1);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read_result = reader->ReadText(refs[0].data(), refs[0].size());
+  ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+  ASSERT_EQ(read_result.ValueOrDie(), text);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading with invalid reference (null pointer)
+TEST_F(LobColumnReaderTest, ReadTextInvalidNullPointer) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read_result = reader->ReadText(nullptr, 0);
+  ASSERT_FALSE(read_result.ok());
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading with invalid LOB reference size
+TEST_F(LobColumnReaderTest, ReadTextInvalidLOBReferenceSize) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // create a fake LOB reference with wrong size
+  std::vector<uint8_t> fake_ref(20, 0);
+  fake_ref[0] = FLAG_LOB_REFERENCE;  // set LOB flag
+
+  auto read_result = reader->ReadText(fake_ref.data(), fake_ref.size());
+  ASSERT_FALSE(read_result.ok());  // should fail due to wrong size
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading after close
+TEST_F(LobColumnReaderTest, ReadTextAfterClose) {
+  std::string text = "test";
+  auto refs = WriteTestData({text});
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(reader->Close());
+  ASSERT_TRUE(reader->IsClosed());
+
+  auto read_result = reader->ReadText(refs[0].data(), refs[0].size());
+  ASSERT_FALSE(read_result.ok());  // should fail - reader is closed
+}
+
+// ==================== ReadBatch Tests ====================
+
+// test batch read with mixed inline and LOB
+TEST_F(LobColumnReaderTest, ReadBatchMixed) {
+  std::vector<std::string> texts = {
+      "short1",                   // inline
+      GenerateRandomString(50),   // LOB
+      "short2",                   // inline
+      GenerateRandomString(100),  // LOB
+      "short3",                   // inline
+  };
+
+  auto refs = WriteTestData(texts);
+  ASSERT_EQ(refs.size(), 5);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // prepare encoded refs
+  std::vector<EncodedRef> encoded_refs;
+  for (const auto& ref : refs) {
+    encoded_refs.push_back({ref.data(), ref.size()});
+  }
+
+  auto read_result = reader->ReadBatch(encoded_refs);
+  ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+  auto read_texts = std::move(read_result).ValueOrDie();
+
+  ASSERT_EQ(read_texts.size(), texts.size());
+  for (size_t i = 0; i < texts.size(); i++) {
+    ASSERT_EQ(read_texts[i], texts[i]) << "mismatch at index " << i;
+  }
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test batch read with empty refs
+TEST_F(LobColumnReaderTest, ReadBatchEmpty) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  std::vector<EncodedRef> empty_refs;
+  auto read_result = reader->ReadBatch(empty_refs);
+  ASSERT_TRUE(read_result.ok());
+  ASSERT_TRUE(read_result.ValueOrDie().empty());
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test batch read with null refs (empty data)
+TEST_F(LobColumnReaderTest, ReadBatchWithNullRefs) {
+  std::vector<std::string> texts = {"hello", GenerateRandomString(50)};
+  auto refs = WriteTestData(texts);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // include null refs in the batch
+  std::vector<EncodedRef> encoded_refs = {
+      {refs[0].data(), refs[0].size()},
+      {nullptr, 0},  // null ref
+      {refs[1].data(), refs[1].size()},
+  };
+
+  auto read_result = reader->ReadBatch(encoded_refs);
+  ASSERT_TRUE(read_result.ok());
+  auto read_texts = std::move(read_result).ValueOrDie();
+
+  ASSERT_EQ(read_texts.size(), 3);
+  ASSERT_EQ(read_texts[0], texts[0]);
+  ASSERT_EQ(read_texts[1], "");  // null ref returns empty string
+  ASSERT_EQ(read_texts[2], texts[1]);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test batch read with only LOB texts (same file)
+TEST_F(LobColumnReaderTest, ReadBatchAllLOBSameFile) {
+  std::vector<std::string> texts;
+  for (int i = 0; i < 10; i++) {
+    texts.push_back(GenerateRandomString(50 + i * 10));
+  }
+
+  auto refs = WriteTestData(texts);
+  ASSERT_EQ(refs.size(), 10);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  std::vector<EncodedRef> encoded_refs;
+  for (const auto& ref : refs) {
+    encoded_refs.push_back({ref.data(), ref.size()});
+  }
+
+  auto read_result = reader->ReadBatch(encoded_refs);
+  ASSERT_TRUE(read_result.ok());
+  auto read_texts = std::move(read_result).ValueOrDie();
+
+  ASSERT_EQ(read_texts.size(), texts.size());
+  for (size_t i = 0; i < texts.size(); i++) {
+    ASSERT_EQ(read_texts[i], texts[i]);
+  }
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test batch read in reverse order
+TEST_F(LobColumnReaderTest, ReadBatchReverseOrder) {
+  std::vector<std::string> texts;
+  for (int i = 0; i < 5; i++) {
+    texts.push_back(GenerateRandomString(50));
+  }
+
+  auto refs = WriteTestData(texts);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // reverse order
+  std::vector<EncodedRef> encoded_refs;
+  for (int i = refs.size() - 1; i >= 0; i--) {
+    encoded_refs.push_back({refs[i].data(), refs[i].size()});
+  }
+
+  auto read_result = reader->ReadBatch(encoded_refs);
+  ASSERT_TRUE(read_result.ok());
+  auto read_texts = std::move(read_result).ValueOrDie();
+
+  ASSERT_EQ(read_texts.size(), texts.size());
+  for (size_t i = 0; i < texts.size(); i++) {
+    ASSERT_EQ(read_texts[i], texts[texts.size() - 1 - i]);
+  }
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Take API Tests ====================
+
+// test Take with valid indices
+TEST_F(LobColumnReaderTest, TakeValidIndices) {
+  std::vector<std::string> texts;
+  for (int i = 0; i < 10; i++) {
+    texts.push_back(GenerateRandomString(50));
+  }
+
+  auto refs = WriteTestData(texts);
+
+  // extract file_id from the first LOB reference
+  ASSERT_TRUE(IsLOBReference(refs[0].data()));
+  auto [file_id_str, row_offset] = DecodeLOBReference(refs[0].data());
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // take specific rows
+  std::vector<int32_t> row_offsets = {0, 2, 5, 9};
+  auto take_result = reader->Take(file_id_str, row_offsets);
+  ASSERT_TRUE(take_result.ok()) << take_result.status().message();
+  auto taken_texts = std::move(take_result).ValueOrDie();
+
+  ASSERT_EQ(taken_texts.size(), 4);
+  ASSERT_EQ(taken_texts[0], texts[0]);
+  ASSERT_EQ(taken_texts[1], texts[2]);
+  ASSERT_EQ(taken_texts[2], texts[5]);
+  ASSERT_EQ(taken_texts[3], texts[9]);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test Take with empty indices - Vortex Take API doesn't support empty indices
+TEST_F(LobColumnReaderTest, TakeEmptyIndices) {
+  std::vector<std::string> texts = {GenerateRandomString(50)};
+  auto refs = WriteTestData(texts);
+
+  auto [file_id_str, row_offset] = DecodeLOBReference(refs[0].data());
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // Note: Vortex Take API returns error for empty indices
+  // This is expected behavior - caller should check for empty indices before calling Take
+  std::vector<int32_t> empty_offsets;
+  auto take_result = reader->Take(file_id_str, empty_offsets);
+  ASSERT_FALSE(take_result.ok()) << "Take with empty indices should return error";
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== ReadArrowArray Tests ====================
+
+// test ReadArrowArray with mixed data
+TEST_F(LobColumnReaderTest, ReadArrowArrayMixed) {
+  std::vector<std::string> texts = {
+      "short1",
+      GenerateRandomString(50),
+      "short2",
+  };
+
+  auto refs = WriteTestData(texts);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // build BinaryArray from refs
+  arrow::BinaryBuilder builder;
+  for (const auto& ref : refs) {
+    ASSERT_STATUS_OK(builder.Append(ref.data(), ref.size()));
+  }
+  std::shared_ptr<arrow::BinaryArray> refs_array;
+  ASSERT_STATUS_OK(builder.Finish(&refs_array));
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read_result = reader->ReadArrowArray(refs_array);
+  ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+  auto output_array = std::move(read_result).ValueOrDie();
+
+  ASSERT_EQ(output_array->length(), refs_array->length());
+  for (int64_t i = 0; i < output_array->length(); i++) {
+    ASSERT_EQ(output_array->GetString(i), texts[i]);
+  }
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test ReadArrowArray with nulls
+TEST_F(LobColumnReaderTest, ReadArrowArrayWithNulls) {
+  std::vector<std::string> texts = {"hello", GenerateRandomString(50)};
+  auto refs = WriteTestData(texts);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  // build BinaryArray with nulls
+  arrow::BinaryBuilder builder;
+  ASSERT_STATUS_OK(builder.Append(refs[0].data(), refs[0].size()));
+  ASSERT_STATUS_OK(builder.AppendNull());
+  ASSERT_STATUS_OK(builder.Append(refs[1].data(), refs[1].size()));
+  std::shared_ptr<arrow::BinaryArray> refs_array;
+  ASSERT_STATUS_OK(builder.Finish(&refs_array));
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read_result = reader->ReadArrowArray(refs_array);
+  ASSERT_TRUE(read_result.ok());
+  auto output_array = std::move(read_result).ValueOrDie();
+
+  ASSERT_EQ(output_array->length(), 3);
+  ASSERT_FALSE(output_array->IsNull(0));
+  ASSERT_TRUE(output_array->IsNull(1));
+  ASSERT_FALSE(output_array->IsNull(2));
+  ASSERT_EQ(output_array->GetString(0), texts[0]);
+  ASSERT_EQ(output_array->GetString(2), texts[1]);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Cache Tests ====================
+
+// test ClearCache
+TEST_F(LobColumnReaderTest, ClearCache) {
+  std::vector<std::string> texts = {GenerateRandomString(50), GenerateRandomString(60)};
+  auto refs = WriteTestData(texts);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // read to populate cache
+  auto read1 = reader->ReadText(refs[0].data(), refs[0].size());
+  ASSERT_TRUE(read1.ok());
+
+  // clear cache
+  reader->ClearCache();
+
+  // read again - should still work (re-opens file)
+  auto read2 = reader->ReadText(refs[1].data(), refs[1].size());
+  ASSERT_TRUE(read2.ok());
+  ASSERT_EQ(read2.ValueOrDie(), texts[1]);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test multiple reads reuse cache
+TEST_F(LobColumnReaderTest, MultipleReadsReuseCache) {
+  std::vector<std::string> texts;
+  for (int i = 0; i < 100; i++) {
+    texts.push_back(GenerateRandomString(50));
+  }
+  auto refs = WriteTestData(texts);
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // read all texts multiple times
+  for (int round = 0; round < 3; round++) {
+    for (size_t i = 0; i < texts.size(); i++) {
+      auto read_result = reader->ReadText(refs[i].data(), refs[i].size());
+      ASSERT_TRUE(read_result.ok()) << "round " << round << ", index " << i;
+      ASSERT_EQ(read_result.ValueOrDie(), texts[i]);
+    }
+  }
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Large Data Tests ====================
+
+// test reading large text
+TEST_F(LobColumnReaderTest, ReadLargeText) {
+  // create a 1MB text
+  std::string large_text = GenerateRandomString(1024 * 1024);
+  auto refs = WriteTestData({large_text});
+
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read_result = reader->ReadText(refs[0].data(), refs[0].size());
+  ASSERT_TRUE(read_result.ok()) << read_result.status().message();
+  ASSERT_EQ(read_result.ValueOrDie(), large_text);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/test/lob_column/lob_column_writer_edge_test.cpp
+++ b/cpp/test/lob_column/lob_column_writer_edge_test.cpp
@@ -1,0 +1,559 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/filesystem/localfs.h>
+#include <boost/filesystem.hpp>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "milvus-storage/lob_column/lob_column_manager.h"
+#include "milvus-storage/lob_column/lob_column_writer.h"
+#include "milvus-storage/lob_column/lob_column_reader.h"
+#include "milvus-storage/lob_column/lob_reference.h"
+
+namespace milvus_storage::lob_column {
+
+class LobColumnWriterEdgeTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // create test directory
+    test_dir_ = "/tmp/lob_column_writer_edge_test_" + std::to_string(std::random_device{}());
+    boost::filesystem::create_directories(test_dir_);
+
+    // create filesystem
+    fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+
+    // create config with small thresholds for testing
+    config_.lob_base_path = test_dir_ + "/lobs/100";
+    config_.field_id = 100;
+    config_.inline_threshold = 20;              // small threshold for testing
+    config_.max_lob_file_bytes = 1024 * 1024;   // 1MB for testing
+    config_.flush_threshold_bytes = 64 * 1024;  // 64KB for testing
+
+    ASSERT_STATUS_OK(InitTestProperties(config_.properties));
+  }
+
+  void TearDown() override {
+    // cleanup test directory
+    boost::filesystem::remove_all(test_dir_);
+  }
+
+  std::string GenerateRandomString(size_t length) {
+    static const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, sizeof(charset) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+      result.push_back(charset[dis(gen)]);
+    }
+    return result;
+  }
+
+  protected:
+  std::string test_dir_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  LobColumnConfig config_;
+};
+
+// ==================== Boundary Threshold Tests ====================
+
+// test text exactly at inline threshold (should be inline)
+TEST_F(LobColumnWriterEdgeTest, TextExactlyAtThreshold) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // text with length = threshold - 1 (should be inline)
+  std::string text_under = GenerateRandomString(config_.inline_threshold - 1);
+  auto ref_under = writer->WriteText(text_under);
+  ASSERT_TRUE(ref_under.ok());
+  ASSERT_TRUE(IsInlineData(ref_under.ValueOrDie().data()));
+
+  // text with length = threshold (should be LOB)
+  std::string text_at = GenerateRandomString(config_.inline_threshold);
+  auto ref_at = writer->WriteText(text_at);
+  ASSERT_TRUE(ref_at.ok());
+  ASSERT_TRUE(IsLOBReference(ref_at.ValueOrDie().data()));
+
+  // text with length = threshold + 1 (should be LOB)
+  std::string text_over = GenerateRandomString(config_.inline_threshold + 1);
+  auto ref_over = writer->WriteText(text_over);
+  ASSERT_TRUE(ref_over.ok());
+  ASSERT_TRUE(IsLOBReference(ref_over.ValueOrDie().data()));
+
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.inline_entries, 1);
+  ASSERT_EQ(stats.lob_entries, 2);
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+// ==================== Unicode/Multi-byte Character Tests ====================
+
+// test Unicode text (Chinese characters)
+TEST_F(LobColumnWriterEdgeTest, UnicodeTextChinese) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // short Chinese text (should be inline)
+  std::string short_chinese = "你好";  // 6 bytes in UTF-8
+  auto ref1 = writer->WriteText(short_chinese);
+  ASSERT_TRUE(ref1.ok());
+  ASSERT_TRUE(IsInlineData(ref1.ValueOrDie().data()));
+
+  // longer Chinese text (should be LOB)
+  std::string long_chinese = "这是一段很长的中文文本，用于测试LOB存储功能是否正常工作。";
+  auto ref2 = writer->WriteText(long_chinese);
+  ASSERT_TRUE(ref2.ok());
+  ASSERT_TRUE(IsLOBReference(ref2.ValueOrDie().data()));
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+
+  // verify read back
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read1 = reader->ReadText(ref1.ValueOrDie().data(), ref1.ValueOrDie().size());
+  ASSERT_TRUE(read1.ok());
+  ASSERT_EQ(read1.ValueOrDie(), short_chinese);
+
+  auto read2 = reader->ReadText(ref2.ValueOrDie().data(), ref2.ValueOrDie().size());
+  ASSERT_TRUE(read2.ok());
+  ASSERT_EQ(read2.ValueOrDie(), long_chinese);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test Unicode text (emoji)
+TEST_F(LobColumnWriterEdgeTest, UnicodeTextEmoji) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // emoji text
+  std::string emoji_text = "Hello 👋 World 🌍 Test 🧪";
+  auto ref = writer->WriteText(emoji_text);
+  ASSERT_TRUE(ref.ok());
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+
+  // verify read back
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read = reader->ReadText(ref.ValueOrDie().data(), ref.ValueOrDie().size());
+  ASSERT_TRUE(read.ok());
+  ASSERT_EQ(read.ValueOrDie(), emoji_text);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test mixed Unicode and ASCII
+TEST_F(LobColumnWriterEdgeTest, MixedUnicodeAndASCII) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  std::string mixed_text = "Hello 你好 مرحبا שלום こんにちは 🎉";
+  auto ref = writer->WriteText(mixed_text);
+  ASSERT_TRUE(ref.ok());
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read = reader->ReadText(ref.ValueOrDie().data(), ref.ValueOrDie().size());
+  ASSERT_TRUE(read.ok());
+  ASSERT_EQ(read.ValueOrDie(), mixed_text);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Empty and Special Cases ====================
+
+// test empty batch write
+TEST_F(LobColumnWriterEdgeTest, EmptyBatchWrite) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  std::vector<std::string> empty_batch;
+  auto refs_result = writer->WriteBatch(empty_batch);
+  ASSERT_TRUE(refs_result.ok());
+  ASSERT_TRUE(refs_result.ValueOrDie().empty());
+
+  ASSERT_EQ(writer->WrittenRows(), 0);
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+  ASSERT_TRUE(close_result.ValueOrDie().empty());  // no LOB files created
+}
+
+// test multiple empty strings
+TEST_F(LobColumnWriterEdgeTest, MultipleEmptyStrings) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  std::vector<std::string> texts = {"", "", "", ""};
+  auto refs_result = writer->WriteBatch(texts);
+  ASSERT_TRUE(refs_result.ok());
+  auto refs = std::move(refs_result).ValueOrDie();
+
+  ASSERT_EQ(refs.size(), 4);
+  for (const auto& ref : refs) {
+    ASSERT_TRUE(IsInlineData(ref.data()));
+    ASSERT_EQ(ref.size(), 1);  // just the flag byte
+  }
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+
+  // verify read back
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  for (size_t i = 0; i < refs.size(); i++) {
+    auto read = reader->ReadText(refs[i].data(), refs[i].size());
+    ASSERT_TRUE(read.ok());
+    ASSERT_EQ(read.ValueOrDie(), "");
+  }
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Multiple Flush Tests ====================
+
+// test multiple flushes
+TEST_F(LobColumnWriterEdgeTest, MultipleFlushes) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  std::vector<std::vector<uint8_t>> all_refs;
+
+  // write and flush multiple times
+  for (int round = 0; round < 5; round++) {
+    std::string text = GenerateRandomString(50);
+    auto ref_result = writer->WriteText(text);
+    ASSERT_TRUE(ref_result.ok());
+    all_refs.push_back(std::move(ref_result).ValueOrDie());
+
+    ASSERT_STATUS_OK(writer->Flush());
+  }
+
+  ASSERT_EQ(writer->WrittenRows(), 5);
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+// test flush on empty writer
+TEST_F(LobColumnWriterEdgeTest, FlushOnEmptyWriter) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // flush without writing anything
+  ASSERT_STATUS_OK(writer->Flush());
+  ASSERT_STATUS_OK(writer->Flush());
+  ASSERT_STATUS_OK(writer->Flush());
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+  ASSERT_TRUE(close_result.ValueOrDie().empty());
+}
+
+// ==================== Abort Tests ====================
+
+// test abort immediately after write
+TEST_F(LobColumnWriterEdgeTest, AbortAfterWrite) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write some LOB texts
+  for (int i = 0; i < 10; i++) {
+    auto ref = writer->WriteText(GenerateRandomString(100));
+    ASSERT_TRUE(ref.ok());
+  }
+
+  // abort
+  ASSERT_STATUS_OK(writer->Abort());
+  ASSERT_TRUE(writer->IsClosed());
+
+  // verify no files remain
+  auto lob_data_dir = config_.lob_base_path + "/_data";
+  if (boost::filesystem::exists(lob_data_dir)) {
+    ASSERT_TRUE(boost::filesystem::is_empty(lob_data_dir));
+  }
+}
+
+// test abort without writing
+TEST_F(LobColumnWriterEdgeTest, AbortWithoutWrite) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // abort immediately
+  ASSERT_STATUS_OK(writer->Abort());
+  ASSERT_TRUE(writer->IsClosed());
+}
+
+// test double abort
+TEST_F(LobColumnWriterEdgeTest, DoubleAbort) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  auto ref = writer->WriteText(GenerateRandomString(100));
+  ASSERT_TRUE(ref.ok());
+
+  ASSERT_STATUS_OK(writer->Abort());
+  ASSERT_STATUS_OK(writer->Abort());  // should be idempotent
+}
+
+// ==================== Write After Close/Abort Tests ====================
+
+// test write after close
+TEST_F(LobColumnWriterEdgeTest, WriteAfterClose) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+
+  // try to write after close
+  auto ref = writer->WriteText("test");
+  ASSERT_FALSE(ref.ok());
+}
+
+// test write after abort
+TEST_F(LobColumnWriterEdgeTest, WriteAfterAbort) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(writer->Abort());
+
+  // try to write after abort
+  auto ref = writer->WriteText("test");
+  ASSERT_FALSE(ref.ok());
+}
+
+// ==================== Large Text Tests ====================
+
+// test very large text (10MB)
+TEST_F(LobColumnWriterEdgeTest, VeryLargeText) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // 10MB text
+  std::string large_text = GenerateRandomString(10 * 1024 * 1024);
+  auto ref = writer->WriteText(large_text);
+  ASSERT_TRUE(ref.ok()) << ref.status().message();
+  ASSERT_TRUE(IsLOBReference(ref.ValueOrDie().data()));
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+
+  // verify read back
+  auto reader_result = manager->CreateReader();
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto read = reader->ReadText(ref.ValueOrDie().data(), ref.ValueOrDie().size());
+  ASSERT_TRUE(read.ok()) << read.status().message();
+  ASSERT_EQ(read.ValueOrDie(), large_text);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Stats Tests ====================
+
+// test stats accuracy
+TEST_F(LobColumnWriterEdgeTest, StatsAccuracy) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // 5 inline texts
+  for (int i = 0; i < 5; i++) {
+    auto ref = writer->WriteText("short");
+    ASSERT_TRUE(ref.ok());
+  }
+
+  // 10 LOB texts
+  size_t lob_bytes = 0;
+  for (int i = 0; i < 10; i++) {
+    std::string text = GenerateRandomString(100);
+    lob_bytes += text.size();
+    auto ref = writer->WriteText(text);
+    ASSERT_TRUE(ref.ok());
+  }
+
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.total_entries, 15);
+  ASSERT_EQ(stats.inline_entries, 5);
+  ASSERT_EQ(stats.lob_entries, 10);
+  ASSERT_EQ(stats.total_bytes, 5 * 5 + lob_bytes);  // 5 "short" + lob_bytes
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+// ==================== Arrow Array Interface Tests ====================
+
+// test WriteArrowArray with all nulls
+TEST_F(LobColumnWriterEdgeTest, WriteArrowArrayAllNulls) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // build array with all nulls
+  arrow::StringBuilder builder;
+  ASSERT_STATUS_OK(builder.AppendNull());
+  ASSERT_STATUS_OK(builder.AppendNull());
+  ASSERT_STATUS_OK(builder.AppendNull());
+
+  std::shared_ptr<arrow::StringArray> input_array;
+  ASSERT_STATUS_OK(builder.Finish(&input_array));
+
+  auto refs_result = writer->WriteArrowArray(input_array);
+  ASSERT_TRUE(refs_result.ok());
+  auto refs_array = std::move(refs_result).ValueOrDie();
+
+  ASSERT_EQ(refs_array->length(), 3);
+  for (int64_t i = 0; i < 3; i++) {
+    ASSERT_TRUE(refs_array->IsNull(i));
+  }
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+// test WriteArrowArray with empty array
+TEST_F(LobColumnWriterEdgeTest, WriteArrowArrayEmpty) {
+  auto manager_result = LobColumnManager::Create(fs_, config_);
+  ASSERT_TRUE(manager_result.ok());
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // build empty array
+  arrow::StringBuilder builder;
+  std::shared_ptr<arrow::StringArray> input_array;
+  ASSERT_STATUS_OK(builder.Finish(&input_array));
+
+  auto refs_result = writer->WriteArrowArray(input_array);
+  ASSERT_TRUE(refs_result.ok());
+  auto refs_array = std::move(refs_result).ValueOrDie();
+
+  ASSERT_EQ(refs_array->length(), 0);
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok());
+}
+
+}  // namespace milvus_storage::lob_column

--- a/cpp/test/lob_column/lob_reference_test.cpp
+++ b/cpp/test/lob_column/lob_reference_test.cpp
@@ -1,0 +1,300 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "milvus-storage/lob_column/lob_reference.h"
+
+using namespace milvus_storage::lob_column;
+
+class LOBReferenceTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // create a sample UUID string (36 chars: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    test_file_id_str_ = "12345678-9abc-def0-1122-334455667788";
+    // create corresponding binary UUID (16 bytes)
+    // UUID string "12345678-9abc-def0-1122-334455667788" -> binary
+    test_file_id_[0] = 0x12;
+    test_file_id_[1] = 0x34;
+    test_file_id_[2] = 0x56;
+    test_file_id_[3] = 0x78;
+    test_file_id_[4] = 0x9a;
+    test_file_id_[5] = 0xbc;
+    test_file_id_[6] = 0xde;
+    test_file_id_[7] = 0xf0;
+    test_file_id_[8] = 0x11;
+    test_file_id_[9] = 0x22;
+    test_file_id_[10] = 0x33;
+    test_file_id_[11] = 0x44;
+    test_file_id_[12] = 0x55;
+    test_file_id_[13] = 0x66;
+    test_file_id_[14] = 0x77;
+    test_file_id_[15] = 0x88;
+  }
+
+  std::string test_file_id_str_;
+  uint8_t test_file_id_[UUID_BINARY_SIZE];
+};
+
+// test EncodeInlineText - variable length encoding
+TEST_F(LOBReferenceTest, EncodeInlineText) {
+  std::string text = "hello";
+  auto encoded = EncodeInlineText(text);
+
+  // inline text: flag (1 byte) + text bytes
+  ASSERT_EQ(encoded.size(), 1 + text.size());
+  ASSERT_EQ(encoded[0], FLAG_INLINE_DATA);  // inline flag
+  // check text data starts immediately after flag
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(&encoded[1]), text.size()), text);
+}
+
+// test EncodeInlineText with empty string
+TEST_F(LOBReferenceTest, EncodeInlineTextEmpty) {
+  std::string text = "";
+  auto encoded = EncodeInlineText(text);
+
+  // empty inline text: just flag byte
+  ASSERT_EQ(encoded.size(), 1);
+  ASSERT_EQ(encoded[0], FLAG_INLINE_DATA);  // inline flag
+}
+
+// test EncodeInlineText with longer text
+TEST_F(LOBReferenceTest, EncodeInlineTextLong) {
+  std::string text = "this is a longer text that would previously be truncated";
+  auto encoded = EncodeInlineText(text);
+
+  // inline text stores the complete text now (variable length)
+  ASSERT_EQ(encoded.size(), 1 + text.size());
+  ASSERT_EQ(encoded[0], FLAG_INLINE_DATA);  // inline flag
+  // check complete text is stored
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(&encoded[1]), text.size()), text);
+}
+
+// test EncodeLOBReference - fixed 24 bytes with padding
+TEST_F(LOBReferenceTest, EncodeLOBReference) {
+  int32_t row_offset = 12345;
+  auto encoded = EncodeLOBReference(test_file_id_, row_offset);
+
+  // LOB reference is fixed 24 bytes: flag (1) + padding (3) + file_id (16) + row_offset (4)
+  ASSERT_EQ(encoded.size(), LOB_REFERENCE_SIZE);
+  ASSERT_EQ(encoded.size(), 24);
+  ASSERT_EQ(encoded[0], FLAG_LOB_REFERENCE);  // LOB flag
+
+  // check padding bytes are zero
+  ASSERT_EQ(encoded[1], 0x00);
+  ASSERT_EQ(encoded[2], 0x00);
+  ASSERT_EQ(encoded[3], 0x00);
+
+  // check file_id binary (starts at offset 4 after padding, 16 bytes)
+  ASSERT_EQ(std::memcmp(&encoded[4], test_file_id_, UUID_BINARY_SIZE), 0);
+
+  // check row_offset (starts at offset 20 = 4 + 16)
+  int32_t decoded_offset;
+  std::memcpy(&decoded_offset, &encoded[20], sizeof(int32_t));
+  ASSERT_EQ(decoded_offset, row_offset);
+}
+
+// test DecodeInlineText - needs size parameter now
+TEST_F(LOBReferenceTest, DecodeInlineText) {
+  std::string text = "hello world";
+  auto encoded = EncodeInlineText(text);
+  auto decoded = DecodeInlineText(encoded.data(), encoded.size());
+
+  ASSERT_EQ(decoded, text);
+}
+
+// test DecodeInlineText with empty string
+TEST_F(LOBReferenceTest, DecodeInlineTextEmpty) {
+  std::string text = "";
+  auto encoded = EncodeInlineText(text);
+  auto decoded = DecodeInlineText(encoded.data(), encoded.size());
+
+  ASSERT_EQ(decoded, text);
+}
+
+// test DecodeInlineText with long text
+TEST_F(LOBReferenceTest, DecodeInlineTextLong) {
+  std::string text = "this is a much longer text that is now stored completely";
+  auto encoded = EncodeInlineText(text);
+  auto decoded = DecodeInlineText(encoded.data(), encoded.size());
+
+  ASSERT_EQ(decoded, text);
+}
+
+// test DecodeLOBReference
+TEST_F(LOBReferenceTest, DecodeLOBReference) {
+  int32_t row_offset = 54321;
+  auto encoded = EncodeLOBReference(test_file_id_, row_offset);
+
+  auto ref = DecodeLOBReference(encoded.data());
+
+  // check file_id_str (should be converted from binary to string)
+  ASSERT_EQ(ref.file_id, test_file_id_str_);
+
+  // check row_offset
+  ASSERT_EQ(ref.row_offset, row_offset);
+}
+
+// test IsLOBReference
+TEST_F(LOBReferenceTest, IsLOBReference) {
+  // test with LOB reference
+  int32_t row_offset = 100;
+  auto lob_encoded = EncodeLOBReference(test_file_id_, row_offset);
+  ASSERT_TRUE(IsLOBReference(lob_encoded.data()));
+
+  // test with inline text
+  std::string text = "test";
+  auto inline_encoded = EncodeInlineText(text);
+  ASSERT_FALSE(IsLOBReference(inline_encoded.data()));
+}
+
+// test IsInlineData
+TEST_F(LOBReferenceTest, IsInlineData) {
+  // test with inline text
+  std::string text = "test";
+  auto inline_encoded = EncodeInlineText(text);
+  ASSERT_TRUE(IsInlineData(inline_encoded.data()));
+
+  // test with LOB reference
+  int32_t row_offset = 100;
+  auto lob_encoded = EncodeLOBReference(test_file_id_, row_offset);
+  ASSERT_FALSE(IsInlineData(lob_encoded.data()));
+}
+
+// test BuildLOBFilePath - takes lob_base_path and file_id_str directly
+TEST_F(LOBReferenceTest, BuildLOBFilePath) {
+  std::string lob_base_path = "/data/collection/partition/lobs/100";
+
+  std::string file_path = BuildLOBFilePath(lob_base_path, test_file_id_str_);
+
+  // should contain lob_base_path, _data, and UUID with .vx extension
+  ASSERT_NE(file_path.find(lob_base_path), std::string::npos);
+  ASSERT_NE(file_path.find("_data"), std::string::npos);
+  ASSERT_NE(file_path.find(".vx"), std::string::npos);
+  ASSERT_NE(file_path.find("12345678-9abc-def0-1122-334455667788"), std::string::npos);
+}
+
+// test BuildLOBFilePath with trailing slash
+TEST_F(LOBReferenceTest, BuildLOBFilePathTrailingSlash) {
+  std::string lob_base_path = "/data/collection/partition/lobs/200/";
+
+  std::string file_path = BuildLOBFilePath(lob_base_path, test_file_id_str_);
+
+  // should not have double slashes
+  ASSERT_EQ(file_path.find("//"), std::string::npos);
+  ASSERT_NE(file_path.find("_data"), std::string::npos);
+}
+
+// test GenerateUUIDBinary and UUIDToString
+TEST_F(LOBReferenceTest, GenerateUUIDBinaryAndToString) {
+  uint8_t uuid1[UUID_BINARY_SIZE];
+  uint8_t uuid2[UUID_BINARY_SIZE];
+  GenerateUUIDBinary(uuid1);
+  GenerateUUIDBinary(uuid2);
+
+  // two generated UUIDs should be different
+  ASSERT_NE(std::memcmp(uuid1, uuid2, UUID_BINARY_SIZE), 0) << "two generated UUIDs should be different";
+
+  // convert to string and check format
+  std::string uuid1_str = UUIDToString(uuid1);
+  std::string uuid2_str = UUIDToString(uuid2);
+
+  // check UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
+  ASSERT_EQ(uuid1_str.size(), 36) << "UUID string should be 36 characters";
+  ASSERT_EQ(uuid2_str.size(), 36) << "UUID string should be 36 characters";
+
+  // check hyphens are in correct positions (8, 13, 18, 23)
+  ASSERT_EQ(uuid1_str[8], '-');
+  ASSERT_EQ(uuid1_str[13], '-');
+  ASSERT_EQ(uuid1_str[18], '-');
+  ASSERT_EQ(uuid1_str[23], '-');
+
+  // check UUID v4 format: version digit at position 14 should be '4'
+  ASSERT_EQ(uuid1_str[14], '4') << "UUID version should be 4";
+
+  // check variant at position 19 should be 8, 9, a, or b
+  char variant = uuid1_str[19];
+  ASSERT_TRUE(variant == '8' || variant == '9' || variant == 'a' || variant == 'b')
+      << "UUID variant should be 8, 9, a, or b";
+}
+
+// test UUIDToString with known binary UUID
+TEST_F(LOBReferenceTest, UUIDToStringKnown) {
+  std::string uuid_str = UUIDToString(test_file_id_);
+  ASSERT_EQ(uuid_str, test_file_id_str_);
+}
+
+// test round-trip: encode then decode inline text
+TEST_F(LOBReferenceTest, RoundTripInlineText) {
+  std::string original = "hello";
+  auto encoded = EncodeInlineText(original);
+  auto decoded = DecodeInlineText(encoded.data(), encoded.size());
+
+  ASSERT_EQ(decoded, original);
+}
+
+// test round-trip with various text sizes
+TEST_F(LOBReferenceTest, RoundTripInlineTextVariousSizes) {
+  std::vector<std::string> test_texts = {
+      "",                              // empty
+      "a",                             // 1 char
+      "ab",                            // 2 chars
+      "hello world",                   // 11 chars
+      "this is a longer test string",  // longer
+      std::string(100, 'x'),           // 100 chars
+      std::string(1000, 'y'),          // 1000 chars
+  };
+
+  for (const auto& original : test_texts) {
+    auto encoded = EncodeInlineText(original);
+    ASSERT_EQ(encoded.size(), 1 + original.size()) << "size mismatch for text length " << original.size();
+
+    auto decoded = DecodeInlineText(encoded.data(), encoded.size());
+    ASSERT_EQ(decoded, original) << "round-trip failed for text length " << original.size();
+  }
+}
+
+// test round-trip: encode then decode LOB reference
+TEST_F(LOBReferenceTest, RoundTripLOBReference) {
+  int32_t original_offset = 99999;
+  auto encoded = EncodeLOBReference(test_file_id_, original_offset);
+
+  auto ref = DecodeLOBReference(encoded.data());
+
+  ASSERT_EQ(ref.file_id, test_file_id_str_);
+  ASSERT_EQ(ref.row_offset, original_offset);
+}
+
+// test LOB_REFERENCE_SIZE constant
+TEST_F(LOBReferenceTest, LOBReferenceSizeConstant) {
+  // LOB reference: flag (1) + padding (3) + file_id (16) + row_offset (4) = 24 bytes
+  ASSERT_EQ(LOB_REFERENCE_SIZE, 24);
+
+  // verify by encoding
+  auto encoded = EncodeLOBReference(test_file_id_, 0);
+  ASSERT_EQ(encoded.size(), LOB_REFERENCE_SIZE);
+}
+
+// test UUID_BINARY_SIZE constant
+TEST_F(LOBReferenceTest, UUIDBinarySizeConstant) {
+  // UUID binary: 16 bytes
+  ASSERT_EQ(UUID_BINARY_SIZE, 16);
+}
+
+// test UUID_STRING_SIZE constant
+TEST_F(LOBReferenceTest, UUIDStringSizeConstant) {
+  // UUID string: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (32 hex + 4 hyphens = 36)
+  ASSERT_EQ(UUID_STRING_SIZE, 36);
+}

--- a/cpp/test/manifest_test.cpp
+++ b/cpp/test/manifest_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -83,6 +84,7 @@ TEST_F(ManifestTest, EmptyManifestRoundTrip) {
   EXPECT_TRUE(read_back->deltaLogs().empty());
   EXPECT_TRUE(read_back->stats().empty());
   EXPECT_TRUE(read_back->indexes().empty());
+  EXPECT_TRUE(read_back->lobFiles().empty());
 }
 
 TEST_F(ManifestTest, ColumnGroupsRoundTrip) {
@@ -175,6 +177,45 @@ TEST_F(ManifestTest, IndexesRoundTrip) {
   EXPECT_TRUE(found_inv->properties.empty());
 }
 
+TEST_F(ManifestTest, LobFilesRoundTrip) {
+  // LOB files live at partition level: base_path/../lobs/{field_id}/_data/
+  // After normalization, the absolute path starts with "lobs/" for base_path_ = "manifest-test"
+  std::string lob_prefix = std::filesystem::path(base_path_).parent_path().string();
+  if (!lob_prefix.empty())
+    lob_prefix += "/";
+  lob_prefix += "lobs/";
+
+  LobFileInfo lob1{lob_prefix + "101/_data/lob_001.vortex", 101, 1000, 900, 1048576};
+  LobFileInfo lob2{lob_prefix + "101/_data/lob_002.vortex", 101, 2000, 1800, 2097152};
+  LobFileInfo lob3{lob_prefix + "102/_data/lob_001.vortex", 102, 500, 450, 524288};
+
+  Manifest manifest({}, {}, {}, {}, {lob1, lob2, lob3});
+  auto read_back = RoundTrip(manifest);
+
+  ASSERT_EQ(read_back->lobFiles().size(), 3);
+
+  EXPECT_EQ(read_back->lobFiles()[0].path, lob1.path);
+  EXPECT_EQ(read_back->lobFiles()[0].field_id, 101);
+  EXPECT_EQ(read_back->lobFiles()[0].total_rows, 1000);
+  EXPECT_EQ(read_back->lobFiles()[0].valid_rows, 900);
+  EXPECT_EQ(read_back->lobFiles()[0].file_size_bytes, 1048576);
+
+  EXPECT_EQ(read_back->lobFiles()[1].path, lob2.path);
+  EXPECT_EQ(read_back->lobFiles()[1].total_rows, 2000);
+
+  EXPECT_EQ(read_back->lobFiles()[2].field_id, 102);
+  EXPECT_EQ(read_back->lobFiles()[2].file_size_bytes, 524288);
+
+  // getLobFilesForField filtering
+  auto field101 = read_back->getLobFilesForField(101);
+  ASSERT_EQ(field101.size(), 2);
+
+  auto field102 = read_back->getLobFilesForField(102);
+  ASSERT_EQ(field102.size(), 1);
+
+  EXPECT_TRUE(read_back->getLobFilesForField(999).empty());
+}
+
 TEST_F(ManifestTest, FullManifestRoundTrip) {
   // Populate all fields
   auto cg1 =
@@ -197,18 +238,29 @@ TEST_F(ManifestTest, FullManifestRoundTrip) {
                                  .path = get_index_filepath(base_path_, "vec.idx"),
                                  .properties = {{"M", "16"}}}};
 
-  Manifest manifest({cg1, cg2}, deltas, stats, indexes);
+  std::string lob_prefix = std::filesystem::path(base_path_).parent_path().string();
+  if (!lob_prefix.empty())
+    lob_prefix += "/";
+  lob_prefix += "lobs/";
+  std::vector<LobFileInfo> lob_files = {{lob_prefix + "100/_data/lob_001.vortex", 100, 500, 480, 65536}};
+
+  Manifest manifest({cg1, cg2}, deltas, stats, indexes, lob_files);
   auto read_back = RoundTrip(manifest);
 
   EXPECT_EQ(read_back->columnGroups().size(), 2);
   EXPECT_EQ(read_back->deltaLogs().size(), 1);
   EXPECT_EQ(read_back->stats().size(), 1);
   EXPECT_EQ(read_back->indexes().size(), 1);
+  EXPECT_EQ(read_back->lobFiles().size(), 1);
 
   // Verify multi-file column group
   EXPECT_EQ(read_back->columnGroups()[0]->files.size(), 2);
   EXPECT_EQ(read_back->columnGroups()[0]->files[0].end_index, 500);
   EXPECT_EQ(read_back->columnGroups()[0]->files[1].start_index, 500);
+
+  // Verify LOB file
+  EXPECT_EQ(read_back->lobFiles()[0].field_id, 100);
+  EXPECT_EQ(read_back->lobFiles()[0].total_rows, 500);
 }
 
 // ---------- Column Group Policy Tests ----------

--- a/cpp/test/segment/segment_reader_text_test.cpp
+++ b/cpp/test/segment/segment_reader_text_test.cpp
@@ -1,0 +1,1028 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+#include <boost/filesystem.hpp>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/segment/segment_writer.h"
+#include "milvus-storage/segment/segment_reader.h"
+#include "milvus-storage/transaction/transaction.h"
+
+namespace milvus_storage::segment {
+
+class SegmentReaderTextTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // create test directory
+    test_dir_ = "/tmp/segment_reader_text_test_" + std::to_string(std::random_device{}());
+    boost::filesystem::create_directories(test_dir_);
+
+    // create filesystem
+    fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+
+    // create test schema with TEXT column
+    // field IDs: id=100, content=101, value=102
+    schema_ = arrow::schema({
+        arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+        arrow::field("content", arrow::utf8(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"})),
+        arrow::field("value", arrow::float64(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"102"})),
+    });
+
+    // configure writer
+    writer_config_.segment_path = test_dir_ + "/segments/seg-001";
+
+    // TEXT column config
+    lob_column::LobColumnConfig text_config;
+    text_config.lob_base_path = test_dir_ + "/lobs/101";
+    text_config.field_id = 101;
+    text_config.inline_threshold = 20;
+    text_config.max_lob_file_bytes = 1024 * 1024;
+    text_config.flush_threshold_bytes = 64 * 1024;
+    ASSERT_STATUS_OK(InitTestProperties(text_config.properties));
+
+    writer_config_.lob_columns[101] = text_config;
+    ASSERT_STATUS_OK(InitTestProperties(writer_config_.properties));
+    writer_config_.properties[PROPERTY_WRITER_POLICY] = LOON_COLUMN_GROUP_POLICY_SINGLE;
+    writer_config_.properties[PROPERTY_FORMAT] = LOON_FORMAT_PARQUET;
+
+    // configure reader
+    reader_config_.lob_columns = writer_config_.lob_columns;
+    ASSERT_STATUS_OK(InitTestProperties(reader_config_.properties));
+  }
+
+  void TearDown() override { boost::filesystem::remove_all(test_dir_); }
+
+  std::string GenerateRandomString(size_t length) {
+    static const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, sizeof(charset) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+      result.push_back(charset[dis(gen)]);
+    }
+    return result;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateTestBatch(int64_t num_rows,
+                                                                     int64_t start_id = 0,
+                                                                     bool use_lob = true) {
+    arrow::Int64Builder id_builder;
+    arrow::StringBuilder content_builder;
+    arrow::DoubleBuilder value_builder;
+
+    ARROW_RETURN_NOT_OK(id_builder.Reserve(num_rows));
+    ARROW_RETURN_NOT_OK(content_builder.Reserve(num_rows));
+    ARROW_RETURN_NOT_OK(value_builder.Reserve(num_rows));
+
+    for (int64_t i = 0; i < num_rows; i++) {
+      ARROW_RETURN_NOT_OK(id_builder.Append(start_id + i));
+      ARROW_RETURN_NOT_OK(value_builder.Append(static_cast<double>(start_id + i) * 0.1));
+
+      if (use_lob && i % 3 != 0) {
+        // LOB text
+        ARROW_RETURN_NOT_OK(content_builder.Append(GenerateRandomString(50 + i % 50)));
+      } else {
+        // inline text
+        ARROW_RETURN_NOT_OK(content_builder.Append("short" + std::to_string(start_id + i)));
+      }
+    }
+
+    std::shared_ptr<arrow::Int64Array> id_array;
+    std::shared_ptr<arrow::StringArray> content_array;
+    std::shared_ptr<arrow::DoubleArray> value_array;
+
+    ARROW_RETURN_NOT_OK(id_builder.Finish(&id_array));
+    ARROW_RETURN_NOT_OK(content_builder.Finish(&content_array));
+    ARROW_RETURN_NOT_OK(value_builder.Finish(&value_array));
+
+    return arrow::RecordBatch::Make(schema_, num_rows, {id_array, content_array, value_array});
+  }
+
+  // write test data and return committed version
+  int64_t WriteTestData(int64_t num_rows) {
+    auto writer_result = SegmentWriter::Create(fs_, schema_, writer_config_);
+    EXPECT_TRUE(writer_result.ok()) << writer_result.status().message();
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto batch_result = CreateTestBatch(num_rows);
+    EXPECT_TRUE(batch_result.ok());
+    EXPECT_TRUE(writer->Write(batch_result.ValueOrDie()).ok());
+
+    auto close_result = writer->Close();
+    EXPECT_TRUE(close_result.ok()) << close_result.status().message();
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path);
+    EXPECT_TRUE(txn_result.ok()) << txn_result.status().message();
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    EXPECT_TRUE(commit_result.ok()) << commit_result.status().message();
+    return commit_result.ValueOrDie();
+  }
+
+  // helper: open transaction and get manifest
+  std::shared_ptr<api::Manifest> OpenManifest(const std::string& segment_path, int64_t version) {
+    auto txn_result = api::transaction::Transaction::Open(fs_, segment_path, version,
+                                                          api::transaction::FailResolver, 1);
+    EXPECT_TRUE(txn_result.ok()) << txn_result.status().message();
+    auto txn = std::move(txn_result).ValueOrDie();
+    auto manifest_result = txn->GetManifest();
+    EXPECT_TRUE(manifest_result.ok()) << manifest_result.status().message();
+    return std::move(manifest_result).ValueOrDie();
+  }
+
+  protected:
+  std::string test_dir_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> schema_;
+  SegmentWriterConfig writer_config_;
+  SegmentReaderConfig reader_config_;
+};
+
+// ==================== Basic Read Tests ====================
+
+// test reading all columns including TEXT
+TEST_F(SegmentReaderTextTest, ReadAllColumns) {
+  int64_t num_rows = 50;
+  int64_t version = WriteTestData(num_rows);
+  ASSERT_GT(version, 0);
+
+  // open reader
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // read all batches
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+
+    total_rows += batch->num_rows();
+
+    // verify schema - TEXT column should be utf8 (resolved from binary)
+    ASSERT_EQ(batch->schema()->field(1)->type()->id(), arrow::Type::STRING);
+
+    // verify TEXT data is readable
+    auto content_array = std::static_pointer_cast<arrow::StringArray>(batch->column(1));
+    for (int64_t i = 0; i < batch->num_rows(); i++) {
+      if (!content_array->IsNull(i)) {
+        ASSERT_FALSE(content_array->GetString(i).empty());
+      }
+    }
+  }
+
+  ASSERT_EQ(total_rows, num_rows);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading only TEXT column
+TEST_F(SegmentReaderTextTest, ReadOnlyLobColumn) {
+  int64_t num_rows = 30;
+  int64_t version = WriteTestData(num_rows);
+
+  // open reader with only TEXT column
+  std::vector<std::string> columns = {"content"};
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, columns, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // verify schema has only one column
+  ASSERT_EQ(reader->schema()->num_fields(), 1);
+  ASSERT_EQ(reader->schema()->field(0)->name(), "content");
+  ASSERT_EQ(reader->schema()->field(0)->type()->id(), arrow::Type::STRING);
+
+  // read all batches
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+
+    total_rows += batch->num_rows();
+    ASSERT_EQ(batch->num_columns(), 1);
+  }
+
+  ASSERT_EQ(total_rows, num_rows);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading TEXT column with other columns
+TEST_F(SegmentReaderTextTest, ReadTextWithOtherColumns) {
+  int64_t num_rows = 40;
+  int64_t version = WriteTestData(num_rows);
+
+  // open reader with TEXT and id columns
+  std::vector<std::string> columns = {"id", "content"};
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, columns, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // verify schema
+  ASSERT_EQ(reader->schema()->num_fields(), 2);
+  ASSERT_EQ(reader->schema()->field(0)->name(), "id");
+  ASSERT_EQ(reader->schema()->field(1)->name(), "content");
+
+  // read and verify
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+
+    total_rows += batch->num_rows();
+    ASSERT_EQ(batch->num_columns(), 2);
+
+    auto id_array = std::static_pointer_cast<arrow::Int64Array>(batch->column(0));
+    auto content_array = std::static_pointer_cast<arrow::StringArray>(batch->column(1));
+
+    // verify data consistency
+    for (int64_t i = 0; i < batch->num_rows(); i++) {
+      int64_t id = id_array->Value(i);
+      std::string content = content_array->GetString(i);
+
+      // inline texts start with "short"
+      if (id % 3 == 0) {
+        ASSERT_TRUE(content.find("short") == 0) << "id=" << id << ", content=" << content;
+      }
+    }
+  }
+
+  ASSERT_EQ(total_rows, num_rows);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test reading without TEXT column
+TEST_F(SegmentReaderTextTest, ReadWithoutLobColumn) {
+  int64_t num_rows = 25;
+  int64_t version = WriteTestData(num_rows);
+
+  // open reader without TEXT column
+  std::vector<std::string> columns = {"id", "value"};
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, columns, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // verify schema - no TEXT column
+  ASSERT_EQ(reader->schema()->num_fields(), 2);
+  ASSERT_EQ(reader->schema()->field(0)->name(), "id");
+  ASSERT_EQ(reader->schema()->field(1)->name(), "value");
+
+  // read all batches
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+
+    total_rows += batch->num_rows();
+    ASSERT_EQ(batch->num_columns(), 2);
+  }
+
+  ASSERT_EQ(total_rows, num_rows);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Take API Tests ====================
+
+// test Take with TEXT column
+TEST_F(SegmentReaderTextTest, TakeWithLobColumn) {
+  int64_t num_rows = 100;
+  int64_t version = WriteTestData(num_rows);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // take specific rows
+  std::vector<int64_t> row_indices = {0, 10, 25, 50, 99};
+  auto take_result = reader->Take(row_indices);
+  ASSERT_TRUE(take_result.ok()) << take_result.status().message();
+  auto table = std::move(take_result).ValueOrDie();
+
+  ASSERT_EQ(table->num_rows(), static_cast<int64_t>(row_indices.size()));
+  ASSERT_EQ(table->num_columns(), 3);
+
+  // verify TEXT column
+  auto content_column = table->column(1);
+  ASSERT_EQ(content_column->type()->id(), arrow::Type::STRING);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test Take with only TEXT column selected
+TEST_F(SegmentReaderTextTest, TakeOnlyLobColumn) {
+  int64_t num_rows = 50;
+  int64_t version = WriteTestData(num_rows);
+
+  std::vector<std::string> columns = {"content"};
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, columns, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  std::vector<int64_t> row_indices = {5, 15, 25, 35, 45};
+  auto take_result = reader->Take(row_indices);
+  ASSERT_TRUE(take_result.ok()) << take_result.status().message();
+  auto table = std::move(take_result).ValueOrDie();
+
+  ASSERT_EQ(table->num_rows(), static_cast<int64_t>(row_indices.size()));
+  ASSERT_EQ(table->num_columns(), 1);
+  ASSERT_EQ(table->schema()->field(0)->name(), "content");
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Multiple Writes and Reads ====================
+
+// test incremental writes and reads
+TEST_F(SegmentReaderTextTest, IncrementalWritesAndReads) {
+  int64_t version1 = 0, version2 = 0;
+
+  // first write
+  {
+    auto writer_result = SegmentWriter::Create(fs_, schema_, writer_config_);
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto batch_result = CreateTestBatch(20);
+    ASSERT_TRUE(batch_result.ok());
+    ASSERT_STATUS_OK(writer->Write(batch_result.ValueOrDie()));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok());
+    version1 = commit_result.ValueOrDie();
+  }
+
+  // second write (incremental)
+  {
+    SegmentWriterConfig config2 = writer_config_;
+
+    auto writer_result = SegmentWriter::Create(fs_, schema_, config2);
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto batch_result = CreateTestBatch(30, 20);
+    ASSERT_TRUE(batch_result.ok());
+    ASSERT_STATUS_OK(writer->Write(batch_result.ValueOrDie()));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version1);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok());
+    version2 = commit_result.ValueOrDie();
+  }
+
+  ASSERT_GT(version2, version1);
+
+  // read version1 - should have 20 rows
+  {
+    auto manifest1 = OpenManifest(writer_config_.segment_path, version1);
+    auto reader_result = SegmentReader::Open(fs_, manifest1, schema_, {}, reader_config_);
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    int64_t total = 0;
+    while (true) {
+      std::shared_ptr<arrow::RecordBatch> batch;
+      ASSERT_STATUS_OK(reader->ReadNext(&batch));
+      if (!batch)
+        break;
+      total += batch->num_rows();
+    }
+    ASSERT_EQ(total, 20);
+    ASSERT_STATUS_OK(reader->Close());
+  }
+
+  // read version2 - should have 50 rows (20 + 30)
+  {
+    auto manifest2 = OpenManifest(writer_config_.segment_path, version2);
+    auto reader_result = SegmentReader::Open(fs_, manifest2, schema_, {}, reader_config_);
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    int64_t total = 0;
+    while (true) {
+      std::shared_ptr<arrow::RecordBatch> batch;
+      ASSERT_STATUS_OK(reader->ReadNext(&batch));
+      if (!batch)
+        break;
+      total += batch->num_rows();
+    }
+    ASSERT_EQ(total, 50);
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// ==================== NULL Handling Tests ====================
+
+// test reading with NULL TEXT values
+TEST_F(SegmentReaderTextTest, ReadWithNullTextValues) {
+  // write batch with NULL TEXT values
+  {
+    auto writer_result = SegmentWriter::Create(fs_, schema_, writer_config_);
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    // create batch with NULLs
+    arrow::Int64Builder id_builder;
+    arrow::StringBuilder content_builder;
+    arrow::DoubleBuilder value_builder;
+
+    ASSERT_STATUS_OK(id_builder.Append(1));
+    ASSERT_STATUS_OK(content_builder.Append("text1"));
+    ASSERT_STATUS_OK(value_builder.Append(1.0));
+
+    ASSERT_STATUS_OK(id_builder.Append(2));
+    ASSERT_STATUS_OK(content_builder.AppendNull());
+    ASSERT_STATUS_OK(value_builder.Append(2.0));
+
+    ASSERT_STATUS_OK(id_builder.Append(3));
+    ASSERT_STATUS_OK(content_builder.Append(GenerateRandomString(50)));
+    ASSERT_STATUS_OK(value_builder.Append(3.0));
+
+    ASSERT_STATUS_OK(id_builder.Append(4));
+    ASSERT_STATUS_OK(content_builder.AppendNull());
+    ASSERT_STATUS_OK(value_builder.Append(4.0));
+
+    std::shared_ptr<arrow::Int64Array> id_array;
+    std::shared_ptr<arrow::StringArray> content_array;
+    std::shared_ptr<arrow::DoubleArray> value_array;
+
+    ASSERT_STATUS_OK(id_builder.Finish(&id_array));
+    ASSERT_STATUS_OK(content_builder.Finish(&content_array));
+    ASSERT_STATUS_OK(value_builder.Finish(&value_array));
+
+    auto batch = arrow::RecordBatch::Make(schema_, 4, {id_array, content_array, value_array});
+    ASSERT_STATUS_OK(writer->Write(batch));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok());
+  }
+
+  // read and verify NULLs are preserved
+  {
+    auto manifest = OpenManifest(writer_config_.segment_path, -1);
+    auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    ASSERT_NE(batch, nullptr);
+    ASSERT_EQ(batch->num_rows(), 4);
+
+    auto content_array = std::static_pointer_cast<arrow::StringArray>(batch->column(1));
+    ASSERT_FALSE(content_array->IsNull(0));
+    ASSERT_TRUE(content_array->IsNull(1));
+    ASSERT_FALSE(content_array->IsNull(2));
+    ASSERT_TRUE(content_array->IsNull(3));
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// ==================== Large Data Tests ====================
+
+// test reading large TEXT data
+TEST_F(SegmentReaderTextTest, ReadLargeTextData) {
+  // write large texts
+  {
+    auto writer_result = SegmentWriter::Create(fs_, schema_, writer_config_);
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    arrow::Int64Builder id_builder;
+    arrow::StringBuilder content_builder;
+    arrow::DoubleBuilder value_builder;
+
+    for (int i = 0; i < 10; i++) {
+      ASSERT_STATUS_OK(id_builder.Append(i));
+      // 100KB text per row
+      ASSERT_STATUS_OK(content_builder.Append(GenerateRandomString(100 * 1024)));
+      ASSERT_STATUS_OK(value_builder.Append(i * 0.1));
+    }
+
+    std::shared_ptr<arrow::Int64Array> id_array;
+    std::shared_ptr<arrow::StringArray> content_array;
+    std::shared_ptr<arrow::DoubleArray> value_array;
+
+    ASSERT_STATUS_OK(id_builder.Finish(&id_array));
+    ASSERT_STATUS_OK(content_builder.Finish(&content_array));
+    ASSERT_STATUS_OK(value_builder.Finish(&value_array));
+
+    auto batch = arrow::RecordBatch::Make(schema_, 10, {id_array, content_array, value_array});
+    ASSERT_STATUS_OK(writer->Write(batch));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok());
+  }
+
+  // read and verify
+  {
+    auto manifest = OpenManifest(writer_config_.segment_path, -1);
+    auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    int64_t total_rows = 0;
+    while (true) {
+      std::shared_ptr<arrow::RecordBatch> batch;
+      ASSERT_STATUS_OK(reader->ReadNext(&batch));
+      if (!batch)
+        break;
+
+      total_rows += batch->num_rows();
+
+      auto content_array = std::static_pointer_cast<arrow::StringArray>(batch->column(1));
+      for (int64_t i = 0; i < batch->num_rows(); i++) {
+        ASSERT_EQ(content_array->GetString(i).size(), 100 * 1024);
+      }
+    }
+
+    ASSERT_EQ(total_rows, 10);
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// ==================== Create Factory Tests ====================
+
+// test Create from ColumnGroups directly
+TEST_F(SegmentReaderTextTest, CreateFromColumnGroups) {
+  int64_t num_rows = 30;
+  int64_t version = WriteTestData(num_rows);
+
+  // open transaction to get column groups
+  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
+                                                        api::transaction::FailResolver, 1);
+  ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
+  auto txn = std::move(txn_result).ValueOrDie();
+
+  auto manifest_result = txn->GetManifest();
+  ASSERT_TRUE(manifest_result.ok());
+  auto manifest = std::move(manifest_result).ValueOrDie();
+  auto column_groups = std::make_shared<api::ColumnGroups>(manifest->columnGroups());
+
+  // create reader from ColumnGroups
+  auto reader_result = SegmentReader::Create(fs_, column_groups, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // read all rows
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+    total_rows += batch->num_rows();
+  }
+  ASSERT_EQ(total_rows, num_rows);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test Create with column selection
+TEST_F(SegmentReaderTextTest, CreateWithColumnSelection) {
+  int64_t num_rows = 20;
+  int64_t version = WriteTestData(num_rows);
+
+  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
+                                                        api::transaction::FailResolver, 1);
+  ASSERT_TRUE(txn_result.ok());
+  auto txn = std::move(txn_result).ValueOrDie();
+  auto manifest_result = txn->GetManifest();
+  ASSERT_TRUE(manifest_result.ok());
+  auto column_groups = std::make_shared<api::ColumnGroups>(manifest_result.ValueOrDie()->columnGroups());
+
+  std::vector<std::string> columns = {"id", "content"};
+  auto reader_result = SegmentReader::Create(fs_, column_groups, schema_, columns, reader_config_);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_EQ(reader->schema()->num_fields(), 2);
+  ASSERT_EQ(reader->schema()->field(0)->name(), "id");
+  ASSERT_EQ(reader->schema()->field(1)->name(), "content");
+
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+    total_rows += batch->num_rows();
+  }
+  ASSERT_EQ(total_rows, num_rows);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Error Path Tests ====================
+
+// test Create with null filesystem
+TEST_F(SegmentReaderTextTest, CreateWithNullFs) {
+  int64_t version = WriteTestData(10);
+
+  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
+                                                        api::transaction::FailResolver, 1);
+  ASSERT_TRUE(txn_result.ok());
+  auto txn = std::move(txn_result).ValueOrDie();
+  auto manifest_result = txn->GetManifest();
+  ASSERT_TRUE(manifest_result.ok());
+  auto column_groups = std::make_shared<api::ColumnGroups>(manifest_result.ValueOrDie()->columnGroups());
+
+  auto result = SegmentReader::Create(nullptr, column_groups, schema_, {}, reader_config_);
+  ASSERT_FALSE(result.ok());
+}
+
+// test Create with null schema
+TEST_F(SegmentReaderTextTest, CreateWithNullSchema) {
+  int64_t version = WriteTestData(10);
+
+  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
+                                                        api::transaction::FailResolver, 1);
+  ASSERT_TRUE(txn_result.ok());
+  auto txn = std::move(txn_result).ValueOrDie();
+  auto manifest_result = txn->GetManifest();
+  ASSERT_TRUE(manifest_result.ok());
+  auto column_groups = std::make_shared<api::ColumnGroups>(manifest_result.ValueOrDie()->columnGroups());
+
+  auto result = SegmentReader::Create(fs_, column_groups, nullptr, {}, reader_config_);
+  ASSERT_FALSE(result.ok());
+}
+
+// test Create with null column_groups
+TEST_F(SegmentReaderTextTest, CreateWithNullColumnGroups) {
+  auto result = SegmentReader::Create(fs_, nullptr, schema_, {}, reader_config_);
+  ASSERT_FALSE(result.ok());
+}
+
+// test Open with null filesystem
+TEST_F(SegmentReaderTextTest, OpenWithNullFs) {
+  int64_t version = WriteTestData(10);
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto result = SegmentReader::Open(nullptr, manifest, schema_, {}, reader_config_);
+  ASSERT_FALSE(result.ok());
+}
+
+// test Open with null schema
+TEST_F(SegmentReaderTextTest, OpenWithNullSchema) {
+  int64_t version = WriteTestData(10);
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto result = SegmentReader::Open(fs_, manifest, nullptr, {}, reader_config_);
+  ASSERT_FALSE(result.ok());
+}
+
+// test Open with null manifest
+TEST_F(SegmentReaderTextTest, OpenWithNullManifest) {
+  auto result = SegmentReader::Open(fs_, nullptr, schema_, {}, reader_config_);
+  ASSERT_FALSE(result.ok());
+}
+
+// test ReadNext on closed reader
+TEST_F(SegmentReaderTextTest, ReadNextAfterClose) {
+  int64_t version = WriteTestData(10);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(reader->Close());
+  ASSERT_TRUE(reader->IsClosed());
+
+  std::shared_ptr<arrow::RecordBatch> batch;
+  auto status = reader->ReadNext(&batch);
+  ASSERT_FALSE(status.ok());
+}
+
+// test Take on closed reader
+TEST_F(SegmentReaderTextTest, TakeAfterClose) {
+  int64_t version = WriteTestData(10);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(reader->Close());
+
+  std::vector<int64_t> indices = {0, 1};
+  auto result = reader->Take(indices);
+  ASSERT_FALSE(result.ok());
+}
+
+// test double Close is safe
+TEST_F(SegmentReaderTextTest, DoubleClose) {
+  int64_t version = WriteTestData(10);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(reader->Close());
+  ASSERT_STATUS_OK(reader->Close());  // second close should be OK
+}
+
+// ==================== Take Edge Case Tests ====================
+
+// test Take with empty indices returns empty table
+TEST_F(SegmentReaderTextTest, TakeEmptyIndices) {
+  int64_t version = WriteTestData(20);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  std::vector<int64_t> empty_indices;
+  auto take_result = reader->Take(empty_indices);
+  ASSERT_TRUE(take_result.ok()) << take_result.status().message();
+  auto table = std::move(take_result).ValueOrDie();
+
+  ASSERT_EQ(table->num_rows(), 0);
+  ASSERT_EQ(table->num_columns(), 3);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== Accessor Tests ====================
+
+// test GetOriginalSchema, GetExtractedColumns, GetTotalRows, IsClosed
+TEST_F(SegmentReaderTextTest, Accessors) {
+  int64_t num_rows = 20;
+  int64_t version = WriteTestData(num_rows);
+
+  // open with column subset
+  std::vector<std::string> columns = {"id", "content"};
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, columns, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // GetOriginalSchema should return full schema
+  auto original_schema = reader->GetOriginalSchema();
+  ASSERT_EQ(original_schema->num_fields(), 3);
+  ASSERT_EQ(original_schema->field(0)->name(), "id");
+  ASSERT_EQ(original_schema->field(1)->name(), "content");
+  ASSERT_EQ(original_schema->field(2)->name(), "value");
+
+  // schema() should return extracted schema
+  auto extracted_schema = reader->schema();
+  ASSERT_EQ(extracted_schema->num_fields(), 2);
+
+  // GetExtractedColumns
+  auto& extracted_columns = reader->GetExtractedColumns();
+  ASSERT_EQ(extracted_columns.size(), 2u);
+  ASSERT_EQ(extracted_columns[0], "id");
+  ASSERT_EQ(extracted_columns[1], "content");
+
+  // IsClosed should be false before close
+  ASSERT_FALSE(reader->IsClosed());
+
+  // GetTotalRows should be 0 before reading
+  ASSERT_EQ(reader->GetTotalRows(), 0);
+
+  // read all data
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(reader->ReadNext(&batch));
+    if (!batch)
+      break;
+  }
+
+  // GetTotalRows should reflect total read
+  ASSERT_EQ(reader->GetTotalRows(), num_rows);
+
+  ASSERT_STATUS_OK(reader->Close());
+  ASSERT_TRUE(reader->IsClosed());
+}
+
+// ==================== GetStream Tests ====================
+
+// test GetStream without predicate
+TEST_F(SegmentReaderTextTest, GetStreamNoPredicate) {
+  int64_t num_rows = 30;
+  int64_t version = WriteTestData(num_rows);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto stream_result = reader->GetStream();
+  ASSERT_TRUE(stream_result.ok()) << stream_result.status().message();
+  auto stream = std::move(stream_result).ValueOrDie();
+
+  // read all batches from stream
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(stream->ReadNext(&batch));
+    if (!batch)
+      break;
+
+    total_rows += batch->num_rows();
+
+    // verify TEXT column is resolved (utf8 type)
+    ASSERT_EQ(batch->schema()->field(1)->type()->id(), arrow::Type::STRING);
+  }
+  ASSERT_EQ(total_rows, num_rows);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test GetStream on closed reader
+TEST_F(SegmentReaderTextTest, GetStreamAfterClose) {
+  int64_t version = WriteTestData(10);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(reader->Close());
+
+  auto stream_result = reader->GetStream();
+  ASSERT_FALSE(stream_result.ok());
+}
+
+// test GetStream without LOB columns (no wrapping)
+TEST_F(SegmentReaderTextTest, GetStreamWithoutLobColumns) {
+  int64_t num_rows = 20;
+  int64_t version = WriteTestData(num_rows);
+
+  // open reader with only non-LOB columns
+  std::vector<std::string> columns = {"id", "value"};
+  SegmentReaderConfig config_no_lob;
+  ASSERT_STATUS_OK(InitTestProperties(config_no_lob.properties));
+  // no lob_columns configured
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, columns, config_no_lob);
+  ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto stream_result = reader->GetStream();
+  ASSERT_TRUE(stream_result.ok()) << stream_result.status().message();
+  auto stream = std::move(stream_result).ValueOrDie();
+
+  int64_t total_rows = 0;
+  while (true) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    ASSERT_STATUS_OK(stream->ReadNext(&batch));
+    if (!batch)
+      break;
+    total_rows += batch->num_rows();
+  }
+  ASSERT_EQ(total_rows, num_rows);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// ==================== GetChunkReader Tests ====================
+
+// test GetChunkReader
+TEST_F(SegmentReaderTextTest, GetChunkReader) {
+  int64_t num_rows = 30;
+  int64_t version = WriteTestData(num_rows);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  // get chunk reader for column group 0
+  auto chunk_reader_result = reader->GetChunkReader(0);
+  ASSERT_TRUE(chunk_reader_result.ok()) << chunk_reader_result.status().message();
+  auto chunk_reader = std::move(chunk_reader_result).ValueOrDie();
+
+  // verify chunk reader is usable
+  auto total_chunks = chunk_reader->total_number_of_chunks();
+  ASSERT_GT(total_chunks, 0u);
+
+  // read first chunk
+  auto chunk_result = chunk_reader->get_chunk(0);
+  ASSERT_TRUE(chunk_result.ok()) << chunk_result.status().message();
+  auto chunk = std::move(chunk_result).ValueOrDie();
+  ASSERT_GT(chunk->num_rows(), 0);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+// test GetChunkReader on closed reader
+TEST_F(SegmentReaderTextTest, GetChunkReaderAfterClose) {
+  int64_t version = WriteTestData(10);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(reader->Close());
+
+  auto chunk_reader_result = reader->GetChunkReader(0);
+  ASSERT_FALSE(chunk_reader_result.ok());
+}
+
+// ==================== GetColumnGroups Test ====================
+
+// test GetColumnGroups returns valid column groups
+TEST_F(SegmentReaderTextTest, GetColumnGroups) {
+  int64_t version = WriteTestData(20);
+
+  auto manifest = OpenManifest(writer_config_.segment_path, version);
+  auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config_);
+  ASSERT_TRUE(reader_result.ok());
+  auto reader = std::move(reader_result).ValueOrDie();
+
+  auto column_groups = reader->GetColumnGroups();
+  ASSERT_NE(column_groups, nullptr);
+
+  ASSERT_STATUS_OK(reader->Close());
+}
+
+}  // namespace milvus_storage::segment

--- a/cpp/test/segment/segment_writer_test.cpp
+++ b/cpp/test/segment/segment_writer_test.cpp
@@ -1,0 +1,557 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+#include <boost/filesystem.hpp>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "test_env.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/segment/segment_writer.h"
+#include "milvus-storage/segment/segment_reader.h"
+#include "milvus-storage/transaction/transaction.h"
+
+namespace milvus_storage::segment {
+
+class SegmentWriterTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // create test directory
+    test_dir_ = "/tmp/segment_writer_test_" + std::to_string(std::random_device{}());
+    boost::filesystem::create_directories(test_dir_);
+
+    // create filesystem
+    fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+
+    // create test schema with TEXT column
+    // field IDs: id=100, content=101, value=102
+    schema_ = arrow::schema({
+        arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+        arrow::field("content", arrow::utf8(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"})),
+        arrow::field("value", arrow::float64(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"102"})),
+    });
+
+    // configure writer
+    config_.segment_path = test_dir_ + "/segments/seg-001";
+
+    // TEXT column config (field_id=101 is the TEXT column)
+    lob_column::LobColumnConfig text_config;
+    text_config.lob_base_path = test_dir_ + "/lobs/101";
+    text_config.field_id = 101;
+    text_config.inline_threshold = 20;  // small threshold for testing
+    text_config.max_lob_file_bytes = 1024 * 1024;
+    text_config.flush_threshold_bytes = 64 * 1024;
+    ASSERT_STATUS_OK(InitTestProperties(text_config.properties));
+
+    config_.lob_columns[101] = text_config;
+
+    // properties for ColumnGroupPolicy (single policy - all columns in one group)
+    ASSERT_STATUS_OK(InitTestProperties(config_.properties));
+    config_.properties[PROPERTY_WRITER_POLICY] = LOON_COLUMN_GROUP_POLICY_SINGLE;
+    config_.properties[PROPERTY_FORMAT] = LOON_FORMAT_PARQUET;
+  }
+
+  void TearDown() override {
+    // cleanup test directory
+    boost::filesystem::remove_all(test_dir_);
+  }
+
+  std::string GenerateRandomString(size_t length) {
+    static const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, sizeof(charset) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+      result.push_back(charset[dis(gen)]);
+    }
+    return result;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateTestBatch(int64_t num_rows, int64_t start_id = 0) {
+    // build id array
+    arrow::Int64Builder id_builder;
+    ARROW_RETURN_NOT_OK(id_builder.Reserve(num_rows));
+    for (int64_t i = 0; i < num_rows; i++) {
+      ARROW_RETURN_NOT_OK(id_builder.Append(start_id + i));
+    }
+    std::shared_ptr<arrow::Int64Array> id_array;
+    ARROW_RETURN_NOT_OK(id_builder.Finish(&id_array));
+
+    // build content array (mix of inline and LOB)
+    arrow::StringBuilder content_builder;
+    ARROW_RETURN_NOT_OK(content_builder.Reserve(num_rows));
+    for (int64_t i = 0; i < num_rows; i++) {
+      if (i % 3 == 0) {
+        // inline text
+        ARROW_RETURN_NOT_OK(content_builder.Append("short" + std::to_string(i)));
+      } else {
+        // LOB text
+        ARROW_RETURN_NOT_OK(content_builder.Append(GenerateRandomString(50 + i % 50)));
+      }
+    }
+    std::shared_ptr<arrow::StringArray> content_array;
+    ARROW_RETURN_NOT_OK(content_builder.Finish(&content_array));
+
+    // build value array
+    arrow::DoubleBuilder value_builder;
+    ARROW_RETURN_NOT_OK(value_builder.Reserve(num_rows));
+    for (int64_t i = 0; i < num_rows; i++) {
+      ARROW_RETURN_NOT_OK(value_builder.Append(static_cast<double>(i) * 0.1));
+    }
+    std::shared_ptr<arrow::DoubleArray> value_array;
+    ARROW_RETURN_NOT_OK(value_builder.Finish(&value_array));
+
+    return arrow::RecordBatch::Make(schema_, num_rows, {id_array, content_array, value_array});
+  }
+
+  protected:
+  std::string test_dir_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> schema_;
+  SegmentWriterConfig config_;
+};
+
+// test writer creation
+TEST_F(SegmentWriterTest, CreateWriter) {
+  auto result = SegmentWriter::Create(fs_, schema_, config_);
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto writer = std::move(result).ValueOrDie();
+  ASSERT_NE(writer, nullptr);
+  ASSERT_FALSE(writer->IsClosed());
+  ASSERT_EQ(writer->WrittenRows(), 0);
+
+  // verify storage schema has binary type for TEXT column
+  auto storage_schema = writer->GetStorageSchema();
+  ASSERT_EQ(storage_schema->field(1)->type()->id(), arrow::Type::BINARY);
+
+  // original schema should have utf8
+  auto original_schema = writer->GetOriginalSchema();
+  ASSERT_EQ(original_schema->field(1)->type()->id(), arrow::Type::STRING);
+}
+
+// test writer creation with invalid config
+TEST_F(SegmentWriterTest, CreateWriterInvalidConfig) {
+  // null filesystem
+  auto result1 = SegmentWriter::Create(nullptr, schema_, config_);
+  ASSERT_FALSE(result1.ok());
+
+  // null schema
+  auto result2 = SegmentWriter::Create(fs_, nullptr, config_);
+  ASSERT_FALSE(result2.ok());
+
+  // empty segment path
+  SegmentWriterConfig invalid_config = config_;
+  invalid_config.segment_path = "";
+  auto result4 = SegmentWriter::Create(fs_, schema_, invalid_config);
+  ASSERT_FALSE(result4.ok());
+
+  // missing writer policy
+  invalid_config = config_;
+  invalid_config.properties.erase(PROPERTY_WRITER_POLICY);
+  auto result5 = SegmentWriter::Create(fs_, schema_, invalid_config);
+  ASSERT_FALSE(result5.ok());
+}
+
+// test writing single batch
+TEST_F(SegmentWriterTest, WriteSingleBatch) {
+  auto writer_result = SegmentWriter::Create(fs_, schema_, config_);
+  ASSERT_TRUE(writer_result.ok()) << writer_result.status().message();
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // create test batch
+  auto batch_result = CreateTestBatch(10);
+  ASSERT_TRUE(batch_result.ok()) << batch_result.status().message();
+  auto batch = std::move(batch_result).ValueOrDie();
+
+  // write batch
+  auto write_status = writer->Write(batch);
+  ASSERT_TRUE(write_status.ok()) << write_status.message();
+  ASSERT_EQ(writer->WrittenRows(), 10);
+
+  // close writer (commits transaction)
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+  ASSERT_TRUE(writer->IsClosed());
+
+  auto output = std::move(close_result).ValueOrDie();
+
+  // verify output
+  ASSERT_EQ(output.rows_written, 10);
+  ASSERT_NE(output.column_groups, nullptr);
+
+  // commit via Transaction
+  auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path);
+  ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
+  auto txn = std::move(txn_result).ValueOrDie();
+  txn->AppendFiles(*output.column_groups);
+  for (const auto& lob : output.lob_files) {
+    txn->AddLobFile(lob);
+  }
+  auto commit_result = txn->Commit();
+  ASSERT_TRUE(commit_result.ok()) << commit_result.status().message();
+  ASSERT_GT(commit_result.ValueOrDie(), 0);
+
+  // check stats
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.total_rows, 10);
+  ASSERT_GE(stats.parquet_files_created, 1);
+}
+
+// test writing multiple batches
+TEST_F(SegmentWriterTest, WriteMultipleBatches) {
+  auto writer_result = SegmentWriter::Create(fs_, schema_, config_);
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write multiple batches
+  for (int i = 0; i < 5; i++) {
+    auto batch_result = CreateTestBatch(20, i * 20);
+    ASSERT_TRUE(batch_result.ok());
+    auto batch = std::move(batch_result).ValueOrDie();
+
+    auto write_status = writer->Write(batch);
+    ASSERT_TRUE(write_status.ok()) << write_status.message();
+  }
+
+  ASSERT_EQ(writer->WrittenRows(), 100);
+
+  // close writer
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+
+  auto result = std::move(close_result).ValueOrDie();
+  ASSERT_EQ(result.rows_written, 100);
+
+  auto stats = writer->GetStats();
+  ASSERT_EQ(stats.total_rows, 100);
+}
+
+// test write and read round trip using Open (from manifest)
+TEST_F(SegmentWriterTest, WriteAndReadFromManifest) {
+  // prepare test data
+  auto batch_result = CreateTestBatch(50);
+  ASSERT_TRUE(batch_result.ok());
+  auto original_batch = std::move(batch_result).ValueOrDie();
+
+  int64_t committed_version = 0;
+
+  // write
+  {
+    auto writer_result = SegmentWriter::Create(fs_, schema_, config_);
+    ASSERT_TRUE(writer_result.ok()) << writer_result.status().message();
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    ASSERT_STATUS_OK(writer->Write(original_batch));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+
+    auto output = std::move(close_result).ValueOrDie();
+
+    // commit via Transaction
+    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path);
+    ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok()) << commit_result.status().message();
+    committed_version = commit_result.ValueOrDie();
+    ASSERT_GT(committed_version, 0);
+  }
+
+  // read using Open (from manifest)
+  {
+    SegmentReaderConfig reader_config;
+    reader_config.lob_columns = config_.lob_columns;
+    ASSERT_STATUS_OK(InitTestProperties(reader_config.properties));
+
+    // open transaction to get manifest
+    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path, -1,
+                                                          api::transaction::FailResolver, 1);
+    ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
+    auto txn = std::move(txn_result).ValueOrDie();
+    auto manifest_result = txn->GetManifest();
+    ASSERT_TRUE(manifest_result.ok()) << manifest_result.status().message();
+    auto manifest = std::move(manifest_result).ValueOrDie();
+
+    auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config);
+    ASSERT_TRUE(reader_result.ok()) << reader_result.status().message();
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    // read all batches
+    std::vector<std::shared_ptr<arrow::RecordBatch>> read_batches;
+    while (true) {
+      std::shared_ptr<arrow::RecordBatch> batch;
+      auto read_status = reader->ReadNext(&batch);
+      ASSERT_TRUE(read_status.ok()) << read_status.message();
+
+      if (!batch) {
+        break;
+      }
+      read_batches.push_back(batch);
+    }
+
+    ASSERT_FALSE(read_batches.empty());
+
+    // concatenate read batches and verify
+    int64_t total_rows = 0;
+    for (const auto& batch : read_batches) {
+      total_rows += batch->num_rows();
+    }
+    ASSERT_EQ(total_rows, original_batch->num_rows());
+
+    // verify schema
+    ASSERT_TRUE(reader->schema()->Equals(schema_));
+
+    // verify data for first batch
+    auto first_batch = read_batches[0];
+    ASSERT_EQ(first_batch->schema()->field(1)->type()->id(), arrow::Type::STRING);
+
+    // close reader
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test incremental writes (multiple commits)
+TEST_F(SegmentWriterTest, IncrementalWrites) {
+  int64_t version1 = 0, version2 = 0;
+
+  // first write
+  {
+    auto writer_result = SegmentWriter::Create(fs_, schema_, config_);
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto batch_result = CreateTestBatch(10);
+    ASSERT_TRUE(batch_result.ok());
+    ASSERT_STATUS_OK(writer->Write(batch_result.ValueOrDie()));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok());
+    version1 = commit_result.ValueOrDie();
+  }
+
+  // second write (reads from version1, writes version2)
+  {
+    SegmentWriterConfig config2 = config_;
+
+    auto writer_result = SegmentWriter::Create(fs_, schema_, config2);
+    ASSERT_TRUE(writer_result.ok());
+    auto writer = std::move(writer_result).ValueOrDie();
+
+    auto batch_result = CreateTestBatch(20, 10);
+    ASSERT_TRUE(batch_result.ok());
+    ASSERT_STATUS_OK(writer->Write(batch_result.ValueOrDie()));
+
+    auto close_result = writer->Close();
+    ASSERT_TRUE(close_result.ok());
+    auto output = std::move(close_result).ValueOrDie();
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path, version1);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    txn->AppendFiles(*output.column_groups);
+    for (const auto& lob : output.lob_files) {
+      txn->AddLobFile(lob);
+    }
+    auto commit_result = txn->Commit();
+    ASSERT_TRUE(commit_result.ok());
+    version2 = commit_result.ValueOrDie();
+  }
+
+  ASSERT_GT(version2, version1);
+
+  // read version2 - should have data from both writes
+  {
+    SegmentReaderConfig reader_config;
+    reader_config.lob_columns = config_.lob_columns;
+    ASSERT_STATUS_OK(InitTestProperties(reader_config.properties));
+
+    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path, version2,
+                                                          api::transaction::FailResolver, 1);
+    ASSERT_TRUE(txn_result.ok());
+    auto txn = std::move(txn_result).ValueOrDie();
+    auto manifest_result = txn->GetManifest();
+    ASSERT_TRUE(manifest_result.ok());
+    auto manifest = std::move(manifest_result).ValueOrDie();
+
+    auto reader_result = SegmentReader::Open(fs_, manifest, schema_, {}, reader_config);
+    ASSERT_TRUE(reader_result.ok());
+    auto reader = std::move(reader_result).ValueOrDie();
+
+    // count total rows
+    int64_t total_rows = 0;
+    while (true) {
+      std::shared_ptr<arrow::RecordBatch> batch;
+      ASSERT_STATUS_OK(reader->ReadNext(&batch));
+      if (!batch)
+        break;
+      total_rows += batch->num_rows();
+    }
+
+    // should have 10 + 20 = 30 rows
+    ASSERT_EQ(total_rows, 30);
+
+    ASSERT_STATUS_OK(reader->Close());
+  }
+}
+
+// test abort
+TEST_F(SegmentWriterTest, WriterAbort) {
+  auto writer_result = SegmentWriter::Create(fs_, schema_, config_);
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // write some data
+  auto batch_result = CreateTestBatch(20);
+  ASSERT_TRUE(batch_result.ok());
+  auto batch = std::move(batch_result).ValueOrDie();
+
+  ASSERT_STATUS_OK(writer->Write(batch));
+
+  // abort instead of close
+  auto abort_status = writer->Abort();
+  ASSERT_TRUE(abort_status.ok());
+  ASSERT_TRUE(writer->IsClosed());
+
+  // verify no manifest was created (transaction was not committed)
+  // manifest directory at segment level might exist but should be empty or not contain new version
+}
+
+// test writing with null values in TEXT column
+TEST_F(SegmentWriterTest, WriteWithNullText) {
+  auto writer_result = SegmentWriter::Create(fs_, schema_, config_);
+  ASSERT_TRUE(writer_result.ok());
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // build batch with null TEXT values
+  arrow::Int64Builder id_builder;
+  arrow::StringBuilder content_builder;
+  arrow::DoubleBuilder value_builder;
+
+  ASSERT_STATUS_OK(id_builder.Append(1));
+  ASSERT_STATUS_OK(content_builder.Append("hello"));
+  ASSERT_STATUS_OK(value_builder.Append(1.0));
+
+  ASSERT_STATUS_OK(id_builder.Append(2));
+  ASSERT_STATUS_OK(content_builder.AppendNull());  // null TEXT
+  ASSERT_STATUS_OK(value_builder.Append(2.0));
+
+  ASSERT_STATUS_OK(id_builder.Append(3));
+  ASSERT_STATUS_OK(content_builder.Append(GenerateRandomString(100)));  // LOB
+  ASSERT_STATUS_OK(value_builder.Append(3.0));
+
+  std::shared_ptr<arrow::Int64Array> id_array;
+  std::shared_ptr<arrow::StringArray> content_array;
+  std::shared_ptr<arrow::DoubleArray> value_array;
+
+  ASSERT_STATUS_OK(id_builder.Finish(&id_array));
+  ASSERT_STATUS_OK(content_builder.Finish(&content_array));
+  ASSERT_STATUS_OK(value_builder.Finish(&value_array));
+
+  auto batch = arrow::RecordBatch::Make(schema_, 3, {id_array, content_array, value_array});
+
+  // write batch
+  ASSERT_STATUS_OK(writer->Write(batch));
+
+  // close
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+}
+
+// test schema without TEXT columns
+TEST_F(SegmentWriterTest, SchemaWithoutLobColumns) {
+  // create schema without TEXT columns
+  auto no_text_schema = arrow::schema({
+      arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("value", arrow::float64(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"102"})),
+  });
+
+  // config without TEXT columns
+  SegmentWriterConfig no_text_config;
+  no_text_config.segment_path = test_dir_ + "/no_text/segments/seg-001";
+  boost::filesystem::create_directories(test_dir_ + "/no_text");
+  ASSERT_STATUS_OK(InitTestProperties(no_text_config.properties));
+  no_text_config.properties[PROPERTY_WRITER_POLICY] = LOON_COLUMN_GROUP_POLICY_SINGLE;
+  no_text_config.properties[PROPERTY_FORMAT] = LOON_FORMAT_PARQUET;
+
+  auto writer_result = SegmentWriter::Create(fs_, no_text_schema, no_text_config);
+  ASSERT_TRUE(writer_result.ok()) << writer_result.status().message();
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  // storage schema should be same as original (no TEXT columns)
+  ASSERT_TRUE(writer->GetStorageSchema()->Equals(writer->GetOriginalSchema()));
+
+  // write data
+  arrow::Int64Builder id_builder;
+  arrow::DoubleBuilder value_builder;
+  for (int i = 0; i < 10; i++) {
+    ASSERT_STATUS_OK(id_builder.Append(i));
+    ASSERT_STATUS_OK(value_builder.Append(i * 0.5));
+  }
+  std::shared_ptr<arrow::Int64Array> id_array;
+  std::shared_ptr<arrow::DoubleArray> value_array;
+  ASSERT_STATUS_OK(id_builder.Finish(&id_array));
+  ASSERT_STATUS_OK(value_builder.Finish(&value_array));
+
+  auto batch = arrow::RecordBatch::Make(no_text_schema, 10, {id_array, value_array});
+  ASSERT_STATUS_OK(writer->Write(batch));
+
+  // close
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+
+  auto output = std::move(close_result).ValueOrDie();
+  ASSERT_NE(output.column_groups, nullptr);
+
+  // commit via Transaction
+  auto txn_result = api::transaction::Transaction::Open(fs_, no_text_config.segment_path);
+  ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
+  auto txn = std::move(txn_result).ValueOrDie();
+  txn->AppendFiles(*output.column_groups);
+  auto commit_result = txn->Commit();
+  ASSERT_TRUE(commit_result.ok()) << commit_result.status().message();
+  ASSERT_GT(commit_result.ValueOrDie(), 0);
+}
+
+}  // namespace milvus_storage::segment

--- a/java/src/main/scala/io/milvus/storage/MilvusSegmentReader.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusSegmentReader.scala
@@ -1,0 +1,84 @@
+package io.milvus.storage
+
+/**
+ * Scala wrapper for MilvusStorage SegmentReader.
+ *
+ * Reads parquet data with automatic LOBRef → TEXT resolution.
+ * TEXT columns are returned as utf8 strings (LOBReferences auto-decoded).
+ *
+ * Usage:
+ * {{{
+ *   val reader = new MilvusSegmentReader()
+ *   reader.open(segmentPath, version, schemaPtr, neededColumns, lobColumns, propertiesPtr)
+ *   val streamPtr = reader.getStream()  // ArrowArrayStream with TEXT auto-decoded
+ *   // use ArrowUtils to read batches from streamPtr
+ *   reader.destroy()
+ * }}}
+ */
+class MilvusSegmentReader {
+  NativeLibraryLoader.loadLibrary()
+  private var handle: Long = 0
+  private var isDestroyed: Boolean = false
+
+  /**
+   * Open a SegmentReader from manifest.
+   *
+   * @param segmentPath   Base path where manifest and data files are stored
+   * @param version       Manifest version to read (-1 = latest)
+   * @param schemaPtr     Pointer to Arrow schema (TEXT columns as utf8)
+   * @param neededColumns Column names to read (null = all columns)
+   * @param lobColumns    TEXT column configurations for LOB resolution
+   * @param propertiesPtr Pointer to storage properties
+   */
+  def open(segmentPath: String, version: Long, schemaPtr: Long,
+           neededColumns: Array[String], lobColumns: Seq[LobColumnConfig],
+           propertiesPtr: Long): Unit = {
+    if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
+
+    val fieldIds = lobColumns.map(_.fieldId).toArray
+    val basePaths = lobColumns.map(_.lobBasePath).toArray
+    val inlines = lobColumns.map(_.inlineThreshold).toArray
+    val maxFiles = lobColumns.map(_.maxLobFileBytes).toArray
+    val flushes = lobColumns.map(_.flushThresholdBytes).toArray
+
+    handle = segmentReaderOpen(segmentPath, version, schemaPtr, neededColumns,
+      if (fieldIds.isEmpty) null else fieldIds,
+      if (basePaths.isEmpty) null else basePaths,
+      if (inlines.isEmpty) null else inlines,
+      if (maxFiles.isEmpty) null else maxFiles,
+      if (flushes.isEmpty) null else flushes,
+      propertiesPtr)
+  }
+
+  /**
+   * Get an ArrowArrayStream from the reader.
+   * TEXT columns are automatically decoded from LOBRef to utf8 strings.
+   *
+   * @return Pointer to ArrowArrayStream (use ArrowUtilsNative to read batches)
+   */
+  def getStream(): Long = {
+    if (isDestroyed) throw new IllegalStateException("Reader has been destroyed")
+    if (handle == 0) throw new IllegalStateException("Reader not initialized")
+    segmentReaderGetStream(handle)
+  }
+
+  def destroy(): Unit = {
+    if (handle != 0 && !isDestroyed) {
+      segmentReaderDestroy(handle)
+      handle = 0
+      isDestroyed = true
+    }
+  }
+
+  def isValid: Boolean = !isDestroyed && handle != 0
+
+  @native private def segmentReaderOpen(
+      segmentPath: String, version: Long, schemaPtr: Long,
+      neededColumns: Array[String],
+      lobFieldIds: Array[Long], lobBasePaths: Array[String],
+      lobInlineThresholds: Array[Long], lobMaxFileBytes: Array[Long], lobFlushThresholds: Array[Long],
+      propertiesPtr: Long): Long
+
+  @native private def segmentReaderGetStream(handle: Long): Long
+  @native private def segmentReaderDestroy(handle: Long): Unit
+}

--- a/java/src/main/scala/io/milvus/storage/MilvusSegmentWriter.scala
+++ b/java/src/main/scala/io/milvus/storage/MilvusSegmentWriter.scala
@@ -1,0 +1,154 @@
+package io.milvus.storage
+
+/**
+ * Configuration for a TEXT (LOB) column.
+ *
+ * @param fieldId         Field ID of the TEXT column
+ * @param lobBasePath     Base path for LOB files: {partition_path}/lobs/{field_id}
+ * @param inlineThreshold Texts smaller than this are stored inline (default 256 bytes)
+ * @param maxLobFileBytes Maximum bytes per LOB file before rolling (default 64MB)
+ * @param flushThresholdBytes Flush buffer when it exceeds this size (default 16MB)
+ */
+case class LobColumnConfig(
+    fieldId: Long,
+    lobBasePath: String,
+    inlineThreshold: Long = 256,
+    maxLobFileBytes: Long = 64 * 1024 * 1024,
+    flushThresholdBytes: Long = 16 * 1024 * 1024
+)
+
+/**
+ * LOB file metadata returned by SegmentWriter.close().
+ */
+case class LobFileResult(
+    fieldId: Long,
+    path: String,
+    totalRows: Long,
+    validRows: Long,
+    fileSizeBytes: Long
+)
+
+/**
+ * Output of SegmentWriter.close().
+ * Contains columnGroupsPtr (for Transaction.commit) and LOB file metadata.
+ */
+case class SegmentWriteResult(
+    columnGroupsPtr: Long,
+    lobFiles: Seq[LobFileResult],
+    rowsWritten: Long
+)
+
+/**
+ * Scala wrapper for MilvusStorage SegmentWriter.
+ *
+ * Writes parquet data + LOB files for TEXT columns.
+ * Close() returns ColumnGroups + LOB file info — caller commits via Transaction.
+ *
+ * Usage:
+ * {{{
+ *   val writer = new MilvusSegmentWriter()
+ *   writer.create(schemaPtr, segmentPath, lobColumns, propertiesPtr)
+ *   writer.write(arrayPtr)
+ *   val result = writer.close()  // returns ColumnGroups + LobFiles
+ *
+ *   // commit via Transaction
+ *   val txn = new MilvusStorageTransaction()
+ *   txn.begin(basePath, propertiesPtr)
+ *   txn.commit(0, 0, result.columnGroupsPtr)  // also need to add LOB files
+ *   writer.destroy()
+ * }}}
+ */
+class MilvusSegmentWriter {
+  NativeLibraryLoader.loadLibrary()
+  private var handle: Long = 0
+  private var isDestroyed: Boolean = false
+
+  def create(schemaPtr: Long, segmentPath: String,
+             lobColumns: Seq[LobColumnConfig], propertiesPtr: Long): Unit = {
+    if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")
+
+    val fieldIds = lobColumns.map(_.fieldId).toArray
+    val basePaths = lobColumns.map(_.lobBasePath).toArray
+    val inlines = lobColumns.map(_.inlineThreshold).toArray
+    val maxFiles = lobColumns.map(_.maxLobFileBytes).toArray
+    val flushes = lobColumns.map(_.flushThresholdBytes).toArray
+
+    handle = segmentWriterNew(schemaPtr, segmentPath,
+      if (fieldIds.isEmpty) null else fieldIds,
+      if (basePaths.isEmpty) null else basePaths,
+      if (inlines.isEmpty) null else inlines,
+      if (maxFiles.isEmpty) null else maxFiles,
+      if (flushes.isEmpty) null else flushes,
+      propertiesPtr)
+  }
+
+  def write(arrayPtr: Long): Unit = {
+    if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")
+    if (handle == 0) throw new IllegalStateException("Writer not initialized")
+    segmentWriterWrite(handle, arrayPtr)
+  }
+
+  def flush(): Unit = {
+    if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")
+    if (handle == 0) throw new IllegalStateException("Writer not initialized")
+    segmentWriterFlush(handle)
+  }
+
+  /**
+   * Close the writer and return write output.
+   * Returns ColumnGroups pointer + LOB file metadata.
+   * Caller must commit via MilvusStorageTransaction.
+   */
+  def close(): SegmentWriteResult = {
+    if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")
+    if (handle == 0) throw new IllegalStateException("Writer not initialized")
+
+    // Pre-allocate output arrays for LOB files (max reasonable size)
+    val maxLobFiles = 64
+    val lobFieldIds = new Array[Long](maxLobFiles)
+    val lobPaths = new Array[String](maxLobFiles)
+    val lobTotalRows = new Array[Long](maxLobFiles)
+    val lobValidRows = new Array[Long](maxLobFiles)
+    val lobFileSizes = new Array[Long](maxLobFiles)
+
+    val columnGroupsPtr = segmentWriterClose(handle, lobFieldIds, lobPaths,
+      lobTotalRows, lobValidRows, lobFileSizes)
+
+    // collect non-null LOB file results
+    val lobFiles = lobPaths.zipWithIndex.takeWhile(_._1 != null).map { case (path, i) =>
+      LobFileResult(lobFieldIds(i), path, lobTotalRows(i), lobValidRows(i), lobFileSizes(i))
+    }.toSeq
+
+    SegmentWriteResult(columnGroupsPtr, lobFiles, 0)
+  }
+
+  def abort(): Unit = {
+    if (isDestroyed) throw new IllegalStateException("Writer has been destroyed")
+    if (handle == 0) throw new IllegalStateException("Writer not initialized")
+    segmentWriterAbort(handle)
+  }
+
+  def destroy(): Unit = {
+    if (handle != 0 && !isDestroyed) {
+      segmentWriterDestroy(handle)
+      handle = 0
+      isDestroyed = true
+    }
+  }
+
+  def isValid: Boolean = !isDestroyed && handle != 0
+
+  @native private def segmentWriterNew(
+      schemaPtr: Long, segmentPath: String,
+      lobFieldIds: Array[Long], lobBasePaths: Array[String],
+      lobInlineThresholds: Array[Long], lobMaxFileBytes: Array[Long], lobFlushThresholds: Array[Long],
+      propertiesPtr: Long): Long
+
+  @native private def segmentWriterWrite(handle: Long, arrayPtr: Long): Unit
+  @native private def segmentWriterFlush(handle: Long): Unit
+  @native private def segmentWriterClose(handle: Long,
+      outLobFieldIds: Array[Long], outLobPaths: Array[String],
+      outLobTotalRows: Array[Long], outLobValidRows: Array[Long], outLobFileSizes: Array[Long]): Long
+  @native private def segmentWriterAbort(handle: Long): Unit
+  @native private def segmentWriterDestroy(handle: Long): Unit
+}


### PR DESCRIPTION
This adds support for storing large text columns separately from the main columnar data using a LOB (Large Object) storage layer.

The core idea is that text data can be either inlined (for small values under 64KB) or stored in dedicated LOB files, with encoded references kept in the main parquet files. This avoids bloating the columnar storage with large variable-length text.

The main pieces are: a LobColumnManager/Writer/Reader that handles the actual LOB file I/O, a LobReference encoding scheme that distinguishes inline vs file-based data, and a SegmentWriter/SegmentReader layer that transparently intercepts text columns during read/write and routes them through the LOB path. The manifest is bumped to v5 to track LOB file metadata (path, field_id, row counts, file size) for GC and query planning.

FFI (C) and JNI (Java/Scala) bindings are included so the Go and Spark layers can use the new segment reader/writer directly. The Scala side adds MilvusSegmentReader and MilvusSegmentWriter wrappers.

Tests cover the LOB layer (manager, writer, reader, reference encoding), segment-level text round-trips, edge cases like empty strings and large batches, and a cloud storage integration test.
