### PR TITLE
feat: add external filesystem URI resolution and Lance explore support

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -133,6 +133,15 @@ struct StorageUri {
    * @return Result containing parsed StorageUri (always succeeds for relative paths)
    */
   static arrow::Result<StorageUri> Parse(const std::string& uri);
+
+  /**
+   * @brief Construct a URI string from components (inverse of Parse)
+   *
+   * Requires non-empty scheme, bucket_name, and key.
+   * Produces: scheme://address/bucket_name/key
+   * If address is an HTTP URL (e.g., "http://host:port"), it is normalized to bare host:port.
+   */
+  static arrow::Result<std::string> Make(const StorageUri& uri);
 };
 
 // TODO: it's not `arrow` namespace, we should change this struct name.
@@ -238,6 +247,16 @@ class FilesystemCache {
    * @return Result containing the cached or newly created filesystem
    */
   [[nodiscard]] arrow::Result<ArrowFileSystemPtr> get(const api::Properties& properties, const std::string& path = "");
+
+  /**
+   * @brief Resolve filesystem config from properties and URI path
+   *
+   * If path has a scheme, matches extfs.* config by address+bucket.
+   * Otherwise returns default fs.* config.
+   * Does NOT create a filesystem or touch the cache.
+   */
+  [[nodiscard]] static arrow::Result<ArrowFileSystemConfig> resolve_config(const api::Properties& properties,
+                                                                           const std::string& path = "");
 
   /**
    * @brief Get the size of cached filesystems

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -85,6 +85,8 @@ class BlockingDataset {
 
   std::vector<uint64_t> GetAllFragmentIds() const;
 
+  uint64_t GetFragmentRowCount(uint64_t fragment_id) const;
+
   // Dataset-level scan: create a scanner for projected columns
   std::unique_ptr<BlockingScanner> Scan(ArrowSchema& schema, uint32_t batch_size);
 

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -83,6 +83,14 @@ std::vector<uint64_t> BlockingDataset::GetAllFragmentIds() const {
   }
 }
 
+uint64_t BlockingDataset::GetFragmentRowCount(uint64_t fragment_id) const {
+  try {
+    return ffi::get_fragment_row_count(*impl_, fragment_id);
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw LanceException(e.what());
+  }
+}
+
 void BlockingDataset::WriteArrowArrayStream(struct ArrowArrayStream* stream) {
   try {
     impl_->write_stream(reinterpret_cast<uint8_t*>(stream));

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -600,6 +600,22 @@ pub unsafe fn open_fragment_reader(
     Ok(Box::new(reader))
 }
 
+pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64> {
+    let fragment = dataset
+        .get_fragment(fragment_id)
+        .ok_or_else(|| LanceError::InvalidInput {
+            source: format!("Fragment {} not found", fragment_id).into(),
+            location: snafu::location!(),
+        })?;
+    fragment
+        .num_rows()
+        .map(|n| n as u64)
+        .ok_or_else(|| LanceError::InvalidInput {
+            source: format!("Fragment {} has no row count metadata", fragment_id).into(),
+            location: snafu::location!(),
+        })
+}
+
 //=============================================================================
 // BlockingScanner: dataset-level scan support
 //=============================================================================

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -72,6 +72,7 @@ pub mod lance_ffi {
 
         pub unsafe fn write_stream(self: &mut BlockingDataset, stream_ptr: *mut u8) -> Result<()>;
         pub fn get_all_fragment_ids(self: &BlockingDataset) -> Vec<u64>;
+        pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64>;
 
         type BlockingFragmentReader;
         pub unsafe fn open_fragment_reader(

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -41,12 +41,16 @@ arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
   std::shared_ptr<FormatReader> format_reader;
   if (format == LOON_FORMAT_PARQUET) {
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
-    format_reader = std::make_shared<parquet::ParquetFormatReader>(file_system, file.path, properties, needed_columns,
-                                                                   key_retriever);
+    ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(file.path));
+    std::string resolved_path = uri.scheme.empty() ? file.path : uri.key;
+    format_reader = std::make_shared<parquet::ParquetFormatReader>(file_system, resolved_path, properties,
+                                                                   needed_columns, key_retriever);
   } else if (format == LOON_FORMAT_VORTEX) {
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
+    ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(file.path));
+    std::string resolved_path = uri.scheme.empty() ? file.path : uri.key;
     format_reader =
-        std::make_shared<vortex::VortexFormatReader>(file_system, schema, file.path, properties, needed_columns);
+        std::make_shared<vortex::VortexFormatReader>(file_system, schema, resolved_path, properties, needed_columns);
   } else if (format == LOON_FORMAT_LANCE_TABLE) {
     std::string base_path;
     uint64_t fragment_id;

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -28,6 +28,7 @@
 
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/layout.h"
+#include "milvus-storage/filesystem/fs.h"
 
 // Specialize codec_traits for custom types in the avro namespace
 namespace avro {
@@ -132,6 +133,11 @@ static inline std::string ToAbsolute(const std::string& path,
                                      const std::optional<std::string>& base_path,
                                      const std::string& dir_path) {
   if (!base_path.has_value()) {
+    return path;
+  }
+
+  auto uri_result = milvus_storage::StorageUri::Parse(path);
+  if (uri_result.ok() && !uri_result.ValueOrDie().scheme.empty()) {
     return path;
   }
 


### PR DESCRIPTION
Explore now produces full URI paths (scheme://address/bucket/key) instead of bare relative paths, so the reader side can resolve back to the correct external filesystem when reading.

Added StorageUri::Make as the inverse of Parse to construct URIs from components. Both normalize HTTP addresses to bare host:port format.

Extracted resolve_config from FilesystemCache::get so that Lance explore can resolve extfs config without creating a filesystem instance. The address comparison normalizes extfs addresses (e.g. "http://localhost:9000" vs "localhost:9000") to handle the mismatch between stored config and URI-parsed values.

Added get_lance_cg_files which uses resolve_config + Lance bridge to open the dataset, enumerate fragments, and get per-fragment row counts via the new GetFragmentRowCount FFI. This gives accurate start_index/end_index needed for Take API row mapping.

The reader side (format_reader, get_file_info) now parses URIs and strips scheme+address+bucket to get the key path for filesystem operations. Manifest ToAbsolute skips URI paths since they're already absolute.

read_manifest switched from direct CreateArrowFileSystem to FilesystemCache::get for consistency and caching.