### PR TITLE
fix: Remove incorrect path concatenation in exttable explore

### DIFF
--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -55,15 +55,14 @@ static inline arrow::Result<std::vector<milvus_storage::api::ColumnGroupFile>> g
 
   std::vector<ColumnGroupFile> files;
   for (const auto& file_info : file_infos) {
-    const std::string& file_name = file_info.base_name();
     if (file_info.type() != arrow::fs::FileType::File) {
       continue;
     }
 
     files.emplace_back(milvus_storage::api::ColumnGroupFile{
-        file_info.path() + kSep + file_name, -1, /*start_index */
-        -1,                                      /*end_index */
-        std::vector<uint8_t>(),                  /*metadata */
+        file_info.path(), -1,   /*start_index */
+        -1,                     /*end_index */
+        std::vector<uint8_t>(), /*metadata */
     });
   }
 


### PR DESCRIPTION
See #413

Fix incorrect file path construction in get_cg_files that caused
duplicated path segments. Add regression test to verify file paths
are valid.

Test plan:
- Added test_exttable_explore_file_paths_valid test
- All FFI tests pass (Test_FFI - 54 tests, 0 failed)