### PR TITLE
enhance: use CRC32C instead of MD5 for S3 upload checksum

### DIFF
--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -977,6 +977,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     req.SetKey(ToAwsString(path_.key));
     req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
     req.SetContentLength(nbytes);
+    req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
 
     if (!background_writes_) {
       req.SetBody(std::make_shared<StringViewStream>(data, nbytes));


### PR DESCRIPTION
The AWS SDK defaults to MD5 for PutObject and UploadPart checksum calculation, which showed up as ~6.5% CPU usage in flamegraph profiling(800 thread with 100k write IO). Switch to CRC32C which is hardware-accelerated on modern CPUs (SSE4.2/ARM CRC instructions) and significantly faster.