### PR TITLE
feat: use Avro DataFile API for manifest serialization

### DIFF
--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -112,6 +112,7 @@ class Manifest final {
    * @brief Get all column groups
    */
   [[nodiscard]] ColumnGroups& columnGroups() { return column_groups_; }
+  [[nodiscard]] const ColumnGroups& columnGroups() const { return column_groups_; }
 
   /**
    * @brief Find the column group that contains the specified column
@@ -124,16 +125,19 @@ class Manifest final {
    * @brief Get all delta log entries
    */
   [[nodiscard]] std::vector<DeltaLog>& deltaLogs() { return delta_logs_; }
+  [[nodiscard]] const std::vector<DeltaLog>& deltaLogs() const { return delta_logs_; }
 
   /**
    * @brief Get all stats
    */
   [[nodiscard]] std::map<std::string, Statistics>& stats() { return stats_; }
+  [[nodiscard]] const std::map<std::string, Statistics>& stats() const { return stats_; }
 
   /**
    * @brief Get all indexes
    */
   [[nodiscard]] std::vector<Index>& indexes() { return indexes_; }
+  [[nodiscard]] const std::vector<Index>& indexes() const { return indexes_; }
 
   /**
    * @brief Find index by column name and type
@@ -149,6 +153,11 @@ class Manifest final {
   private:
   Manifest(const Manifest&);
   Manifest& operator=(const Manifest&);
+
+  /**
+   * @brief Deserialize legacy MILV format (v1-v3)
+   */
+  void deserializeLegacy(std::istream& input_stream);
 
   /**
    * @brief Copy the manifest and convert paths to relative

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -16,10 +16,13 @@
 
 #include <sstream>
 #include <algorithm>
+#include <cstring>
 #include <filesystem>
 
 #include <arrow/status.h>
 #include <arrow/result.h>
+#include <avro/Compiler.hh>
+#include <avro/DataFile.hh>
 #include <avro/Decoder.hh>
 #include <avro/Encoder.hh>
 #include <avro/Specific.hh>
@@ -133,12 +136,79 @@ struct codec_traits<milvus_storage::api::Statistics> {
   }
 };
 
+template <>
+struct codec_traits<milvus_storage::api::Manifest> {
+  static void encode(Encoder& e, const milvus_storage::api::Manifest& m) {
+    avro::encode(e, m.columnGroups());
+    avro::encode(e, m.deltaLogs());
+    avro::encode(e, m.stats());
+    avro::encode(e, m.indexes());
+  }
+
+  static void decode(Decoder& d, milvus_storage::api::Manifest& m) {
+    avro::decode(d, m.columnGroups());
+    avro::decode(d, m.deltaLogs());
+    avro::decode(d, m.stats());
+    avro::decode(d, m.indexes());
+  }
+};
+
 }  // namespace avro
 
 namespace milvus_storage::api {
 
-// Manifest format constants (implementation detail)
+// Legacy manifest format magic number (used for detecting old format)
 constexpr int32_t MANIFEST_MAGIC = 0x4D494C56;  // "MILV" in ASCII
+
+// Avro schema describing the Manifest record structure.
+// Field order must match codec_traits<Manifest> encode/decode order.
+static const char* const MANIFEST_SCHEMA_JSON = R"({
+  "type": "record",
+  "name": "Manifest",
+  "namespace": "milvus_storage",
+  "fields": [
+    {"name": "column_groups", "type": {"type": "array", "items": {
+      "type": "record", "name": "ColumnGroup", "fields": [
+        {"name": "columns", "type": {"type": "array", "items": "string"}},
+        {"name": "files", "type": {"type": "array", "items": {
+          "type": "record", "name": "ColumnGroupFile", "fields": [
+            {"name": "path", "type": "string"},
+            {"name": "start_index", "type": "long", "default": 0},
+            {"name": "end_index", "type": "long", "default": 0},
+            {"name": "metadata", "type": "bytes", "default": ""}
+          ]
+        }}},
+        {"name": "format", "type": "string"}
+      ]
+    }}},
+    {"name": "delta_logs", "type": {"type": "array", "items": {
+      "type": "record", "name": "DeltaLog", "fields": [
+        {"name": "path", "type": "string"},
+        {"name": "type", "type": "int"},
+        {"name": "num_entries", "type": "long"}
+      ]
+    }}},
+    {"name": "stats", "type": {"type": "map", "values": {
+      "type": "record", "name": "Statistics", "fields": [
+        {"name": "paths", "type": {"type": "array", "items": "string"}},
+        {"name": "metadata", "type": {"type": "map", "values": "string"}, "default": {}}
+      ]
+    }}, "default": {}},
+    {"name": "indexes", "type": {"type": "array", "items": {
+      "type": "record", "name": "Index", "fields": [
+        {"name": "column_name", "type": "string"},
+        {"name": "index_type", "type": "string"},
+        {"name": "path", "type": "string"},
+        {"name": "properties", "type": {"type": "map", "values": "string"}, "default": {}}
+      ]
+    }}, "default": []}
+  ]
+})";
+
+static const avro::ValidSchema& getManifestSchema() {
+  static const avro::ValidSchema schema = avro::compileJsonSchemaFromString(MANIFEST_SCHEMA_JSON);
+  return schema;
+}
 
 static inline std::string ToRelative(const std::string& path,
                                      const std::optional<std::string>& base_path,
@@ -218,33 +288,10 @@ arrow::Status Manifest::serialize(std::ostream& output_stream, const std::option
       return normalized_manifest.serialize(output_stream, std::nullopt);
     }
 
-    // Convert std::ostream to avro::OutputStream
-    std::unique_ptr<avro::OutputStream> avro_output = avro::ostreamOutputStream(output_stream);
-
-    // Create encoder from output stream
-    avro::EncoderPtr encoder = avro::binaryEncoder();
-    encoder->init(*avro_output);
-
-    // Encode MAGIC number first (through Avro encoder to maintain Avro compatibility)
-    avro::encode(*encoder, MANIFEST_MAGIC);
-
-    // Encode version second
-    avro::encode(*encoder, version_);
-
-    // Encode column groups
-    avro::encode(*encoder, column_groups_);
-
-    // Encode delta logs
-    avro::encode(*encoder, delta_logs_);
-
-    // Encode stats
-    avro::encode(*encoder, stats_);
-
-    // Encode indexes (version 2+)
-    avro::encode(*encoder, indexes_);
-
-    // Flush encoder to ensure all data is written
-    encoder->flush();
+    auto avro_output = avro::ostreamOutputStream(output_stream);
+    avro::DataFileWriter<Manifest> writer(std::move(avro_output), getManifestSchema());
+    writer.write(*this);
+    writer.close();
 
     return arrow::Status::OK();
   } catch (const avro::Exception& e) {
@@ -259,7 +306,6 @@ arrow::Status Manifest::serialize(std::ostream& output_stream, const std::option
 }
 
 arrow::Status Manifest::deserialize(std::istream& input_stream, const std::optional<std::string>& base_path) {
-  // Helper to clear state and return error
   auto error = [this](const std::string& msg) {
     column_groups_.clear();
     delta_logs_.clear();
@@ -269,72 +315,29 @@ arrow::Status Manifest::deserialize(std::istream& input_stream, const std::optio
   };
 
   try {
-    // Check the stream length.
-    input_stream.seekg(0, std::ios::end);
-    std::streampos end_pos = input_stream.tellg();
-    input_stream.seekg(0, std::ios::beg);
-
-    if (end_pos <= 0 || (end_pos == std::streampos(-1) && input_stream.fail())) {
-      return error(fmt::format("Cannot deserialize Manifest: stream is empty or invalid, base path: {}",
+    // Peek first 4 bytes to detect format
+    char header[4] = {};
+    input_stream.read(header, 4);
+    if (!input_stream || input_stream.gcount() < 4) {
+      return error(fmt::format("Cannot deserialize Manifest: stream is empty or too short, base path: {}",
                                base_path.value_or("no exist")));
     }
-
-    // Reset stream state after size check
     input_stream.clear();
-    input_stream.seekg(0, std::ios::beg);
+    input_stream.seekg(0);
 
-    // Create Avro input stream and decoder
-    std::unique_ptr<avro::InputStream> avro_input = avro::istreamInputStream(input_stream);
-    avro::DecoderPtr decoder = avro::binaryDecoder();
-    decoder->init(*avro_input);
-
-    // Read and validate MAGIC number
-    int32_t magic = 0;
-    avro::decode(*decoder, magic);
-    if (magic != MANIFEST_MAGIC) {
-      return error(fmt::format("Invalid MAGIC number: not a valid Manifest file (expected {}, got {}), base path: {}",
-                               MANIFEST_MAGIC,  // NOLINT
-                               magic,           // NOLINT
-                               base_path.value_or("no exist")));
-    }
-
-    // Read and validate version
-    int32_t version = 0;
-    avro::decode(*decoder, version);
-    version_ = version;
-    // Support version 1 (original) and version 2 (with indexes)
-    if (version < 1 || version > MANIFEST_VERSION) {
-      return error(fmt::format("Unsupported manifest version: {} (expected 1-{}), base path: {}",
-                               version,           // NOLINT
-                               MANIFEST_VERSION,  // NOLINT
-                               base_path.value_or("no exist")));
-    }
-    avro::decode(*decoder, column_groups_);
-    avro::decode(*decoder, delta_logs_);
-
-    if (version >= 3) {
-      avro::decode(*decoder, stats_);
-    } else {
-      // Legacy format: map<string, vector<string>> - convert to Statistics
-      std::map<std::string, std::vector<std::string>> legacy_stats;
-      avro::decode(*decoder, legacy_stats);
-      stats_.clear();
-      for (auto& [key, files] : legacy_stats) {
-        Statistics stat;
-        stat.paths = std::move(files);
-        stats_[key] = std::move(stat);
+    if (std::memcmp(header, "Obj\x01", 4) == 0) {
+      // Standard Avro OCF format - schema resolution is automatic
+      auto avro_input = avro::istreamInputStream(input_stream);
+      avro::DataFileReader<Manifest> reader(std::move(avro_input), getManifestSchema());
+      if (!reader.read(*this)) {
+        return error(fmt::format("Failed to deserialize Manifest: no record in Avro file, base path: {}",
+                                 base_path.value_or("no exist")));
       }
-    }
-
-    // Decode indexes only for version 2+
-    if (version >= 2) {
-      avro::decode(*decoder, indexes_);
+      version_ = MANIFEST_VERSION;
     } else {
-      indexes_.clear();
+      deserializeLegacy(input_stream);
     }
 
-    // resolve the absolute path to relative path
-    // direct copy modify the original column groups
     if (base_path.has_value()) {
       ToAbsolutePaths(base_path.value());
     }
@@ -352,6 +355,44 @@ arrow::Status Manifest::deserialize(std::istream& input_stream, const std::optio
     return error(
         fmt::format("Failed to deserialize Manifest: unknown error (possibly invalid or empty stream), base path: {}",
                     base_path.value_or("no exist")));
+  }
+}
+
+void Manifest::deserializeLegacy(std::istream& input_stream) {
+  auto avro_input = avro::istreamInputStream(input_stream);
+  auto decoder = avro::binaryDecoder();
+  decoder->init(*avro_input);
+
+  int32_t magic = 0;
+  avro::decode(*decoder, magic);
+  if (magic != MANIFEST_MAGIC) {
+    throw avro::Exception("Invalid MILV magic number");
+  }
+
+  int32_t version = 0;
+  avro::decode(*decoder, version);
+  version_ = version;
+
+  avro::decode(*decoder, column_groups_);
+  avro::decode(*decoder, delta_logs_);
+
+  if (version >= 3) {
+    avro::decode(*decoder, stats_);
+  } else {
+    std::map<std::string, std::vector<std::string>> legacy_stats;
+    avro::decode(*decoder, legacy_stats);
+    stats_.clear();
+    for (auto& [key, files] : legacy_stats) {
+      Statistics stat;
+      stat.paths = std::move(files);
+      stats_[key] = std::move(stat);
+    }
+  }
+
+  if (version >= 2) {
+    avro::decode(*decoder, indexes_);
+  } else {
+    indexes_.clear();
   }
 }
 

--- a/cpp/test/column_groups_test.cpp
+++ b/cpp/test/column_groups_test.cpp
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <random>
 
+#include <avro/Specific.hh>
 #include <avro/Stream.hh>
 #include <avro/Encoder.hh>
 #include <avro/Decoder.hh>
@@ -127,25 +128,29 @@ TEST_F(ColumnGroupsTest, ColumnLookup) {
 }
 
 TEST_F(ColumnGroupsTest, InvalidAvro) {
-  // Test deserialization with empty string
   auto deserialized_manifest = std::make_shared<Manifest>();
-  // Empty string is generally invalid for Avro binary decoding if it expects data
-  // but our implementation might handle it or throw EOF.
-  // Let's just ensure it doesn't crash.
+
+  // Empty stream should fail (too short to read header)
   {
     std::string empty_str = "";
     std::istringstream in1(empty_str);
     auto status = deserialized_manifest->deserialize(in1);
-    // Depending on implementation, might return Invalid or just empty.
-    // Currently checking if it survives.
     EXPECT_FALSE(status.ok());
   }
 
+  // Garbage data falls through to legacy path and fails
   {
-    // Test with garbage data
     std::string garbage = "garbage_data_12345";
     std::istringstream in2(garbage);
     auto status = deserialized_manifest->deserialize(in2);
+    EXPECT_FALSE(status.ok());
+  }
+
+  // Data starting with OCF magic but truncated should fail
+  {
+    std::string truncated_ocf = "Obj\x01";
+    std::istringstream in3(truncated_ocf);
+    auto status = deserialized_manifest->deserialize(in3);
     EXPECT_FALSE(status.ok());
   }
 }
@@ -281,6 +286,290 @@ TEST_F(ColumnGroupsTest, EmptyIndexes) {
 
   // Verify empty indexes
   EXPECT_TRUE(deserialized_manifest->indexes().empty());
+}
+
+// ==================== Stats & DeltaLog Serialization Tests ====================
+
+TEST_F(ColumnGroupsTest, StatsRoundTrip) {
+  std::map<std::string, Statistics> stats;
+  Statistics stat1;
+  stat1.paths = {"/stats/bloom_filter_100.bin", "/stats/bloom_filter_101.bin"};
+  stat1.metadata = {{"type", "bloom_filter"}, {"num_bits", "1024"}};
+  stats["bloom_filter.100"] = stat1;
+
+  Statistics stat2;
+  stat2.paths = {"/stats/bm25_200.bin"};
+  stats["bm25.200"] = stat2;
+
+  auto manifest = std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), stats);
+
+  std::ostringstream oss;
+  ASSERT_STATUS_OK(manifest->serialize(oss));
+
+  auto deserialized = std::make_shared<Manifest>();
+  std::istringstream in(oss.str());
+  ASSERT_STATUS_OK(deserialized->deserialize(in));
+
+  const auto& ds = deserialized->stats();
+  ASSERT_EQ(ds.size(), 2);
+
+  ASSERT_EQ(ds.at("bloom_filter.100").paths.size(), 2);
+  EXPECT_EQ(ds.at("bloom_filter.100").paths[0], "/stats/bloom_filter_100.bin");
+  EXPECT_EQ(ds.at("bloom_filter.100").metadata.at("type"), "bloom_filter");
+  EXPECT_EQ(ds.at("bloom_filter.100").metadata.at("num_bits"), "1024");
+
+  ASSERT_EQ(ds.at("bm25.200").paths.size(), 1);
+  EXPECT_TRUE(ds.at("bm25.200").metadata.empty());
+}
+
+TEST_F(ColumnGroupsTest, DeltaLogRoundTrip) {
+  std::vector<DeltaLog> delta_logs;
+  delta_logs.push_back({"/delta/pk_delete_1.bin", DeltaLogType::PRIMARY_KEY, 100});
+  delta_logs.push_back({"/delta/pos_delete_2.bin", DeltaLogType::POSITIONAL, 50});
+
+  auto manifest = std::make_shared<Manifest>(test_cgs_, delta_logs, std::map<std::string, Statistics>());
+
+  std::ostringstream oss;
+  ASSERT_STATUS_OK(manifest->serialize(oss));
+
+  auto deserialized = std::make_shared<Manifest>();
+  std::istringstream in(oss.str());
+  ASSERT_STATUS_OK(deserialized->deserialize(in));
+
+  const auto& dl = deserialized->deltaLogs();
+  ASSERT_EQ(dl.size(), 2);
+  EXPECT_EQ(dl[0].path, "/delta/pk_delete_1.bin");
+  EXPECT_EQ(dl[0].type, DeltaLogType::PRIMARY_KEY);
+  EXPECT_EQ(dl[0].num_entries, 100);
+  EXPECT_EQ(dl[1].path, "/delta/pos_delete_2.bin");
+  EXPECT_EQ(dl[1].type, DeltaLogType::POSITIONAL);
+  EXPECT_EQ(dl[1].num_entries, 50);
+}
+
+TEST_F(ColumnGroupsTest, AllFieldsRoundTrip) {
+  std::vector<DeltaLog> delta_logs;
+  delta_logs.push_back({"/delta/del.bin", DeltaLogType::EQUALITY, 10});
+
+  std::map<std::string, Statistics> stats;
+  Statistics stat;
+  stat.paths = {"/stats/s.bin"};
+  stat.metadata = {{"k", "v"}};
+  stats["key"] = stat;
+
+  std::vector<Index> indexes;
+  Index idx;
+  idx.column_name = "embedding";
+  idx.index_type = "hnsw";
+  idx.path = "/index/emb.idx";
+  idx.properties = {{"M", "16"}};
+  indexes.push_back(idx);
+
+  auto manifest = std::make_shared<Manifest>(test_cgs_, delta_logs, stats, indexes);
+
+  std::ostringstream oss;
+  ASSERT_STATUS_OK(manifest->serialize(oss));
+
+  auto deserialized = std::make_shared<Manifest>();
+  std::istringstream in(oss.str());
+  ASSERT_STATUS_OK(deserialized->deserialize(in));
+
+  EXPECT_EQ(deserialized->columnGroups().size(), 2);
+  EXPECT_EQ(deserialized->deltaLogs().size(), 1);
+  EXPECT_EQ(deserialized->deltaLogs()[0].type, DeltaLogType::EQUALITY);
+  EXPECT_EQ(deserialized->stats().size(), 1);
+  EXPECT_EQ(deserialized->stats().at("key").metadata.at("k"), "v");
+  EXPECT_EQ(deserialized->indexes().size(), 1);
+  EXPECT_EQ(deserialized->indexes()[0].properties.at("M"), "16");
+}
+
+// ==================== Legacy Format Deserialization Tests ====================
+
+// Helper: produce a legacy MILV-format binary using raw Avro binary encoder.
+// Encodes each field manually to match the old serialize() order, since
+// codec_traits for custom types are not visible from this translation unit.
+static void encodeColumnGroupFile(avro::Encoder& e, const ColumnGroupFile& file) {
+  avro::encode(e, file.path);
+  avro::encode(e, file.start_index);
+  avro::encode(e, file.end_index);
+  avro::encode(e, file.metadata);
+}
+
+static void encodeColumnGroup(avro::Encoder& e, const ColumnGroup& group) {
+  avro::encode(e, group.columns);
+  e.arrayStart();
+  if (!group.files.empty()) {
+    e.setItemCount(group.files.size());
+    for (const auto& f : group.files) {
+      e.startItem();
+      encodeColumnGroupFile(e, f);
+    }
+  }
+  e.arrayEnd();
+  avro::encode(e, group.format);
+}
+
+static void encodeDeltaLog(avro::Encoder& e, const DeltaLog& dl) {
+  avro::encode(e, dl.path);
+  avro::encode(e, static_cast<int32_t>(dl.type));
+  avro::encode(e, dl.num_entries);
+}
+
+static void encodeIndex(avro::Encoder& e, const Index& idx) {
+  avro::encode(e, idx.column_name);
+  avro::encode(e, idx.index_type);
+  avro::encode(e, idx.path);
+  avro::encode(e, idx.properties);
+}
+
+static void encodeStatistics(avro::Encoder& e, const Statistics& stat) {
+  avro::encode(e, stat.paths);
+  avro::encode(e, stat.metadata);
+}
+
+static std::string encodeLegacyManifest(int32_t version,
+                                        const ColumnGroups& cgs,
+                                        const std::vector<DeltaLog>& delta_logs,
+                                        const std::map<std::string, Statistics>& stats,
+                                        const std::vector<Index>& indexes) {
+  std::ostringstream oss;
+  auto avro_output = avro::ostreamOutputStream(oss);
+  auto encoder = avro::binaryEncoder();
+  encoder->init(*avro_output);
+
+  constexpr int32_t MILV_MAGIC = 0x4D494C56;
+  avro::encode(*encoder, MILV_MAGIC);
+  avro::encode(*encoder, version);
+
+  // Encode column groups
+  encoder->arrayStart();
+  if (!cgs.empty()) {
+    encoder->setItemCount(cgs.size());
+    for (const auto& cg : cgs) {
+      encoder->startItem();
+      encodeColumnGroup(*encoder, *cg);
+    }
+  }
+  encoder->arrayEnd();
+
+  // Encode delta logs
+  encoder->arrayStart();
+  if (!delta_logs.empty()) {
+    encoder->setItemCount(delta_logs.size());
+    for (const auto& dl : delta_logs) {
+      encoder->startItem();
+      encodeDeltaLog(*encoder, dl);
+    }
+  }
+  encoder->arrayEnd();
+
+  // Encode stats
+  if (version >= 3) {
+    encoder->mapStart();
+    if (!stats.empty()) {
+      encoder->setItemCount(stats.size());
+      for (const auto& [key, stat] : stats) {
+        encoder->startItem();
+        avro::encode(*encoder, key);
+        encodeStatistics(*encoder, stat);
+      }
+    }
+    encoder->mapEnd();
+  } else {
+    // v1/v2: stats is map<string, vector<string>>
+    std::map<std::string, std::vector<std::string>> legacy_stats;
+    for (const auto& [key, stat] : stats) {
+      legacy_stats[key] = stat.paths;
+    }
+    avro::encode(*encoder, legacy_stats);
+  }
+
+  // Encode indexes (v2+ only)
+  if (version >= 2) {
+    encoder->arrayStart();
+    if (!indexes.empty()) {
+      encoder->setItemCount(indexes.size());
+      for (const auto& idx : indexes) {
+        encoder->startItem();
+        encodeIndex(*encoder, idx);
+      }
+    }
+    encoder->arrayEnd();
+  }
+
+  encoder->flush();
+  return oss.str();
+}
+
+TEST_F(ColumnGroupsTest, LegacyV3Deserialize) {
+  std::map<std::string, Statistics> stats;
+  Statistics stat;
+  stat.paths = {"/stats/s.bin"};
+  stat.metadata = {{"k", "v"}};
+  stats["key"] = stat;
+
+  std::vector<Index> indexes;
+  Index idx;
+  idx.column_name = "col";
+  idx.index_type = "hnsw";
+  idx.path = "/index/i.idx";
+  idx.properties = {{"M", "8"}};
+  indexes.push_back(idx);
+
+  std::string legacy_bytes = encodeLegacyManifest(3, test_cgs_, {}, stats, indexes);
+
+  // Verify it does NOT start with OCF magic
+  ASSERT_NE(legacy_bytes.substr(0, 4), std::string("Obj\x01", 4));
+
+  auto deserialized = std::make_shared<Manifest>();
+  std::istringstream in(legacy_bytes);
+  ASSERT_STATUS_OK(deserialized->deserialize(in));
+
+  EXPECT_EQ(deserialized->columnGroups().size(), 2);
+  EXPECT_EQ(deserialized->stats().at("key").paths[0], "/stats/s.bin");
+  EXPECT_EQ(deserialized->stats().at("key").metadata.at("k"), "v");
+  EXPECT_EQ(deserialized->indexes().size(), 1);
+  EXPECT_EQ(deserialized->indexes()[0].properties.at("M"), "8");
+}
+
+TEST_F(ColumnGroupsTest, LegacyV1Deserialize) {
+  // v1: no indexes, stats as map<string, vector<string>>
+  std::map<std::string, Statistics> stats;
+  Statistics stat;
+  stat.paths = {"/stats/old.bin"};
+  stats["old_key"] = stat;
+
+  std::string legacy_bytes = encodeLegacyManifest(1, test_cgs_, {}, stats, {});
+
+  auto deserialized = std::make_shared<Manifest>();
+  std::istringstream in(legacy_bytes);
+  ASSERT_STATUS_OK(deserialized->deserialize(in));
+
+  EXPECT_EQ(deserialized->columnGroups().size(), 2);
+  EXPECT_EQ(deserialized->stats().at("old_key").paths[0], "/stats/old.bin");
+  EXPECT_TRUE(deserialized->stats().at("old_key").metadata.empty());
+  EXPECT_TRUE(deserialized->indexes().empty());
+}
+
+TEST_F(ColumnGroupsTest, LegacyV2Deserialize) {
+  // v2: has indexes, stats as map<string, vector<string>>
+  std::vector<Index> indexes;
+  Index idx;
+  idx.column_name = "col";
+  idx.index_type = "ivf";
+  idx.path = "/index/v2.idx";
+  idx.properties = {};
+  indexes.push_back(idx);
+
+  std::string legacy_bytes = encodeLegacyManifest(2, test_cgs_, {}, {}, indexes);
+
+  auto deserialized = std::make_shared<Manifest>();
+  std::istringstream in(legacy_bytes);
+  ASSERT_STATUS_OK(deserialized->deserialize(in));
+
+  EXPECT_EQ(deserialized->columnGroups().size(), 2);
+  EXPECT_TRUE(deserialized->stats().empty());
+  EXPECT_EQ(deserialized->indexes().size(), 1);
+  EXPECT_EQ(deserialized->indexes()[0].index_type, "ivf");
 }
 
 TEST_F(ColumnGroupsTest, IndexRoundTripPreservesData) {


### PR DESCRIPTION
Replace the custom MILV binary format with standard Avro Object
Container Format (OCF) for manifest serialization.

- Serialize: DataFileWriter embeds schema in file header
- Deserialize: detect OCF by peeking 4-byte magic, fall back to
  deserializeLegacy() for v1-v3 files with full version handling
- Add codec_traits<Manifest>, Avro schema JSON, const accessors
- Add tests for stats, delta logs, legacy v1/v2/v3 deserialization