### PR TITLE
feat: cache file size and footer size in manifest to skip S3 HEAD requests

### DIFF
--- a/cpp/include/milvus-storage/column_groups.h
+++ b/cpp/include/milvus-storage/column_groups.h
@@ -15,17 +15,42 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include "milvus-storage/common/properties_convert.h"
+
 namespace milvus_storage::api {
+
+// Well-known property keys for ColumnGroupFile
+constexpr const char* kPropertyFileSize = "file_size";
+constexpr const char* kPropertyFooterSize = "footer_size";
+constexpr const char* kPropertyMetadata = "metadata";
 
 /**
  * @brief File metadata for a column group
  */
 struct ColumnGroupFile {
-  std::string path;               ///< Physical file path where the column group is stored
-  int64_t start_index;            ///< Start index of data in the file
-  int64_t end_index;              ///< End index of data in the file
-  std::vector<uint8_t> metadata;  ///< metadata for external table
+  std::string path;                                         ///< Physical file path where the column group is stored
+  int64_t start_index;                                      ///< Start index of data in the file
+  int64_t end_index;                                        ///< End index of data in the file
+  std::unordered_map<std::string, std::string> properties;  ///< Extensible key-value properties
+
+  template <typename T>
+  T Get(const char* key, T default_val = {}) const {
+    auto it = properties.find(key);
+    if (it == properties.end())
+      return default_val;
+    auto [ok, val] = convert::convertFunc<T>(it->second);
+    return ok ? val : default_val;
+  }
+
+  template <typename T>
+  void Set(const char* key, const T& value) {
+    properties[key] = std::to_string(value);
+  }
+  void Set(const char* key, const std::string& value) { properties[key] = value; }
+  void Set(const char* key, const char* value) { properties[key] = value; }
 };
 
 /**

--- a/cpp/include/milvus-storage/common/properties_convert.h
+++ b/cpp/include/milvus-storage/common/properties_convert.h
@@ -1,0 +1,94 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <boost/algorithm/string/trim.hpp>
+
+namespace milvus_storage::api::convert {
+
+/// Convert a string to a typed value.
+/// Returns {true, value} on success, {false, T{}} on failure.
+template <typename T>
+std::pair<bool, T> convertFunc(const std::string& str);
+
+// --- integer types via std::from_chars ---
+
+template <typename I>
+std::pair<bool, I> convertIntFunc(const std::string& str) {
+  I result{};
+  auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
+  return {ec == std::errc{} && ptr == str.data() + str.size(), result};
+}
+
+template <>
+inline std::pair<bool, int32_t> convertFunc<int32_t>(const std::string& str) {
+  return convertIntFunc<int32_t>(str);
+}
+
+template <>
+inline std::pair<bool, int64_t> convertFunc<int64_t>(const std::string& str) {
+  return convertIntFunc<int64_t>(str);
+}
+
+template <>
+inline std::pair<bool, uint32_t> convertFunc<uint32_t>(const std::string& str) {
+  return convertIntFunc<uint32_t>(str);
+}
+
+template <>
+inline std::pair<bool, uint64_t> convertFunc<uint64_t>(const std::string& str) {
+  return convertIntFunc<uint64_t>(str);
+}
+
+// --- bool ---
+
+template <>
+inline std::pair<bool, bool> convertFunc<bool>(const std::string& str) {
+  std::string lower = str;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  return {lower == "true" || lower == "false", lower == "true"};
+}
+
+// --- vector<string> (comma-separated) ---
+
+template <typename I>
+std::pair<bool, std::vector<I>> convertVectorFunc(const std::string& str) {
+  std::vector<I> result;
+  if (!str.empty()) {
+    size_t start = 0;
+    size_t end = str.find(',');
+    while (end != std::string::npos) {
+      result.push_back(boost::trim_copy(str.substr(start, end - start)));
+      start = end + 1;
+      end = str.find(',', start);
+    }
+    result.push_back(boost::trim_copy(str.substr(start)));
+  }
+  return {true, result};
+}
+
+template <>
+inline std::pair<bool, std::vector<std::string>> convertFunc<std::vector<std::string>>(const std::string& str) {
+  return convertVectorFunc<std::string>(str);
+}
+
+}  // namespace milvus_storage::api::convert

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -177,9 +177,10 @@ typedef struct LoonColumnGroupFile {
   int64_t start_index;
   int64_t end_index;
 
-  // producer-specific data
-  uint8_t* metadata;
-  uint64_t metadata_size;
+  // Extensible key-value properties
+  const char** property_keys;
+  const char** property_values;
+  uint32_t num_properties;
 } LoonColumnGroupFile;
 
 typedef struct LoonColumnGroup {

--- a/cpp/include/milvus-storage/ffi_filesystem_c.h
+++ b/cpp/include/milvus-storage/ffi_filesystem_c.h
@@ -183,11 +183,13 @@ FFI_EXPORT LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
  * @param handle The filesystem instance.
  * @param path_ptr The path of the file.
  * @param path_len The length of the path.
+ * @param file_size Known file size in bytes (0 = unknown, will issue a HEAD request to determine size).
  * @return result of FFI
  */
 FFI_EXPORT LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
                                                      const char* path_ptr,
                                                      uint32_t path_len,
+                                                     uint64_t file_size,
                                                      FileSystemReaderHandle* out_reader_ptr);
 
 /**

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -33,7 +33,9 @@ class ParquetFormatReader final : public FormatReader {
                       const std::string& path,
                       const milvus_storage::api::Properties& properties,
                       const std::vector<std::string>& needed_columns,
-                      const std::function<std::string(const std::string&)>& key_retriever);
+                      const std::function<std::string(const std::string&)>& key_retriever,
+                      uint64_t file_size = 0,
+                      uint64_t footer_size = 0);
 
   // open the file
   [[nodiscard]] arrow::Status open() override;
@@ -76,6 +78,8 @@ class ParquetFormatReader final : public FormatReader {
   milvus_storage::api::Properties properties_;
   std::vector<std::string> needed_columns_;
   std::function<std::string(const std::string&)> key_retriever_;
+  uint64_t file_size_ = 0;    ///< Pre-known file size to skip S3 HEAD requests
+  uint64_t footer_size_ = 0;  ///< Pre-known footer size for single-IO footer read
 
   // init after open()
   std::vector<int> needed_column_indices_;

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -30,7 +30,9 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
                      const std::shared_ptr<arrow::Schema>& schema,
                      const std::string& path,
                      const milvus_storage::api::Properties& properties,
-                     const std::vector<std::string>& needed_columns);
+                     const std::vector<std::string>& needed_columns,
+                     uint64_t file_size = 0,
+                     uint64_t footer_size = 0);
 
   [[nodiscard]] arrow::Status open() override;
 
@@ -78,6 +80,8 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   std::string path_;
   std::shared_ptr<arrow::Schema> read_schema_;
   milvus_storage::api::Properties properties_;
+  uint64_t file_size_ = 0;    ///< Pre-known file size to skip S3 HEAD requests
+  uint64_t footer_size_ = 0;  ///< Pre-known footer size for single-IO footer read
 
   std::shared_ptr<arrow::Schema> file_schema_;  // always derived from file in open()
 

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -35,7 +35,8 @@ namespace milvus_storage::api {
 // - Version 1: Initial format with column_groups, delta_logs, stats
 // - Version 2: Added indexes field for index metadata support
 // - Version 3: Changed stats from map<string, vector<string>> to map<string, Statistics>
-constexpr int32_t MANIFEST_VERSION = 3;
+// - Version 4: Changed ColumnGroupFile fields (metadata) to properties map
+constexpr int32_t MANIFEST_VERSION = 4;
 
 /**
  * @brief Type of delta log entry

--- a/cpp/src/ffi/bridge.cpp
+++ b/cpp/src/ffi/bridge.cpp
@@ -39,14 +39,25 @@ static void export_column_group_file(const ColumnGroupFile* cgf, LoonColumnGroup
   ccgf->start_index = cgf->start_index;
   ccgf->end_index = cgf->end_index;
 
-  // Copy metadata
-  if (!cgf->metadata.empty()) {
-    ccgf->metadata = new uint8_t[cgf->metadata.size()];
-    std::copy(cgf->metadata.begin(), cgf->metadata.end(), ccgf->metadata);
-    ccgf->metadata_size = cgf->metadata.size();
+  // Copy properties
+  size_t num_props = cgf->properties.size();
+  ccgf->num_properties = num_props;
+  if (num_props > 0) {
+    ccgf->property_keys = new const char*[num_props];
+    ccgf->property_values = new const char*[num_props];
+    size_t idx = 0;
+    for (const auto& [k, v] : cgf->properties) {
+      auto* key = new char[k.size() + 1];
+      std::memcpy(key, k.c_str(), k.size() + 1);
+      ccgf->property_keys[idx] = key;
+      auto* val = new char[v.size() + 1];
+      std::memcpy(val, v.c_str(), v.size() + 1);
+      ccgf->property_values[idx] = val;
+      ++idx;
+    }
   } else {
-    ccgf->metadata = nullptr;
-    ccgf->metadata_size = 0;
+    ccgf->property_keys = nullptr;
+    ccgf->property_values = nullptr;
   }
 }
 
@@ -89,8 +100,8 @@ static void import_column_group_file(const LoonColumnGroupFile* in_ccgf, ColumnG
   cgf->start_index = in_ccgf->start_index;
   cgf->end_index = in_ccgf->end_index;
 
-  if (in_ccgf->metadata != nullptr) {
-    cgf->metadata = std::vector<uint8_t>(in_ccgf->metadata, in_ccgf->metadata + in_ccgf->metadata_size);
+  for (uint32_t i = 0; i < in_ccgf->num_properties; ++i) {
+    cgf->properties[in_ccgf->property_keys[i]] = in_ccgf->property_values[i];
   }
 }
 
@@ -360,8 +371,11 @@ std::string column_groups_debug_string(const LoonColumnGroups* ccgs) {
     result += fmt::format("    num_of_files: {}\n", cg.num_of_files);
     for (uint32_t j = 0; j < cg.num_of_files; j++) {
       const auto& f = cg.files[j];
-      result += fmt::format("      File[{}]: path={}, start_index={}, end_index={}, metadata_size={}\n", j,
-                            f.path ? f.path : "(null)", f.start_index, f.end_index, f.metadata_size);
+      result += fmt::format("      File[{}]: path={}, start_index={}, end_index={}, num_properties={}\n", j,
+                            f.path ? f.path : "(null)", f.start_index, f.end_index, f.num_properties);
+      for (uint32_t k = 0; k < f.num_properties; k++) {
+        result += fmt::format("        {}={}\n", f.property_keys[k], f.property_values[k]);
+      }
     }
   }
 

--- a/cpp/src/ffi/column_groups_c.cpp
+++ b/cpp/src/ffi/column_groups_c.cpp
@@ -50,7 +50,11 @@ LoonFFIResult loon_column_groups_create(const char** columns,
         RETURN_ERROR(LOON_INVALID_ARGS, "Path is null [index=" + std::to_string(file_idx) + "]");
       }
 
-      cg->files.emplace_back(ColumnGroupFile{paths[file_idx], start_indices[file_idx], end_indices[file_idx]});
+      cg->files.emplace_back(ColumnGroupFile{
+          .path = paths[file_idx],
+          .start_index = start_indices[file_idx],
+          .end_index = end_indices[file_idx],
+      });
     }
     cg->format = format;
     cgs.push_back(cg);
@@ -80,11 +84,17 @@ static void destroy_column_group_file(LoonColumnGroupFile* ccgf) {
     ccgf->path = nullptr;
   }
 
-  // Free metadata
-  if (ccgf->metadata) {
-    delete[] ccgf->metadata;
-    ccgf->metadata = nullptr;
-    ccgf->metadata_size = 0;
+  // Free properties
+  if (ccgf->property_keys) {
+    for (uint32_t i = 0; i < ccgf->num_properties; i++) {
+      delete[] const_cast<char*>(ccgf->property_keys[i]);
+      delete[] const_cast<char*>(ccgf->property_values[i]);
+    }
+    delete[] ccgf->property_keys;
+    delete[] ccgf->property_values;
+    ccgf->property_keys = nullptr;
+    ccgf->property_values = nullptr;
+    ccgf->num_properties = 0;
   }
 }
 

--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -82,9 +82,9 @@ static inline arrow::Result<std::vector<milvus_storage::api::ColumnGroupFile>> g
     uri_base.key = file_info.path();
     ARROW_ASSIGN_OR_RAISE(auto file_uri, milvus_storage::StorageUri::Make(uri_base));
     files.emplace_back(milvus_storage::api::ColumnGroupFile{
-        std::move(file_uri), -1, /*start_index */
-        -1,                      /*end_index */
-        std::vector<uint8_t>(),  /*metadata */
+        .path = std::move(file_uri),
+        .start_index = -1,
+        .end_index = -1,
     });
   }
 
@@ -113,9 +113,9 @@ static inline arrow::Result<std::vector<ColumnGroupFile>> get_lance_cg_files(con
   for (auto frag_id : fragment_ids) {
     auto row_count = dataset->GetFragmentRowCount(frag_id);
     files.emplace_back(ColumnGroupFile{
-        MakeLanceUri(lance_base_uri, frag_id), 0, /*start_index */
-        static_cast<int64_t>(row_count),          /*end_index */
-        std::vector<uint8_t>(),                   /*metadata */
+        .path = MakeLanceUri(lance_base_uri, frag_id),
+        .start_index = 0,
+        .end_index = static_cast<int64_t>(row_count),
     });
   }
 
@@ -140,10 +140,16 @@ static inline arrow::Result<std::vector<ColumnGroupFile>> get_iceberg_cg_files(c
   std::vector<ColumnGroupFile> files;
   files.reserve(file_infos.size());
   for (const auto& info : file_infos) {
+    std::unordered_map<std::string, std::string> file_props;
+    if (!info.delete_metadata_json.empty()) {
+      // Safe: delete_metadata_json is always valid UTF-8 JSON, so the bytes-to-string conversion is lossless.
+      file_props[kPropertyMetadata] = std::string(info.delete_metadata_json.begin(), info.delete_metadata_json.end());
+    }
     files.emplace_back(ColumnGroupFile{
-        info.data_file_path, 0,                  /*start_index */
+        info.data_file_path,
+        0,                                       /*start_index */
         static_cast<int64_t>(info.record_count), /*end_index */
-        info.delete_metadata_json,               /*metadata */
+        std::move(file_props),
     });
   }
 

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -286,6 +286,7 @@ LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
 LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
                                           const char* path_ptr,
                                           uint32_t path_len,
+                                          uint64_t file_size,
                                           FileSystemReaderHandle* out_reader_ptr) {
   try {
     if (!handle || !path_ptr || path_len == 0 || !out_reader_ptr) {
@@ -295,7 +296,17 @@ LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
 
     auto fs = reinterpret_cast<FileSystemWrapper*>(handle)->get();
     std::string path(reinterpret_cast<const char*>(path_ptr), path_len);
-    auto input_file_result = fs->OpenInputFile(path);
+
+    arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> input_file_result;
+    if (file_size > 0) {
+      arrow::fs::FileInfo info;
+      info.set_path(path);
+      info.set_type(arrow::fs::FileType::File);
+      info.set_size(static_cast<int64_t>(file_size));
+      input_file_result = fs->OpenInputFile(info);
+    } else {
+      input_file_result = fs->OpenInputFile(path);
+    }
     if (!input_file_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, input_file_result.status().ToString());
     }

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -163,7 +163,7 @@ class VortexWriter {
   static VortexWriter Open(uint8_t* fs_rawptr, const std::string& path, const bool enable_stats);
 
   void Write(ArrowSchema& in_schema, ArrowArray& in_array);
-  void Close();
+  ffi::VortexWriteSummary Close();
 
   VortexWriter(VortexWriter&& other) noexcept = default;
   VortexWriter& operator=(VortexWriter&& other) noexcept = default;
@@ -180,8 +180,11 @@ class VortexWriter {
 
 class VortexFile {
   public:
-  static VortexFile Open(uint8_t* fs_rawptr, const std::string& path);
-  static std::unique_ptr<VortexFile> OpenUnique(uint8_t* fs_rawptr, const std::string& path);
+  static VortexFile Open(uint8_t* fs_rawptr, const std::string& path, uint64_t file_size = 0, uint64_t footer_size = 0);
+  static std::unique_ptr<VortexFile> OpenUnique(uint8_t* fs_rawptr,
+                                                const std::string& path,
+                                                uint64_t file_size = 0,
+                                                uint64_t footer_size = 0);
 
   VortexFile(VortexFile&& other) noexcept = default;
   VortexFile& operator=(VortexFile&& other) noexcept = default;

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -66,6 +66,25 @@ unsafe extern "C" {
         len: u64,
         out_buf: *mut u8, // need pre-allocated buffer
     ) -> LoonFFIResult;
+
+    // C-ABI: open a RandomAccessFile reader handle (one OpenInputFile, reuse for multiple ReadAt)
+    unsafe fn loon_filesystem_open_reader(
+        fs: *mut std::ffi::c_void,
+        path_ptr: *const u8,
+        path_len: u32,
+        file_size: u64,
+        out_reader_ptr: *mut *mut std::ffi::c_void,
+    ) -> LoonFFIResult;
+
+    unsafe fn loon_filesystem_reader_readat(
+        reader: *mut std::ffi::c_void,
+        offset: u64,
+        nbytes: u64,
+        out_data: *mut u8,
+    ) -> LoonFFIResult;
+
+    unsafe fn loon_filesystem_reader_close(reader: *mut std::ffi::c_void) -> LoonFFIResult;
+    unsafe fn loon_filesystem_reader_destroy(reader: *mut std::ffi::c_void);
 }
 
 
@@ -191,22 +210,65 @@ impl Write for ObjectStoreWriterCpp {
 }
 
 const COALESCING_WINDOW: CoalesceWindow = CoalesceWindow {
-    distance: 1024 * 1024,      // 1 MB
-    max_size: 16 * 1024 * 1024, // 16 MB
+    distance: 1024 * 1024,       // 1 MB
+    max_size: 1 * 1024 * 1024,   // 1 MB
 };
 const CONCURRENCY: usize = 192;
 
+/// Arc-wrapped reader handle that ensures the underlying C++ RandomAccessFile
+/// is only closed/destroyed after all concurrent spawn_blocking tasks are done.
+struct ReaderHandle {
+    ptr: *mut c_void,
+}
+
+unsafe impl Send for ReaderHandle {}
+unsafe impl Sync for ReaderHandle {}
+
+impl ReaderHandle {
+    fn as_ptr(&self) -> *mut c_void {
+        self.ptr
+    }
+}
+
+impl Drop for ReaderHandle {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.ptr.is_null() {
+                let mut result = loon_filesystem_reader_close(self.ptr);
+                if let Err(e) = check_loon_ffi_result(&mut result, "Failed to close ReaderHandle") {
+                    eprintln!("Warning: ReaderHandle close failed: {e}");
+                }
+                loon_filesystem_reader_destroy(self.ptr);
+            }
+        }
+    }
+}
+
 pub struct ObjectStoreReadSourceCpp {
     inner: ThreadSafePtr<std::ffi::c_void>,
+    reader: Arc<ReaderHandle>,
     path: String,
     uri: Arc<str>,
     coalesce_window: Option<CoalesceWindow>,
 }
 
 impl ObjectStoreReadSourceCpp {
-    pub fn new(fs_rawptr: *mut std::ffi::c_void, path: &str) -> VortexResult<Self> {
+    pub fn new(fs_rawptr: *mut std::ffi::c_void, path: &str, file_size: u64) -> VortexResult<Self> {
+        let mut reader_raw: *mut c_void = std::ptr::null_mut();
+        let path_bytes = path.as_bytes();
+        unsafe {
+            let mut result = loon_filesystem_open_reader(
+                fs_rawptr,
+                path_bytes.as_ptr(),
+                path_bytes.len() as u32,
+                file_size,
+                &mut reader_raw,
+            );
+            check_loon_ffi_result(&mut result, "Failed to open reader in ObjectStoreReadSourceCpp")?;
+        }
         Ok(Self {
             inner: ThreadSafePtr::new(fs_rawptr),
+            reader: Arc::new(ReaderHandle { ptr: reader_raw }),
             path: path.to_string(),
             uri: Arc::from(path.to_string()),
             coalesce_window: Some(COALESCING_WINDOW),
@@ -277,56 +339,49 @@ impl ReadSource for ObjectStoreIoSourceCpp {
         let self2 = self.clone();
         requests
         .map(move |req| {
-            let store = self.io.inner.clone();
-            let path = self.io.path.clone();
+                let reader = self.io.reader.clone();
 
-            let range = req.range();
-            let start = range.start;
-            let end = range.end;
-            let len = end - start;
+                let range = req.range();
+                let start = range.start;
+                let end = range.end;
+                let len = end - start;
 
-            let alignment = req.alignment();
+                let alignment = req.alignment();
 
-            // Offload sync FFI to blocking pool, copy into Rust-owned Vec<u8>
-            let blocking = self.handle.spawn_blocking(move || -> VortexResult<Vec<u8>> {
-                let path_bytes = path.into_bytes();
-                // Preallocate buffer with exact capacity; FFI will fill it.
-                let mut owned: Vec<u8> = Vec::with_capacity(len as usize);
+                // Offload sync FFI to blocking pool, reuse the pre-opened reader handle
+                let blocking = self.handle.spawn_blocking(move || -> VortexResult<Vec<u8>> {
+                    let mut owned: Vec<u8> = Vec::with_capacity(len as usize);
 
-                unsafe {
-                    let mut result = loon_filesystem_read_file(
-                        store.as_ptr(),
-                        path_bytes.as_ptr(),
-                        path_bytes.len() as u64,
-                        start,
-                        len,
-                        owned.as_mut_ptr(),
-                    );
+                    unsafe {
+                        let mut result = loon_filesystem_reader_readat(
+                            reader.as_ptr(),
+                            start,
+                            len,
+                            owned.as_mut_ptr(),
+                        );
 
-                    // Convert FFI error to VortexError (also frees message via loon_ffi_free_result)
-                    check_loon_ffi_result(
-                        &mut result,
-                        "Failed to get object range from ObjectStoreIoSourceCpp",
-                    )?;
+                        check_loon_ffi_result(
+                            &mut result,
+                            "Failed to readat from ObjectStoreIoSourceCpp",
+                        )?;
 
-                    // Mark the bytes as initialized after successful fill
-                    owned.set_len(len as usize);
-                }
+                        owned.set_len(len as usize);
+                    }
 
-                Ok(owned)
-            });
+                    Ok(owned)
+                });
 
-            let fut = async move {
-                let bytes: Vec<u8> = Compat::new(blocking).await?;
-                let mut buffer = ByteBufferMut::with_capacity_aligned(len as usize, alignment);
-                buffer.extend_from_slice(&bytes);
-                Ok(buffer.freeze())
-            };
+                let fut = async move {
+                    let bytes: Vec<u8> = Compat::new(blocking).await?;
+                    let mut buffer = ByteBufferMut::with_capacity_aligned(len as usize, alignment);
+                    buffer.extend_from_slice(&bytes);
+                    Ok(buffer.freeze())
+                };
 
-            async move { req.resolve(Compat::new(fut).await) }
-        })
-        .map(move |f| self2.handle.spawn(f))
-        .buffer_unordered(CONCURRENCY)
+                async move { req.resolve(Compat::new(fut).await) }
+            })
+            .map(move |f| self2.handle.spawn(f))
+            .buffer_unordered(CONCURRENCY)
         .collect::<()>()
         .boxed()
     }

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -146,6 +146,11 @@ pub mod lance_ffi {
 
 #[cxx::bridge(namespace = "milvus_storage::vortex::ffi")]
 pub mod vortex_ffi {
+    struct VortexWriteSummary {
+        file_size: u64,
+        footer_size: u64,
+    }
+
     extern "Rust" {
         type DType;
         // Factory functions for creating DType
@@ -199,7 +204,7 @@ pub mod vortex_ffi {
         unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool) -> Result<Box<VortexWriter>>;
         // unsafe fn write(self: &mut VortexWriter, in_stream: *mut u8) -> Result<()>;
         unsafe fn write(self: &mut VortexWriter, in_schema: *mut u8, in_array: *mut u8) -> Result<()>;
-        unsafe fn close(self: &mut VortexWriter) -> Result<()>;
+        unsafe fn close(self: &mut VortexWriter) -> Result<VortexWriteSummary>;
 
         // reader
         type VortexFile;
@@ -210,7 +215,7 @@ pub mod vortex_ffi {
         fn splits(self: &VortexFile) -> Result<Vec<u64>>;
         fn uncompressed_sizes(self: &VortexFile) -> Vec<u64>;
 
-        unsafe fn open_file(fswrapper_ptr: *mut u8, path: &str) -> Result<Box<VortexFile>>;
+        unsafe fn open_file(fswrapper_ptr: *mut u8, path: &str, file_size: u64, footer_size: u64) -> Result<Box<VortexFile>>;
 
         type VortexScanBuilder;
         fn with_filter(self: &mut VortexScanBuilder, filter: Box<Expr>);

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -154,26 +154,29 @@ void VortexWriter::Write(ArrowSchema& in_schema, ArrowArray& in_array) {
   }
 }
 
-void VortexWriter::Close() {
+ffi::VortexWriteSummary VortexWriter::Close() {
   try {
-    impl_->close();
+    return impl_->close();
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }
 }
 
-VortexFile VortexFile::Open(uint8_t* fs_rawptr, const std::string& path) {
+VortexFile VortexFile::Open(uint8_t* fs_rawptr, const std::string& path, uint64_t file_size, uint64_t footer_size) {
   try {
-    return VortexFile(ffi::open_file(fs_rawptr, rust::Str(path.data(), path.length())));
+    return VortexFile(ffi::open_file(fs_rawptr, rust::Str(path.data(), path.length()), file_size, footer_size));
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }
 }
 
-std::unique_ptr<VortexFile> VortexFile::OpenUnique(uint8_t* fs_rawptr, const std::string& path) {
+std::unique_ptr<VortexFile> VortexFile::OpenUnique(uint8_t* fs_rawptr,
+                                                   const std::string& path,
+                                                   uint64_t file_size,
+                                                   uint64_t footer_size) {
   try {
     return std::unique_ptr<VortexFile>(
-        new VortexFile(ffi::open_file(fs_rawptr, rust::Str(path.data(), path.length()))));
+        new VortexFile(ffi::open_file(fs_rawptr, rust::Str(path.data(), path.length()), file_size, footer_size)));
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -499,11 +499,33 @@ pub(crate) unsafe fn write(&mut self, in_schema: *mut u8, in_array: *mut u8) -> 
     Ok(())
 }
 
-pub(crate) unsafe fn close(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) unsafe fn close(&mut self) -> Result<crate::vortex_ffi::VortexWriteSummary, Box<dyn std::error::Error>> {
     if let Some(w) = self.inner_writer.take() {
-        w.finish().map_err(|e| Box::new(VortexError::from(e)))?;
+        let summary = w.finish().map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
+        let file_size = summary.size();
+
+        // Re-serialize the footer to compute the exact footer region size on disk.
+        // This size is used as `with_initial_read_size()` when opening the file,
+        // so the reader can fetch the entire footer in a single IO.
+        //
+        // serialize() produces all buffers that make up the footer region:
+        //   [dtype fb] [layout fb] [statistics fb] [footer fb] [postscript] [EOF 8B]
+        //
+        // Why re-serialization is accurate:
+        // - with_offset() only affects the absolute offsets stored inside the postscript,
+        //   not the buffer sizes (see FooterSerializer::write_flatbuffer), so offset=0 is safe.
+        // - exclude_dtype defaults to false, matching our writer which never excludes dtype.
+        let footer_size: u64 = summary.footer().clone()
+            .into_serializer()
+            .serialize()
+            .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?
+            .iter()
+            .map(|b| b.len() as u64)
+            .sum();
+
+        return Ok(crate::vortex_ffi::VortexWriteSummary { file_size, footer_size });
     }
-    Ok(())
+    Ok(crate::vortex_ffi::VortexWriteSummary { file_size: 0, footer_size: 0 })
 }
 
 }
@@ -590,11 +612,21 @@ impl VortexFile {
 
 pub(crate) unsafe fn open_file(
     fswrapper_ptr: *mut u8,
-    path: &str) -> Result<Box<VortexFile>> {
+    path: &str,
+    file_size: u64,
+    footer_size: u64) -> Result<Box<VortexFile>> {
 
-    let read_source = ObjectStoreReadSourceCpp::new(fswrapper_ptr as *mut c_void, path)
+    let read_source = ObjectStoreReadSourceCpp::new(fswrapper_ptr as *mut c_void, path, file_size)
         .map_err(VortexError::from)?;
-    let open_options = VORTEX_SESSION.open_options();
+    let mut open_options = VORTEX_SESSION.open_options();
+    if file_size > 0 {
+        // Use pre-known file size to skip the S3 HEAD request that size() would trigger.
+        open_options = open_options.with_file_size(file_size);
+    }
+    if footer_size > 0 {
+        // Use cached footer size as initial read size to read entire footer in one IO.
+        open_options = open_options.with_initial_read_size(footer_size as usize);
+    }
     let file = VORTEX_RT.block_on(async move {
         open_options
             .open(read_source)

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -44,14 +44,16 @@ arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
     ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(file.path));
     std::string resolved_path = uri.scheme.empty() ? file.path : uri.key;
-    format_reader = std::make_shared<parquet::ParquetFormatReader>(file_system, resolved_path, properties,
-                                                                   needed_columns, key_retriever);
+    format_reader = std::make_shared<parquet::ParquetFormatReader>(
+        file_system, resolved_path, properties, needed_columns, key_retriever,
+        file.Get<uint64_t>(api::kPropertyFileSize), file.Get<uint64_t>(api::kPropertyFooterSize));
   } else if (format == LOON_FORMAT_VORTEX) {
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
     ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(file.path));
     std::string resolved_path = uri.scheme.empty() ? file.path : uri.key;
-    format_reader = std::make_shared<vortex::VortexFormatReader>(file_system, read_schema, resolved_path, properties,
-                                                                 needed_columns);
+    format_reader = std::make_shared<vortex::VortexFormatReader>(
+        file_system, read_schema, resolved_path, properties, needed_columns, file.Get<uint64_t>(api::kPropertyFileSize),
+        file.Get<uint64_t>(api::kPropertyFooterSize));
   } else if (format == LOON_FORMAT_LANCE_TABLE) {
     std::string base_path;
     uint64_t fragment_id;
@@ -62,8 +64,15 @@ arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
     ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(file.path));
     std::string resolved_path = uri.scheme.empty() ? file.path : uri.key;
-    format_reader = std::make_shared<iceberg::IcebergFormatReader>(file_system, resolved_path, file.path, file.metadata,
-                                                                   properties, needed_columns, key_retriever);
+    // Safe: the metadata property stores UTF-8 JSON (written from IcebergFileInfo::delete_metadata_json),
+    // so the string-to-bytes conversion here is the exact inverse of the write path.
+    std::vector<uint8_t> delete_metadata;
+    auto it = file.properties.find(api::kPropertyMetadata);
+    if (it != file.properties.end()) {
+      delete_metadata.assign(it->second.begin(), it->second.end());
+    }
+    format_reader = std::make_shared<iceberg::IcebergFormatReader>(
+        file_system, resolved_path, file.path, delete_metadata, properties, needed_columns, key_retriever);
   } else {
     return arrow::Status::Invalid(fmt::format("Unknown file format: {}", format));
   }

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -14,6 +14,7 @@
 
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -29,6 +30,7 @@
 #include <arrow/type.h>
 #include <arrow/util/key_value_metadata.h>
 #include <parquet/arrow/schema.h>
+#include <parquet/metadata.h>
 #include <parquet/type_fwd.h>
 
 #include "milvus-storage/format/parquet/key_retriever.h"
@@ -96,20 +98,75 @@ ParquetFormatReader::ParquetFormatReader(const std::shared_ptr<arrow::fs::FileSy
                                          const std::string& path,
                                          const milvus_storage::api::Properties& properties,
                                          const std::vector<std::string>& needed_columns,
-                                         const std::function<std::string(const std::string&)>& key_retriever)
+                                         const std::function<std::string(const std::string&)>& key_retriever,
+                                         uint64_t file_size,
+                                         uint64_t footer_size)
     : path_(path),
       fs_(fs),
       schema_(nullptr),
       properties_(properties),
       needed_columns_(needed_columns),
       key_retriever_(key_retriever),
+      file_size_(file_size),
+      footer_size_(footer_size),
       file_reader_(nullptr) {}
+
+// Parquet file trailer: [4B footer_length (LE)] [4B magic "PAR1"]
+// Pre-read the parquet footer in a single IO instead of Arrow's default 2-step approach
+// (read trailer for length+magic, then read the Thrift metadata).
+// Returns nullptr on any failure, letting the caller fall back to Arrow's normal path.
+static std::shared_ptr<::parquet::FileMetaData> try_read_footer(
+    const std::shared_ptr<arrow::io::RandomAccessFile>& file,
+    uint64_t file_size,
+    uint64_t footer_size,
+    const ::parquet::ReaderProperties& reader_props) {
+  // Parquet file trailer: [4B footer_length (LE)] [4B magic "PAR1"]
+#define PARQUET_MAGIC "PAR1"
+#define PARQUET_MAGIC_SIZE 4
+#define PARQUET_FOOTER_TRAILER_SIZE 8  // footer_length(4B) + magic(4B)
+
+  // Read the last `footer_size` bytes of the file in one IO.
+  // The suffix should contain: [Thrift FileMetaData] [4B footer_length LE] [4B magic "PAR1"]
+  auto suffix_result = file->ReadAt(file_size - footer_size, footer_size);
+  if (!suffix_result.ok()) {
+    return nullptr;
+  }
+  auto suffix = *suffix_result;
+  if (static_cast<uint64_t>(suffix->size()) < PARQUET_FOOTER_TRAILER_SIZE) {
+    return nullptr;
+  }
+  const uint8_t* data = suffix->data();
+
+  // Parse footer_length from the 4 bytes before the magic.
+  uint32_t footer_length = 0;
+  std::memcpy(&footer_length, data + suffix->size() - PARQUET_FOOTER_TRAILER_SIZE, sizeof(footer_length));
+
+  // Validate magic bytes and ensure the suffix covers the entire Thrift metadata.
+  if (std::memcmp(data + suffix->size() - PARQUET_MAGIC_SIZE, PARQUET_MAGIC, PARQUET_MAGIC_SIZE) != 0 ||
+      footer_length + PARQUET_FOOTER_TRAILER_SIZE > static_cast<uint64_t>(suffix->size())) {
+    return nullptr;
+  }
+
+  // Deserialize the Thrift FileMetaData from the suffix buffer.
+  const uint8_t* thrift_data = data + suffix->size() - PARQUET_FOOTER_TRAILER_SIZE - footer_length;
+  try {
+    return ::parquet::FileMetaData::Make(thrift_data, &footer_length, reader_props);
+  } catch (...) {
+    return nullptr;
+  }
+
+#undef PARQUET_FOOTER_TRAILER_SIZE
+#undef PARQUET_MAGIC_SIZE
+#undef PARQUET_MAGIC
+}
 
 static arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> create_parquet_file_reader(
     const std::shared_ptr<arrow::fs::FileSystem>& fs,
     const std::string& file_path,
     const std::function<std::string(const std::string&)>& key_retriever,
-    const std::shared_ptr<::parquet::FileMetaData>& metadata = nullptr) {
+    std::shared_ptr<::parquet::FileMetaData> metadata = nullptr,
+    uint64_t file_size = 0,
+    uint64_t footer_size = 0) {
   std::unique_ptr<::parquet::arrow::FileReader> result;
 
   ::parquet::arrow::FileReaderBuilder builder;
@@ -124,9 +181,20 @@ static arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> create_parqu
   }
   arrow_reader_props.set_batch_size(INT64_MAX);
 
-  // FIXME(jiaqizho): Although current input no call the close is fine(see ObjectInputFile::Close()),
-  // but better to call Close() in function.
-  ARROW_ASSIGN_OR_RAISE(auto parquet_file, fs->OpenInputFile(file_path));
+  std::shared_ptr<arrow::io::RandomAccessFile> parquet_file;
+  if (file_size > 0) {
+    // Use pre-known file size to skip the S3 HEAD request that OpenInputFile(path) would trigger.
+    arrow::fs::FileInfo file_info(file_path, arrow::fs::FileType::File);
+    file_info.set_size(static_cast<int64_t>(file_size));
+    ARROW_ASSIGN_OR_RAISE(parquet_file, fs->OpenInputFile(file_info));
+  } else {
+    ARROW_ASSIGN_OR_RAISE(parquet_file, fs->OpenInputFile(file_path));
+  }
+
+  if (footer_size > 0 && !metadata && file_size > 0 && footer_size <= file_size) {
+    metadata = try_read_footer(parquet_file, file_size, footer_size, reader_props);
+  }
+
   ARROW_RETURN_NOT_OK(builder.Open(std::move(parquet_file), reader_props, metadata));
   ARROW_RETURN_NOT_OK(
       builder.memory_pool(arrow::default_memory_pool())->properties(arrow_reader_props)->Build(&result));
@@ -137,7 +205,8 @@ arrow::Status ParquetFormatReader::open() {
   assert(file_reader_ == nullptr);
 
   // create file reader
-  ARROW_ASSIGN_OR_RAISE(file_reader_, create_parquet_file_reader(fs_, path_, key_retriever_, nullptr /* metadata */));
+  ARROW_ASSIGN_OR_RAISE(file_reader_, create_parquet_file_reader(fs_, path_, key_retriever_, nullptr /* metadata */,
+                                                                 file_size_, footer_size_));
   // create row group infos
   assert(file_reader_->parquet_reader() && "arrow logical fault");
   ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(file_reader_->parquet_reader()->metadata()));
@@ -415,8 +484,9 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> ParquetFormatReader::re
 arrow::Result<std::shared_ptr<FormatReader>> ParquetFormatReader::clone_reader() {
   assert(file_reader_);
 
-  ARROW_ASSIGN_OR_RAISE(auto parquet_reader, create_parquet_file_reader(fs_, path_, key_retriever_,
-                                                                        file_reader_->parquet_reader()->metadata()));
+  ARROW_ASSIGN_OR_RAISE(
+      auto parquet_reader,
+      create_parquet_file_reader(fs_, path_, key_retriever_, file_reader_->parquet_reader()->metadata(), file_size_));
   return std::shared_ptr<ParquetFormatReader>(new ParquetFormatReader(*this, std::move(parquet_reader)));
 }
 
@@ -428,6 +498,8 @@ ParquetFormatReader::ParquetFormatReader(const ParquetFormatReader& other,
       properties_(other.properties_),
       needed_columns_(other.needed_columns_),
       key_retriever_(other.key_retriever_),
+      file_size_(other.file_size_),
+      footer_size_(other.footer_size_),
       needed_column_indices_(other.needed_column_indices_),
       row_group_infos_(other.row_group_infos_),
       file_reader_(std::move(cloned_file_reader)) {}

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <parquet/properties.h>
+#include <parquet/metadata.h>
 #include <boost/variant.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -33,6 +34,7 @@
 #include "milvus-storage/filesystem/upload_sizable.h"
 
 #include <arrow/io/buffered.h>
+#include <arrow/io/memory.h>
 
 namespace milvus_storage::parquet {
 
@@ -343,10 +345,21 @@ arrow::Result<api::ColumnGroupFile> ParquetFileWriter::Close() {
   ARROW_RETURN_NOT_OK(AppendKVMetadata(milvus_storage::ROW_GROUP_META_KEY, row_group_metadata_.Serialize()));
   ARROW_RETURN_NOT_OK(AppendKVMetadata(milvus_storage::STORAGE_VERSION_KEY, "1.0.0"));
   ARROW_RETURN_NOT_OK(writer_->AddKeyValueMetadata(kv_metadata_));
+
   ARROW_RETURN_NOT_OK(writer_->Close());
   ARROW_ASSIGN_OR_RAISE(auto pos, sink_->Tell());
+
+  // Measure footer size by re-serializing the metadata to a buffer.
+  // Parquet footer = [Thrift FileMetaData][4B footer_length][4B magic "PAR1"]
+  // Note: FileMetaData::size() only works for read-path metadata, not writer-created metadata.
+  ARROW_ASSIGN_OR_RAISE(auto meta_sink, arrow::io::BufferOutputStream::Create());
+  writer_->metadata()->WriteTo(meta_sink.get());
+  ARROW_ASSIGN_OR_RAISE(auto meta_buffer, meta_sink->Finish());
+  auto footer_size = static_cast<uint64_t>(meta_buffer->size()) + 8;
+
   cached_tell_ = static_cast<size_t>(pos);
   ARROW_RETURN_NOT_OK(sink_->Flush());
+  ARROW_ASSIGN_OR_RAISE(auto file_size, sink_->Tell());
   ARROW_RETURN_NOT_OK(sink_->Close());
 
   closed_ = true;
@@ -354,7 +367,8 @@ arrow::Result<api::ColumnGroupFile> ParquetFileWriter::Close() {
       .path = file_path_,
       .start_index = 0,
       .end_index = written_rows_,
-      .metadata = {},
+      .properties = {{api::kPropertyFileSize, std::to_string(file_size)},
+                     {api::kPropertyFooterSize, std::to_string(footer_size)}},
   };
 }
 

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -100,12 +100,16 @@ VortexFormatReader::VortexFormatReader(const std::shared_ptr<arrow::fs::FileSyst
                                        const std::shared_ptr<arrow::Schema>& schema,
                                        const std::string& path,
                                        const milvus_storage::api::Properties& properties,
-                                       const std::vector<std::string>& needed_columns)
+                                       const std::vector<std::string>& needed_columns,
+                                       uint64_t file_size,
+                                       uint64_t footer_size)
     : fs_holder_(std::make_shared<FileSystemWrapper>(fs)),
       proj_cols_(needed_columns),
       path_(path),
       read_schema_(schema),
       properties_(properties),
+      file_size_(file_size),
+      footer_size_(footer_size),
       vxfile_(nullptr) {}
 
 arrow::Status VortexFormatReader::open() {
@@ -115,7 +119,7 @@ arrow::Status VortexFormatReader::open() {
   if (read_schema_ && read_schema_->num_fields() == 0) {
     read_schema_ = nullptr;
   }
-  vxfile_ = VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder_.get()), path_);
+  vxfile_ = VortexFile::OpenUnique((uint8_t*)fs_holder_.get(), path_, file_size_, footer_size_);
 
   // Always derive full file schema from file metadata
   {

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -71,14 +71,16 @@ arrow::Result<api::ColumnGroupFile> VortexFileWriter::Close() {
   assert(!closed_);
 
   ARROW_RETURN_NOT_OK(Flush());
-  vx_writer_.Close();
+  // Close returns the total file size and footer size from WriteSummary
+  auto summary = vx_writer_.Close();
 
   closed_ = true;
   return api::ColumnGroupFile{
       .path = file_path_,
       .start_index = 0,
       .end_index = written_rows_,
-      .metadata = {},
+      .properties = {{api::kPropertyFileSize, std::to_string(summary.file_size)},
+                     {api::kPropertyFooterSize, std::to_string(summary.footer_size)}},
   };
 }
 

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -37,20 +37,51 @@
 // Specialize codec_traits for custom types in the avro namespace
 namespace avro {
 
+// Avro natively supports std::map but not std::unordered_map.
+// This codec_traits bridges unordered_map to Avro's map wire format.
+template <typename V>
+struct codec_traits<std::unordered_map<std::string, V>> {
+  static void encode(Encoder& e, const std::unordered_map<std::string, V>& m) {
+    e.mapStart();
+    if (!m.empty()) {
+      e.setItemCount(m.size());
+      for (const auto& [k, v] : m) {
+        e.startItem();
+        avro::encode(e, k);
+        avro::encode(e, v);
+      }
+    }
+    e.mapEnd();
+  }
+
+  static void decode(Decoder& d, std::unordered_map<std::string, V>& m) {
+    m.clear();
+    for (size_t n = d.mapStart(); n != 0; n = d.mapNext()) {
+      for (size_t i = 0; i < n; ++i) {
+        std::string key;
+        avro::decode(d, key);
+        V val;
+        avro::decode(d, val);
+        m[std::move(key)] = std::move(val);
+      }
+    }
+  }
+};
+
 template <>
 struct codec_traits<milvus_storage::api::ColumnGroupFile> {
   static void encode(Encoder& e, const milvus_storage::api::ColumnGroupFile& file) {
     avro::encode(e, file.path);
     avro::encode(e, file.start_index);
     avro::encode(e, file.end_index);
-    avro::encode(e, file.metadata);
+    avro::encode(e, file.properties);
   }
 
   static void decode(Decoder& d, milvus_storage::api::ColumnGroupFile& file) {
     avro::decode(d, file.path);
     avro::decode(d, file.start_index);
     avro::decode(d, file.end_index);
-    avro::decode(d, file.metadata);
+    avro::decode(d, file.properties);
   }
 };
 
@@ -176,7 +207,7 @@ static const char* const MANIFEST_SCHEMA_JSON = R"({
             {"name": "path", "type": "string"},
             {"name": "start_index", "type": "long", "default": 0},
             {"name": "end_index", "type": "long", "default": 0},
-            {"name": "metadata", "type": "bytes", "default": ""}
+            {"name": "properties", "type": {"type": "map", "values": "string"}, "default": {}}
           ]
         }}},
         {"name": "format", "type": "string"}
@@ -356,7 +387,31 @@ void Manifest::deserializeLegacy(std::istream& input_stream) {
   avro::decode(*decoder, version);
   version_ = version;
 
-  avro::decode(*decoder, column_groups_);
+  // Manually decode column groups for legacy format.
+  // Legacy ColumnGroupFile does not contain file_size/footer_size fields,
+  // so we cannot use codec_traits<ColumnGroupFile> which expects those fields.
+  column_groups_.clear();
+  for (size_t n = decoder->arrayStart(); n != 0; n = decoder->arrayNext()) {
+    for (size_t i = 0; i < n; ++i) {
+      auto cg = std::make_shared<ColumnGroup>();
+      avro::decode(*decoder, cg->columns);
+      // Decode files from legacy format (had metadata bytes, no file_size/footer_size)
+      cg->files.clear();
+      for (size_t fn = decoder->arrayStart(); fn != 0; fn = decoder->arrayNext()) {
+        for (size_t fi = 0; fi < fn; ++fi) {
+          ColumnGroupFile file;
+          avro::decode(*decoder, file.path);
+          avro::decode(*decoder, file.start_index);
+          avro::decode(*decoder, file.end_index);
+          std::vector<uint8_t> unused_bytes;
+          avro::decode(*decoder, unused_bytes);  // legacy metadata field, skipped
+          cg->files.push_back(std::move(file));
+        }
+      }
+      avro::decode(*decoder, cg->format);
+      column_groups_.push_back(std::move(cg));
+    }
+  }
   avro::decode(*decoder, delta_logs_);
 
   if (version >= 3) {

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -14,14 +14,9 @@
 
 #include "milvus-storage/properties.h"
 
-#include <algorithm>
-#include <charconv>
-#include <string>
-#include <vector>
 #include <optional>
 #include <sstream>
 #include <cassert>
-#include <cctype>
 #include <type_traits>
 #include <utility>
 #include <cstdint>
@@ -29,74 +24,13 @@
 #include <thread>
 
 #include <fmt/format.h>
-#include <boost/algorithm/string/trim.hpp>
 
 #include "milvus-storage/ffi_c.h"  // for FFI Properties definition
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/properties_convert.h"
 #include "milvus-storage/filesystem/fs.h"
 
 namespace milvus_storage::api {
-namespace convert {
-
-template <typename T>
-std::pair<bool, T> convertFunc(const std::string& str);
-
-template <>
-std::pair<bool, bool> convertFunc<bool>(const std::string& str) {
-  std::string str_cpy = str;
-  std::transform(str_cpy.begin(), str_cpy.end(), str_cpy.begin(), ::tolower);
-  return {str_cpy == "true" || str_cpy == "false", str_cpy == "true"};
-}
-
-template <typename I>
-std::pair<bool, I> convertIntFunc(const std::string& str) {
-  I result;
-  auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
-  return {ec == std::errc{} && ptr == str.data() + str.size(), result};
-}
-
-template <>
-std::pair<bool, int32_t> convertFunc<int32_t>(const std::string& str) {
-  return convertIntFunc<int32_t>(str);
-}
-
-template <>
-std::pair<bool, int64_t> convertFunc<int64_t>(const std::string& str) {
-  return convertIntFunc<int64_t>(str);
-}
-
-template <>
-std::pair<bool, uint32_t> convertFunc<uint32_t>(const std::string& str) {
-  return convertIntFunc<uint32_t>(str);
-}
-
-template <>
-std::pair<bool, uint64_t> convertFunc<uint64_t>(const std::string& str) {
-  return convertIntFunc<uint64_t>(str);
-}
-
-template <typename I>
-std::pair<bool, std::vector<I>> convertVectorFunc(const std::string& str) {
-  std::vector<I> result;
-  if (!str.empty()) {
-    size_t start = 0;
-    size_t end = str.find(',');
-    while (end != std::string::npos) {
-      result.push_back(boost::trim_copy(str.substr(start, end - start)));
-      start = end + 1;
-      end = str.find(',', start);
-    }
-    result.push_back(boost::trim_copy(str.substr(start)));
-  }
-  return {true, result};
-}
-
-template <>
-std::pair<bool, std::vector<std::string>> convertFunc<std::vector<std::string>>(const std::string& str) {
-  return convertVectorFunc<std::string>(str);
-}
-
-}  // namespace convert
 
 PropertiesValidator::PropertiesValidator() : fn(nullptr) {}
 PropertiesValidator::PropertiesValidator(ValidatorFunc f) : fn(std::move(f)) {}

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -59,8 +59,10 @@ class TransactionTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    // Clean up test directory
-    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    // Clean up test directory (fs_ may be null if SetUp failed)
+    if (fs_) {
+      ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    }
   }
 
   arrow::Result<ManifestPtr> CreateSampleManifest(const std::string& dummy_name,

--- a/cpp/test/column_groups_test.cpp
+++ b/cpp/test/column_groups_test.cpp
@@ -120,14 +120,12 @@ TEST_F(ColumnGroupsTest, ColumnLookup) {
   EXPECT_EQ(missing_cg, nullptr);
 }
 
-TEST_F(ColumnGroupsTest, TestPrivateData) {
-  uint8_t private_data[] = {0x01, 0x02, 0x03, 0x04};
-  auto pvec = std::vector<uint8_t>(private_data, private_data + sizeof(private_data));
+TEST_F(ColumnGroupsTest, TestProperties) {
   auto cg1 = std::make_shared<ColumnGroup>();
   cg1->columns = {"test_column"};
   cg1->files.emplace_back(ColumnGroupFile{
       .path = base_path_ + "/_data/test_path",
-      .metadata = pvec,
+      .properties = {{"key1", "val1"}, {"key2", "val2"}},
   });
   cg1->format = LOON_FORMAT_PARQUET;
 
@@ -138,8 +136,8 @@ TEST_F(ColumnGroupsTest, TestPrivateData) {
   ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
   auto deserialized_cg = deserialized->getColumnGroup("test_column");
-  ASSERT_EQ(deserialized_cg->files[0].metadata,
-            std::vector<uint8_t>(private_data, private_data + sizeof(private_data)));
+  ASSERT_EQ(deserialized_cg->files[0].properties.at("key1"), "val1");
+  ASSERT_EQ(deserialized_cg->files[0].properties.at("key2"), "val2");
 }
 
 // ==================== Index Serialization Tests ====================
@@ -300,7 +298,8 @@ static void encodeColumnGroupFile(avro::Encoder& e, const ColumnGroupFile& file)
   avro::encode(e, file.path);
   avro::encode(e, file.start_index);
   avro::encode(e, file.end_index);
-  avro::encode(e, file.metadata);
+  // Legacy format only had metadata (bytes), no file_size/footer_size
+  avro::encode(e, std::vector<uint8_t>());  // metadata
 }
 
 static void encodeColumnGroup(avro::Encoder& e, const ColumnGroup& group) {

--- a/cpp/test/ffi/bridge_test.cpp
+++ b/cpp/test/ffi/bridge_test.cpp
@@ -35,20 +35,19 @@ TEST_F(BridgeTest, ExportImportColumnGroups) {
   ColumnGroups cgs;
 
   ColumnGroupFile cgf1{
-      .path = "test_file1", .start_index = 0, .end_index = 10, .metadata = std::vector<uint8_t>({1, 2, 3, 4})};
+      .path = "test_file1", .start_index = 0, .end_index = 10, .properties = {{"key1", "val1"}, {"key2", "val2"}}};
 
   ColumnGroupFile cgf2{
       .path = "test_file2",
       .start_index = 2000,
       .end_index = 10000,
-      .metadata = std::vector<uint8_t>(),
   };
 
   ColumnGroupFile cgf3{
       .path = "test_file2",
       .start_index = 100,
       .end_index = 200,
-      .metadata = std::vector<uint8_t>({1, 3, 4, 5}),
+      .properties = {{"key3", "val3"}},
   };
 
   ColumnGroup cg1{
@@ -86,15 +85,12 @@ TEST_F(BridgeTest, ExportImportColumnGroups) {
     ASSERT_EQ(ccgs->column_group_array[0].files[0].path, cg1.files[0].path);
     ASSERT_EQ(ccgs->column_group_array[0].files[0].start_index, cg1.files[0].start_index);
     ASSERT_EQ(ccgs->column_group_array[0].files[0].end_index, cg1.files[0].end_index);
-    ASSERT_EQ(std::vector<uint8_t>(
-                  ccgs->column_group_array[0].files[0].metadata,
-                  ccgs->column_group_array[0].files[0].metadata + ccgs->column_group_array[0].files[0].metadata_size),
-              cg1.files[0].metadata);
+    ASSERT_EQ(ccgs->column_group_array[0].files[0].num_properties, 2u);
 
     ASSERT_EQ(ccgs->column_group_array[0].files[1].path, cg1.files[1].path);
     ASSERT_EQ(ccgs->column_group_array[0].files[1].start_index, cg1.files[1].start_index);
     ASSERT_EQ(ccgs->column_group_array[0].files[1].end_index, cg1.files[1].end_index);
-    ASSERT_EQ(ccgs->column_group_array[0].files[1].metadata, nullptr);
+    ASSERT_EQ(ccgs->column_group_array[0].files[1].num_properties, 0u);
 
     ASSERT_NE(ccgs->column_group_array[1].columns, nullptr);
     ASSERT_EQ(ccgs->column_group_array[1].num_of_columns, 1);
@@ -106,10 +102,7 @@ TEST_F(BridgeTest, ExportImportColumnGroups) {
     ASSERT_EQ(ccgs->column_group_array[1].files[0].path, cgf3.path);
     ASSERT_EQ(ccgs->column_group_array[1].files[0].start_index, cgf3.start_index);
     ASSERT_EQ(ccgs->column_group_array[1].files[0].end_index, cgf3.end_index);
-    ASSERT_EQ(std::vector<uint8_t>(
-                  ccgs->column_group_array[1].files[0].metadata,
-                  ccgs->column_group_array[1].files[0].metadata + ccgs->column_group_array[1].files[0].metadata_size),
-              cgf3.metadata);
+    ASSERT_EQ(ccgs->column_group_array[1].files[0].num_properties, 1u);
   }
 
   ColumnGroups imported_cgs;
@@ -129,7 +122,7 @@ TEST_F(BridgeTest, ExportImportColumnGroups) {
         ASSERT_EQ(left_cg->files[j].path, right_cg->files[j].path);
         ASSERT_EQ(left_cg->files[j].start_index, right_cg->files[j].start_index);
         ASSERT_EQ(left_cg->files[j].end_index, right_cg->files[j].end_index);
-        ASSERT_EQ(left_cg->files[j].metadata, right_cg->files[j].metadata);
+        ASSERT_EQ(left_cg->files[j].properties, right_cg->files[j].properties);
       }
     }
   }
@@ -162,7 +155,7 @@ TEST_F(BridgeTest, ImportInvalidColumnGroups) {
 TEST_F(BridgeTest, ExportImportManifestWithDeltaLogsAndStats) {
   // Create column groups
   ColumnGroups cgs;
-  ColumnGroupFile cgf{.path = "data_file.parquet", .start_index = 0, .end_index = 100, .metadata = {}};
+  ColumnGroupFile cgf{.path = "data_file.parquet", .start_index = 0, .end_index = 100};
   ColumnGroup cg{.columns = {"col1", "col2"}, .format = "parquet", .files = {cgf}};
   cgs.push_back(std::make_shared<ColumnGroup>(cg));
 
@@ -288,7 +281,7 @@ TEST_F(BridgeTest, ColumnGroupsDebugStringNull) {
 // Test column_groups_debug_string with valid input
 TEST_F(BridgeTest, ColumnGroupsDebugStringValid) {
   ColumnGroups cgs;
-  ColumnGroupFile cgf{.path = "test.parquet", .start_index = 0, .end_index = 100, .metadata = {1, 2, 3}};
+  ColumnGroupFile cgf{.path = "test.parquet", .start_index = 0, .end_index = 100, .properties = {{"k1", "v1"}}};
   ColumnGroup cg{.columns = {"col1", "col2"}, .format = "parquet", .files = {cgf}};
   cgs.push_back(std::make_shared<ColumnGroup>(cg));
 
@@ -312,7 +305,7 @@ TEST_F(BridgeTest, ManifestDebugStringNull) {
 // Test manifest_debug_string with valid input
 TEST_F(BridgeTest, ManifestDebugStringValid) {
   ColumnGroups cgs;
-  ColumnGroupFile cgf{.path = "data.parquet", .start_index = 0, .end_index = 50, .metadata = {}};
+  ColumnGroupFile cgf{.path = "data.parquet", .start_index = 0, .end_index = 50};
   ColumnGroup cg{.columns = {"col1"}, .format = "parquet", .files = {cgf}};
   cgs.push_back(std::make_shared<ColumnGroup>(cg));
 

--- a/cpp/test/ffi/ffi_external_test.c
+++ b/cpp/test/ffi/ffi_external_test.c
@@ -245,8 +245,7 @@ static void test_exttable_explore_and_read(void) {
     ck_assert(ccg0->files[i].path != NULL);
     ck_assert_int_eq(ccg0->files[i].start_index, -1);
     ck_assert_int_eq(ccg0->files[i].end_index, -1);
-    ck_assert(ccg0->files[i].metadata == NULL);
-    ck_assert_int_eq(ccg0->files[i].metadata_size, 0);
+    ck_assert_int_eq(ccg0->files[i].num_properties, 0);
   }
 
   loon_free_cstr(out_column_groups_file_path);

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -159,7 +159,7 @@ static void test_filesystem_write_and_read(void) {
     uint8_t read_buffer[TEST_BUFFER_SIZE];
     size_t read_len;
 
-    rc = loon_filesystem_open_reader(fs_handle, TEST_FILE_NAME, strlen(TEST_FILE_NAME), &reader_handle);
+    rc = loon_filesystem_open_reader(fs_handle, TEST_FILE_NAME, strlen(TEST_FILE_NAME), 0, &reader_handle);
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert(reader_handle != 0);
 
@@ -550,11 +550,11 @@ static void test_filesystem_error_handling(void) {
   loon_ffi_free_result(&rc);
 
   // Test loon_filesystem_open_reader with null arguments
-  rc = loon_filesystem_open_reader(0, "path", 4, &reader_handle);
+  rc = loon_filesystem_open_reader(0, "path", 4, 0, &reader_handle);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 
-  rc = loon_filesystem_open_reader(fs_handle, NULL, 0, &reader_handle);
+  rc = loon_filesystem_open_reader(fs_handle, NULL, 0, 0, &reader_handle);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -93,8 +93,7 @@ TEST_P(FormatReaderTest, ReadParquetWithoutMeta) {
                     FormatReader::create(schema_, LOON_FORMAT_PARQUET,
                                          api::ColumnGroupFile{.path = base_path_ + "/test.parquet",
                                                               .start_index = 0,
-                                                              .end_index = test_batch_->num_rows() * 10,
-                                                              .metadata = {}},
+                                                              .end_index = test_batch_->num_rows() * 10},
                                          properties_, std::vector<std::string>{"id"}, nullptr));
 
   ASSERT_AND_ASSIGN(auto row_group_infos, format_reader->get_row_group_infos());

--- a/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
@@ -95,9 +95,9 @@ class IcebergFormatReaderTest : public ::testing::Test {
   }
 
   // Build delete metadata JSON for a positional delete file
-  std::vector<uint8_t> MakeDeleteMetadataJson(const std::string& pos_delete_path) {
+  std::unordered_map<std::string, std::string> MakeDeleteMetadataJson(const std::string& pos_delete_path) {
     std::string json = R"([{"path":")" + pos_delete_path + R"(","file_type":"position"}])";
-    return {json.begin(), json.end()};
+    return {{kPropertyMetadata, json}};
   }
 
   std::shared_ptr<arrow::fs::FileSystem> fs_;
@@ -247,7 +247,7 @@ TEST_F(IcebergFormatReaderTest, EqualityDeleteRejected) {
   WriteDataFile(5);
 
   std::string json = R"([{"path":"eq-delete.parquet","file_type":"equality","equality_ids":[1]}])";
-  std::vector<uint8_t> metadata(json.begin(), json.end());
+  std::unordered_map<std::string, std::string> metadata{{kPropertyMetadata, json}};
 
   ColumnGroupFile file{data_file_path_, 0, data_num_rows_, metadata};
   auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_,
@@ -263,7 +263,7 @@ TEST_F(IcebergFormatReaderTest, InvalidJsonMetadata) {
   WriteDataFile(5);
 
   std::string json = "not-valid-json";
-  std::vector<uint8_t> metadata(json.begin(), json.end());
+  std::unordered_map<std::string, std::string> metadata{{kPropertyMetadata, json}};
 
   ColumnGroupFile file{data_file_path_, 0, data_num_rows_, metadata};
   auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_,

--- a/cpp/test/format/iceberg/iceberg_integration_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_integration_test.cpp
@@ -26,6 +26,15 @@ namespace {
 
 using namespace milvus_storage::api;
 
+// Helper: build a ColumnGroupFile from IcebergFileInfo, converting delete_metadata_json bytes to properties.
+static ColumnGroupFile MakeCgFile(const IcebergFileInfo& info) {
+  std::unordered_map<std::string, std::string> props;
+  if (!info.delete_metadata_json.empty()) {
+    props[kPropertyMetadata] = std::string(info.delete_metadata_json.begin(), info.delete_metadata_json.end());
+  }
+  return ColumnGroupFile{info.data_file_path, 0, static_cast<int64_t>(info.record_count), std::move(props)};
+}
+
 class IcebergIntegrationTest : public ::testing::Test {
   protected:
   static void SetUpTestSuite() {
@@ -83,12 +92,7 @@ TEST_F(IcebergIntegrationTest, ExploreAndReadBasic) {
   ASSERT_TRUE(file_infos[0].delete_metadata_json.empty());
 
   // 3. Read: create FormatReader and read all data
-  ColumnGroupFile cg_file{
-      file_infos[0].data_file_path,
-      0,
-      static_cast<int64_t>(file_infos[0].record_count),
-      file_infos[0].delete_metadata_json,
-  };
+  auto cg_file = MakeCgFile(file_infos[0]);
 
   std::vector<std::string> columns = {"id", "name", "value"};
   ASSERT_AND_ASSIGN(auto reader,
@@ -147,12 +151,7 @@ TEST_F(IcebergIntegrationTest, ExploreAndReadWithPositionalDeletes) {
   ASSERT_FALSE(file_infos[0].delete_metadata_json.empty());
 
   // 3. Read with delete filtering
-  ColumnGroupFile cg_file{
-      file_infos[0].data_file_path,
-      0,
-      static_cast<int64_t>(file_infos[0].record_count),
-      file_infos[0].delete_metadata_json,
-  };
+  auto cg_file = MakeCgFile(file_infos[0]);
 
   std::vector<std::string> columns = {"id", "name", "value"};
   ASSERT_AND_ASSIGN(auto reader,
@@ -208,12 +207,7 @@ TEST_F(IcebergIntegrationTest, TakeWithPositionalDeletes) {
   auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
   ASSERT_EQ(file_infos.size(), 1);
 
-  ColumnGroupFile cg_file{
-      file_infos[0].data_file_path,
-      0,
-      static_cast<int64_t>(file_infos[0].record_count),
-      file_infos[0].delete_metadata_json,
-  };
+  auto cg_file = MakeCgFile(file_infos[0]);
 
   std::vector<std::string> columns = {"id", "value"};
   ASSERT_AND_ASSIGN(auto reader,
@@ -250,12 +244,7 @@ TEST_F(IcebergIntegrationTest, ColumnProjection) {
   auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
   ASSERT_EQ(file_infos.size(), 1);
 
-  ColumnGroupFile cg_file{
-      file_infos[0].data_file_path,
-      0,
-      static_cast<int64_t>(file_infos[0].record_count),
-      file_infos[0].delete_metadata_json,
-  };
+  auto cg_file = MakeCgFile(file_infos[0]);
 
   // Read only "name" column
   std::vector<std::string> columns = {"name"};
@@ -282,12 +271,7 @@ TEST_F(IcebergIntegrationTest, CloneReaderSharesDeletes) {
   IcebergStorageOptions storage_options;
   auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
 
-  ColumnGroupFile cg_file{
-      file_infos[0].data_file_path,
-      0,
-      static_cast<int64_t>(file_infos[0].record_count),
-      file_infos[0].delete_metadata_json,
-  };
+  auto cg_file = MakeCgFile(file_infos[0]);
 
   std::vector<std::string> columns = {"id"};
   ASSERT_AND_ASSIGN(auto reader,

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cstring>
 #include <arrow/array.h>
 #include <arrow/builder.h>
 #include <arrow/record_batch.h>
@@ -32,6 +33,7 @@
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/packed/writer.h"
+#include "milvus-storage/format/parquet/parquet_format_reader.h"
 
 namespace milvus_storage::test {
 
@@ -495,6 +497,85 @@ TEST_F(ParquetFileWriterTest, PackedWriterTell) {
 
   ASSERT_AND_ASSIGN(auto file_info2, fs_->GetFileInfo(temp_file2));
   ASSERT_EQ(positions[1], static_cast<size_t>(file_info2.size()));
+}
+
+TEST_F(ParquetFileWriterTest, FooterSizeMatchesActualFile) {
+  ASSERT_AND_ASSIGN(auto test_schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(test_schema));
+
+  std::string temp_file = base_path_ + "/data/test_footer_size.parquet";
+
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(test_schema, fs_, temp_file, config));
+
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+  ASSERT_AND_ASSIGN(auto close_result, writer->Close());
+
+  auto cached_footer_size = close_result.Get<uint64_t>(api::kPropertyFooterSize);
+  ASSERT_GT(cached_footer_size, 0u);
+
+  // Read actual footer size from the file:
+  // Parquet tail: [Thrift metadata][4B footer_length LE][4B magic "PAR1"]
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(temp_file));
+  ASSERT_AND_ASSIGN(auto file_size, file->GetSize());
+
+  // Read last 8 bytes
+  ASSERT_AND_ASSIGN(auto tail_buf, file->ReadAt(file_size - 8, 8));
+  const uint8_t* tail = tail_buf->data();
+
+  uint32_t footer_length = 0;
+  std::memcpy(&footer_length, tail, 4);
+  // Verify magic
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(tail + 4), 4), "PAR1");
+
+  uint64_t actual_footer_size = static_cast<uint64_t>(footer_length) + 8;
+  EXPECT_EQ(cached_footer_size, actual_footer_size)
+      << "cached footer_size=" << cached_footer_size << " actual=" << actual_footer_size;
+
+  // Also verify file_size
+  EXPECT_EQ(close_result.Get<uint64_t>(api::kPropertyFileSize), static_cast<uint64_t>(file_size));
+}
+
+TEST_F(ParquetFileWriterTest, FooterSizeNotMatch) {
+  ASSERT_AND_ASSIGN(auto test_schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(test_schema));
+
+  std::string temp_file = base_path_ + "/data/test_footer_size_mismatch.parquet";
+
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(test_schema, fs_, temp_file, config));
+
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+  ASSERT_AND_ASSIGN(auto close_result, writer->Close());
+  auto cached_footer_size = close_result.Get<uint64_t>(api::kPropertyFooterSize);
+  auto cached_file_size = close_result.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(cached_footer_size, 0u);
+  ASSERT_GT(cached_file_size, cached_footer_size);
+
+  // Test reading with different footer_size values passed to ParquetFormatReader.
+  // The reader uses footer_size to pre-read the footer in a single IO;
+  // if the size is wrong, it falls back to Arrow's normal 2-step footer read.
+  auto verify_read = [&](uint64_t footer_size) {
+    auto reader =
+        milvus_storage::parquet::ParquetFormatReader(fs_, temp_file, properties_, /*needed_columns=*/{},
+                                                     /*key_retriever=*/nullptr, cached_file_size, footer_size);
+    ASSERT_STATUS_OK(reader.open());
+
+    ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
+    ASSERT_GT(row_group_infos.size(), 0u);
+
+    // Read first row group to verify data integrity
+    ASSERT_AND_ASSIGN(auto rb, reader.get_chunk(0));
+    ASSERT_GT(rb->num_rows(), 0);
+  };
+
+  // Case 1: footer_size too small (1 byte).
+  // Pre-read can't cover the Thrift metadata → falls back to Arrow's normal 2-step footer read.
+  verify_read(1);
+
+  // Case 2: footer_size too large (= file_size).
+  // Pre-reads entire file as suffix. Correctly locates footer_length and magic at the end.
+  verify_read(cached_file_size);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -18,6 +18,7 @@
 #include <set>
 #include <vector>
 #include <cstdint>
+#include <cstring>
 
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/filesystem/localfs.h>
@@ -398,6 +399,96 @@ TEST_F(VortexBasicTest, TestBasicTake) {
   take_verify(vx_reader, rangeNumbers<int64_t>(0, recordBatchsRows()), recordBatchsRows());
   // Note: vortex 0.56+ does not gracefully handle out-of-range indices (panics instead of returning error),
   // so we removed the out-of-range index tests.
+}
+
+TEST_F(VortexBasicTest, FooterSizeMatchesActualFile) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  for (const auto& rb : record_bacths_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+
+  auto vx_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto vx_file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(vx_footer_size, 0u);
+  ASSERT_GT(vx_file_size, vx_footer_size);
+
+  // Verify file_size matches actual file
+  ASSERT_AND_ASSIGN(auto file, file_system_->OpenInputFile(test_file_name_));
+  ASSERT_AND_ASSIGN(auto actual_file_size, file->GetSize());
+  EXPECT_EQ(vx_file_size, static_cast<uint64_t>(actual_file_size));
+
+  // Read EOF (last 8 bytes): [version 2B][postscript_len 2B][magic "VTXF" 4B]
+  ASSERT_AND_ASSIGN(auto eof_buf, file->ReadAt(actual_file_size - 8, 8));
+  const uint8_t* eof = eof_buf->data();
+
+  // Verify magic
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(eof + 4), 4), "VTXF");
+
+  // Get postscript_len from EOF
+  uint16_t postscript_len = 0;
+  std::memcpy(&postscript_len, eof + 2, 2);
+
+  // Read postscript to get the earliest segment offset (= start of footer)
+  int64_t postscript_offset = actual_file_size - 8 - postscript_len;
+  ASSERT_GT(postscript_offset, 0);
+
+  std::cout << "vx_footer_size: " << vx_footer_size << std::endl;
+  std::cout << "postscript_len: " << postscript_len << std::endl;
+
+  // The footer spans from the earliest segment to the end of file.
+  // The postscript contains segment descriptors with absolute offsets.
+  // We can parse the postscript flatbuffer to find the earliest offset,
+  // but a simpler sanity check: footer_size must be > postscript_len + 8 (postscript + EOF)
+  // and footer_size must be < file_size - 4 (exclude file header magic).
+  EXPECT_GT(vx_footer_size, static_cast<uint64_t>(postscript_len) + 8)
+      << "footer_size should include postscript + EOF + segment data";
+  EXPECT_LT(vx_footer_size, vx_file_size - 4) << "footer_size should be less than file_size minus header magic";
+}
+
+TEST_F(VortexBasicTest, FooterSizeNotMatch) {
+  // Write a vortex file
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+  for (const auto& rb : record_bacths_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  auto vx_footer_size2 = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto vx_file_size2 = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(vx_footer_size2, 0u);
+  ASSERT_GT(vx_file_size2, vx_footer_size2);
+
+  auto verify_read = [&](uint64_t footer_size) {
+    auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+    auto vxfile = VortexFile::Open((uint8_t*)fs_holder.get(), test_file_name_, vx_file_size2, footer_size);
+    ASSERT_EQ(vxfile.RowCount(), static_cast<uint64_t>(recordBatchsRows()));
+
+    auto vx_reader =
+        vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
+                                   std::vector<std::string>{"int32", "int64", "binary"}, vx_file_size2, footer_size);
+    ASSERT_STATUS_OK(vx_reader.open());
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+    ASSERT_EQ(3, rb->num_columns());
+
+    auto i32array = std::dynamic_pointer_cast<arrow::Int32Array>(rb->column(0));
+    for (int i = 0; i < i32array->length(); ++i) {
+      ASSERT_EQ(i32array->Value(i), (int32_t)i);
+    }
+  };
+
+  // Case 1: footer_size too small (1 byte).
+  // Vortex clamps initial_read_size to at least ~65KB and uses NeedMoreData loop for remaining segments.
+  verify_read(1);
+
+  // Case 2: footer_size too large (= file_size, reads entire file as initial read).
+  // Vortex clamps to min(initial_read_size, file_size). Extra bytes get cached as segments.
+  verify_read(vx_file_size2);
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/manifest_test.cpp
+++ b/cpp/test/manifest_test.cpp
@@ -87,7 +87,7 @@ TEST_F(ManifestTest, EmptyManifestRoundTrip) {
 
 TEST_F(ManifestTest, ColumnGroupsRoundTrip) {
   auto cg = MakeCG({"id", "name"}, LOON_FORMAT_PARQUET,
-                    {{.path = get_data_filepath(base_path_, "file1.parquet"), .start_index = 0, .end_index = 100}});
+                   {{.path = get_data_filepath(base_path_, "file1.parquet"), .start_index = 0, .end_index = 100}});
 
   Manifest manifest({cg});
   auto read_back = RoundTrip(manifest);
@@ -104,9 +104,8 @@ TEST_F(ManifestTest, ColumnGroupsRoundTrip) {
 }
 
 TEST_F(ManifestTest, DeltaLogsRoundTrip) {
-  DeltaLog d1{.path = get_delta_filepath(base_path_, "del1.parquet"),
-              .type = DeltaLogType::PRIMARY_KEY,
-              .num_entries = 50};
+  DeltaLog d1{
+      .path = get_delta_filepath(base_path_, "del1.parquet"), .type = DeltaLogType::PRIMARY_KEY, .num_entries = 50};
   DeltaLog d2{
       .path = get_delta_filepath(base_path_, "del2.parquet"), .type = DeltaLogType::POSITIONAL, .num_entries = 30};
   DeltaLog d3{
@@ -178,13 +177,12 @@ TEST_F(ManifestTest, IndexesRoundTrip) {
 
 TEST_F(ManifestTest, FullManifestRoundTrip) {
   // Populate all fields
-  auto cg1 = MakeCG({"id", "name"}, LOON_FORMAT_PARQUET,
-                     {{.path = get_data_filepath(base_path_, "cg1_part0.parquet"), .start_index = 0, .end_index = 500},
-                      {.path = get_data_filepath(base_path_, "cg1_part1.parquet"),
-                       .start_index = 500,
-                       .end_index = 1000}});
+  auto cg1 =
+      MakeCG({"id", "name"}, LOON_FORMAT_PARQUET,
+             {{.path = get_data_filepath(base_path_, "cg1_part0.parquet"), .start_index = 0, .end_index = 500},
+              {.path = get_data_filepath(base_path_, "cg1_part1.parquet"), .start_index = 500, .end_index = 1000}});
   auto cg2 = MakeCG({"value", "vector"}, LOON_FORMAT_PARQUET,
-                     {{.path = get_data_filepath(base_path_, "cg2.parquet"), .start_index = 0, .end_index = 1000}});
+                    {{.path = get_data_filepath(base_path_, "cg2.parquet"), .start_index = 0, .end_index = 1000}});
 
   std::vector<DeltaLog> deltas = {
       {.path = get_delta_filepath(base_path_, "del.parquet"), .type = DeltaLogType::PRIMARY_KEY, .num_entries = 20}};
@@ -289,13 +287,13 @@ TEST_F(ManifestTest, HybridFormatsInSingleManifest) {
              {{.path = get_data_filepath(base_path_, "cg_parquet.parquet"), .start_index = 0, .end_index = 100}});
 
   auto cg_iceberg = MakeCG({"value"}, LOON_FORMAT_ICEBERG_TABLE,
-                            {{.path = "s3://bucket/warehouse/table/data/file1.parquet",
-                              .start_index = 0,
-                              .end_index = 100,
-                              .metadata = {0x01, 0x02, 0x03}}});
+                           {{.path = "s3://bucket/warehouse/table/data/file1.parquet",
+                             .start_index = 0,
+                             .end_index = 100,
+                             .properties = {{api::kPropertyMetadata, std::string({'\x01', '\x02', '\x03'})}}}});
 
   auto cg_lance = MakeCG({"vector"}, LOON_FORMAT_LANCE_TABLE,
-                          {{.path = "s3://bucket/lance/table.lance", .start_index = 0, .end_index = 100}});
+                         {{.path = "s3://bucket/lance/table.lance", .start_index = 0, .end_index = 100}});
 
   Manifest manifest({cg_parquet, cg_iceberg, cg_lance});
   auto read_back = RoundTrip(manifest);
@@ -306,7 +304,8 @@ TEST_F(ManifestTest, HybridFormatsInSingleManifest) {
   EXPECT_EQ(read_back->columnGroups()[2]->format, LOON_FORMAT_LANCE_TABLE);
 
   // Verify iceberg column group metadata bytes survived roundtrip
-  EXPECT_EQ(read_back->columnGroups()[1]->files[0].metadata, std::vector<uint8_t>({0x01, 0x02, 0x03}));
+  EXPECT_EQ(read_back->columnGroups()[1]->files[0].properties.at(api::kPropertyMetadata),
+            std::string({'\x01', '\x02', '\x03'}));
 
   // Verify external table paths are preserved as-is (absolute URIs)
   EXPECT_EQ(read_back->columnGroups()[1]->files[0].path, "s3://bucket/warehouse/table/data/file1.parquet");
@@ -315,10 +314,12 @@ TEST_F(ManifestTest, HybridFormatsInSingleManifest) {
 
 TEST_F(ManifestTest, HybridFormatsWithGetColumnGroup) {
   auto cg_parquet = MakeCG({"id"}, LOON_FORMAT_PARQUET,
-                            {{.path = get_data_filepath(base_path_, "p.parquet"), .start_index = 0, .end_index = 50}});
-  auto cg_iceberg =
-      MakeCG({"name", "value"}, LOON_FORMAT_ICEBERG_TABLE,
-             {{.path = "s3://bucket/iceberg/data.parquet", .start_index = 0, .end_index = 50, .metadata = {0xAB}}});
+                           {{.path = get_data_filepath(base_path_, "p.parquet"), .start_index = 0, .end_index = 50}});
+  auto cg_iceberg = MakeCG({"name", "value"}, LOON_FORMAT_ICEBERG_TABLE,
+                           {{.path = "s3://bucket/iceberg/data.parquet",
+                             .start_index = 0,
+                             .end_index = 50,
+                             .properties = {{api::kPropertyMetadata, std::string(1, '\xAB')}}}});
 
   Manifest manifest({cg_parquet, cg_iceberg});
   auto read_back = RoundTrip(manifest);
@@ -365,26 +366,29 @@ TEST_F(ManifestTest, MultipleFilesInOneColumnGroup) {
 }
 
 TEST_F(ManifestTest, MultipleFilesWithMetadata) {
-  std::vector<uint8_t> meta1 = {0x10, 0x20, 0x30};
-  std::vector<uint8_t> meta2 = {0xAA, 0xBB};
-  std::vector<uint8_t> meta3 = {};
+  std::string meta1 = {'\x10', '\x20', '\x30'};
+  std::string meta2 = {'\xAA', '\xBB'};
+  std::string meta3 = {};
 
   auto cg = MakeCG({"id"}, LOON_FORMAT_ICEBERG_TABLE,
-                    {{.path = "s3://bucket/data/part0.parquet", .start_index = 0, .end_index = 500, .metadata = meta1},
-                     {.path = "s3://bucket/data/part1.parquet", .start_index = 500, .end_index = 1000, .metadata = meta2},
-                     {.path = "s3://bucket/data/part2.parquet",
-                      .start_index = 1000,
-                      .end_index = 1500,
-                      .metadata = meta3}});
+                   {{.path = "s3://bucket/data/part0.parquet",
+                     .start_index = 0,
+                     .end_index = 500,
+                     .properties = {{api::kPropertyMetadata, meta1}}},
+                    {.path = "s3://bucket/data/part1.parquet",
+                     .start_index = 500,
+                     .end_index = 1000,
+                     .properties = {{api::kPropertyMetadata, meta2}}},
+                    {.path = "s3://bucket/data/part2.parquet", .start_index = 1000, .end_index = 1500}});
 
   Manifest manifest({cg});
   auto read_back = RoundTrip(manifest);
 
   auto& rcg = read_back->columnGroups()[0];
   ASSERT_EQ(rcg->files.size(), 3);
-  EXPECT_EQ(rcg->files[0].metadata, meta1);
-  EXPECT_EQ(rcg->files[1].metadata, meta2);
-  EXPECT_EQ(rcg->files[2].metadata, meta3);
+  EXPECT_EQ(rcg->files[0].properties.at(api::kPropertyMetadata), meta1);
+  EXPECT_EQ(rcg->files[1].properties.at(api::kPropertyMetadata), meta2);
+  EXPECT_TRUE(rcg->files[2].properties.find(api::kPropertyMetadata) == rcg->files[2].properties.end());
 }
 
 // ---------- Edge Cases ----------
@@ -401,7 +405,7 @@ TEST_F(ManifestTest, WriteToExistingPathFails) {
 
 TEST_F(ManifestTest, ReadFromCachesResult) {
   auto cg = MakeCG({"id"}, LOON_FORMAT_PARQUET,
-                    {{.path = get_data_filepath(base_path_, "cached.parquet"), .start_index = 0, .end_index = 10}});
+                   {{.path = get_data_filepath(base_path_, "cached.parquet"), .start_index = 0, .end_index = 10}});
 
   Manifest manifest({cg});
   std::string path = get_manifest_filepath(base_path_, 1);
@@ -436,16 +440,20 @@ TEST_F(ManifestTest, ColumnGroupsXFormatsXFiles) {
               {.path = get_data_filepath(base_path_, "v1.vortex"), .start_index = 1500, .end_index = 3000}});
 
   auto cg_lance = MakeCG({"value"}, LOON_FORMAT_LANCE_TABLE,
-                          {{.path = "s3://bucket/lance/table.lance", .start_index = 0, .end_index = 3000}});
+                         {{.path = "s3://bucket/lance/table.lance", .start_index = 0, .end_index = 3000}});
 
-  auto cg_iceberg = MakeCG(
-      {"vector"}, LOON_FORMAT_ICEBERG_TABLE,
-      {{.path = "s3://bucket/iceberg/data/i0.parquet", .start_index = 0, .end_index = 1500, .metadata = {0x01}},
-       {.path = "s3://bucket/iceberg/data/i1.parquet", .start_index = 1500, .end_index = 3000, .metadata = {0x02}}});
+  auto cg_iceberg = MakeCG({"vector"}, LOON_FORMAT_ICEBERG_TABLE,
+                           {{.path = "s3://bucket/iceberg/data/i0.parquet",
+                             .start_index = 0,
+                             .end_index = 1500,
+                             .properties = {{api::kPropertyMetadata, std::string(1, '\x01')}}},
+                            {.path = "s3://bucket/iceberg/data/i1.parquet",
+                             .start_index = 1500,
+                             .end_index = 3000,
+                             .properties = {{api::kPropertyMetadata, std::string(1, '\x02')}}}});
 
-  DeltaLog delta{.path = get_delta_filepath(base_path_, "del.parquet"),
-                 .type = DeltaLogType::POSITIONAL,
-                 .num_entries = 100};
+  DeltaLog delta{
+      .path = get_delta_filepath(base_path_, "del.parquet"), .type = DeltaLogType::POSITIONAL, .num_entries = 100};
 
   Statistics stat;
   stat.paths = {get_stats_filepath(base_path_, "bloom.bin")};
@@ -469,7 +477,7 @@ TEST_F(ManifestTest, ColumnGroupsXFormatsXFiles) {
   EXPECT_EQ(read_back->columnGroups()[2]->files.size(), 1);
   EXPECT_EQ(read_back->columnGroups()[3]->format, LOON_FORMAT_ICEBERG_TABLE);
   EXPECT_EQ(read_back->columnGroups()[3]->files.size(), 2);
-  EXPECT_EQ(read_back->columnGroups()[3]->files[0].metadata, std::vector<uint8_t>({0x01}));
+  EXPECT_EQ(read_back->columnGroups()[3]->files[0].properties.at(api::kPropertyMetadata), std::string(1, '\x01'));
 
   // External table paths preserved as absolute URIs
   EXPECT_EQ(read_back->columnGroups()[2]->files[0].path, "s3://bucket/lance/table.lance");

--- a/cpp/test/tools/loon_test.cpp
+++ b/cpp/test/tools/loon_test.cpp
@@ -32,6 +32,7 @@ namespace {
 using milvus_storage::api::ColumnGroup;
 using milvus_storage::api::ColumnGroupFile;
 using milvus_storage::api::ColumnGroups;
+using milvus_storage::api::kPropertyMetadata;
 using milvus_storage::api::Manifest;
 using milvus_storage::api::Properties;
 using milvus_storage::api::SetValue;
@@ -90,8 +91,12 @@ TEST_F(LoonTest, CreateAndReadIceberg) {
   std::vector<ColumnGroupFile> files;
   files.reserve(file_infos.size());
   for (const auto& info : file_infos) {
+    std::unordered_map<std::string, std::string> file_props;
+    if (!info.delete_metadata_json.empty()) {
+      file_props[kPropertyMetadata] = std::string(info.delete_metadata_json.begin(), info.delete_metadata_json.end());
+    }
     files.emplace_back(
-        ColumnGroupFile{info.data_file_path, 0, static_cast<int64_t>(info.record_count), info.delete_metadata_json});
+        ColumnGroupFile{info.data_file_path, 0, static_cast<int64_t>(info.record_count), std::move(file_props)});
   }
 
   std::vector<std::string> columns = {"id", "name", "value"};
@@ -150,8 +155,13 @@ TEST_F(LoonTest, CreateAndTakeWithDeletes) {
 
   // Build manifest
   std::vector<ColumnGroupFile> files;
+  std::unordered_map<std::string, std::string> props;
+  if (!file_infos[0].delete_metadata_json.empty()) {
+    props[kPropertyMetadata] =
+        std::string(file_infos[0].delete_metadata_json.begin(), file_infos[0].delete_metadata_json.end());
+  }
   files.emplace_back(ColumnGroupFile{file_infos[0].data_file_path, 0, static_cast<int64_t>(file_infos[0].record_count),
-                                     file_infos[0].delete_metadata_json});
+                                     std::move(props)});
 
   std::vector<std::string> columns = {"id", "value"};
   ColumnGroups cgs;
@@ -196,8 +206,15 @@ TEST_F(LoonTest, SequentialReadFiltersDeletes) {
   auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
 
   std::vector<ColumnGroupFile> files;
-  files.emplace_back(ColumnGroupFile{file_infos[0].data_file_path, 0, static_cast<int64_t>(file_infos[0].record_count),
-                                     file_infos[0].delete_metadata_json});
+  {
+    std::unordered_map<std::string, std::string> file_props;
+    if (!file_infos[0].delete_metadata_json.empty()) {
+      file_props[kPropertyMetadata] =
+          std::string(file_infos[0].delete_metadata_json.begin(), file_infos[0].delete_metadata_json.end());
+    }
+    files.emplace_back(ColumnGroupFile{file_infos[0].data_file_path, 0,
+                                       static_cast<int64_t>(file_infos[0].record_count), std::move(file_props)});
+  }
 
   std::vector<std::string> columns = {"id", "name", "value"};
   ColumnGroups cgs;
@@ -252,11 +269,14 @@ TEST_F(LoonTest, ManifestPreservesDeleteMetadata) {
 
   // Commit manifest with delete metadata
   std::vector<ColumnGroupFile> files;
-  auto original_metadata = file_infos[0].delete_metadata_json;
+  auto& original_metadata = file_infos[0].delete_metadata_json;
   ASSERT_FALSE(original_metadata.empty());
 
+  std::string original_metadata_str(original_metadata.begin(), original_metadata.end());
+  std::unordered_map<std::string, std::string> file_props;
+  file_props[kPropertyMetadata] = original_metadata_str;
   files.emplace_back(ColumnGroupFile{file_infos[0].data_file_path, 0, static_cast<int64_t>(file_infos[0].record_count),
-                                     original_metadata});
+                                     std::move(file_props)});
 
   std::vector<std::string> columns = {"id"};
   ColumnGroups cgs;
@@ -271,9 +291,10 @@ TEST_F(LoonTest, ManifestPreservesDeleteMetadata) {
   auto manifest_path = get_manifest_filepath(target_dir_, version);
   ASSERT_AND_ASSIGN(auto manifest, Manifest::ReadFrom(fs_, manifest_path));
 
-  auto& round_tripped = manifest->columnGroups()[0]->files[0].metadata;
-  ASSERT_EQ(round_tripped.size(), original_metadata.size());
-  ASSERT_EQ(round_tripped, original_metadata);
+  auto& round_tripped_props = manifest->columnGroups()[0]->files[0].properties;
+  auto it = round_tripped_props.find(kPropertyMetadata);
+  ASSERT_NE(it, round_tripped_props.end());
+  ASSERT_EQ(it->second, original_metadata_str);
 }
 
 }  // namespace

--- a/cpp/tools/loon.cpp
+++ b/cpp/tools/loon.cpp
@@ -50,6 +50,7 @@ using milvus_storage::api::ColumnGroup;
 using milvus_storage::api::ColumnGroupFile;
 using milvus_storage::api::ColumnGroups;
 using milvus_storage::api::GetValue;
+using milvus_storage::api::kPropertyMetadata;
 using milvus_storage::api::Manifest;
 using milvus_storage::api::Properties;
 using milvus_storage::api::SetValue;
@@ -233,12 +234,12 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreParquetOrVortex(
       // SubTreeFileSystem at "/" strips the leading /, so prepend it.
       std::string abs_path = "/" + fi.path();
       files.emplace_back(ColumnGroupFile{
-          std::move(abs_path), -1, -1, std::vector<uint8_t>()});
+          std::move(abs_path), -1, -1, {}});
     } else {
       uri_base.key = fi.path();
       ARROW_ASSIGN_OR_RAISE(auto file_uri, StorageUri::Make(uri_base));
       files.emplace_back(ColumnGroupFile{
-          std::move(file_uri), -1, -1, std::vector<uint8_t>()});
+          std::move(file_uri), -1, -1, {}});
     }
   }
   return files;
@@ -271,7 +272,7 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreLance(
         milvus_storage::lance::MakeLanceUri(lance_base_uri, frag_id),
         0,
         static_cast<int64_t>(row_count),
-        std::vector<uint8_t>()});
+        {}});
   }
   return files;
 }
@@ -295,11 +296,16 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreIceberg(
   std::vector<ColumnGroupFile> files;
   files.reserve(file_infos.size());
   for (const auto& info : file_infos) {
+    std::unordered_map<std::string, std::string> file_props;
+    if (!info.delete_metadata_json.empty()) {
+      // Safe: delete_metadata_json is always valid UTF-8 JSON, so the bytes-to-string conversion is lossless.
+      file_props[kPropertyMetadata] = std::string(info.delete_metadata_json.begin(), info.delete_metadata_json.end());
+    }
     files.emplace_back(ColumnGroupFile{
         info.data_file_path,
         0,
         static_cast<int64_t>(info.record_count),
-        info.delete_metadata_json});
+        std::move(file_props)});
   }
   return files;
 }
@@ -391,7 +397,7 @@ static int DoCreate(int argc, char** argv) {
       if (files[i].end_index > 0) {
         std::cout << "  (rows: " << files[i].end_index << ")";
       }
-      if (!files[i].metadata.empty()) {
+      if (files[i].properties.count(kPropertyMetadata) > 0) {
         std::cout << "  (has metadata)";
       }
       std::cout << std::endl;
@@ -497,8 +503,9 @@ static int DoDescribe(int argc, char** argv) {
             ("path", f.path)
             ("start_index", f.start_index)
             ("end_index", f.end_index);
-        if (!f.metadata.empty()) {
-          fobj["metadata"] = std::string(f.metadata.begin(), f.metadata.end());
+        auto meta_it = f.properties.find(kPropertyMetadata);
+        if (meta_it != f.properties.end()) {
+          fobj["metadata"] = meta_it->second;
         } else {
           fobj["metadata"] = nullptr;
         }
@@ -622,10 +629,10 @@ static int DoRead(int argc, char** argv) {
         auto& f = cg->files[fi];
         std::cout << "    file[" << fi << "] path=" << f.path
                   << "  range=[" << f.start_index << "," << f.end_index << ")"
-                  << "  metadata_size=" << f.metadata.size() << std::endl;
-        if (!f.metadata.empty()) {
-          std::string meta(f.metadata.begin(), f.metadata.end());
-          std::cout << "    metadata: " << meta << std::endl;
+                  << "  has_metadata=" << (f.properties.count(kPropertyMetadata) > 0 ? "true" : "false") << std::endl;
+        auto meta_it = f.properties.find(kPropertyMetadata);
+        if (meta_it != f.properties.end()) {
+          std::cout << "    metadata: " << meta_it->second << std::endl;
         }
       }
     }

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -147,8 +147,9 @@ _ffi.cdef(
         const char* path;
         int64_t start_index;
         int64_t end_index;
-        uint8_t* metadata;
-        uint64_t metadata_size;
+        const char** property_keys;
+        const char** property_values;
+        uint32_t num_properties;
     } LoonColumnGroupFile;
 
     typedef struct LoonColumnGroup {
@@ -408,6 +409,7 @@ _ffi.cdef(
     LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
                                               const char* path_ptr,
                                               uint32_t path_len,
+                                              uint64_t file_size,
                                               FileSystemReaderHandle* out_reader_ptr);
 
     LoonFFIResult loon_filesystem_reader_readat(FileSystemReaderHandle handle,

--- a/python/milvus_storage/filesystem.py
+++ b/python/milvus_storage/filesystem.py
@@ -746,7 +746,7 @@ class Filesystem:
 
         handle = self._ffi.new("FileSystemReaderHandle*")
         result = self._lib.loon_filesystem_open_reader(
-            self._handle, path_bytes, len(path_bytes), handle
+            self._handle, path_bytes, len(path_bytes), 0, handle
         )
         check_result(result)
 

--- a/python/milvus_storage/manifest.py
+++ b/python/milvus_storage/manifest.py
@@ -200,16 +200,32 @@ class ColumnGroups:
                         c_file.start_index = f.start_index
                         c_file.end_index = f.end_index
 
-                        # Metadata
+                        # Properties (convert metadata bytes to property if present)
+                        props = {}
                         if f.metadata:
-                            meta_buf = ffi.new("uint8_t[]", len(f.metadata))
-                            ffi.memmove(meta_buf, f.metadata, len(f.metadata))
-                            buffers.append(meta_buf)
-                            c_file.metadata = meta_buf
-                            c_file.metadata_size = len(f.metadata)
+                            meta = f.metadata
+                            if isinstance(meta, bytes):
+                                meta = meta.decode("utf-8")
+                            props["metadata"] = meta
+
+                        if props:
+                            keys = list(props.keys())
+                            values = list(props.values())
+                            key_bufs = [ffi.new("char[]", k.encode("utf-8")) for k in keys]
+                            val_bufs = [ffi.new("char[]", v.encode("utf-8")) for v in values]
+                            buffers.extend(key_bufs)
+                            buffers.extend(val_bufs)
+                            keys_arr = ffi.new("const char*[]", key_bufs)
+                            vals_arr = ffi.new("const char*[]", val_bufs)
+                            buffers.append(keys_arr)
+                            buffers.append(vals_arr)
+                            c_file.property_keys = keys_arr
+                            c_file.property_values = vals_arr
+                            c_file.num_properties = len(props)
                         else:
-                            c_file.metadata = ffi.NULL
-                            c_file.metadata_size = 0
+                            c_file.property_keys = ffi.NULL
+                            c_file.property_values = ffi.NULL
+                            c_file.num_properties = 0
                 else:
                     c_cg.files = ffi.NULL
 
@@ -252,9 +268,13 @@ class ColumnGroups:
                 f = cg.files[k]
                 path = self._ffi.string(f.path).decode("utf-8") if f.path else ""
 
+                # Extract metadata from properties if present
                 metadata = None
-                if f.metadata != self._ffi.NULL and f.metadata_size > 0:
-                    metadata = bytes(self._ffi.buffer(f.metadata, f.metadata_size))
+                for pi in range(f.num_properties):
+                    key = self._ffi.string(f.property_keys[pi]).decode("utf-8")
+                    if key == "metadata":
+                        val = self._ffi.string(f.property_values[pi]).decode("utf-8")
+                        metadata = val.encode("utf-8")
 
                 files.append(ColumnGroupFile(path, f.start_index, f.end_index, metadata))
 
@@ -433,9 +453,13 @@ class Manifest:
                 f = cg.files[k]
                 path = ffi.string(f.path).decode("utf-8") if f.path else ""
 
+                # Extract metadata from properties if present
                 metadata = None
-                if f.metadata != ffi.NULL and f.metadata_size > 0:
-                    metadata = bytes(ffi.buffer(f.metadata, f.metadata_size))
+                for pi in range(f.num_properties):
+                    key = ffi.string(f.property_keys[pi]).decode("utf-8")
+                    if key == "metadata":
+                        val = ffi.string(f.property_values[pi]).decode("utf-8")
+                        metadata = val.encode("utf-8")
 
                 files.append(ColumnGroupFile(path, f.start_index, f.end_index, metadata))
 


### PR DESCRIPTION
When we open a file on S3, Arrow always does a HeadObject first just to figure out the file size. That's wasteful since we already know the size at write time. Now both Parquet and Vortex writers capture the file size and footer size when they close, and we store them in ColumnGroupFile in the manifest. On the read side, if the file size is known we pass it via FileInfo so Arrow skips the HEAD entirely. For the footer, if we know its exact size we pre-read the whole thing in one IO instead of Arrow's default two-step approach (read the 8-byte trailer first, then go back for the Thrift metadata).

Also refactored the Vortex read path to open a RandomAccessFile handle once and reuse it for all ReadAt calls, instead of re-opening per request. The reader handle is wrapped in Arc<ReaderHandle> so that if the read future gets cancelled, any in-flight spawn_blocking tasks still hold a valid reference and the underlying C++ object won't get freed from under them.

Updated the FFI layer across C++, Rust and Python to thread file_size and footer_size through. The C struct LoonColumnGroupFile and the Python cffi definition now both include these fields to stay in sync with the internal ColumnGroupFile. The coalescing window max_size was also tuned down to 1 MB to better match our actual read patterns.
