### PR TITLE
fix: replace fmt header-only target with compiled fmt in libavrocpp

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -128,7 +128,7 @@ class StorageConan(ConanFile):
         self.requires("zlib/1.3.1")
         self.requires("libcurl/8.10.1")
         self.requires("folly/2024.08.12.00@milvus/dev")
-        self.requires("libavrocpp/1.12.1@milvus/dev")
+        self.requires("libavrocpp/1.12.1.1@milvus/dev")
         self.requires("google-cloud-cpp/2.28.0")
         # Force override transitive deps to align with milvus-common
         self.requires("protobuf/5.27.0@milvus/dev", force=True, override=True)


### PR DESCRIPTION
After upgrading `folly` in storage, The `fmt` lib can no longer be used as `header_only`. However `libavrocpp`'s CMakeLists still references `fmt::fmt-header-only`, which breaks the build. This patch replaces it with `fmt::fmt` so both `folly` and `libavrocpp` can share the same compiled fmt.