### PR TITLE
feat: support configurable background_writes option for S3 filesystem

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -97,6 +97,8 @@ FFI_EXPORT extern const char* loon_properties_fs_role_arn;
 FFI_EXPORT extern const char* loon_properties_fs_session_name;
 FFI_EXPORT extern const char* loon_properties_fs_external_id;
 FFI_EXPORT extern const char* loon_properties_fs_load_frequency;
+FFI_EXPORT extern const char* loon_properties_fs_tls_min_version;
+FFI_EXPORT extern const char* loon_properties_fs_background_writes;
 
 // --- Export Writer property keys ---
 FFI_EXPORT extern const char* loon_properties_writer_policy;

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -206,6 +206,10 @@ struct ArrowFileSystemConfig {
   // Empty string means use the system/library default.
   std::string tls_min_version = "";
 
+  // Whether OutputStream writes will be issued in the background, without blocking.
+  // Only applies to S3 filesystem. It will use the thread pool which in arrow.
+  bool background_writes = true;
+
   // Alias for external filesystem identification (e.g., "prod", "backup")
   // Empty for default filesystem
   std::string alias = "";

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -96,6 +96,7 @@ struct PropertyInfo {
 #define PROPERTY_FS_EXTERNAL_ID "fs.external_id"
 #define PROPERTY_FS_LOAD_FREQUENCY "fs.load_frequency"
 #define PROPERTY_FS_TLS_MIN_VERSION "fs.tls_min_version"
+#define PROPERTY_FS_BACKGROUND_WRITES "fs.background_writes"
 
 // --- External Filesystem Properties ---
 // External filesystems are configured with properties following the pattern:

--- a/cpp/src/common/metadata.cpp
+++ b/cpp/src/common/metadata.cpp
@@ -178,7 +178,9 @@ int64_t RowGroupMetadata::row_offset() const { return row_offset_; }
 
 std::string RowGroupMetadata::ToString() const {
   std::stringstream ss;
-  ss << "memory_size=" << memory_size_ << "," << "row_num=" << row_num_ << "," << "row_offset=" << row_offset_;
+  ss << "memory_size=" << memory_size_ << ","
+     << "row_num=" << row_num_ << ","
+     << "row_offset=" << row_offset_;
   return ss.str();
 }
 

--- a/cpp/src/ffi/properties_c.cpp
+++ b/cpp/src/ffi/properties_c.cpp
@@ -60,6 +60,8 @@ const char* loon_properties_fs_role_arn = PROPERTY_FS_ROLE_ARN;
 const char* loon_properties_fs_session_name = PROPERTY_FS_SESSION_NAME;
 const char* loon_properties_fs_external_id = PROPERTY_FS_EXTERNAL_ID;
 const char* loon_properties_fs_load_frequency = PROPERTY_FS_LOAD_FREQUENCY;
+const char* loon_properties_fs_tls_min_version = PROPERTY_FS_TLS_MIN_VERSION;
+const char* loon_properties_fs_background_writes = PROPERTY_FS_BACKGROUND_WRITES;
 
 // --- Define Writer property keys ---
 const char* loon_properties_writer_policy = PROPERTY_WRITER_POLICY;

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -144,6 +144,7 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
   ARROW_ASSIGN_OR_RAISE(result.load_frequency, api::GetValue<int32_t>(properties_map, PROPERTY_FS_LOAD_FREQUENCY));
   ARROW_ASSIGN_OR_RAISE(result.tls_min_version,
                         api::GetValue<std::string>(properties_map, PROPERTY_FS_TLS_MIN_VERSION));
+  ARROW_ASSIGN_OR_RAISE(result.background_writes, api::GetValue<bool>(properties_map, PROPERTY_FS_BACKGROUND_WRITES));
   return arrow::Status::OK();
 }
 

--- a/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
@@ -86,10 +86,12 @@ AliyunSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
   //     -H "SignatureNonce: $SignatureNonce" \
   //     -d
   //     "RoleArn=$RoleArn&OIDCProviderArn=$OIDCProviderArn&OIDCToken=$OIDCToken&RoleSessionName=$RoleSessionName&Version=$Version"
-  ss << "Action=AssumeRoleWithOIDC" << "&Timestamp=" /*iso8601*/
+  ss << "Action=AssumeRoleWithOIDC"
+     << "&Timestamp=" /*iso8601*/
      << Aws::Utils::StringUtils::URLEncode(
             Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601).c_str())
-     << "&Version=2015-04-01" << "&SignatureNonce="
+     << "&Version=2015-04-01"
+     << "&SignatureNonce="
      << Aws::Utils::HashingUtils::HashString(Aws::Utils::StringUtils::to_string(IntRand(0, INT_MAX)).c_str())
      << "&RoleSessionName=" << Aws::Utils::StringUtils::URLEncode(request.roleSessionName.c_str())
      << "&RoleArn=" << Aws::Utils::StringUtils::URLEncode(request.roleArn.c_str())

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -378,6 +378,7 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
   options.max_connections = config_.max_connections;
   options.multi_part_upload_size = config_.multi_part_upload_size;
   options.cloud_provider = config_.cloud_provider;
+  options.background_writes = config_.background_writes;
 
   // Credential configuration priority:
   // 1. AssumeRole (role_arn) — AWS only

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -134,7 +134,8 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
 
 std::string ChunkInfo::ToString() const {
   std::stringstream ss;
-  ss << "ChunkInfo{" << "file_index=" << file_index << ", row_offset_in_row_group=" << row_offset_in_row_group
+  ss << "ChunkInfo{"
+     << "file_index=" << file_index << ", row_offset_in_row_group=" << row_offset_in_row_group
      << ", row_offset_in_file=" << row_offset_in_file << ", number_of_rows=" << number_of_rows
      << ", row_group_index_in_file=" << row_group_index_in_file << ", global_row_end=" << global_row_end
      << ", avg_memory_size=" << avg_memory_size << "}";

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -26,8 +26,8 @@ namespace milvus_storage {
 
 std::string RowGroupInfo::ToString() const {
   std::stringstream ss;
-  ss << "RowGroupInfo{" << "start_offset=" << start_offset << ", end_offset=" << end_offset
-     << ", memory_size=" << memory_size << "}";
+  ss << "RowGroupInfo{"
+     << "start_offset=" << start_offset << ", end_offset=" << end_offset << ", memory_size=" << memory_size << "}";
   return ss.str();
 }
 

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -217,7 +217,8 @@ arrow::Status ParquetFileWriter::init() {
   // TODO: Remove this once azurefs is ported with internal buffering support.
   if (needs_buffering && !IsLocalFileSystem(fs_)) {
     auto buffer_size = storage_config_.part_size > 0 ? storage_config_.part_size : DEFAULT_MULTIPART_UPLOAD_PART_SIZE;
-    ARROW_ASSIGN_OR_RAISE(sink_, arrow::io::BufferedOutputStream::Create(buffer_size, arrow::default_memory_pool(), sink_));
+    ARROW_ASSIGN_OR_RAISE(sink_,
+                          arrow::io::BufferedOutputStream::Create(buffer_size, arrow::default_memory_pool(), sink_));
   }
 
   auto writer_result = ::parquet::arrow::FileWriter::Open(*schema_, arrow::default_memory_pool(), sink_, writer_props_);

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -456,6 +456,12 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "Empty string means use the system/library default.",
                       std::string(""),
                       ValidatePropertyType() + ValidatePropertyEnum<std::string>("", "1.0", "1.1", "1.2", "1.3")),
+    REGISTER_PROPERTY(PROPERTY_FS_BACKGROUND_WRITES,
+                      PropertyType::BOOL,
+                      "Whether OutputStream writes will be issued in the background, without blocking. "
+                      "Only applies to S3 filesystem.",
+                      true,
+                      ValidatePropertyType()),
     // --- writer properties define ---
     REGISTER_PROPERTY(PROPERTY_WRITER_POLICY,
                       PropertyType::STRING,
@@ -630,7 +636,8 @@ std::optional<std::string> SetValue(Properties& properties,
     } else {
       {
         std::ostringstream oss;
-        oss << "undefined key: '" << key << "'." << " should define the property first.";
+        oss << "undefined key: '" << key << "'."
+            << " should define the property first.";
         return oss.str();
       }
     }

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <sstream>
+#include <thread>
 #include <type_traits>
 
 #include <boost/filesystem/path.hpp>
@@ -993,6 +994,82 @@ TEST_F(S3UnitTest, TestS3ClientHolder) {
     auto moved = lock.Move();
     EXPECT_EQ(moved.get(), ptr_before);
   }
+}
+
+// ============================================================================
+// background_writes cloud-env tests
+// ============================================================================
+
+TEST_F(S3FsTest, BackgroundWritesConcurrent) {
+  constexpr int kNumThreads = 10;
+  const std::string base_dir = "/test_background_writes";
+
+  auto run_concurrent_writes = [&](bool background_writes) {
+    // Clear the global fs cache to force re-creation with new config
+    FilesystemCache::getInstance().clean();
+
+    api::Properties properties;
+    ASSERT_STATUS_OK(InitTestProperties(properties));
+    api::SetValue(properties, PROPERTY_FS_BACKGROUND_WRITES, background_writes ? "true" : "false");
+
+    ASSERT_AND_ASSIGN(auto fs, GetFileSystem(properties));
+
+    std::string dir = base_dir + (background_writes ? "/bg_true" : "/bg_false");
+    (void)fs->DeleteDirContents(dir, true);
+    ASSERT_STATUS_OK(fs->CreateDir(dir));
+
+    std::vector<std::thread> threads;
+    std::vector<arrow::Status> statuses(kNumThreads);
+
+    for (int i = 0; i < kNumThreads; ++i) {
+      threads.emplace_back([&, i]() {
+        std::string path = dir + "/file_" + std::to_string(i) + ".txt";
+        std::string content = "thread_" + std::to_string(i) + "_data";
+
+        auto out_result = fs->OpenOutputStream(path);
+        if (!out_result.ok()) {
+          statuses[i] = out_result.status();
+          return;
+        }
+        auto out = out_result.ValueOrDie();
+        auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+        statuses[i] = out->Write(buf);
+        if (statuses[i].ok()) {
+          statuses[i] = out->Close();
+        }
+      });
+    }
+
+    for (auto& t : threads) {
+      t.join();
+    }
+
+    for (int i = 0; i < kNumThreads; ++i) {
+      EXPECT_TRUE(statuses[i].ok()) << "Thread " << i << " failed: " << statuses[i].ToString();
+    }
+
+    // Verify all files exist and content is correct
+    for (int i = 0; i < kNumThreads; ++i) {
+      std::string path = dir + "/file_" + std::to_string(i) + ".txt";
+      std::string expected = "thread_" + std::to_string(i) + "_data";
+
+      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(path));
+      ASSERT_AND_ASSIGN(auto buf, input->Read(expected.size()));
+      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), expected)
+          << "Content mismatch for thread " << i;
+    }
+
+    // Cleanup
+    (void)fs->DeleteDirContents(dir, true);
+  };
+
+  // 1. background_writes = true
+  run_concurrent_writes(true);
+
+  // 2. background_writes = false
+  run_concurrent_writes(false);
+
+  (void)fs_->DeleteDirContents(base_dir, true);
 }
 
 }  // namespace milvus_storage


### PR DESCRIPTION
This adds a new `fs.background_writes` property that controls whether S3 OutputStream writes are issued in the background using Arrow's internal thread pool. It defaults to true, which matches Arrow's own default behavior.

The property goes through the full pipeline: property definition, registration with validation, ArrowFileSystemConfig, S3Options passthrough, and FFI/C export. Also added a concurrent write test under S3FsTest to verify both background and synchronous write modes work correctly with multiple threads.

Some minor formatting cleanups are included as well, mostly breaking long string-concatenation lines for better readability.