### PR TITLE
fix: [2.6]wrap Azure output stream with BufferedOutputStream to avoid BlockCountExceedsLimit

### DIFF
--- a/cpp/include/milvus-storage/common/config.h
+++ b/cpp/include/milvus-storage/common/config.h
@@ -24,7 +24,7 @@ static constexpr int64_t DEFAULT_MAX_ROW_GROUP_SIZE = 1024 * 1024;  // 1 MB
 
 // Default number of rows to read when using ::arrow::RecordBatchReader
 static constexpr int64_t DEFAULT_READ_BATCH_SIZE = 1024;
-static constexpr int64_t DEFAULT_READ_BUFFER_SIZE = 16 * 1024 * 1024;   // 16 MB
+static constexpr int64_t DEFAULT_READ_BUFFER_SIZE = 16 * 1024 * 1024;            // 16 MB
 static constexpr int64_t DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024 * 1024;           // 16 MB
 static constexpr int64_t DEFAULT_MULTIPART_UPLOAD_PART_SIZE = 10 * 1024 * 1024;  // 10 MB
 

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -196,10 +196,10 @@ arrow::Status ParquetFileWriter::init() {
     // TODO: Remove this once azurefs is ported with internal buffering support.
     if (!is_local_fs) {
       auto buffer_size = storage_config_.part_size > 0 ? storage_config_.part_size : DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
-      ARROW_ASSIGN_OR_RAISE(sink_, arrow::io::BufferedOutputStream::Create(buffer_size, arrow::default_memory_pool(), sink_));
+      ARROW_ASSIGN_OR_RAISE(sink_,
+                            arrow::io::BufferedOutputStream::Create(buffer_size, arrow::default_memory_pool(), sink_));
     }
   }
-
 
   auto writer_result = ::parquet::arrow::FileWriter::Open(*schema_, arrow::default_memory_pool(), sink_, writer_props_);
   if (!writer_result.ok()) {


### PR DESCRIPTION
Azure Block Blob has a hard limit of 100,000 uncommitted blocks per blob. Arrow's Azure ObjectAppendStream creates a new StageBlock for every Write() call without internal buffering. During large compaction outputs (e.g., 8GB), the Parquet writer produces many small writes (one per row group column page), easily exceeding the 100K block limit.

This fix wraps the output stream with arrow::io::BufferedOutputStream (default 10MB buffer) for non-local filesystems that don't implement UploadSizable (i.e., Azure). This reduces ~100K+ StageBlock calls to ~800 for 8GB data.

S3 and local filesystem paths are unaffected.