### PR TITLE
enhance: add FixedSizeBinary support for Vortex via transparent type conversion

### DIFF
--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -73,10 +73,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -1243,6 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1251,9 +1296,22 @@ version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1281,6 +1339,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comfy-table"
@@ -1461,6 +1525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf99ab37ee7072d64d906aa2dada9a3422f1d975cdf8c8055a573bc84897ed8"
+dependencies = [
+ "half",
+ "libloading",
 ]
 
 [[package]]
@@ -2330,12 +2404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-hash"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
-
-[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2442,26 @@ name = "enum-iterator-derive"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2476,9 +2564,9 @@ checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastlanes"
-version = "0.2.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b32ae222e7610a7d2ed53b733ec7a4f2fe15b8bd1d4cffc80d1a6e9b2d91959"
+checksum = "414cb755aee48ff7b0907995d2949c68c8c17900970076dff6a808e18e592d71"
 dependencies = [
  "arrayref",
  "const_for",
@@ -2577,9 +2665,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffdff7a2d68d22afc0657eddde3e946371ce7cfe730a3f78a5ed44ea5b1cb2e"
+checksum = "33c3b76530d0755759d6537bdb19b849b2b108b9013a379be1be6036d2cd210c"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -2928,6 +3016,8 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
  "zerocopy",
 ]
 
@@ -3406,6 +3496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c439decbc304e180748e34bb6d3df729069a222e83e74e2185c38f107136e9"
+checksum = "993c0199f4c8291dec6e545a523d2ac97875f455bf6f27b8e60504a68c7654d3"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3612,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ee5508b225456d3d56998eaeef0d8fbce5ea93856df47b12a94d2e74153210"
+checksum = "590272235088a62bf7fb7d3b13820af76c0d9092a6cffab8989e93c628fc8451"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3632,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c065fb3bd4a8cc4f78428443e990d4921aa08f707b676753db740e0b402a21"
+checksum = "75a1e0c990610227ec0d048f4c2cda80d7474de5c63498694a90408d62dcac32"
 dependencies = [
  "arrayref",
  "paste",
@@ -3643,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8856abad92e624b75cd57a04703f6441948a239463bdf973f2ac1924b0bcdbe"
+checksum = "ea4a8f6f2c25f6a74f460a58caecce62a288abaad9172c199e1ec3c004e5d74e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3681,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8835308044cef5467d7751be87fcbefc2db01c22370726a8704bd62991693f"
+checksum = "6cc44f88d68610cc7df1308cd852ba1ae5c341ac6132a9fce1873843957c2985"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3713,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612de1e888bb36f6bf51196a6eb9574587fdf256b1759a4c50e643e00d5f96d0"
+checksum = "fef9a3d6436f234e98a5e8cbb292fdce0d78febea152d738117d3d70f86cbb58"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3732,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b456b29b135d3c7192602e516ccade38b5483986e121895fa43cf1fdb38bf60"
+checksum = "31f32004e88abb4819d6d6386cf26e3dfc2258d4e3d0b2748364fb279b6787a6"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3771,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1538d14d5bb3735b4222b3f5aff83cfa59cc6ef7cdd3dd9139e4c77193c80b"
+checksum = "7d261cb07db8aac64b8926e61cef73caf6d0aa3bd49e9fc8401eff1768fb9aa0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3805,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a69a2f3b55703d9c240ad7c5ffa2c755db69e9cf8aa05efe274a212910472d"
+checksum = "5144f9f1ce0faaac0c791df55d5c9a0945a2a48489f108e12915f8e0b9e7ce2f"
 dependencies = [
  "datafusion",
  "geo-types",
@@ -3818,9 +3914,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea84613df6fa6b9168a1f056ba4f9cb73b90a1b452814c6fd4b3529bcdbfc78"
+checksum = "30dfdff485125e321f411f17a12a7878ef51234554237a2f416a1f8988a0a403"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3881,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3fc4c1d941fceef40a0edbd664dbef108acfc5d559bb9e7f588d0c733cbc35"
+checksum = "2b44d19e7ee99c3cdb417785ded67bac1fd8a9c9cbd9d1751fba0348294e6f3f"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3923,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ffbc5ce367fbf700a69de3fe0612ee1a11191a64a632888610b6bacfa0f63"
+checksum = "28e275333cfcd97cabfe7bbd77bad4df48a324499ebdf6c05febeef050efc685"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3941,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791bbcd868ee758123a34e07d320a1fb99379432b5ecc0e78d6b4686e999b629"
+checksum = "eb58614e43573a083ca6425a3f22e20c67ce69d3259428b9cda25bc8b68ccc69"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3968,9 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fdb2d56bfa4d1511c765fa0cc00fdaa37e5d2d1cd2f57b3c6355d9072177052"
+checksum = "3ef592598d62f12b11117a937859d180e4e46df85643988300e6a7bca44a714f"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4113,6 +4209,16 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -4693,6 +4799,12 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "parking_lot_core",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneshot"
@@ -6956,6 +7068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6981,9 +7099,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vortex"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f87dbcf3ea568c10ee254b9a5d6aee1283ef831fa898ca2705b7306c52f5e5"
+checksum = "0f957a752db04201527a5f44c1f64544a64c4d1f94e89924d00d39aafcff126f"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -6992,10 +7110,8 @@ dependencies = [
  "vortex-bytebool",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-fastlanes",
  "vortex-file",
  "vortex-flatbuffers",
@@ -7011,6 +7127,7 @@ dependencies = [
  "vortex-scalar",
  "vortex-scan",
  "vortex-sequence",
+ "vortex-session",
  "vortex-sparse",
  "vortex-utils",
  "vortex-zigzag",
@@ -7019,9 +7136,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-alp"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0786312fb694d1d05104700627e1cc9698452b4103a431a74bb9861641f8b832"
+checksum = "7809fc263b1930bf1d6000778975f1b48cfed9531679705a8bc5ae93fa7550ab"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -7039,9 +7156,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-array"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a14b31dc2681195c11f3c138ac86d29a5ecc8901416b2384225cb8ab1136f6"
+checksum = "66ba62607af32da3a08c0d6eea4b913547e5febe31c75f6f3e718d95b1721e55"
 dependencies = [
  "arcref",
  "arrow-arith",
@@ -7056,6 +7173,7 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "enum-iterator",
+ "enum-map",
  "flatbuffers",
  "futures",
  "getrandom 0.3.4",
@@ -7068,31 +7186,34 @@ dependencies = [
  "num_enum",
  "parking_lot",
  "paste",
- "pin-project",
+ "pin-project-lite",
  "prost 0.14.1",
  "rand 0.9.2",
  "rustc-hash",
- "serde",
  "simdutf8",
  "static_assertions",
  "termtree",
  "vortex-buffer",
+ "vortex-compute",
  "vortex-dtype",
  "vortex-error",
  "vortex-flatbuffers",
+ "vortex-io",
  "vortex-mask",
  "vortex-metrics",
+ "vortex-proto",
  "vortex-scalar",
+ "vortex-session",
  "vortex-utils",
+ "vortex-vector",
 ]
 
 [[package]]
 name = "vortex-btrblocks"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1002e8af05fe3bf32d57f89b28b222e74bcc2db4fa755e67618c69120f20cf7c"
+checksum = "ef94127186f19195ddeb1f3a6238f3b8cd87aea62ffaab7fbb9ad004d4ae8c47"
 dependencies = [
- "arrow-buffer",
  "getrandom 0.3.4",
  "itertools 0.14.0",
  "log",
@@ -7104,7 +7225,6 @@ dependencies = [
  "vortex-buffer",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
  "vortex-fastlanes",
@@ -7120,12 +7240,14 @@ dependencies = [
 
 [[package]]
 name = "vortex-buffer"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de68f5c9799886ece9da8b41866aa428c6ed75ee7944a81e5ad2be09faf1d98"
+checksum = "e4bf1a90619f7ef3f45b3bff8f177fedfc3e00c79db3de3839600a158c2a80ac"
 dependencies = [
  "arrow-buffer",
+ "bitvec",
  "bytes",
+ "cudarc",
  "itertools 0.14.0",
  "num-traits",
  "simdutf8",
@@ -7134,11 +7256,10 @@ dependencies = [
 
 [[package]]
 name = "vortex-bytebool"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4385b3fc69a2565d0592574a703a03f40832917c0f61b53102c14e48e040deb"
+checksum = "a1258f0fd3720e77a24d22bbf981117c5b55dc5ed0c27a7f7a289094d1b87f37"
 dependencies = [
- "arrow-buffer",
  "num-traits",
  "vortex-array",
  "vortex-buffer",
@@ -7149,10 +7270,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "vortex-datetime-parts"
-version = "0.53.0"
+name = "vortex-compute"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b7d961c76496dc8b7dce1e28b45678b374edf9fe54afcadc52abdc55b295f5"
+checksum = "3dc8da56c88eee6485942ad34ee1481e2c575b9d07847aa4599c1bb24d9f8449"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "num-traits",
+ "vortex-buffer",
+ "vortex-dtype",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-vector",
+]
+
+[[package]]
+name = "vortex-datetime-parts"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bbd31e8e8fc15a14f46a865a6d4c2d6837cbdc39ad5477fc6afd950712e594"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -7166,9 +7304,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-decimal-byte-parts"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906fc70ec7b9c6b9f9e8d517709dcac6d48592ccc14f28149f519f0fc1afe993"
+checksum = "59168e08e8564efca157086c8fd2459fc46b680fb40657ba809e466b7c841b7e"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -7178,34 +7316,15 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
-]
-
-[[package]]
-name = "vortex-dict"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e4b451cd602f81103ccfedb6f02c156a087c10c7c1ce23a9ced0861fe0afa6"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "num-traits",
- "prost 0.14.1",
- "rustc-hash",
- "vortex-array",
- "vortex-buffer",
- "vortex-dtype",
- "vortex-error",
- "vortex-mask",
- "vortex-scalar",
- "vortex-utils",
 ]
 
 [[package]]
 name = "vortex-dtype"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d90cfb741ac2712ffeafe93a2f3c277b091be6724408dd50dfb399407a02d14"
+checksum = "ad4bb9776fe0483b3c74180515a14de8a3b27efe17bc8b4cff0781229faf9141"
 dependencies = [
+ "arrow-buffer",
  "arrow-schema",
  "flatbuffers",
  "half",
@@ -7217,6 +7336,7 @@ dependencies = [
  "prost 0.14.1",
  "serde",
  "static_assertions",
+ "vortex-buffer",
  "vortex-error",
  "vortex-flatbuffers",
  "vortex-proto",
@@ -7225,9 +7345,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-error"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212f048b5d5cfa74a6bb884e5de367cc2e3584e6224fe907ffa4e9e75a25921b"
+checksum = "d3d205fa3696ba6040dbd710404922c1b41da8c4231bc4629b617c3f3bb98328"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -7237,35 +7357,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vortex-expr"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487bc0f84b6eee6eeaa168a4e566405ba9c4b2866c4df020934ff873734fb120"
-dependencies = [
- "arcref",
- "async-trait",
- "dyn-hash",
- "futures",
- "itertools 0.14.0",
- "parking_lot",
- "paste",
- "prost 0.14.1",
- "termtree",
- "vortex-array",
- "vortex-buffer",
- "vortex-dtype",
- "vortex-error",
- "vortex-mask",
- "vortex-proto",
- "vortex-scalar",
- "vortex-utils",
-]
-
-[[package]]
 name = "vortex-fastlanes"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ff93259195161ffba1327ef640a7939dc9a46caed090302bcec7031bdd3d35"
+checksum = "9932a1ab9f0cf69aba55dbbe12616c450c8e881580c0789626b31822b28efbd2"
 dependencies = [
  "arrayref",
  "arrow-buffer",
@@ -7275,23 +7370,27 @@ dependencies = [
  "log",
  "num-traits",
  "prost 0.14.1",
+ "static_assertions",
  "vortex-array",
  "vortex-buffer",
+ "vortex-compute",
  "vortex-dtype",
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
  "vortex-utils",
+ "vortex-vector",
 ]
 
 [[package]]
 name = "vortex-file"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db90678b3594e2ff746809a1a9aba955a25f25b9d62cc93f06e931d459c23e89"
+checksum = "95e16dd1be6920cf55807049179295e848c5b33d3a65e1b3d61511dbff05f1a4"
 dependencies = [
  "async-trait",
  "bytes",
+ "cudarc",
  "flatbuffers",
  "futures",
  "getrandom 0.3.4",
@@ -7306,13 +7405,12 @@ dependencies = [
  "vortex-bytebool",
  "vortex-datetime-parts",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-fastlanes",
  "vortex-flatbuffers",
  "vortex-fsst",
+ "vortex-gpu",
  "vortex-io",
  "vortex-layout",
  "vortex-metrics",
@@ -7321,6 +7419,7 @@ dependencies = [
  "vortex-scalar",
  "vortex-scan",
  "vortex-sequence",
+ "vortex-session",
  "vortex-sparse",
  "vortex-utils",
  "vortex-zigzag",
@@ -7329,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-flatbuffers"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efa2e313f85f7e4088b8099b55f99566da554666b73b30292e674243bc86242"
+checksum = "c0f536161b5661ec03eb6613596d613374a501cf0e07ce722dcbd1d6d9db71e2"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -7339,9 +7438,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-fsst"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7923e957a64508affea0e8ea51d09d1e2db9077e9482b69500d87ee04e84d712"
+checksum = "9a0f8cec024b739c92f2b2df45c072dce70aa1910bb4dfa8e78f54cb8c28514e"
 dependencies = [
  "async-trait",
  "fsst-rs",
@@ -7352,15 +7451,47 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-vector",
+]
+
+[[package]]
+name = "vortex-gpu"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2827e04adc64cbdce2f29c14bcb41a5b3fd4d16f79242364be97d3b06b8bbb44"
+dependencies = [
+ "anyhow",
+ "cudarc",
+ "vortex-alp",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-dtype",
+ "vortex-error",
+ "vortex-fastlanes",
+ "vortex-gpu-kernels",
+ "vortex-mask",
+ "walkdir",
+]
+
+[[package]]
+name = "vortex-gpu-kernels"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83eed1fafb7834cd491e989f161d7ee55c1b7988734ffb7f2a23d161af5e174d"
+dependencies = [
+ "anyhow",
+ "clap",
+ "fastlanes",
 ]
 
 [[package]]
 name = "vortex-io"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8352f56440d9e9b6cc99ed7094a4b7fe66422f1760b75833ab38ea670c13822d"
+checksum = "95b69bd9cdfd79197754066ed4f1fc29851e284fc51185be7efecb8445dfac0f"
 dependencies = [
  "async-compat",
+ "async-fs",
  "async-stream",
  "async-trait",
  "bytes",
@@ -7379,14 +7510,15 @@ dependencies = [
  "vortex-buffer",
  "vortex-error",
  "vortex-metrics",
+ "vortex-session",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "vortex-ipc"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63fffe5e6bd26e3b68dc9a98477fc6fdc892076416fcc21bd34c00a56f00b8f"
+checksum = "8fdc271a6bb8b9e7d4357e800e99dee518ae8db6bb6bc69b84ceb7bbd4a01008"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -7402,17 +7534,17 @@ dependencies = [
 
 [[package]]
 name = "vortex-layout"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba83e4f11de309aad5ba0e172d0da3a59b75f163619cd26f73ecf9355172d13c"
+checksum = "131022b7d32a2e9bedbf2be93f9d604ec3d904d8d57bc3622b7a26ce8d78df25"
 dependencies = [
  "arcref",
  "arrow-buffer",
  "async-stream",
  "async-trait",
+ "cudarc",
  "flatbuffers",
  "futures",
- "getrandom 0.3.4",
  "itertools 0.14.0",
  "kanal",
  "log",
@@ -7425,55 +7557,57 @@ dependencies = [
  "pin-project-lite",
  "prost 0.14.1",
  "rustc-hash",
- "tracing",
+ "termtree",
  "uuid",
  "vortex-array",
  "vortex-btrblocks",
  "vortex-buffer",
  "vortex-decimal-byte-parts",
- "vortex-dict",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
  "vortex-flatbuffers",
+ "vortex-gpu",
  "vortex-io",
  "vortex-mask",
  "vortex-metrics",
  "vortex-pco",
  "vortex-scalar",
  "vortex-sequence",
+ "vortex-session",
  "vortex-utils",
  "vortex-zstd",
 ]
 
 [[package]]
 name = "vortex-mask"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf26d4c28b1fde2a9f7e9972ae45d01c12216dbc05ee81e6c619aa69df57cfe1"
+checksum = "38e9d3dcbee22ba7b1aef678c51bf036c5635b95e31f864b4c2e3639659d8a96"
 dependencies = [
- "arrow-buffer",
  "itertools 0.14.0",
+ "vortex-buffer",
  "vortex-error",
 ]
 
 [[package]]
 name = "vortex-metrics"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5683b78c53f06b024168258583149b9dfd3dc27c799e6c4ec9b89dbf66b1bf79"
+checksum = "353b827b1164d9905f1e48b7d1881d5eb6ba6732e9d916b41bbcd035c91903be"
 dependencies = [
  "getrandom 0.3.4",
  "parking_lot",
+ "vortex-session",
  "witchcraft-metrics",
 ]
 
 [[package]]
 name = "vortex-pco"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9313c2c58af7c605680917d908f2a7df4591a2e018489da4a9489273e456527b"
+checksum = "cc4dcd529b20016a0526f78cfe14140175fa9de2aba51c4bb31c18fe4fb96084"
 dependencies = [
+ "itertools 0.14.0",
  "pco",
  "prost 0.14.1",
  "vortex-array",
@@ -7486,9 +7620,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-proto"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a56c48b1a6039c59c639a3123d3747d73666974452014cb1e33e5502d5a487"
+checksum = "c9e2a5333db46a461c12fdb2d87775ca4e454be8bc2daf523ee7071de252a74b"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -7496,9 +7630,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-runend"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30518e8c63dc1a2f020ec45e1d3fbd0069d1d66825c9049b293b42c224293a1f"
+checksum = "da7646fdcb086f02af3345d26f76706c2aab58e19f7a52a40231a809a7ce19ed"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -7515,12 +7649,11 @@ dependencies = [
 
 [[package]]
 name = "vortex-scalar"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2da1d8c350e97fc0f4aa7240fc17959e82046baa6584930510090d07320688c"
+checksum = "74be634609faaa3fc30e617ffdfdb098e0262064f06136e335ed386ef1347228"
 dependencies = [
  "arrow-array",
- "arrow-buffer",
  "bytes",
  "itertools 0.14.0",
  "num-traits",
@@ -7535,15 +7668,14 @@ dependencies = [
 
 [[package]]
 name = "vortex-scan"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44ac099f26aa0eeb0b69154b27c4ddd59cd644ede01423349a853c32afbd184"
+checksum = "9a5070a976d0f766621014e766fad3235904a3952b8a450327439bf9f93b93fc"
 dependencies = [
  "arrow-array",
  "arrow-schema",
  "bit-vec",
- "crossbeam-deque",
- "crossbeam-queue",
+ "cudarc",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -7553,18 +7685,19 @@ dependencies = [
  "vortex-buffer",
  "vortex-dtype",
  "vortex-error",
- "vortex-expr",
+ "vortex-gpu",
  "vortex-io",
  "vortex-layout",
  "vortex-mask",
  "vortex-metrics",
+ "vortex-session",
 ]
 
 [[package]]
 name = "vortex-sequence"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cef5b5480b8d463d44f88069ba27f19eb56efecc5a696e926feb053d09f97d5"
+checksum = "958cc0ef0816ad4bf445d80a923186fd5ac34585bfeaba1c9a5d9d971371b4a7"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -7576,13 +7709,25 @@ dependencies = [
  "vortex-mask",
  "vortex-proto",
  "vortex-scalar",
+ "vortex-vector",
+]
+
+[[package]]
+name = "vortex-session"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ee61ffbb29ca31c5d18db76fd3af807625e03cc5f8fd44ff30c076eefe76e6"
+dependencies = [
+ "dashmap",
+ "vortex-error",
+ "vortex-utils",
 ]
 
 [[package]]
 name = "vortex-sparse"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac023181a757edd4dea8520f88668a7e0ccb0841e27e48b6f3044d3c4bc727a2"
+checksum = "8d1ac292157002b70281d2fef9d801464f5202dfd7ee9923337ad2d9521a9ab7"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -7593,24 +7738,40 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-vector",
 ]
 
 [[package]]
 name = "vortex-utils"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40fff894e5ff5108ca2cdaf8b0728e07ea65eac8acc5a7570e0232a2f35fb78"
+checksum = "e56d2b72b7872fdd19aa283a0572995f9112d4f9b027e0cfaeb2e7f302c3d1ed"
 dependencies = [
  "dashmap",
  "hashbrown 0.16.0",
 ]
 
 [[package]]
-name = "vortex-zigzag"
-version = "0.53.0"
+name = "vortex-vector"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7bea8198f7fd5d3ea2c13af768df0a655a0ad6ecaf1421d2e072ee7efde330"
+checksum = "1ee51915843380525f000bedc74ad615317eb853b38aee7c8ba0ae8bfbf309dd"
 dependencies = [
+ "paste",
+ "static_assertions",
+ "vortex-buffer",
+ "vortex-dtype",
+ "vortex-error",
+ "vortex-mask",
+]
+
+[[package]]
+name = "vortex-zigzag"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbeda4ece19015b996dea4e806d9cf866f5c84ebed133d85c449168d42cd4859"
+dependencies = [
+ "itertools 0.14.0",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
@@ -7622,9 +7783,9 @@ dependencies = [
 
 [[package]]
 name = "vortex-zstd"
-version = "0.53.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81360eec4d1bede3ee284d8305702f65f68cb4af217cbe591c75172d9f46193"
+checksum = "42a05edb1532a7e973780ae7dbe981ac5cff460a70ecbc72fa0c54066688d8f3"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.1",
@@ -7635,6 +7796,7 @@ dependencies = [
  "vortex-mask",
  "vortex-scalar",
  "vortex-sparse",
+ "vortex-vector",
  "zstd",
 ]
 

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -24,14 +24,14 @@ arrow-data = {version = "56.2.0", features = ["ffi"]}
 arrow-schema = "56.2.0"
 
 # Vortex Ecosystem
-vortex = "0.53.0"
-vortex-io = { version = "0.53.0", features = ["tokio"] }
+vortex = "0.56.0"
+vortex-io = { version = "0.56.0", features = ["tokio"] }
 
 # Lance Ecosystem
-lance = "1.0.0"
-lance-index = "1.0.0"
-lance-io = "1.0.0"
-lance-table = "1.0.0"
+lance = "=1.0.0"
+lance-index = "=1.0.0"
+lance-io = "=1.0.0"
+lance-table = "=1.0.0"
 
 # CXX bridge
 cxx = "1.0.184"

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -27,7 +27,6 @@ use lance::dataset::refs::{Ref, TagContents};
 use lance::dataset::statistics::{DataStatistics, DatasetStatisticsExt};
 use lance::dataset::transaction::{Operation, Transaction};
 use lance::dataset::{CommitBuilder, Dataset, ReadParams, Version, WriteMode, WriteParams};
-use lance::datatypes::Schema;
 use lance::{Error as LanceError, Result};
 
 use lance_index::traits::DatasetIndexExt;

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -294,20 +294,4 @@ ArrowArrayStream ScanBuilder::IntoStream() && {
   }
 }
 
-StreamDriver ScanBuilder::IntoStreamDriver() && {
-  try {
-    rust::Box<ffi::ThreadsafeCloneableReader> reader =
-        ffi::scan_builder_into_threadsafe_cloneable_reader(std::move(impl_));
-    return StreamDriver(std::move(reader));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw VortexException(e.what());
-  }
-}
-
-ArrowArrayStream StreamDriver::CreateArrayStream() const {
-  ArrowArrayStream stream;
-  impl_->clone_a_stream(reinterpret_cast<uint8_t*>(&stream));
-  return stream;
-}
-
 }  // namespace milvus_storage::vortex


### PR DESCRIPTION
Vortex doesn't natively support Arrow FixedSizeBinary type. This adds transparent conversion between FixedSizeBinary(N) and FixedSizeList<u8, N> which have identical memory layouts, enabling zero-copy conversion.

On write, FixedSizeBinary columns are converted to FixedSizeList<u8>. On read, FixedSizeList<u8> columns are converted back to FixedSizeBinary based on the original schema.

Also renamed RUNTIME to VORTEX_RT for clarity.