### PR TITLE
enhance: make CRC32C checksum configurable and extend to all supported S3 requests

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -99,6 +99,7 @@ FFI_EXPORT extern const char* loon_properties_fs_external_id;
 FFI_EXPORT extern const char* loon_properties_fs_load_frequency;
 FFI_EXPORT extern const char* loon_properties_fs_tls_min_version;
 FFI_EXPORT extern const char* loon_properties_fs_background_writes;
+FFI_EXPORT extern const char* loon_properties_fs_use_crc32c_checksum;
 
 // --- Export Writer property keys ---
 FFI_EXPORT extern const char* loon_properties_writer_policy;

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -210,6 +210,11 @@ struct ArrowFileSystemConfig {
   // Only applies to S3 filesystem. It will use the thread pool which in arrow.
   bool background_writes = true;
 
+  // Whether to use CRC32C checksum for S3 uploads.
+  // Only AWS S3 and MinIO support this; other providers (Huawei OBS, Aliyun OSS,
+  // Tencent COS, GCS S3-compat) will silently ignore the checksum header.
+  bool use_crc32c_checksum = false;
+
   // Alias for external filesystem identification (e.g., "prod", "backup")
   // Empty for default filesystem
   std::string alias = "";
@@ -237,7 +242,8 @@ struct ArrowFileSystemConfig {
        << ", ssl_ca_cert_length=" << ssl_ca_cert.size()  // only print cert length
        << ", use_iam=" << std::boolalpha << use_iam << ", use_virtual_host=" << std::boolalpha << use_virtual_host
        << ", request_timeout_ms=" << request_timeout_ms << ", max_connections=" << max_connections
-       << ", tls_min_version=" << (tls_min_version.empty() ? "(default)" : tls_min_version);
+       << ", tls_min_version=" << (tls_min_version.empty() ? "(default)" : tls_min_version)
+       << ", use_crc32c_checksum=" << std::boolalpha << use_crc32c_checksum;
     if (!alias.empty()) {
       ss << ", alias=" << alias;
     }

--- a/cpp/include/milvus-storage/filesystem/s3/s3_options.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_options.h
@@ -172,6 +172,9 @@ struct S3Options {
   /// Cloud provider name, e.g., "aws", "gcp", "azure", "aliyun", "tencent", "huawei"
   std::string cloud_provider;
 
+  /// Whether to use CRC32C checksum for S3 uploads.
+  bool use_crc32c_checksum = false;
+
   S3Options();
 
   /// Configure with the default AWS credentials provider chain.

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -97,6 +97,7 @@ struct PropertyInfo {
 #define PROPERTY_FS_LOAD_FREQUENCY "fs.load_frequency"
 #define PROPERTY_FS_TLS_MIN_VERSION "fs.tls_min_version"
 #define PROPERTY_FS_BACKGROUND_WRITES "fs.background_writes"
+#define PROPERTY_FS_USE_CRC32C_CHECKSUM "fs.use_crc32c_checksum"
 
 // --- External Filesystem Properties ---
 // External filesystems are configured with properties following the pattern:

--- a/cpp/src/ffi/properties_c.cpp
+++ b/cpp/src/ffi/properties_c.cpp
@@ -62,6 +62,7 @@ const char* loon_properties_fs_external_id = PROPERTY_FS_EXTERNAL_ID;
 const char* loon_properties_fs_load_frequency = PROPERTY_FS_LOAD_FREQUENCY;
 const char* loon_properties_fs_tls_min_version = PROPERTY_FS_TLS_MIN_VERSION;
 const char* loon_properties_fs_background_writes = PROPERTY_FS_BACKGROUND_WRITES;
+const char* loon_properties_fs_use_crc32c_checksum = PROPERTY_FS_USE_CRC32C_CHECKSUM;
 
 // --- Define Writer property keys ---
 const char* loon_properties_writer_policy = PROPERTY_WRITER_POLICY;

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -145,6 +145,8 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
   ARROW_ASSIGN_OR_RAISE(result.tls_min_version,
                         api::GetValue<std::string>(properties_map, PROPERTY_FS_TLS_MIN_VERSION));
   ARROW_ASSIGN_OR_RAISE(result.background_writes, api::GetValue<bool>(properties_map, PROPERTY_FS_BACKGROUND_WRITES));
+  ARROW_ASSIGN_OR_RAISE(result.use_crc32c_checksum,
+                        api::GetValue<bool>(properties_map, PROPERTY_FS_USE_CRC32C_CHECKSUM));
   return arrow::Status::OK();
 }
 

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -635,6 +635,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         metadata_(metadata),
         default_metadata_(options.default_metadata),
         background_writes_(options.background_writes),
+        use_crc32c_checksum_(options.use_crc32c_checksum),
         part_upload_size_(part_size),
         allow_delayed_open_(true) {}
 
@@ -680,6 +681,9 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     S3Model::CreateMultipartUploadRequest req;
     req.SetBucket(ToAwsString(path_.bucket));
     req.SetKey(ToAwsString(path_.key));
+    if (use_crc32c_checksum_) {
+      req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+    }
     ARROW_RETURN_NOT_OK(SetMetadataInRequest(&req));
 
     auto outcome = client_lock.Move()->CreateMultipartUpload(req);
@@ -977,7 +981,9 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     req.SetKey(ToAwsString(path_.key));
     req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
     req.SetContentLength(nbytes);
-    req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+    if (use_crc32c_checksum_) {
+      req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+    }
 
     if (!background_writes_) {
       req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
@@ -1148,6 +1154,9 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     // (will be needed for upload completion in Close())
     part.SetPartNumber(part_number);
     part.SetETag(result.GetETag());
+    if (!result.GetChecksumCRC32C().empty()) {
+      part.SetChecksumCRC32C(result.GetChecksumCRC32C());
+    }
     int slot = part_number - 1;
     if (state->completed_parts.size() <= static_cast<size_t>(slot)) {
       state->completed_parts.resize(slot + 1);
@@ -1163,6 +1172,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   const std::shared_ptr<const arrow::KeyValueMetadata> metadata_;
   const std::shared_ptr<const arrow::KeyValueMetadata> default_metadata_;
   const bool background_writes_;
+  const bool use_crc32c_checksum_;
   const bool allow_delayed_open_;
 
   int64_t part_upload_size_;
@@ -1291,6 +1301,9 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     req.SetBucket(ToAwsString(bucket));
     req.SetKey(ToAwsString(key));
     req.SetContentType(kAwsDirectoryContentType);
+    if (options().use_crc32c_checksum) {
+      req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+    }
     return OutcomeToStatus(std::forward_as_tuple("When creating key '", key, "' in bucket '", bucket, "': "),
                            "PutObject", client_lock.Move()->PutObject(req));
   }
@@ -1314,6 +1327,9 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     // ARROW-13048: Copy source "Must be URL-encoded" according to AWS SDK docs.
     // However at least in 1.8 and 1.9 the SDK URL-encodes the path for you
     req.SetCopySource(src_path.ToAwsString());
+    if (options().use_crc32c_checksum) {
+      req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+    }
     return OutcomeToStatus(std::forward_as_tuple("When copying key '", src_path.key, "' in bucket '", src_path.bucket,
                                                  "' to key '", dest_path.key, "' in bucket '", dest_path.bucket, "': "),
                            "CopyObject", client_lock.Move()->CopyObject(req));
@@ -1744,6 +1760,9 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       }
       req.SetBucket(ToAwsString(bucket));
       req.SetDelete(std::move(del));
+      if (options().use_crc32c_checksum) {
+        req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+      }
       ARROW_ASSIGN_OR_RAISE(
           auto fut, SubmitIO(io_context_, [holder = holder_, req = std::move(req), delete_cb]() -> arrow::Status {
             ARROW_ASSIGN_OR_RAISE(auto client_lock, holder->Lock());

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -379,6 +379,7 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
   options.multi_part_upload_size = config_.multi_part_upload_size;
   options.cloud_provider = config_.cloud_provider;
   options.background_writes = config_.background_writes;
+  options.use_crc32c_checksum = config_.use_crc32c_checksum;
 
   // Credential configuration priority:
   // 1. AssumeRole (role_arn) — AWS only

--- a/cpp/src/filesystem/s3/s3_options.cpp
+++ b/cpp/src/filesystem/s3/s3_options.cpp
@@ -265,7 +265,8 @@ bool S3Options::Equals(const S3Options& other) const {
           scheme == other.scheme && role_arn == other.role_arn && session_name == other.session_name &&
           external_id == other.external_id && load_frequency == other.load_frequency &&
           proxy_options.Equals(other.proxy_options) && credentials_kind == other.credentials_kind &&
-          background_writes == other.background_writes && allow_bucket_creation == other.allow_bucket_creation &&
+          background_writes == other.background_writes && use_crc32c_checksum == other.use_crc32c_checksum &&
+          allow_bucket_creation == other.allow_bucket_creation &&
           allow_bucket_deletion == other.allow_bucket_deletion && default_metadata_equals &&
           GetAccessKey() == other.GetAccessKey() && GetSecretKey() == other.GetSecretKey() &&
           GetSessionToken() == other.GetSessionToken());

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -462,6 +462,12 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "Only applies to S3 filesystem.",
                       true,
                       ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_USE_CRC32C_CHECKSUM,
+                      PropertyType::BOOL,
+                      "Whether to use CRC32C checksum for S3 uploads. "
+                      "Only AWS S3 and MinIO support this.",
+                      false,
+                      ValidatePropertyType()),
     // --- writer properties define ---
     REGISTER_PROPERTY(PROPERTY_WRITER_POLICY,
                       PropertyType::STRING,

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -1072,4 +1072,106 @@ TEST_F(S3FsTest, BackgroundWritesConcurrent) {
   (void)fs_->DeleteDirContents(base_dir, true);
 }
 
+// ============================================================================
+// use_crc32c_checksum cloud-env tests
+// ============================================================================
+
+TEST_F(S3FsTest, Crc32cChecksumWriteAndRead) {
+  const std::string base_dir = "/test_crc32c_checksum";
+
+  auto run_with_checksum = [&](bool use_crc32c) {
+    FilesystemCache::getInstance().clean();
+
+    api::Properties properties;
+    ASSERT_STATUS_OK(InitTestProperties(properties));
+    api::SetValue(properties, PROPERTY_FS_USE_CRC32C_CHECKSUM, use_crc32c ? "true" : "false");
+    // Use the minimum S3 part size (5MB) to trigger multipart upload with less data
+    api::SetValue(properties, PROPERTY_FS_MULTI_PART_UPLOAD_SIZE, "5242880");
+
+    ASSERT_AND_ASSIGN(auto fs, GetFileSystem(properties));
+
+    std::string dir = base_dir + (use_crc32c ? "/crc32c_on" : "/crc32c_off");
+    (void)fs->DeleteDirContents(dir, true);
+
+    // 1. CreateDir - exercises CreateEmptyDir (PutObjectRequest with CRC32C)
+    ASSERT_STATUS_OK(fs->CreateDir(dir));
+    std::string subdir = dir + "/subdir";
+    ASSERT_STATUS_OK(fs->CreateDir(subdir));
+
+    // 2. Single PutObject - small file write (PutObjectRequest via Upload template)
+    std::string path = dir + "/test_file.txt";
+    std::string content = "Hello, CRC32C checksum test!";
+    {
+      ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(path));
+      auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+      ASSERT_STATUS_OK(out->Write(buf));
+      ASSERT_STATUS_OK(out->Close());
+    }
+
+    // Read back and verify
+    {
+      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(path));
+      ASSERT_AND_ASSIGN(auto buf, input->Read(content.size()));
+      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), content);
+    }
+
+    // 3. Multipart upload - write a buffer larger than part size to trigger multipart
+    {
+      std::string mp_path = dir + "/multipart_file.bin";
+      const int64_t kTotalSize = 15LL * 1024 * 1024;  // 15MB, guarantees multiple parts
+      std::string large_content(kTotalSize, 'A');
+      // Fill with a pattern so we can verify integrity
+      for (int64_t i = 0; i < kTotalSize; ++i) {
+        large_content[i] = static_cast<char>('A' + (i % 26));
+      }
+      {
+        ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(mp_path));
+        auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(large_content.data()),
+                                                   large_content.size());
+        ASSERT_STATUS_OK(out->Write(buf));
+        ASSERT_STATUS_OK(out->Close());
+      }
+      // Read back and verify
+      {
+        ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(mp_path));
+        ASSERT_AND_ASSIGN(auto buf, input->Read(kTotalSize));
+        ASSERT_EQ(buf->size(), kTotalSize);
+        EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), large_content);
+      }
+    }
+
+    // 5. CopyObject - exercises CopyObjectRequest with CRC32C
+    std::string copy_path = dir + "/test_file_copy.txt";
+    ASSERT_STATUS_OK(fs->CopyFile(path, copy_path));
+    {
+      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(copy_path));
+      ASSERT_AND_ASSIGN(auto buf, input->Read(content.size()));
+      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), content);
+    }
+
+    // 6. DeleteDirContents - exercises DeleteObjectsRequest with CRC32C (batch delete)
+    // Create several files then batch-delete them
+    for (int i = 0; i < 3; ++i) {
+      std::string p = subdir + "/del_" + std::to_string(i) + ".txt";
+      ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(p));
+      std::string data = "delete_me_" + std::to_string(i);
+      auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+      ASSERT_STATUS_OK(out->Write(buf));
+      ASSERT_STATUS_OK(out->Close());
+    }
+    ASSERT_STATUS_OK(fs->DeleteDirContents(subdir));
+
+    // Cleanup
+    (void)fs->DeleteDirContents(dir, true);
+  };
+
+  // 1. use_crc32c_checksum = true
+  run_with_checksum(true);
+
+  // 2. use_crc32c_checksum = false
+  run_with_checksum(false);
+
+  (void)fs_->DeleteDirContents(base_dir, true);
+}
+
 }  // namespace milvus_storage


### PR DESCRIPTION
The previous CRC32C change (#441) was hardcoded and only applied to PutObject/UploadPart. That's a problem because not all cloud providers support x-amz-checksum-algorithm — only AWS S3 and MinIO do. Huawei OBS, Aliyun OSS, Tencent COS and GCS S3-compat would just silently ignore it, so it makes more sense to let callers opt in explicitly.

This adds a new fs.use_crc32c_checksum config (default false) that flows through ArrowFileSystemConfig -> S3Options -> CustomOutputStream / Impl. When enabled, CRC32C is now also set on CreateMultipartUpload, CreateEmptyDir (PutObject), CopyObject, and DeleteObjects — basically every S3 request type that supports SetChecksumAlgorithm.

Also added an integration test that exercises all four newly covered operations with checksum on and off against a real S3 endpoint.