### PR TITLE
fix: guard folly force_load for static libraries only

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -77,11 +77,15 @@ target_compile_options(milvus-storage PRIVATE -fPIC)
 
 # On macOS, folly's static archive dead-strips IOThreadPoolExecutor.cpp,
 # losing the FLAGS_folly_iothreadpoolexecutor_max_read_at_once definition.
-# Force-load the archive to prevent this.
+# Force-load the archive to prevent this. Only needed for static libraries;
+# shared libraries export all symbols and don't have this problem.
 if(APPLE)
-  target_link_options(milvus-storage PRIVATE
-    -Wl,-force_load,$<TARGET_FILE:Folly::folly>
-  )
+  get_target_property(_folly_type Folly::folly TYPE)
+  if(_folly_type STREQUAL "STATIC_LIBRARY")
+    target_link_options(milvus-storage PRIVATE
+      -Wl,-force_load,$<TARGET_FILE:Folly::folly>
+    )
+  endif()
 endif()
 
 # Set RPATH to look for dependencies in the same directory ($ORIGIN)


### PR DESCRIPTION
## Summary
- `-Wl,-force_load` only works with static archives (`.a`); applying it to a shared library (`.dylib`) causes a linker error
- Add a `get_target_property(TYPE)` check so `force_load` is only applied when `Folly::folly` is a `STATIC_LIBRARY`
- Fixes macOS builds where Conan provides folly as a shared library

## Test plan
- [ ] Build on macOS with folly as shared library (Conan default) — should no longer error on `-force_load`
- [ ] Build on macOS with folly as static library — `force_load` still applied, dead-stripping prevented
- [ ] Run unit tests (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)