### PR TITLE
fix: use RPATH for milvus_test and finalize S3 in test teardown

### DIFF
--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -21,6 +21,18 @@ target_include_directories(milvus_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/includ
 set_target_properties(milvus_test PROPERTIES
   CXX_STANDARD 17
 )
+# Force the linker to emit RPATH instead of RUNPATH (Linux only).
+# RUNPATH only applies to direct dependencies, so when milvus_test loads
+# libmilvus-storage.so -> libfolly.so -> libgflags_nothreads.so, the search
+# paths in milvus_test's RUNPATH are NOT used to locate libgflags.
+# RPATH propagates to the entire transitive dependency chain, which is
+# required for gtest_discover_tests to run the binary at build time
+# without setting LD_LIBRARY_PATH.
+# This became necessary after folly/gflags switched to shared libraries
+# in commit bd46999 ("adjust conan dependencies for folly shared").
+if (NOT APPLE)
+  target_link_options(milvus_test PRIVATE "LINKER:--disable-new-dtags")
+endif()
 
 
 target_link_libraries(

--- a/cpp/test/filesystem/s3_provider_test.cpp
+++ b/cpp/test/filesystem/s3_provider_test.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
+#include <mutex>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -227,7 +228,13 @@ class MockHttpClientFactory : public Aws::Http::HttpClientFactory {
 
 class S3ProviderTest : public ::testing::Test {
   protected:
-  static void SetUpTestSuite() { ASSERT_TRUE(EnsureS3Initialized().ok()); }
+  static void SetUpTestSuite() {
+    ASSERT_TRUE(EnsureS3Initialized().ok());
+    // Register S3 cleanup at process exit, so it runs after all test suites
+    // but before AwsInstance's static destructor (which would warn otherwise).
+    static std::once_flag flag;
+    std::call_once(flag, [] { std::atexit([] { EnsureS3Finalized().ok(); }); });
+  }
 
   void SetUp() override {
     mock_client_ = std::make_shared<MockHttpClient>();


### PR DESCRIPTION
After folly/gflags switched to shared libraries (bd46999), milvus_test failed to resolve transitive shared library dependencies (e.g. libgflags_nothreads.so loaded via folly) during gtest_discover_tests at build time. This is because the default RUNPATH does not propagate to indirect dependencies, unlike RPATH.

Fix by adding --disable-new-dtags to emit RPATH instead of RUNPATH for milvus_test on Linux.

Also add TearDownTestSuite to S3ProviderTest to call EnsureS3Finalized(), fixing the "FinalizeS3 was not called" warning at exit.