### PR TITLE
fix: wrap Azure output stream with BufferedOutputStream to avoid BlockCountExceedsLimit

### DIFF
--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -31,6 +31,8 @@
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/upload_sizable.h"
 
+#include <arrow/io/buffered.h>
+
 namespace milvus_storage::parquet {
 
 static ::parquet::Compression::type convert_compression_type(const std::string& compression) {
@@ -187,22 +189,36 @@ arrow::Status ParquetFileWriter::init() {
 
   // Try OpenOutputStreamWithUploadSize first, fall back to normal OpenOutputStream if not supported
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> sink_result;
+  bool needs_buffering = false;
   auto upload_size_fs = std::dynamic_pointer_cast<UploadSizable>(fs_);
   if (upload_size_fs) {
     sink_result = upload_size_fs->OpenOutputStreamWithUploadSize(file_path_, nullptr, storage_config_.part_size);
     // If not supported, fall back to normal OpenOutputStream
     if (!sink_result.ok() && sink_result.status().code() == arrow::StatusCode::NotImplemented) {
       sink_result = fs_->OpenOutputStream(file_path_);
+      needs_buffering = true;
     }
   } else {
     // Not an UploadSizable filesystem, use normal OpenOutputStream
     sink_result = fs_->OpenOutputStream(file_path_);
+    needs_buffering = true;
   }
 
   if (!sink_result.ok()) {
     return arrow::Status::IOError(fmt::format("Failed to open output stream: {}", sink_result.status().ToString()));
   }
   sink_ = std::move(sink_result).ValueOrDie();
+
+  // HOTFIX: For non-local filesystems without built-in upload buffering (e.g., Azure Blob Storage),
+  // wrap with BufferedOutputStream to reduce the number of remote write calls.
+  // Azure Block Blob has a limit of 100,000 uncommitted blocks per blob; without buffering,
+  // each small Parquet write becomes a separate StageBlock, easily exceeding this limit
+  // for large compaction outputs (e.g., 8GB data can produce >100K blocks).
+  // TODO: Remove this once azurefs is ported with internal buffering support.
+  if (needs_buffering && !IsLocalFileSystem(fs_)) {
+    auto buffer_size = storage_config_.part_size > 0 ? storage_config_.part_size : DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
+    ARROW_ASSIGN_OR_RAISE(sink_, arrow::io::BufferedOutputStream::Create(buffer_size, arrow::default_memory_pool(), sink_));
+  }
 
   auto writer_result = ::parquet::arrow::FileWriter::Open(*schema_, arrow::default_memory_pool(), sink_, writer_props_);
   if (!writer_result.ok()) {


### PR DESCRIPTION
Azure Block Blob has a hard limit of 100,000 uncommitted blocks per blob. Arrow's Azure ObjectAppendStream creates a new StageBlock for every Write() call without internal buffering. During large compaction outputs (e.g., 8GB), the Parquet writer produces many small writes (one per row group column page), easily exceeding the 100K block limit.

This fix wraps the output stream with arrow::io::BufferedOutputStream (default 10MB buffer) for non-local filesystems that don't implement UploadSizable (i.e., Azure). This reduces ~100K+ StageBlock calls to ~800 for 8GB data.

S3 and local filesystem paths are unaffected.