### PR TITLE
fix: add back resolve_id to loon_transaction_begin

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -609,6 +609,7 @@ typedef uintptr_t LoonTransactionHandle;
  * @param base_path Base path in the filesystem for the transaction
  * @param properties configuration properties
  * @param read_version Version to read (<0 means fetch greatest version)
+ * @param resolve_id The resolve strategy, see LOON_TRANSACTION_RESOLVE_*
  * @param retry_limit Maximum number of retry attempts on commit conflicts (default: 1)
  * @param out_handle Output transaction handle
  * @return result of FFI
@@ -616,6 +617,7 @@ typedef uintptr_t LoonTransactionHandle;
 FFI_EXPORT LoonFFIResult loon_transaction_begin(const char* base_path,
                                                 const LoonProperties* properties,
                                                 int64_t read_version,
+                                                int32_t resolve_id,
                                                 uint32_t retry_limit,
                                                 LoonTransactionHandle* out_handle);
 
@@ -639,12 +641,9 @@ FFI_EXPORT LoonFFIResult loon_transaction_get_manifest(LoonTransactionHandle han
 FFI_EXPORT LoonFFIResult loon_transaction_get_read_version(LoonTransactionHandle handle, int64_t* out_read_version);
 
 /**
- * @brief Commits the transaction with the provided manifest
+ * @brief Commits the transaction
  *
  * @param handle Transaction handle
- * @param resolve_id The resolve strategy, more info see LOON_TRANSACTION_RESOLVE_*
- * @param in_manifest The new manifest handle need updated
- *                    Input NULL if current transaction have not any write operation
  * @param out_committed_version Output committed version (valid only if commit succeeds)
  * @return result of FFI
  */

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -35,6 +35,7 @@ using namespace milvus_storage::api::transaction;
 LoonFFIResult loon_transaction_begin(const char* base_path,
                                      const ::LoonProperties* properties,
                                      int64_t read_version,
+                                     int32_t resolve_id,
                                      uint32_t retry_limit,
                                      LoonTransactionHandle* out_handle) {
   if (!base_path || !properties) {
@@ -54,8 +55,23 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
     }
     auto fs = fs_result.ValueOrDie();
 
+    // Select resolver based on resolve_id
+    Resolver resolver;
+    switch (resolve_id) {
+      case LOON_TRANSACTION_RESOLVE_MERGE:
+        resolver = MergeResolver;
+        break;
+      case LOON_TRANSACTION_RESOLVE_OVERWRITE:
+        resolver = OverwriteResolver;
+        break;
+      case LOON_TRANSACTION_RESOLVE_FAIL:
+      default:
+        resolver = FailResolver;
+        break;
+    }
+
     // Open transaction (automatically begun)
-    auto transaction_result = Transaction::Open(fs, base_path, read_version, FailResolver, retry_limit);
+    auto transaction_result = Transaction::Open(fs, base_path, read_version, resolver, retry_limit);
     if (!transaction_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, transaction_result.status().ToString());
     }

--- a/cpp/src/jni/manifest_jni.cpp
+++ b/cpp/src/jni/manifest_jni.cpp
@@ -30,8 +30,9 @@ JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageManifestNative_
 
     // Begin a transaction to get the latest manifest
     LoonTransactionHandle transaction_handle;
-    LoonFFIResult result = loon_transaction_begin(base_path_cstr, properties, -1 /* read_version */,
-                                                  1 /* retry_limit */, &transaction_handle);
+    LoonFFIResult result =
+        loon_transaction_begin(base_path_cstr, properties, -1 /* read_version */, LOON_TRANSACTION_RESOLVE_FAIL,
+                               1 /* retry_limit */, &transaction_handle);
 
     if (!loon_ffi_is_success(&result)) {
       env->ReleaseStringUTFChars(base_path, base_path_cstr);
@@ -91,7 +92,8 @@ JNIEXPORT jlongArray JNICALL Java_io_milvus_storage_MilvusStorageManifestNative_
     // Begin a transaction with the specified read version
     LoonTransactionHandle transaction_handle;
     LoonFFIResult result =
-        loon_transaction_begin(base_path_cstr, properties, read_version, 1 /* retry_limit */, &transaction_handle);
+        loon_transaction_begin(base_path_cstr, properties, read_version, LOON_TRANSACTION_RESOLVE_FAIL,
+                               1 /* retry_limit */, &transaction_handle);
 
     if (!loon_ffi_is_success(&result)) {
       env->ReleaseStringUTFChars(base_path, base_path_cstr);
@@ -152,8 +154,9 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageTransaction_transact
     LoonProperties* properties = reinterpret_cast<LoonProperties*>(properties_ptr);
 
     LoonTransactionHandle transaction_handle;
-    LoonFFIResult result = loon_transaction_begin(base_path_cstr, properties, -1 /* read_version */,
-                                                  1 /* retry_limit */, &transaction_handle);
+    LoonFFIResult result =
+        loon_transaction_begin(base_path_cstr, properties, -1 /* read_version */, LOON_TRANSACTION_RESOLVE_FAIL,
+                               1 /* retry_limit */, &transaction_handle);
 
     env->ReleaseStringUTFChars(base_path, base_path_cstr);
 

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -118,7 +118,8 @@ static void test_empty_manifests(void) {
   ck_assert_msg(mrc == 0, "can't mkdir test base path errno: %d", mrc);
 
   // Open transaction to get latest manifest
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &transaction);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   // Get read version
@@ -183,7 +184,8 @@ static void test_manifests_write_read(void) {
 
   create_writer_test_file(TEST_BASE_PATH, &out_cgs, 1, 20, false);
 
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &tranhandle);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &tranhandle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   ck_assert(tranhandle != 0);
 
@@ -197,7 +199,8 @@ static void test_manifests_write_read(void) {
   loon_transaction_destroy(tranhandle);
 
   // Open a new transaction to read the committed manifest
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &read_transaction);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &read_transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   int64_t read_version = -1;
@@ -233,7 +236,8 @@ static void test_abort(void) {
   ck_assert_msg(mrc == 0, "can't mkdir test base path errno: %d", mrc);
 
   // Open first transaction to read initial state
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &read_transaction1);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &read_transaction1);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   int64_t read_version = -1;
@@ -244,14 +248,16 @@ static void test_abort(void) {
   rc = loon_transaction_get_manifest(read_transaction1, &cmanifest1);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* read_version */, 1 /* retry_limit */, &tranhandle);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* read_version */, LOON_TRANSACTION_RESOLVE_FAIL,
+                              1 /* retry_limit */, &tranhandle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   ck_assert(tranhandle != 0);
 
   loon_transaction_destroy(tranhandle);
 
   // Open second transaction to read state after abort
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &read_transaction2);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &read_transaction2);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   rc = loon_transaction_get_read_version(read_transaction2, &read_version);
@@ -296,7 +302,8 @@ static void test_add_column_group(void) {
   ck_assert(out_cgs->num_of_column_groups > 0);
 
   // Open transaction
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &tranhandle);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &tranhandle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   // Add column group (use the first one from writer output)
@@ -311,7 +318,8 @@ static void test_add_column_group(void) {
   loon_transaction_destroy(tranhandle);
 
   // Verify by reading the manifest
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &read_transaction);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &read_transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
@@ -343,7 +351,8 @@ static void test_add_delta_log(void) {
   ck_assert_msg(mrc == 0, "can't mkdir test base path errno: %d", mrc);
 
   // Open transaction
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &tranhandle);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &tranhandle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   // Add delta log
@@ -362,7 +371,8 @@ static void test_add_delta_log(void) {
   loon_transaction_destroy(tranhandle);
 
   // Verify by reading the manifest
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &read_transaction);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &read_transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
@@ -403,7 +413,8 @@ static void test_update_stat(void) {
   ck_assert_msg(mrc == 0, "can't mkdir test base path errno: %d", mrc);
 
   // Open transaction
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &tranhandle);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &tranhandle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   // Add stat with multiple files
@@ -424,7 +435,8 @@ static void test_update_stat(void) {
   loon_transaction_destroy(tranhandle);
 
   // Verify by reading the manifest
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, 1 /* retry_limit */, &read_transaction);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1 /* LATEST */, LOON_TRANSACTION_RESOLVE_FAIL, 1 /* retry_limit */,
+                              &read_transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
@@ -480,7 +492,7 @@ static void test_update_stat_with_metadata(void) {
   int mrc = make_directory(TEST_ROOT_PATH, TEST_BASE_PATH);
   ck_assert_msg(mrc == 0, "can't mkdir test base path errno: %d", mrc);
 
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, 1, &tranhandle);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &tranhandle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   // Add stat with files and metadata
@@ -500,7 +512,7 @@ static void test_update_stat_with_metadata(void) {
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   loon_transaction_destroy(tranhandle);
 
-  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, 1, &read_transaction);
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &read_transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
   rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
@@ -559,7 +571,7 @@ static void test_transaction_error_handling(void) {
   int64_t version = 0;
 
   // Test null arguments for loon_transaction_begin
-  rc = loon_transaction_begin(NULL, NULL, -1, 1, &handle);
+  rc = loon_transaction_begin(NULL, NULL, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &handle);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -295,6 +295,7 @@ _ffi.cdef(
     LoonFFIResult loon_transaction_begin(const char* base_path,
                                          const LoonProperties* properties,
                                          int64_t read_version,
+                                         int32_t resolve_id,
                                          uint32_t retry_limit,
                                          LoonTransactionHandle* out_handle);
 

--- a/python/milvus_storage/transaction.py
+++ b/python/milvus_storage/transaction.py
@@ -58,6 +58,7 @@ class Transaction:
         base_path: str,
         properties: Optional[Dict[str, str]] = None,
         read_version: int = -1,
+        resolve_id: int = LOON_TRANSACTION_RESOLVE_FAIL,
         retry_limit: int = 1,
     ):
         """
@@ -67,6 +68,7 @@ class Transaction:
             base_path: Base path for the dataset
             properties: Optional configuration properties
             read_version: Version to read (-1 for latest)
+            resolve_id: Conflict resolution strategy (see ResolveStrategy)
             retry_limit: Maximum retries on commit conflicts (default: 1)
 
         Raises:
@@ -89,6 +91,7 @@ class Transaction:
             base_path.encode("utf-8"),
             self._props._get_c_properties(),
             read_version,
+            resolve_id,
             retry_limit,
             handle,
         )


### PR DESCRIPTION
Previously the resolver was hardcoded to FailResolver in loon_transaction_begin(which been removed by previously commits). Now callers can pick between Fail, Merge, and Overwrite strategies by passing a resolve_id.

Updated the C FFI signature and implementation with a switch to map resolve_id to the corresponding resolver. All C tests and JNI call sites are updated accordingly. Python bindings also got the new param wired through, with FailResolver as the default.