### PR TITLE
enhance: do the sync read  when parallelism hint is 1

### DIFF
--- a/cpp/include/milvus-storage/format/column_group_lazy_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_lazy_reader.h
@@ -31,6 +31,8 @@ class ColumnGroupLazyReader {
   /**
    * @brief Take a table from the column group
    *
+   * Thread-safe: each call clones the FormatReader, safe for concurrent use on the same object.
+   *
    * @param row_indices the row indices to take, MUST be uniqued and sorted
    * @return arrow::Result<std::shared_ptr<arrow::Table>>
    */

--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -31,8 +31,10 @@ class ColumnGroupReader {
   virtual size_t total_rows() const = 0;
   virtual arrow::Result<std::vector<int64_t>> get_chunk_indices(const std::vector<int64_t>& row_indices) = 0;
 
+  // NOT thread-safe: concurrent calls on the same object may race on the underlying FormatReader.
   virtual arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) = 0;
 
+  // Thread-safe: each call clones the FormatReader, safe for concurrent use on the same object.
   virtual arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
       const std::vector<int64_t>& chunk_indices, size_t parallelism = 1) = 0;
 

--- a/cpp/include/milvus-storage/thread_pool.h
+++ b/cpp/include/milvus-storage/thread_pool.h
@@ -53,6 +53,17 @@ class ThreadPoolHolder {
     return thread_pool_;
   }
 
+  // get the parallelism degree
+  //
+  // Returns the thread pool size if a singleton exists, otherwise returns 1.
+  static size_t GetParallelism() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!thread_pool_) {
+      return 1;
+    }
+    return thread_pool_->numThreads();
+  }
+
   // release the thread pool
   //
   // If current thread pool still have active thread


### PR DESCRIPTION
Pulled the core read logic out of the parallel lambdas into standalone methods (take_rows_from_files and read_chunks_from_files) so both the serial and parallel paths can share the same code. When parallelism is 1, we now skip the thread pool entirely and just call the method directly, which avoids unnecessary overhead.

Also added GetParallelism() to ThreadPoolHolder so PackedRecordBatchReader can pick up the configured thread pool size automatically instead of hardcoding 1.

Fixed a subtle issue in the futures collection loop: previously if one future returned an error, ARROW_ASSIGN_OR_RAISE would early-return while other tasks were still running with a captured this pointer. Now we wait for all futures to finish first, then check for errors.