### PR TITLE
enhance: redesign manifest I/O with ReadFrom/WriteTo and LRU cache

### DIFF
--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -100,6 +100,7 @@ _loon_column_groups_debug_string
 # Manifest interface
 _loon_manifest_destroy
 _loon_manifest_debug_string
+_loon_reset_context
 
 # ThreadPool interface
 _loon_thread_pool_singleton

--- a/cpp/include/milvus-storage/common/config.h
+++ b/cpp/include/milvus-storage/common/config.h
@@ -48,9 +48,4 @@ struct StorageConfig {
 #define LOON_COLUMN_GROUP_POLICY_SINGLE "single"
 #define LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED "schema_based"
 #define LOON_COLUMN_GROUP_POLICY_SIZE_BASED "size_based"
-
-#define TRANSACTION_HANDLER_TYPE_UNSAFE "unsafe"
-#define TRANSACTION_HANDLER_TYPE_CONDITIONAL "conditional"
-#define TRANSACTION_HANDLER_TYPE_DEFAULT TRANSACTION_HANDLER_TYPE_UNSAFE
-
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/common/layout.h
+++ b/cpp/include/milvus-storage/common/layout.h
@@ -62,6 +62,7 @@ inline const std::string kIndexPath = kIndexDir + kSep;
 std::string get_manifest_path(const std::string& base_path);
 std::string get_manifest_filename(const size_t& version);
 std::string get_manifest_filepath(const std::string& base_path, const size_t& version);
+std::string base_path_for_manifest(const std::string& manifest_path);
 
 std::string get_data_path(const std::string& base_path);
 std::string get_data_filename(const size_t& column_group_id, const std::string& format);

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -712,6 +712,17 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
 
 // ==================== End of Manifest C Interface ====================
 
+// ==================== Test-only Interface ====================
+#ifdef BUILD_GTEST
+/**
+ * @brief Reset all global context: filesystem cache, manifest cache, etc.
+ *
+ * Not intended for production use. Useful in testing to ensure
+ * test isolation when the same paths are reused across tests.
+ */
+void loon_reset_context(void);
+#endif  // BUILD_GTEST
+
 #endif  // LOON_FFI_C
 
 #ifdef __cplusplus

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -26,6 +26,8 @@
 #include <ostream>
 
 #include "milvus-storage/column_groups.h"
+#include "milvus-storage/common/lrucache.h"
+#include "milvus-storage/filesystem/fs.h"
 
 namespace milvus_storage::api {
 
@@ -78,6 +80,9 @@ struct Statistics {
   std::map<std::string, std::string> metadata;  ///< Arbitrary key-value metadata
 };
 
+class Manifest;
+using ManifestPtr = std::shared_ptr<Manifest>;
+
 /**
  * @brief Manifest class containing column groups, delta logs, and stats
  *
@@ -91,22 +96,12 @@ class Manifest final {
                     const std::vector<Index>& indexes = {},
                     uint32_t version = MANIFEST_VERSION);
 
-  // Enable move constructor and assignment operator
+  Manifest(const Manifest&);
+  Manifest& operator=(const Manifest&);
   Manifest(Manifest&&) = default;
   Manifest& operator=(Manifest&&) = default;
 
   ~Manifest() = default;
-
-  /**
-   * @brief Serializes the manifest to a standard output stream
-   */
-  [[nodiscard]] arrow::Status serialize(std::ostream& output_stream,
-                                        const std::optional<std::string>& base_path = std::nullopt) const;
-
-  /**
-   * @brief Deserializes the manifest from a standard input stream
-   */
-  arrow::Status deserialize(std::istream& input_stream, const std::optional<std::string>& base_path = std::nullopt);
 
   /**
    * @brief Get all column groups
@@ -150,23 +145,38 @@ class Manifest final {
    */
   [[nodiscard]] int32_t version() const { return version_; }
 
-  private:
-  Manifest(const Manifest&);
-  Manifest& operator=(const Manifest&);
+  /**
+   * @brief Read a manifest from filesystem, using cache for immutable manifests.
+   * @param fs Arrow filesystem (must be FileSystemProxy wrapping SubTreeFileSystem)
+   * @param path Path to the manifest file (relative to fs root)
+   * @return Shared pointer to the deserialized manifest
+   */
+  static arrow::Result<std::shared_ptr<Manifest>> ReadFrom(const milvus_storage::ArrowFileSystemPtr& fs,
+                                                           const std::string& path);
 
   /**
-   * @brief Deserialize legacy MILV format (v1-v3)
+   * @brief Write a manifest to filesystem. Always uses conditional write (fails if file exists).
+   * @param fs Arrow filesystem (must be FileSystemProxy wrapping SubTreeFileSystem)
+   * @param path Path to write the manifest file
+   * @param manifest Manifest to write
+   * @return Status (AlreadyExists if file already exists)
    */
+  static arrow::Status WriteTo(const milvus_storage::ArrowFileSystemPtr& fs,
+                               const std::string& path,
+                               const Manifest& manifest);
+
+  /**
+   * @brief Clean the manifest cache
+   */
+  static void CleanCache();
+
+  private:
+  [[nodiscard]] arrow::Status serialize(std::ostream& output_stream) const;
+  arrow::Status deserialize(std::istream& input_stream);
+
   void deserializeLegacy(std::istream& input_stream);
 
-  /**
-   * @brief Copy the manifest and convert paths to relative
-   */
-  Manifest ToRelativePaths(const std::string& base_path) const;
-
-  /**
-   * @brief Convert paths to absolute
-   */
+  [[nodiscard]] Manifest toRelativePaths(const std::string& base_path) const;
   void ToAbsolutePaths(const std::string& base_path);
 
   private:
@@ -175,8 +185,8 @@ class Manifest final {
   std::vector<DeltaLog> delta_logs_;         ///< Delta log entries
   std::map<std::string, Statistics> stats_;  ///< Stats entries keyed by stat name
   std::vector<Index> indexes_;               ///< Index entries for columns
-};
 
-using ManifestPtr = std::shared_ptr<Manifest>;
+  static milvus_storage::LRUCache<std::string, std::shared_ptr<Manifest>>& getCache();
+};
 
 }  // namespace milvus_storage::api

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -16,7 +16,6 @@
 
 #include <cstdint>
 #include <string>
-#include <string_view>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -24,7 +23,6 @@
 
 #include <arrow/status.h>
 
-#include "milvus-storage/properties.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/manifest.h"
 
@@ -230,21 +228,6 @@ class Transaction {
   arrow::Result<std::shared_ptr<Manifest>> read_manifest(int64_t version);
 
   arrow::Status write_manifest(const std::shared_ptr<Manifest>& manifest, int64_t old_version, int64_t new_version);
-
-  // Write manifest file, dispatches to conditional_write or unsafe_write
-  static arrow::Status write_manifest_file(const std::shared_ptr<arrow::fs::FileSystem>& fs,
-                                           const std::string& path,
-                                           std::string_view data);
-
-  // Atomic write via UploadConditional (e.g. S3 conditional put)
-  static arrow::Status conditional_write(const std::shared_ptr<UploadConditional>& fs,
-                                         const std::string& path,
-                                         std::string_view data);
-
-  // Non-atomic write with per-file mutex for same-process safety
-  static arrow::Status unsafe_write(const std::shared_ptr<arrow::fs::FileSystem>& fs,
-                                    const std::string& path,
-                                    std::string_view data);
 
   int64_t read_version_;
   std::shared_ptr<Manifest> read_manifest_;

--- a/cpp/src/common/layout.cpp
+++ b/cpp/src/common/layout.cpp
@@ -42,6 +42,13 @@ std::string get_manifest_filepath(const std::string& base_path, const size_t& ve
   return (manifest_path / get_manifest_filename(version)).lexically_normal().string();
 }
 
+std::string base_path_for_manifest(const std::string& manifest_path) {
+  // Manifest path format: {base_path}/_metadata/manifest-{version}.avro
+  // Strip the filename and the _metadata directory to get base_path.
+  std::filesystem::path p(manifest_path);
+  return p.parent_path().parent_path().string();
+}
+
 std::string get_data_path(const std::string& base_path) {
   std::filesystem::path path(base_path);
   return (path / kDataPath).lexically_normal().string();

--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -17,13 +17,10 @@
 
 #include <cstring>
 #include <optional>
-#include <sstream>
 
 #include <parquet/arrow/reader.h>
 #include <arrow/c/bridge.h>
 #include <arrow/type_fwd.h>
-#include <avro/Stream.hh>
-#include <avro/Decoder.hh>
 
 #include "milvus-storage/common/path_util.h"  // for kSep
 #include "milvus-storage/common/layout.h"
@@ -184,13 +181,6 @@ LoonFFIResult loon_exttable_explore(const char** columns,
       files = cg_files_result.ValueOrDie();
     }
 
-    // create origin filesystem (always needed for Transaction commit)
-    auto fs_res = milvus_storage::FilesystemCache::getInstance().get(properties_map);
-    if (!fs_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_res.status().ToString());
-    }
-    auto fs = fs_res.ValueOrDie();
-
     std::vector<std::string> columns_cpp;
     for (size_t i = 0; i < col_lens; i++) {
       columns_cpp.emplace_back(columns[i]);
@@ -201,8 +191,12 @@ LoonFFIResult loon_exttable_explore(const char** columns,
     cgs.push_back(std::make_shared<ColumnGroup>(
         ColumnGroup{.columns = columns_cpp, .format = std::string(format), .files = files}));
 
-    // commit the column groups with origin filesystem
-    auto transaction_result = Transaction::Open(fs, base_path);
+    // commit the column groups
+    auto fs_result = milvus_storage::FilesystemCache::getInstance().get(properties_map);
+    if (!fs_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+    }
+    auto transaction_result = Transaction::Open(fs_result.ValueOrDie(), base_path);
     if (!transaction_result.ok()) {
       RETURN_ERROR(LOON_LOGICAL_ERROR, transaction_result.status().ToString());
     }
@@ -323,26 +317,7 @@ static arrow::Result<std::shared_ptr<milvus_storage::api::Manifest>> read_manife
   }
 
   ARROW_ASSIGN_OR_RAISE(auto fs, milvus_storage::FilesystemCache::getInstance().get(properties_map, path));
-
-  // Open input file and get size
-  ARROW_ASSIGN_OR_RAISE(auto input_file, fs->OpenInputFile(path));
-  ARROW_ASSIGN_OR_RAISE(int64_t file_size, input_file->GetSize());
-  ARROW_ASSIGN_OR_RAISE(auto column_groups_buffer, input_file->Read(file_size));
-
-  // Ensure we read the expected size
-  if (column_groups_buffer->size() != file_size) {
-    return arrow::Status::IOError(fmt::format("Failed to read the complete file, expected size ={}, actual size ={}",
-                                              file_size,  // NOLINT
-                                              static_cast<int64_t>(column_groups_buffer->size())));
-  }
-  ARROW_RETURN_NOT_OK(input_file->Close());
-
-  // Read as Manifest
-  auto manifest = std::make_shared<milvus_storage::api::Manifest>();
-  std::string manifest_data(reinterpret_cast<const char*>(column_groups_buffer->data()), column_groups_buffer->size());
-  std::istringstream in(manifest_data);
-  ARROW_RETURN_NOT_OK(manifest->deserialize(in));
-  return manifest;
+  return milvus_storage::api::Manifest::ReadFrom(fs, path);
 }
 
 LoonFFIResult loon_exttable_read_manifest(const char* manifest_file_path,

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -23,7 +23,6 @@
 #include "milvus-storage/ffi_internal/bridge.h"
 #include "milvus-storage/manifest.h"
 #include "milvus-storage/transaction/transaction.h"
-#include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/filesystem/fs.h"
 
 // Forward declaration
@@ -48,13 +47,6 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
       RETURN_ERROR(LOON_INVALID_PROPERTIES, "Failed to parse properties [", opt->c_str(), "]");
     }
 
-    // Get filesystem from properties
-    auto fs_result = milvus_storage::FilesystemCache::getInstance().get(properties_map);
-    if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
-    }
-    auto fs = fs_result.ValueOrDie();
-
     // Select resolver based on resolve_id
     Resolver resolver;
     switch (resolve_id) {
@@ -70,8 +62,12 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
         break;
     }
 
-    // Open transaction (automatically begun)
-    auto transaction_result = Transaction::Open(fs, base_path, read_version, resolver, retry_limit);
+    // Open transaction
+    auto fs_result = milvus_storage::FilesystemCache::getInstance().get(properties_map);
+    if (!fs_result.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+    }
+    auto transaction_result = Transaction::Open(fs_result.ValueOrDie(), base_path, read_version, resolver, retry_limit);
     if (!transaction_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, transaction_result.status().ToString());
     }
@@ -359,3 +355,10 @@ char* loon_manifest_debug_string(const LoonManifest* manifest) {
   std::string result = milvus_storage::manifest_debug_string(manifest);
   return strdup(result.c_str());
 }
+
+#ifdef BUILD_GTEST
+void loon_reset_context(void) {
+  milvus_storage::api::Manifest::CleanCache();
+  milvus_storage::FilesystemCache::getInstance().clean();
+}
+#endif

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -15,7 +15,6 @@
 #include "milvus-storage/manifest.h"
 
 #include <sstream>
-#include <algorithm>
 #include <cstring>
 #include <filesystem>
 
@@ -31,7 +30,9 @@
 
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/layout.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/upload_conditional.h"
 
 // Specialize codec_traits for custom types in the avro namespace
 namespace avro {
@@ -281,13 +282,8 @@ Manifest& Manifest::operator=(const Manifest& other) {
   return *this;
 }
 
-arrow::Status Manifest::serialize(std::ostream& output_stream, const std::optional<std::string>& base_path) const {
+arrow::Status Manifest::serialize(std::ostream& output_stream) const {
   try {
-    if (base_path.has_value()) {
-      Manifest normalized_manifest = ToRelativePaths(base_path.value());
-      return normalized_manifest.serialize(output_stream, std::nullopt);
-    }
-
     auto avro_output = avro::ostreamOutputStream(output_stream);
     avro::DataFileWriter<Manifest> writer(std::move(avro_output), getManifestSchema());
     writer.write(*this);
@@ -295,17 +291,16 @@ arrow::Status Manifest::serialize(std::ostream& output_stream, const std::option
 
     return arrow::Status::OK();
   } catch (const avro::Exception& e) {
-    return arrow::Status::Invalid(fmt::format("Failed to serialize Manifest: {}, base path: {}",
-                                              e.what(),  // NOLINT
-                                              base_path.value_or("no exist")));
+    return arrow::Status::Invalid(fmt::format("Failed to serialize Manifest: {}", e.what()));  // NOLINT
   } catch (const std::exception& e) {
-    return arrow::Status::Invalid(fmt::format("Failed to serialize Manifest (std::exception): {}, base path: {}",
-                                              e.what(),  // NOLINT
-                                              base_path.value_or("no exist")));
+    return arrow::Status::Invalid(
+        fmt::format("Failed to serialize Manifest (std::exception): {}", e.what()));  // NOLINT
+  } catch (...) {
+    return arrow::Status::Invalid("Failed to serialize Manifest: unknown error");
   }
 }
 
-arrow::Status Manifest::deserialize(std::istream& input_stream, const std::optional<std::string>& base_path) {
+arrow::Status Manifest::deserialize(std::istream& input_stream) {
   auto error = [this](const std::string& msg) {
     column_groups_.clear();
     delta_logs_.clear();
@@ -319,8 +314,7 @@ arrow::Status Manifest::deserialize(std::istream& input_stream, const std::optio
     char header[4] = {};
     input_stream.read(header, 4);
     if (!input_stream || input_stream.gcount() < 4) {
-      return error(fmt::format("Cannot deserialize Manifest: stream is empty or too short, base path: {}",
-                               base_path.value_or("no exist")));
+      return error("Cannot deserialize Manifest: stream is empty or too short");
     }
     input_stream.clear();
     input_stream.seekg(0);
@@ -330,31 +324,20 @@ arrow::Status Manifest::deserialize(std::istream& input_stream, const std::optio
       auto avro_input = avro::istreamInputStream(input_stream);
       avro::DataFileReader<Manifest> reader(std::move(avro_input), getManifestSchema());
       if (!reader.read(*this)) {
-        return error(fmt::format("Failed to deserialize Manifest: no record in Avro file, base path: {}",
-                                 base_path.value_or("no exist")));
+        return error("Failed to deserialize Manifest: no record in Avro file");
       }
       version_ = MANIFEST_VERSION;
     } else {
       deserializeLegacy(input_stream);
     }
 
-    if (base_path.has_value()) {
-      ToAbsolutePaths(base_path.value());
-    }
-
     return arrow::Status::OK();
   } catch (const avro::Exception& e) {
-    return error(fmt::format("Failed to deserialize Manifest: {}, base path: {}",
-                             e.what(),  // NOLINT
-                             base_path.value_or("no exist")));
+    return error(fmt::format("Failed to deserialize Manifest: {}", e.what()));  // NOLINT
   } catch (const std::exception& e) {
-    return error(fmt::format("Failed to deserialize Manifest: {}, base path: {}",
-                             e.what(),  // NOLINT
-                             base_path.value_or("no exist")));
+    return error(fmt::format("Failed to deserialize Manifest: {}", e.what()));  // NOLINT
   } catch (...) {
-    return error(
-        fmt::format("Failed to deserialize Manifest: unknown error (possibly invalid or empty stream), base path: {}",
-                    base_path.value_or("no exist")));
+    return error("Failed to deserialize Manifest: unknown error (possibly invalid or empty stream)");
   }
 }
 
@@ -416,7 +399,7 @@ const Index* Manifest::getIndex(const std::string& column_name, const std::strin
   return nullptr;
 }
 
-Manifest Manifest::ToRelativePaths(const std::string& base_path) const {
+Manifest Manifest::toRelativePaths(const std::string& base_path) const {
   Manifest copy_manifest(*this);
 
   for (auto& column_group : copy_manifest.column_groups_) {
@@ -468,6 +451,130 @@ void Manifest::ToAbsolutePaths(const std::string& base_path) {
   for (auto& idx : indexes_) {
     idx.path = ToAbsolute(idx.path, std::optional<std::string>(base_path), milvus_storage::kIndexPath);
   }
+}
+
+// Manifest files are small (~KB) and immutable once written, so caching
+// up to 1024 entries keeps hot-path reads fast without significant memory.
+static constexpr size_t kManifestCacheCapacity = 1024;
+
+// Static cache accessor
+LRUCache<std::string, std::shared_ptr<Manifest>>& Manifest::getCache() {
+  static milvus_storage::LRUCache<std::string, std::shared_ptr<Manifest>> cache(kManifestCacheCapacity);
+  return cache;
+}
+
+void Manifest::CleanCache() { getCache().clean(); }
+
+// Build a globally unique cache key from the filesystem's root path and the file path.
+// All our filesystems are SubTreeFileSystem (via FileSystemProxy), so base_path() gives
+// the root (local absolute path, or S3 bucket name, etc.).
+static std::string MakeCacheKey(const milvus_storage::ArrowFileSystemPtr& fs, const std::string& path) {
+  auto* subtree = dynamic_cast<arrow::fs::SubTreeFileSystem*>(fs.get());
+  if (subtree) {
+    return subtree->base_path() + "/" + path;
+  }
+  // Fallback for non-SubTreeFileSystem (shouldn't happen in practice)
+  return fs->type_name() + "://" + path;
+}
+
+arrow::Result<std::shared_ptr<Manifest>> Manifest::ReadFrom(const milvus_storage::ArrowFileSystemPtr& fs,
+                                                            const std::string& path) {
+  std::string cache_key = MakeCacheKey(fs, path);
+
+  auto& cache = getCache();
+  auto cached = cache.get(cache_key);
+  if (cached.has_value()) {
+    return std::move(cached.value());
+  }
+
+  // Read file into string (single allocation, avro needs std::istream)
+  ARROW_ASSIGN_OR_RAISE(auto input_file, fs->OpenInputFile(path));
+  ARROW_ASSIGN_OR_RAISE(auto file_size, input_file->GetSize());
+  std::string data(file_size, '\0');
+  ARROW_ASSIGN_OR_RAISE(auto bytes_read, input_file->Read(file_size, data.data()));
+  if (bytes_read != file_size) {
+    return arrow::Status::IOError(
+        fmt::format("Failed to read the complete file, expected size={}, actual size={}", file_size, bytes_read));
+  }
+  ARROW_RETURN_NOT_OK(input_file->Close());
+  std::istringstream in(data);
+
+  auto manifest = std::make_shared<Manifest>();
+  ARROW_RETURN_NOT_OK(manifest->deserialize(in));
+
+  std::string base_path = milvus_storage::base_path_for_manifest(path);
+  manifest->ToAbsolutePaths(base_path);
+
+  cache.put(cache_key, manifest);
+  return manifest;
+}
+
+static bool IsConditionalWriteConflict(const arrow::Status& status) {
+  if (!status.IsIOError()) {
+    return false;
+  }
+  auto detail = milvus_storage::ExtendStatusDetail::UnwrapStatus(status);
+  if (!detail) {
+    return false;
+  }
+  return detail->code() == milvus_storage::ExtendStatusCode::AwsErrorPreConditionFailed ||
+         detail->code() == milvus_storage::ExtendStatusCode::AwsErrorConflict;
+}
+
+arrow::Status Manifest::WriteTo(const milvus_storage::ArrowFileSystemPtr& fs,
+                                const std::string& path,
+                                const Manifest& manifest) {
+  std::string base_path = milvus_storage::base_path_for_manifest(path);
+
+  // Convert to relative paths and serialize
+  Manifest relative_manifest = manifest.toRelativePaths(base_path);
+  std::ostringstream oss;
+  ARROW_RETURN_NOT_OK(relative_manifest.serialize(oss));
+  std::string data = oss.str();
+
+  // Local filesystem needs parent directory created upfront
+  if (milvus_storage::IsLocalFileSystem(fs)) {
+    auto [parent, _] = milvus_storage::GetAbstractPathParent(path);
+    if (!parent.empty()) {
+      ARROW_RETURN_NOT_OK(fs->CreateDir(parent));
+    }
+  }
+
+  // Try conditional write first if filesystem supports it
+  auto conditional_fs = std::dynamic_pointer_cast<milvus_storage::UploadConditional>(fs);
+  if (conditional_fs) {
+    auto res = conditional_fs->OpenConditionalOutputStream(path, nullptr);
+    if (res.ok()) {
+      auto output_stream = std::move(res).ValueUnsafe();
+      ARROW_RETURN_NOT_OK(output_stream->Write(data.data(), data.size()));
+      auto close_status = output_stream->Close();
+      if (!close_status.ok()) {
+        if (IsConditionalWriteConflict(close_status)) {
+          return arrow::Status::AlreadyExists("File already exists: ", path);
+        }
+        return close_status;
+      }
+      return arrow::Status::OK();
+    }
+    if (IsConditionalWriteConflict(res.status())) {
+      return arrow::Status::AlreadyExists("File already exists: ", path);
+    }
+    // NotImplemented means the underlying fs has no conditional write support;
+    // fall through to the plain write path below.
+    if (!res.status().IsNotImplemented()) {
+      return res.status();
+    }
+  }
+
+  // Fall back: check existence then write
+  ARROW_ASSIGN_OR_RAISE(auto file_info, fs->GetFileInfo(path));
+  if (file_info.type() != arrow::fs::FileType::NotFound) {
+    return arrow::Status::AlreadyExists("File already exists: ", path);
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto output_stream, fs->OpenOutputStream(path));
+  ARROW_RETURN_NOT_OK(output_stream->Write(data.data(), data.size()));
+  return output_stream->Close();
 }
 
 }  // namespace milvus_storage::api

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -16,27 +16,13 @@
 
 #include <cassert>
 #include <charconv>
-#include <string_view>
-#include <sstream>
-#include <mutex>
-#include <unordered_map>
 #include <set>
 #include <fmt/format.h>
 
 #include <arrow/status.h>
 #include <arrow/result.h>
-#include <arrow/buffer.h>
 #include <arrow/util/logging.h>
-#include <arrow/filesystem/filesystem.h>
-#include <avro/Encoder.hh>
-#include <avro/Decoder.hh>
 
-#include <avro/Stream.hh>
-
-#include "milvus-storage/filesystem/fs.h"
-#include "milvus-storage/filesystem/upload_conditional.h"
-#include "milvus-storage/common/extend_status.h"
-#include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/layout.h"
 #include "milvus-storage/common/config.h"
@@ -84,43 +70,39 @@ const std::vector<std::pair<std::string, std::string>>& Updates::GetDroppedIndex
 
 arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Manifest>& manifest,
                                                       const Updates& updates) {
-  // Get base manifest attributes
-  const auto& base_column_groups = manifest->columnGroups();
-  const auto& base_delta_logs = manifest->deltaLogs();
-  const auto& base_stats = manifest->stats();
-  const auto& base_indexes = manifest->indexes();
+  // Deep copy the entire manifest to avoid mutating the (potentially cached) original
+  auto base = std::make_shared<Manifest>(*manifest);
+
+  auto& cgs = base->columnGroups();
+  auto& delta_logs = base->deltaLogs();
+  auto& stats = base->stats();
+  auto& indexes = base->indexes();
 
   // Validate: Check if adding column groups has existing column names
-  // Also need check current column groups is align
   for (const auto& new_cg : updates.GetAddedColumnGroups()) {
     if (!new_cg) {
       return arrow::Status::Invalid("Cannot add null column group");
     }
     for (const auto& column_name : new_cg->columns) {
-      auto existing_cg = manifest->getColumnGroup(column_name);
-      if (existing_cg != nullptr) {
+      if (base->getColumnGroup(column_name) != nullptr) {
         return arrow::Status::Invalid(fmt::format("Column '{}' already exists in existing column groups", column_name));
       }
     }
 
     // Check column group number of rows aligned
     size_t origin_group_rows = 0;
-    if (!base_column_groups.empty()) {
-      const auto& base0_files = base_column_groups[0]->files;
-
-      for (const auto& base_file : base0_files) {
-        origin_group_rows += base_file.end_index - base_file.start_index;
+    if (!cgs.empty()) {
+      for (const auto& f : cgs[0]->files) {
+        origin_group_rows += f.end_index - f.start_index;
       }
     }
 
     size_t new_group_rows = 0;
-    if (!new_cg->files.empty()) {
-      for (const auto& new_file : new_cg->files) {
-        new_group_rows += new_file.end_index - new_file.start_index;
-      }
+    for (const auto& f : new_cg->files) {
+      new_group_rows += f.end_index - f.start_index;
     }
 
-    if (!base_column_groups.empty() && origin_group_rows != new_group_rows) {
+    if (!cgs.empty() && origin_group_rows != new_group_rows) {
       return arrow::Status::Invalid(fmt::format(
           "Column group size mismatch: existing(column group 0) has {} rows, but appended column group has {} rows",
           origin_group_rows, new_group_rows));
@@ -129,39 +111,28 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
 
   // Validate: Check if appending files are aligned with existing column groups
   for (const auto& new_cgs : updates.GetAppendedFiles()) {
-    // Check size alignment
-    if (!base_column_groups.empty() && base_column_groups.size() != new_cgs.size()) {
+    if (!cgs.empty() && cgs.size() != new_cgs.size()) {
       return arrow::Status::Invalid(
-          fmt::format("Column group size mismatch: existing has {} groups, but appended has {} groups",
-                      base_column_groups.size(), new_cgs.size()));
+          fmt::format("Column group size mismatch: existing has {} groups, but appended has {} groups", cgs.size(),
+                      new_cgs.size()));
     }
 
-    // Check each column group alignment
-    for (size_t i = 0; i < base_column_groups.size() && i < new_cgs.size(); ++i) {
-      const auto& base_cg = base_column_groups[i];
-      const auto& new_cg = new_cgs[i];
-
-      if (!base_cg || !new_cg) {
+    for (size_t i = 0; i < cgs.size() && i < new_cgs.size(); ++i) {
+      if (!cgs[i] || !new_cgs[i]) {
         return arrow::Status::Invalid(fmt::format("Null column group at index {}", i));
       }
-
-      // Check column count
-      if (base_cg->columns.size() != new_cg->columns.size()) {
+      if (cgs[i]->columns.size() != new_cgs[i]->columns.size()) {
         return arrow::Status::Invalid(
             fmt::format("Column count mismatch at index {}: existing has {} columns, but appended has {} columns", i,
-                        base_cg->columns.size(), new_cg->columns.size()));
+                        cgs[i]->columns.size(), new_cgs[i]->columns.size()));
       }
-
-      // Check format
-      if (base_cg->format != new_cg->format) {
+      if (cgs[i]->format != new_cgs[i]->format) {
         return arrow::Status::Invalid(
             fmt::format("Format mismatch at index {}: existing format is '{}', but appended format is '{}'", i,
-                        base_cg->format, new_cg->format));
+                        cgs[i]->format, new_cgs[i]->format));
       }
-
-      // Check columns match
-      std::set<std::string> base_cols(base_cg->columns.begin(), base_cg->columns.end());
-      std::set<std::string> new_cols(new_cg->columns.begin(), new_cg->columns.end());
+      std::set<std::string> base_cols(cgs[i]->columns.begin(), cgs[i]->columns.end());
+      std::set<std::string> new_cols(new_cgs[i]->columns.begin(), new_cgs[i]->columns.end());
       if (base_cols != new_cols) {
         return arrow::Status::Invalid(fmt::format("Column mismatch at index {}: columns do not match", i));
       }
@@ -169,7 +140,6 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
   }
 
   // Collect columns affected by AppendFiles (for index deprecation)
-  // Only columns with actual files appended are affected
   std::set<std::string> affected_columns;
   for (const auto& new_cgs : updates.GetAppendedFiles()) {
     for (const auto& cg : new_cgs) {
@@ -181,82 +151,61 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
     }
   }
 
-  // Prepare indexes: copy from base, excluding those on affected columns
-  std::vector<Index> resolved_indexes;
-  for (const auto& idx : base_indexes) {
-    if (affected_columns.find(idx.column_name) == affected_columns.end()) {
-      resolved_indexes.push_back(idx);
-    }
-    // else: silently drop - column data changed
+  // Resolve indexes: drop affected, apply DropIndex, apply AddIndex
+  indexes.erase(std::remove_if(
+                    indexes.begin(), indexes.end(),
+                    [&](const Index& idx) { return affected_columns.find(idx.column_name) != affected_columns.end(); }),
+                indexes.end());
+
+  for (const auto& dropped : updates.GetDroppedIndexes()) {
+    const auto& col = dropped.first;
+    const auto& type = dropped.second;
+    indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
+                                 [&](const Index& idx) { return idx.column_name == col && idx.index_type == type; }),
+                  indexes.end());
   }
 
-  // Apply explicit DropIndex
-  for (const auto& [col, type] : updates.GetDroppedIndexes()) {
-    const auto& drop_col = col;
-    const auto& drop_type = type;
-    resolved_indexes.erase(
-        std::remove_if(resolved_indexes.begin(), resolved_indexes.end(),
-                       [&](const Index& idx) { return idx.column_name == drop_col && idx.index_type == drop_type; }),
-        resolved_indexes.end());
-  }
-
-  // Apply AddIndex (add or replace)
   for (const auto& new_idx : updates.GetAddedIndexes()) {
-    // Remove existing index with same key if present
-    resolved_indexes.erase(std::remove_if(resolved_indexes.begin(), resolved_indexes.end(),
-                                          [&](const Index& idx) {
-                                            return idx.column_name == new_idx.column_name &&
-                                                   idx.index_type == new_idx.index_type;
-                                          }),
-                           resolved_indexes.end());
-    resolved_indexes.push_back(new_idx);
+    indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
+                                 [&](const Index& idx) {
+                                   return idx.column_name == new_idx.column_name &&
+                                          idx.index_type == new_idx.index_type;
+                                 }),
+                  indexes.end());
+    indexes.push_back(new_idx);
   }
 
-  // Prepare delta logs (copy from base + add new ones)
-  std::vector<DeltaLog> resolved_delta_logs = base_delta_logs;
-  for (const auto& delta_log : updates.GetAddedDeltaLogs()) {
-    resolved_delta_logs.push_back(delta_log);
+  // Apply delta logs
+  for (const auto& dl : updates.GetAddedDeltaLogs()) {
+    delta_logs.push_back(dl);
   }
 
-  // Prepare stats (copy from base + merge new ones, new values override)
-  std::map<std::string, Statistics> resolved_stats = base_stats;
+  // Apply stats (new values override)
   for (const auto& [key, stat] : updates.GetAddedStats()) {
-    resolved_stats[key] = stat;  // Override existing or add new
+    stats[key] = stat;
   }
 
-  // Create a copy of column groups to apply updates
-  ColumnGroups resolved_column_groups = base_column_groups;
-
-  // Apply updates: append files (merge files into existing column groups)
+  // Apply append files
   for (const auto& new_cgs : updates.GetAppendedFiles()) {
-    if (resolved_column_groups.empty()) {
-      // If no existing column groups, directly assign
-      resolved_column_groups = new_cgs;
+    if (cgs.empty()) {
+      cgs = new_cgs;
     } else {
-      // Merge files into existing column groups
-      for (size_t i = 0; i < resolved_column_groups.size() && i < new_cgs.size(); ++i) {
-        auto& base_cg = resolved_column_groups[i];
-        const auto& new_cg = new_cgs[i];
-        if (base_cg && new_cg) {
-          // Append files from new_cg to base_cg
-          for (const auto& file : new_cg->files) {
-            base_cg->files.push_back(file);
+      for (size_t i = 0; i < cgs.size() && i < new_cgs.size(); ++i) {
+        if (cgs[i] && new_cgs[i]) {
+          for (const auto& file : new_cgs[i]->files) {
+            cgs[i]->files.push_back(file);
           }
         }
       }
     }
   }
 
-  // Apply updates: add column groups
+  // Apply add column groups
   for (const auto& cg : updates.GetAddedColumnGroups()) {
-    resolved_column_groups.push_back(cg);
+    cgs.push_back(cg);
   }
 
-  // Create resolved manifest using the copy constructor with all attributes
-  auto resolved = std::make_shared<Manifest>(std::move(resolved_column_groups), resolved_delta_logs, resolved_stats,
-                                             resolved_indexes);
-
-  return resolved;
+  return base;
 }
 
 // ==================== Helper Resolver Functions ====================
@@ -293,141 +242,6 @@ Resolver FailResolver = [](const std::shared_ptr<Manifest>& /*read_manifest*/,
 };
 
 // ==================== Transaction Implementation ====================
-
-// Check if an IOError status indicates a conditional write conflict (file already exists).
-static bool IsConditionalWriteConflict(const arrow::Status& status) {
-  if (!status.IsIOError()) {
-    return false;
-  }
-  auto detail = milvus_storage::ExtendStatusDetail::UnwrapStatus(status);
-  if (!detail) {
-    return false;
-  }
-  return detail->code() == milvus_storage::ExtendStatusCode::AwsErrorPreConditionFailed ||
-         detail->code() == milvus_storage::ExtendStatusCode::AwsErrorConflict;
-}
-
-arrow::Status Transaction::conditional_write(const std::shared_ptr<UploadConditional>& fs,
-                                             const std::string& path,
-                                             std::string_view data) {
-  auto open_result = fs->OpenConditionalOutputStream(path, nullptr);
-  if (!open_result.ok()) {
-    if (IsConditionalWriteConflict(open_result.status())) {
-      return arrow::Status::AlreadyExists("File already exists: ", path);
-    }
-    return open_result.status();
-  }
-  auto output_stream = std::move(open_result).ValueUnsafe();
-  ARROW_RETURN_NOT_OK(output_stream->Write(data.data(), data.size()));
-  auto close_status = output_stream->Close();
-  if (!close_status.ok()) {
-    if (IsConditionalWriteConflict(close_status)) {
-      return arrow::Status::AlreadyExists("File already exists: ", path);
-    }
-    return close_status;
-  }
-  return arrow::Status::OK();
-}
-
-// Per-file mutex with reference counting to avoid unbounded map growth.
-struct RefCountedMutex {
-  std::mutex mtx;
-  int ref_count = 0;
-};
-
-static std::mutex file_mutex_map_mutex;
-static std::unordered_map<std::string, std::unique_ptr<RefCountedMutex>> file_mutex_map;
-
-static std::mutex& acquire_file_mutex(const std::string& path) {
-  std::scoped_lock lock(file_mutex_map_mutex);
-  auto& m = file_mutex_map[path];
-  if (!m) {
-    m = std::make_unique<RefCountedMutex>();
-  }
-  m->ref_count++;
-  return m->mtx;
-}
-
-static void release_file_mutex(const std::string& path) {
-  std::scoped_lock lock(file_mutex_map_mutex);
-  auto it = file_mutex_map.find(path);
-  if (it != file_mutex_map.end() && --it->second->ref_count == 0) {
-    file_mutex_map.erase(it);
-  }
-}
-
-// RAII guard: acquires the per-file mutex and releases the ref count on destruction.
-class FileMutexGuard {
-  public:
-  explicit FileMutexGuard(const std::string& path) : path_(path), lock_(acquire_file_mutex(path)) {}
-  ~FileMutexGuard() {
-    lock_.unlock();
-    lock_.release();
-    release_file_mutex(path_);
-  }
-  FileMutexGuard(const FileMutexGuard&) = delete;
-  FileMutexGuard& operator=(const FileMutexGuard&) = delete;
-
-  private:
-  std::string path_;
-  std::unique_lock<std::mutex> lock_;
-};
-
-arrow::Status Transaction::unsafe_write(const std::shared_ptr<arrow::fs::FileSystem>& fs,
-                                        const std::string& path,
-                                        std::string_view data) {
-  FileMutexGuard guard(path);
-
-  ARROW_ASSIGN_OR_RAISE(auto file_info, fs->GetFileInfo(path));
-  if (file_info.type() != arrow::fs::FileType::NotFound) {
-    return arrow::Status::AlreadyExists("File already exists: ", path);
-  }
-
-  ARROW_ASSIGN_OR_RAISE(auto output_stream, fs->OpenOutputStream(path));
-  ARROW_RETURN_NOT_OK(output_stream->Write(data.data(), data.size()));
-  ARROW_RETURN_NOT_OK(output_stream->Close());
-
-  return arrow::Status::OK();
-}
-
-arrow::Status Transaction::write_manifest_file(const std::shared_ptr<arrow::fs::FileSystem>& fs,
-                                               const std::string& path,
-                                               std::string_view data) {
-  // Local filesystem may not have the parent directory yet
-  if (IsLocalFileSystem(fs)) {
-    auto [parent, _] = milvus_storage::GetAbstractPathParent(path);
-    if (!parent.empty()) {
-      ARROW_RETURN_NOT_OK(fs->CreateDir(parent));
-    }
-  }
-
-  auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs);
-  if (conditional_fs) {
-    return conditional_write(conditional_fs, path, data);
-  }
-  return unsafe_write(fs, path, data);
-}
-
-arrow::Result<std::shared_ptr<arrow::Buffer>> direct_read(const std::shared_ptr<arrow::fs::FileSystem>& fs,
-                                                          const std::string& path) {
-  std::shared_ptr<arrow::Buffer> buffer;
-  // Open input file and get size
-  ARROW_ASSIGN_OR_RAISE(auto input_file, fs->OpenInputFile(path));
-  ARROW_ASSIGN_OR_RAISE(int64_t file_size, input_file->GetSize());
-
-  // Read into an Arrow Buffer (makes memory management automatic)
-  ARROW_ASSIGN_OR_RAISE(buffer, input_file->Read(file_size));
-
-  // Ensure we read the expected size
-  if (buffer->size() != file_size) {
-    return arrow::Status::IOError(fmt::format("Failed to read the complete file, expected size ={}, actual size ={}",
-                                              file_size,                               // NOLINT
-                                              static_cast<int64_t>(buffer->size())));  // NOLINT
-  }
-
-  ARROW_RETURN_NOT_OK(input_file->Close());
-  return buffer;
-}
 
 arrow::Result<std::unique_ptr<Transaction>> Transaction::Open(const milvus_storage::ArrowFileSystemPtr& fs,
                                                               const std::string& base_path,
@@ -576,18 +390,13 @@ arrow::Result<std::shared_ptr<Manifest>> Transaction::read_manifest(int64_t vers
   FIU_RETURN_ON(FIUKEY_MANIFEST_READ_FAIL,
                 arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_READ_FAIL)));
 
-  auto manifest = std::make_shared<Manifest>();
   // If version is 0 or less, return empty manifest (no manifests exist yet)
   if (version <= 0) {
-    return manifest;
+    return std::make_shared<Manifest>();
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto manifest_buffer, direct_read(fs_, get_manifest_filepath(base_path_, version)));
-  std::string manifest_data(reinterpret_cast<const char*>(manifest_buffer->data()), manifest_buffer->size());
-  std::istringstream in(manifest_data);
-  ARROW_RETURN_NOT_OK(manifest->deserialize(in, base_path_));
-
-  return manifest;
+  auto path = get_manifest_filepath(base_path_, version);
+  return Manifest::ReadFrom(fs_, path);
 }
 
 Transaction& Transaction::AddColumnGroup(const std::shared_ptr<ColumnGroup>& cg) {
@@ -621,20 +430,20 @@ Transaction& Transaction::DropIndex(const std::string& column_name, const std::s
 }
 
 arrow::Result<int64_t> Transaction::get_latest_version() {
-  // Check if metadata directory exists
   std::string metadata_dir = get_manifest_path(base_path_);
+
+  // Check if metadata directory exists
   ARROW_ASSIGN_OR_RAISE(auto dir_info, fs_->GetFileInfo(metadata_dir));
   if (dir_info.type() == arrow::fs::FileType::NotFound) {
     return 0;  // No manifests yet, return 0 (next commit will be version 1)
   }
 
+  // List files in metadata directory
   arrow::fs::FileSelector selector;
   selector.base_dir = metadata_dir;
   selector.allow_not_found = false;
   selector.recursive = false;
   selector.max_recursion = 0;
-
-  // list the objects in metadata directory and get the latest manifest file
   ARROW_ASSIGN_OR_RAISE(auto file_infos, fs_->GetFileInfo(selector));
 
   int64_t latest_version = 0;
@@ -669,15 +478,7 @@ arrow::Status Transaction::write_manifest(const std::shared_ptr<Manifest>& manif
   FIU_RETURN_ON(FIUKEY_MANIFEST_WRITE_FAIL,
                 arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_WRITE_FAIL)));
 
-  // Serialize new manifest to Avro
-  std::ostringstream oss;
-  ARROW_RETURN_NOT_OK(manifest->serialize(oss, base_path_));
-  std::string manifest_bytes = oss.str();
-
-  // Write manifest file (tries conditional write, falls back to unsafe write if not supported)
-  arrow::Status result = write_manifest_file(fs_, get_manifest_filepath(base_path_, new_version), manifest_bytes);
-
-  return result;
+  return Manifest::WriteTo(fs_, get_manifest_filepath(base_path_, new_version), *manifest);
 }
 
 }  // namespace milvus_storage::api::transaction

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -27,6 +27,7 @@
 #include <arrow/util/key_value_metadata.h>
 #include <arrow/testing/gtest_util.h>
 
+#include "milvus-storage/common/layout.h"
 #include "milvus-storage/transaction/transaction.h"
 #include "milvus-storage/writer.h"
 #include "milvus-storage/reader.h"
@@ -40,7 +41,8 @@ using namespace milvus_storage::api::transaction;
 class TransactionTest : public ::testing::Test {
   protected:
   void SetUp() override {
-    // Clean up test directory
+    // Clean up manifest cache
+    milvus_storage::api::Manifest::CleanCache();
     ASSERT_STATUS_OK(milvus_storage::InitTestProperties(properties_));
     ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
     base_path_ = GetTestBasePath("transaction-test");
@@ -78,39 +80,6 @@ class TransactionTest : public ::testing::Test {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   api::Properties properties_;
   std::shared_ptr<arrow::Schema> schema_;
-  std::string base_path_;
-};
-
-class TransactionAtomicHandlerTest : public ::testing::TestWithParam<std::string> {
-  protected:
-  void SetUp() override {
-    ASSERT_STATUS_OK(milvus_storage::InitTestProperties(properties_));
-    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
-    base_path_ = GetTestBasePath("transaction-test-atomic-handler");
-    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
-    ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
-  }
-
-  void TearDown() override {
-    // Clean up test directory
-    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
-  }
-
-  arrow::Result<ManifestPtr> CreateSampleManifest(const std::string& dummy_name,
-                                                  std::vector<std::string> cols = {"id", "name"}) {
-    ManifestPtr manifest = std::make_shared<Manifest>();
-    auto cg1 = std::make_shared<ColumnGroup>();
-    cg1->columns = cols;
-    cg1->files = {{.path = base_path_ + dummy_name}};
-    cg1->format = LOON_FORMAT_PARQUET;
-
-    manifest->columnGroups().push_back(cg1);
-    return manifest;
-  }
-
-  protected:
-  std::shared_ptr<arrow::fs::FileSystem> fs_;
-  api::Properties properties_;
   std::string base_path_;
 };
 
@@ -360,32 +329,86 @@ TEST_F(TransactionTest, WriteReadByVersion) {
   ASSERT_EQ(manifest->columnGroups()[0]->files.size(), loop_times);
 }
 
-TEST_P(TransactionAtomicHandlerTest, testConcurrentCommits) {
-  std::string handler_type = GetParam();
-  std::string base_path = base_path_;
+TEST_F(TransactionTest, ReadFromCachesManifest) {
+  // Write a manifest via transaction
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_cache.parquet"));
+    transaction->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
+    ASSERT_EQ(committed_version, 1);
+  }
 
-  if (handler_type == TRANSACTION_HANDLER_TYPE_CONDITIONAL) {
-    // TODO: we need a global remote env for CI test
-    // no need check the env in each test case
-    auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
-    if (storage_type != "remote") {
-      GTEST_SKIP() << "Conditional Atomic Handler only supported on S3";
-    }
-    auto bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("");
-    if (bucket_name.empty()) {
-      GTEST_SKIP() << "ENV_VAR_BUCKET_NAME is not set";
-    }
-    base_path = bucket_name;
+  std::string manifest_path = get_manifest_filepath(base_path_, 1);
+
+  // Two ReadFrom calls should return the same cached pointer
+  Manifest::CleanCache();
+  ASSERT_AND_ASSIGN(auto manifest1, Manifest::ReadFrom(fs_, manifest_path));
+  ASSERT_AND_ASSIGN(auto manifest2, Manifest::ReadFrom(fs_, manifest_path));
+  ASSERT_NE(manifest1, nullptr);
+  ASSERT_EQ(manifest1.get(), manifest2.get());
+  ASSERT_EQ(manifest1->columnGroups().size(), 1);
+}
+
+TEST_F(TransactionTest, ManifestCacheKeyIncludesRootPath) {
+  // Write a manifest under base_path_
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_root.parquet"));
+    transaction->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
+    ASSERT_EQ(committed_version, 1);
+  }
+
+  // Create a second filesystem with a different root path
+  std::string alt_base_path = GetTestBasePath("transaction-test-alt");
+  ASSERT_STATUS_OK(DeleteTestDir(fs_, alt_base_path));
+  ASSERT_STATUS_OK(CreateTestDir(fs_, alt_base_path));
+
+  // Write a different manifest under alt_base_path (same relative structure)
+  ASSERT_AND_ASSIGN(auto alt_fs, GetFileSystem(properties_));
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(alt_fs, alt_base_path));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_alt.parquet", {"id", "name", "value"}));
+    transaction->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
+    ASSERT_EQ(committed_version, 1);
+  }
+
+  // Both have manifest-1.avro, but with different base paths in the cache key
+  std::string path1 = get_manifest_filepath(base_path_, 1);
+  std::string path2 = get_manifest_filepath(alt_base_path, 1);
+
+  ASSERT_AND_ASSIGN(auto manifest1, Manifest::ReadFrom(fs_, path1));
+  ASSERT_AND_ASSIGN(auto manifest2, Manifest::ReadFrom(alt_fs, path2));
+
+  // They should be different manifests (different column counts)
+  ASSERT_NE(manifest1.get(), manifest2.get());
+  ASSERT_EQ(manifest1->columnGroups()[0]->columns.size(), 2);
+  ASSERT_EQ(manifest2->columnGroups()[0]->columns.size(), 3);
+
+  // Cleanup
+  ASSERT_STATUS_OK(DeleteTestDir(fs_, alt_base_path));
+}
+
+TEST_F(TransactionTest, ConcurrentCommitsWithConditionalWrite) {
+  // Concurrent commit safety requires conditional write (CAS), only available on S3
+  auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
+  if (storage_type != "remote") {
+    GTEST_SKIP() << "Concurrent commit test requires S3 with conditional write support";
+  }
+  auto bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("");
+  if (bucket_name.empty()) {
+    GTEST_SKIP() << "ENV_VAR_BUCKET_NAME is not set";
   }
 
   size_t num_transactions = 5;
   std::vector<std::unique_ptr<Transaction>> transactions;
   transactions.resize(num_transactions);
   for (size_t i = 0; i < num_transactions; ++i) {
-    ASSERT_AND_ASSIGN(transactions[i], Transaction::Open(fs_, base_path));
+    ASSERT_AND_ASSIGN(transactions[i], Transaction::Open(fs_, bucket_name));
   }
 
-  // Use a shared start signal so all threads begin the commit at the same time.
   std::promise<void> start_promise;
   std::shared_future<void> start_signal(start_promise.get_future());
 
@@ -396,39 +419,27 @@ TEST_P(TransactionAtomicHandlerTest, testConcurrentCommits) {
 
   for (size_t i = 0; i < num_transactions; ++i) {
     threads.emplace_back([&, i, start_signal]() {
-      // wait for the common start signal
       start_signal.wait();
       ASSERT_AND_ASSIGN(auto manifest,
                         CreateSampleManifest(("/dummy_atomic_" + std::to_string(i) + ".parquet").c_str()));
       transactions[i]->AppendFiles(manifest->columnGroups());
       auto arrow_commit_result = transactions[i]->Commit();
-      if (arrow_commit_result.ok()) {
-        commit_success[i] = true;
-      } else {
-        commit_success[i] = false;
-      }
+      commit_success[i] = arrow_commit_result.ok();
     });
   }
 
-  // Release all threads to run concurrently
   start_promise.set_value();
 
-  // Join threads
   for (auto& t : threads) {
     if (t.joinable())
       t.join();
   }
 
-  // Verify that only one transaction succeeded
   size_t success_count =
       std::count_if(commit_success.begin(), commit_success.end(), [](bool success) { return success; });
 
   ASSERT_EQ(success_count, 1) << "Only one transaction should succeed in committing.";
 }
-
-INSTANTIATE_TEST_SUITE_P(TransactionAtomicHandlerTestP,
-                         TransactionAtomicHandlerTest,
-                         ::testing::Values(TRANSACTION_HANDLER_TYPE_UNSAFE, TRANSACTION_HANDLER_TYPE_CONDITIONAL));
 
 // ==================== Index Operations Tests ====================
 
@@ -695,100 +706,6 @@ TEST_F(TransactionTest, IndexMultipleColumnsDeprecationTest) {
     ASSERT_EQ(manifest->getIndex("id", "hnsw"), nullptr);        // Deprecated
     ASSERT_NE(manifest->getIndex("vector", "ivf-pq"), nullptr);  // Still exists
   }
-}
-
-// ==================== write_manifest_file Tests ====================
-
-TEST_F(TransactionTest, UnsafeWriteBasicTest) {
-  std::string file_path = base_path_ + "/test_unsafe_write.bin";
-  std::string data = "hello";
-
-  // First write should succeed
-  ASSERT_STATUS_OK(Transaction::unsafe_write(fs_, file_path, data));
-
-  // Second write to the same path should return AlreadyExists
-  auto status = Transaction::unsafe_write(fs_, file_path, data);
-  ASSERT_TRUE(status.IsAlreadyExists()) << status.ToString();
-}
-
-TEST_F(TransactionTest, WriteManifestFileFallsBackToUnsafeWrite) {
-  // LocalFileSystem does not implement UploadConditional, so write_manifest_file
-  // should fall back to unsafe_write.
-  std::string file_path = base_path_ + "/test_write_manifest.bin";
-  std::string data = "manifest_data";
-
-  ASSERT_STATUS_OK(Transaction::write_manifest_file(fs_, file_path, data));
-
-  // Verify file exists by trying to write again
-  auto status = Transaction::write_manifest_file(fs_, file_path, data);
-  ASSERT_TRUE(status.IsAlreadyExists()) << status.ToString();
-}
-
-TEST_F(TransactionTest, UnsafeWriteConcurrentDifferentFiles) {
-  // Concurrent writes to DIFFERENT files should all succeed (per-file lock, not global).
-  const size_t num_threads = 8;
-  std::vector<std::thread> threads;
-  threads.reserve(num_threads);
-  std::vector<arrow::Status> results(num_threads);
-
-  std::promise<void> start_promise;
-  std::shared_future<void> start_signal(start_promise.get_future());
-
-  for (size_t i = 0; i < num_threads; ++i) {
-    threads.emplace_back([&, i, start_signal]() {
-      start_signal.wait();
-      std::string path = base_path_ + "/concurrent_diff_" + std::to_string(i) + ".bin";
-      results[i] = Transaction::unsafe_write(fs_, path, "data_" + std::to_string(i));
-    });
-  }
-
-  start_promise.set_value();
-  for (auto& t : threads) {
-    t.join();
-  }
-
-  for (size_t i = 0; i < num_threads; ++i) {
-    ASSERT_STATUS_OK(results[i]);
-  }
-}
-
-TEST_F(TransactionTest, UnsafeWriteConcurrentSameFile) {
-  // Concurrent writes to the SAME file: exactly one should succeed, the rest AlreadyExists.
-  const size_t num_threads = 8;
-  std::string file_path = base_path_ + "/concurrent_same.bin";
-
-  std::vector<std::thread> threads;
-  threads.reserve(num_threads);
-  std::vector<arrow::Status> results(num_threads);
-
-  std::promise<void> start_promise;
-  std::shared_future<void> start_signal(start_promise.get_future());
-
-  for (size_t i = 0; i < num_threads; ++i) {
-    threads.emplace_back([&, i, start_signal]() {
-      start_signal.wait();
-      results[i] = Transaction::unsafe_write(fs_, file_path, "data_" + std::to_string(i));
-    });
-  }
-
-  start_promise.set_value();
-  for (auto& t : threads) {
-    t.join();
-  }
-
-  size_t success_count = 0;
-  size_t already_exists_count = 0;
-  for (size_t i = 0; i < num_threads; ++i) {
-    if (results[i].ok()) {
-      success_count++;
-    } else {
-      ASSERT_TRUE(results[i].IsAlreadyExists()) << "Unexpected error: " << results[i].ToString();
-      already_exists_count++;
-    }
-  }
-
-  ASSERT_EQ(success_count, 1) << "Exactly one thread should succeed writing the file";
-  ASSERT_EQ(already_exists_count, num_threads - 1);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -47,6 +47,8 @@ using namespace milvus_storage::api::transaction;
 class APIWriterReaderTest : public ::testing::TestWithParam<std::tuple<std::string, size_t>> {
   protected:
   void SetUp() override {
+    // Clean manifest cache to avoid stale entries from previous tests
+    milvus_storage::api::Manifest::CleanCache();
     // Create temporary directory for test files
     ASSERT_STATUS_OK(InitTestProperties(properties_));
     ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));

--- a/cpp/test/column_groups_test.cpp
+++ b/cpp/test/column_groups_test.cpp
@@ -24,51 +24,59 @@
 
 #include "milvus-storage/manifest.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/layout.h"
 
 #include "test_env.h"
 
+using namespace milvus_storage;
 using namespace milvus_storage::api;
 
 class ColumnGroupsTest : public ::testing::Test {
   protected:
   void SetUp() override {
+    Manifest::CleanCache();
+    ASSERT_STATUS_OK(milvus_storage::InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+    base_path_ = GetTestBasePath("column-groups-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
+
     // Create test column groups
     auto cg1 = std::make_shared<ColumnGroup>();
     cg1->columns = {"id", "name", "age"};
-    // Initialize files using brace initialization (aggregates)
-    // ColumnGroupFile has path, start_index, end_index.
-    // Optional members default to nullopt.
-    cg1->files = {{"/data/cg1_part1.parquet"}, {"/data/cg1_part2.parquet"}};
+    cg1->files = {{base_path_ + "/_data/cg1_part1.parquet"}, {base_path_ + "/_data/cg1_part2.parquet"}};
     cg1->format = LOON_FORMAT_PARQUET;
 
     auto cg2 = std::make_shared<ColumnGroup>();
     cg2->columns = {"embedding", "metadata"};
-    cg2->files = {{"/data/cg2_vectors.vortex"}};
+    cg2->files = {{base_path_ + "/_data/cg2_vectors.vortex"}};
     cg2->format = LOON_FORMAT_VORTEX;
 
     ColumnGroups column_groups = {cg1, cg2};
     test_cgs_ = std::move(column_groups);
   }
 
+  void TearDown() override { ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_)); }
+
+  // Helper: write manifest to file and read back
+  arrow::Result<std::shared_ptr<Manifest>> WriteAndReadBack(const Manifest& manifest, size_t version = 1) {
+    std::string path = milvus_storage::get_manifest_filepath(base_path_, version);
+    ARROW_RETURN_NOT_OK(Manifest::WriteTo(fs_, path, manifest));
+    Manifest::CleanCache();
+    return Manifest::ReadFrom(fs_, path);
+  }
+
   ColumnGroups test_cgs_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::string base_path_;
+  Properties properties_;
 };
 
 TEST_F(ColumnGroupsTest, SerializeDeserialize) {
-  // Create Manifest with test column groups
   auto manifest = std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), std::map<std::string, Statistics>());
 
-  // Serialize to Avro
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-  std::string avro_str = oss.str();
-
-  EXPECT_FALSE(avro_str.empty());
-
-  // Deserialize from Avro
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(avro_str);
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
-  const auto& groups = deserialized_manifest->columnGroups();
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
+  const auto& groups = deserialized->columnGroups();
   const auto& expected_groups = test_cgs_;
 
   EXPECT_EQ(groups.size(), expected_groups.size());
@@ -87,72 +95,29 @@ TEST_F(ColumnGroupsTest, SerializeDeserialize) {
 }
 
 TEST_F(ColumnGroupsTest, EmptyColumnGroups) {
-  // Test empty column groups
   ColumnGroups column_groups = {};
   auto manifest =
       std::make_shared<Manifest>(column_groups, std::vector<DeltaLog>(), std::map<std::string, Statistics>());
 
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-  std::string avro_str = oss.str();
-
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(avro_str);
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
-
-  EXPECT_EQ(deserialized_manifest->columnGroups().size(), 0);
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
+  EXPECT_EQ(deserialized->columnGroups().size(), 0);
 }
 
 TEST_F(ColumnGroupsTest, ColumnLookup) {
-  // Serialize and deserialize
   auto manifest = std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), std::map<std::string, Statistics>());
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-  std::string avro_str = oss.str();
 
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(avro_str);
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
-  // Test column lookup functionality
   const auto& expected_groups = test_cgs_;
   if (!expected_groups.empty() && !expected_groups[0]->columns.empty()) {
     std::string test_col = expected_groups[0]->columns[0];
-    auto cg = deserialized_manifest->getColumnGroup(test_col);
+    auto cg = deserialized->getColumnGroup(test_col);
     ASSERT_NE(cg, nullptr);
     EXPECT_EQ(cg->format, expected_groups[0]->format);
   }
 
-  auto missing_cg = deserialized_manifest->getColumnGroup("nonexistent_column_name_xyz");
+  auto missing_cg = deserialized->getColumnGroup("nonexistent_column_name_xyz");
   EXPECT_EQ(missing_cg, nullptr);
-}
-
-TEST_F(ColumnGroupsTest, InvalidAvro) {
-  auto deserialized_manifest = std::make_shared<Manifest>();
-
-  // Empty stream should fail (too short to read header)
-  {
-    std::string empty_str = "";
-    std::istringstream in1(empty_str);
-    auto status = deserialized_manifest->deserialize(in1);
-    EXPECT_FALSE(status.ok());
-  }
-
-  // Garbage data falls through to legacy path and fails
-  {
-    std::string garbage = "garbage_data_12345";
-    std::istringstream in2(garbage);
-    auto status = deserialized_manifest->deserialize(in2);
-    EXPECT_FALSE(status.ok());
-  }
-
-  // Data starting with OCF magic but truncated should fail
-  {
-    std::string truncated_ocf = "Obj\x01";
-    std::istringstream in3(truncated_ocf);
-    auto status = deserialized_manifest->deserialize(in3);
-    EXPECT_FALSE(status.ok());
-  }
 }
 
 TEST_F(ColumnGroupsTest, TestPrivateData) {
@@ -161,7 +126,7 @@ TEST_F(ColumnGroupsTest, TestPrivateData) {
   auto cg1 = std::make_shared<ColumnGroup>();
   cg1->columns = {"test_column"};
   cg1->files.emplace_back(ColumnGroupFile{
-      .path = "test_path",
+      .path = base_path_ + "/_data/test_path",
       .metadata = pvec,
   });
   cg1->format = LOON_FORMAT_PARQUET;
@@ -170,15 +135,9 @@ TEST_F(ColumnGroupsTest, TestPrivateData) {
   auto manifest = std::make_shared<Manifest>(std::move(column_groups), std::vector<DeltaLog>(),
                                              std::map<std::string, Statistics>());
 
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-  std::string avro_str = oss.str();
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(avro_str);
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
-
-  auto deserialized_cg = deserialized_manifest->getColumnGroup("test_column");
+  auto deserialized_cg = deserialized->getColumnGroup("test_column");
   ASSERT_EQ(deserialized_cg->files[0].metadata,
             std::vector<uint8_t>(private_data, private_data + sizeof(private_data)));
 }
@@ -186,106 +145,73 @@ TEST_F(ColumnGroupsTest, TestPrivateData) {
 // ==================== Index Serialization Tests ====================
 
 TEST_F(ColumnGroupsTest, IndexSerializeDeserialize) {
-  // Create indexes
   std::vector<Index> indexes;
 
   Index idx1;
   idx1.column_name = "embedding";
   idx1.index_type = "hnsw";
-  idx1.path = "/data/_index/embedding_hnsw.idx";
+  idx1.path = base_path_ + "/_index/embedding_hnsw.idx";
   idx1.properties = {{"ef_construction", "128"}, {"M", "16"}};
   indexes.push_back(idx1);
 
   Index idx2;
   idx2.column_name = "id";
   idx2.index_type = "inverted";
-  idx2.path = "/data/_index/id_inverted.idx";
+  idx2.path = base_path_ + "/_index/id_inverted.idx";
   idx2.properties = {};
   indexes.push_back(idx2);
 
-  // Create manifest with indexes
   auto manifest =
       std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), std::map<std::string, Statistics>(), indexes);
 
-  // Serialize
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-  std::string avro_str = oss.str();
-  EXPECT_FALSE(avro_str.empty());
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
-  // Deserialize
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(avro_str);
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
-
-  // Verify indexes
-  const auto& deserialized_indexes = deserialized_manifest->indexes();
+  const auto& deserialized_indexes = deserialized->indexes();
   ASSERT_EQ(deserialized_indexes.size(), 2);
 
-  // Check first index
-  const Index* found1 = deserialized_manifest->getIndex("embedding", "hnsw");
+  const Index* found1 = deserialized->getIndex("embedding", "hnsw");
   ASSERT_NE(found1, nullptr);
   EXPECT_EQ(found1->column_name, "embedding");
   EXPECT_EQ(found1->index_type, "hnsw");
-  EXPECT_EQ(found1->path, "/data/_index/embedding_hnsw.idx");
+  EXPECT_EQ(found1->path, base_path_ + "/_index/embedding_hnsw.idx");
   EXPECT_EQ(found1->properties.size(), 2);
   EXPECT_EQ(found1->properties.at("ef_construction"), "128");
   EXPECT_EQ(found1->properties.at("M"), "16");
 
-  // Check second index
-  const Index* found2 = deserialized_manifest->getIndex("id", "inverted");
+  const Index* found2 = deserialized->getIndex("id", "inverted");
   ASSERT_NE(found2, nullptr);
   EXPECT_EQ(found2->column_name, "id");
   EXPECT_EQ(found2->index_type, "inverted");
-  EXPECT_EQ(found2->path, "/data/_index/id_inverted.idx");
+  EXPECT_EQ(found2->path, base_path_ + "/_index/id_inverted.idx");
   EXPECT_TRUE(found2->properties.empty());
 }
 
 TEST_F(ColumnGroupsTest, IndexLookupNotFound) {
-  // Create manifest with one index
   std::vector<Index> indexes;
   Index idx;
   idx.column_name = "embedding";
   idx.index_type = "hnsw";
-  idx.path = "/data/_index/embedding_hnsw.idx";
+  idx.path = base_path_ + "/_index/embedding_hnsw.idx";
   idx.properties = {};
   indexes.push_back(idx);
 
   auto manifest =
       std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), std::map<std::string, Statistics>(), indexes);
 
-  // Serialize and deserialize
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(oss.str());
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
-  // Test getIndex with non-existent keys
-  EXPECT_EQ(deserialized_manifest->getIndex("nonexistent", "hnsw"), nullptr);
-  EXPECT_EQ(deserialized_manifest->getIndex("embedding", "nonexistent"), nullptr);
-  EXPECT_EQ(deserialized_manifest->getIndex("nonexistent", "nonexistent"), nullptr);
-
-  // Test getIndex with correct key
-  EXPECT_NE(deserialized_manifest->getIndex("embedding", "hnsw"), nullptr);
+  EXPECT_EQ(deserialized->getIndex("nonexistent", "hnsw"), nullptr);
+  EXPECT_EQ(deserialized->getIndex("embedding", "nonexistent"), nullptr);
+  EXPECT_EQ(deserialized->getIndex("nonexistent", "nonexistent"), nullptr);
+  EXPECT_NE(deserialized->getIndex("embedding", "hnsw"), nullptr);
 }
 
 TEST_F(ColumnGroupsTest, EmptyIndexes) {
-  // Create manifest without indexes (empty vector)
   auto manifest = std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), std::map<std::string, Statistics>(),
                                              std::vector<Index>());
 
-  // Serialize
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-
-  // Deserialize
-  auto deserialized_manifest = std::make_shared<Manifest>();
-  std::istringstream in(oss.str());
-  ASSERT_STATUS_OK(deserialized_manifest->deserialize(in));
-
-  // Verify empty indexes
-  EXPECT_TRUE(deserialized_manifest->indexes().empty());
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
+  EXPECT_TRUE(deserialized->indexes().empty());
 }
 
 // ==================== Stats & DeltaLog Serialization Tests ====================
@@ -293,28 +219,23 @@ TEST_F(ColumnGroupsTest, EmptyIndexes) {
 TEST_F(ColumnGroupsTest, StatsRoundTrip) {
   std::map<std::string, Statistics> stats;
   Statistics stat1;
-  stat1.paths = {"/stats/bloom_filter_100.bin", "/stats/bloom_filter_101.bin"};
+  stat1.paths = {base_path_ + "/_stats/bloom_filter_100.bin", base_path_ + "/_stats/bloom_filter_101.bin"};
   stat1.metadata = {{"type", "bloom_filter"}, {"num_bits", "1024"}};
   stats["bloom_filter.100"] = stat1;
 
   Statistics stat2;
-  stat2.paths = {"/stats/bm25_200.bin"};
+  stat2.paths = {base_path_ + "/_stats/bm25_200.bin"};
   stats["bm25.200"] = stat2;
 
   auto manifest = std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), stats);
 
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(oss.str());
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
   const auto& ds = deserialized->stats();
   ASSERT_EQ(ds.size(), 2);
 
   ASSERT_EQ(ds.at("bloom_filter.100").paths.size(), 2);
-  EXPECT_EQ(ds.at("bloom_filter.100").paths[0], "/stats/bloom_filter_100.bin");
+  EXPECT_EQ(ds.at("bloom_filter.100").paths[0], base_path_ + "/_stats/bloom_filter_100.bin");
   EXPECT_EQ(ds.at("bloom_filter.100").metadata.at("type"), "bloom_filter");
   EXPECT_EQ(ds.at("bloom_filter.100").metadata.at("num_bits"), "1024");
 
@@ -324,35 +245,30 @@ TEST_F(ColumnGroupsTest, StatsRoundTrip) {
 
 TEST_F(ColumnGroupsTest, DeltaLogRoundTrip) {
   std::vector<DeltaLog> delta_logs;
-  delta_logs.push_back({"/delta/pk_delete_1.bin", DeltaLogType::PRIMARY_KEY, 100});
-  delta_logs.push_back({"/delta/pos_delete_2.bin", DeltaLogType::POSITIONAL, 50});
+  delta_logs.push_back({base_path_ + "/_delta/pk_delete_1.bin", DeltaLogType::PRIMARY_KEY, 100});
+  delta_logs.push_back({base_path_ + "/_delta/pos_delete_2.bin", DeltaLogType::POSITIONAL, 50});
 
   auto manifest = std::make_shared<Manifest>(test_cgs_, delta_logs, std::map<std::string, Statistics>());
 
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(oss.str());
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
   const auto& dl = deserialized->deltaLogs();
   ASSERT_EQ(dl.size(), 2);
-  EXPECT_EQ(dl[0].path, "/delta/pk_delete_1.bin");
+  EXPECT_EQ(dl[0].path, base_path_ + "/_delta/pk_delete_1.bin");
   EXPECT_EQ(dl[0].type, DeltaLogType::PRIMARY_KEY);
   EXPECT_EQ(dl[0].num_entries, 100);
-  EXPECT_EQ(dl[1].path, "/delta/pos_delete_2.bin");
+  EXPECT_EQ(dl[1].path, base_path_ + "/_delta/pos_delete_2.bin");
   EXPECT_EQ(dl[1].type, DeltaLogType::POSITIONAL);
   EXPECT_EQ(dl[1].num_entries, 50);
 }
 
 TEST_F(ColumnGroupsTest, AllFieldsRoundTrip) {
   std::vector<DeltaLog> delta_logs;
-  delta_logs.push_back({"/delta/del.bin", DeltaLogType::EQUALITY, 10});
+  delta_logs.push_back({base_path_ + "/_delta/del.bin", DeltaLogType::EQUALITY, 10});
 
   std::map<std::string, Statistics> stats;
   Statistics stat;
-  stat.paths = {"/stats/s.bin"};
+  stat.paths = {base_path_ + "/_stats/s.bin"};
   stat.metadata = {{"k", "v"}};
   stats["key"] = stat;
 
@@ -360,18 +276,13 @@ TEST_F(ColumnGroupsTest, AllFieldsRoundTrip) {
   Index idx;
   idx.column_name = "embedding";
   idx.index_type = "hnsw";
-  idx.path = "/index/emb.idx";
+  idx.path = base_path_ + "/_index/emb.idx";
   idx.properties = {{"M", "16"}};
   indexes.push_back(idx);
 
   auto manifest = std::make_shared<Manifest>(test_cgs_, delta_logs, stats, indexes);
 
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(manifest->serialize(oss));
-
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(oss.str());
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*manifest));
 
   EXPECT_EQ(deserialized->columnGroups().size(), 2);
   EXPECT_EQ(deserialized->deltaLogs().size(), 1);
@@ -385,8 +296,6 @@ TEST_F(ColumnGroupsTest, AllFieldsRoundTrip) {
 // ==================== Legacy Format Deserialization Tests ====================
 
 // Helper: produce a legacy MILV-format binary using raw Avro binary encoder.
-// Encodes each field manually to match the old serialize() order, since
-// codec_traits for custom types are not visible from this translation unit.
 static void encodeColumnGroupFile(avro::Encoder& e, const ColumnGroupFile& file) {
   avro::encode(e, file.path);
   avro::encode(e, file.start_index);
@@ -440,7 +349,6 @@ static std::string encodeLegacyManifest(int32_t version,
   avro::encode(*encoder, MILV_MAGIC);
   avro::encode(*encoder, version);
 
-  // Encode column groups
   encoder->arrayStart();
   if (!cgs.empty()) {
     encoder->setItemCount(cgs.size());
@@ -451,7 +359,6 @@ static std::string encodeLegacyManifest(int32_t version,
   }
   encoder->arrayEnd();
 
-  // Encode delta logs
   encoder->arrayStart();
   if (!delta_logs.empty()) {
     encoder->setItemCount(delta_logs.size());
@@ -462,7 +369,6 @@ static std::string encodeLegacyManifest(int32_t version,
   }
   encoder->arrayEnd();
 
-  // Encode stats
   if (version >= 3) {
     encoder->mapStart();
     if (!stats.empty()) {
@@ -475,7 +381,6 @@ static std::string encodeLegacyManifest(int32_t version,
     }
     encoder->mapEnd();
   } else {
-    // v1/v2: stats is map<string, vector<string>>
     std::map<std::string, std::vector<std::string>> legacy_stats;
     for (const auto& [key, stat] : stats) {
       legacy_stats[key] = stat.paths;
@@ -483,7 +388,6 @@ static std::string encodeLegacyManifest(int32_t version,
     avro::encode(*encoder, legacy_stats);
   }
 
-  // Encode indexes (v2+ only)
   if (version >= 2) {
     encoder->arrayStart();
     if (!indexes.empty()) {
@@ -500,10 +404,43 @@ static std::string encodeLegacyManifest(int32_t version,
   return oss.str();
 }
 
+// Helper: strip base_path + dir prefix from file paths to create relative paths for legacy encoding
+static ColumnGroups MakeLegacyCgs(const ColumnGroups& cgs, const std::string& base_path) {
+  ColumnGroups legacy_cgs;
+  for (const auto& cg : cgs) {
+    auto copy = std::make_shared<ColumnGroup>(*cg);
+    for (auto& f : copy->files) {
+      std::string prefix = base_path + "/_data/";
+      if (f.path.find(prefix) == 0) {
+        f.path = f.path.substr(prefix.size());
+      }
+    }
+    legacy_cgs.push_back(copy);
+  }
+  return legacy_cgs;
+}
+
+// Helper: write raw bytes to a manifest file path and read back via ReadFrom
+arrow::Result<std::shared_ptr<Manifest>> WriteLegacyAndReadBack(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                                                const std::string& base_path,
+                                                                const std::string& legacy_bytes,
+                                                                size_t version = 1) {
+  std::string path = milvus_storage::get_manifest_filepath(base_path, version);
+  auto [parent, _] = milvus_storage::GetAbstractPathParent(path);
+  if (!parent.empty()) {
+    ARROW_RETURN_NOT_OK(fs->CreateDir(parent));
+  }
+  ARROW_ASSIGN_OR_RAISE(auto output, fs->OpenOutputStream(path));
+  ARROW_RETURN_NOT_OK(output->Write(legacy_bytes.data(), legacy_bytes.size()));
+  ARROW_RETURN_NOT_OK(output->Close());
+  Manifest::CleanCache();
+  return Manifest::ReadFrom(fs, path);
+}
+
 TEST_F(ColumnGroupsTest, LegacyV3Deserialize) {
   std::map<std::string, Statistics> stats;
   Statistics stat;
-  stat.paths = {"/stats/s.bin"};
+  stat.paths = {"s.bin"};
   stat.metadata = {{"k", "v"}};
   stats["key"] = stat;
 
@@ -511,60 +448,52 @@ TEST_F(ColumnGroupsTest, LegacyV3Deserialize) {
   Index idx;
   idx.column_name = "col";
   idx.index_type = "hnsw";
-  idx.path = "/index/i.idx";
+  idx.path = "i.idx";
   idx.properties = {{"M", "8"}};
   indexes.push_back(idx);
 
-  std::string legacy_bytes = encodeLegacyManifest(3, test_cgs_, {}, stats, indexes);
+  auto legacy_cgs = MakeLegacyCgs(test_cgs_, base_path_);
+  std::string legacy_bytes = encodeLegacyManifest(3, legacy_cgs, {}, stats, indexes);
 
-  // Verify it does NOT start with OCF magic
   ASSERT_NE(legacy_bytes.substr(0, 4), std::string("Obj\x01", 4));
 
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(legacy_bytes);
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteLegacyAndReadBack(fs_, base_path_, legacy_bytes));
 
   EXPECT_EQ(deserialized->columnGroups().size(), 2);
-  EXPECT_EQ(deserialized->stats().at("key").paths[0], "/stats/s.bin");
   EXPECT_EQ(deserialized->stats().at("key").metadata.at("k"), "v");
   EXPECT_EQ(deserialized->indexes().size(), 1);
   EXPECT_EQ(deserialized->indexes()[0].properties.at("M"), "8");
 }
 
 TEST_F(ColumnGroupsTest, LegacyV1Deserialize) {
-  // v1: no indexes, stats as map<string, vector<string>>
   std::map<std::string, Statistics> stats;
   Statistics stat;
-  stat.paths = {"/stats/old.bin"};
+  stat.paths = {"old.bin"};
   stats["old_key"] = stat;
 
-  std::string legacy_bytes = encodeLegacyManifest(1, test_cgs_, {}, stats, {});
+  auto legacy_cgs = MakeLegacyCgs(test_cgs_, base_path_);
+  std::string legacy_bytes = encodeLegacyManifest(1, legacy_cgs, {}, stats, {});
 
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(legacy_bytes);
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteLegacyAndReadBack(fs_, base_path_, legacy_bytes, 2));
 
   EXPECT_EQ(deserialized->columnGroups().size(), 2);
-  EXPECT_EQ(deserialized->stats().at("old_key").paths[0], "/stats/old.bin");
   EXPECT_TRUE(deserialized->stats().at("old_key").metadata.empty());
   EXPECT_TRUE(deserialized->indexes().empty());
 }
 
 TEST_F(ColumnGroupsTest, LegacyV2Deserialize) {
-  // v2: has indexes, stats as map<string, vector<string>>
   std::vector<Index> indexes;
   Index idx;
   idx.column_name = "col";
   idx.index_type = "ivf";
-  idx.path = "/index/v2.idx";
+  idx.path = "v2.idx";
   idx.properties = {};
   indexes.push_back(idx);
 
-  std::string legacy_bytes = encodeLegacyManifest(2, test_cgs_, {}, {}, indexes);
+  auto legacy_cgs = MakeLegacyCgs(test_cgs_, base_path_);
+  std::string legacy_bytes = encodeLegacyManifest(2, legacy_cgs, {}, {}, indexes);
 
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(legacy_bytes);
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteLegacyAndReadBack(fs_, base_path_, legacy_bytes, 3));
 
   EXPECT_EQ(deserialized->columnGroups().size(), 2);
   EXPECT_TRUE(deserialized->stats().empty());
@@ -573,34 +502,25 @@ TEST_F(ColumnGroupsTest, LegacyV2Deserialize) {
 }
 
 TEST_F(ColumnGroupsTest, IndexRoundTripPreservesData) {
-  // Create manifest with indexes
   std::vector<Index> indexes;
   Index idx;
   idx.column_name = "embedding";
   idx.index_type = "hnsw";
-  idx.path = "/data/_index/embedding_hnsw.idx";
+  idx.path = base_path_ + "/_index/embedding_hnsw.idx";
   idx.properties = {{"key", "value"}};
   indexes.push_back(idx);
 
   auto original =
       std::make_shared<Manifest>(test_cgs_, std::vector<DeltaLog>(), std::map<std::string, Statistics>(), indexes);
 
-  // Serialize and deserialize to test data preservation
-  std::ostringstream oss;
-  ASSERT_STATUS_OK(original->serialize(oss));
+  ASSERT_AND_ASSIGN(auto deserialized, WriteAndReadBack(*original));
 
-  auto deserialized = std::make_shared<Manifest>();
-  std::istringstream in(oss.str());
-  ASSERT_STATUS_OK(deserialized->deserialize(in));
-
-  // Verify deserialized has same indexes
   ASSERT_EQ(deserialized->indexes().size(), 1);
   const Index* found = deserialized->getIndex("embedding", "hnsw");
   ASSERT_NE(found, nullptr);
   EXPECT_EQ(found->properties.at("key"), "value");
 
-  // Modify original indexes, deserialized should be independent
   original->indexes().clear();
   EXPECT_EQ(original->indexes().size(), 0);
-  EXPECT_EQ(deserialized->indexes().size(), 1);  // Deserialized unchanged
+  EXPECT_EQ(deserialized->indexes().size(), 1);
 }

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -644,11 +644,18 @@ static void test_transaction_error_handling(void) {
 
 void run_manifest_suite(void) {
   RUN_TEST(test_empty_manifests);
+  loon_reset_context();
   RUN_TEST(test_manifests_write_read);
+  loon_reset_context();
   RUN_TEST(test_abort);
+  loon_reset_context();
   RUN_TEST(test_add_column_group);
+  loon_reset_context();
   RUN_TEST(test_add_delta_log);
+  loon_reset_context();
   RUN_TEST(test_update_stat);
+  loon_reset_context();
   RUN_TEST(test_update_stat_with_metadata);
+  loon_reset_context();
   RUN_TEST(test_transaction_error_handling);
 }

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "milvus-storage/ffi_c.h"
 #include "milvus-storage/ffi_filesystem_c.h"
 #include "test_runner.h"
 #include <stdlib.h>
@@ -38,7 +39,7 @@ int main(void) {
   run_filesystem_suite();
   run_fiu_suite();
 
-  loon_close_filesystems();
+  loon_reset_context();
   loon_thread_pool_singleton_release();
 
   printf("\nRan %d tests, %d failed.\n", global_tests_run, global_tests_failed);


### PR DESCRIPTION
Move manifest serialization behind static ReadFrom/WriteTo methods
with an LRU cache keyed by filesystem root path + relative path.
This ensures cached manifests are globally unique across different
filesystems.

- Make serialize/deserialize private; add DeepCopy() method
- Add Manifest::ReadFrom with LRU cache, WriteTo with conditional
  write support
- Use DeepCopy in applyUpdates to protect cached manifests
- Remove properties-based Transaction::Open overload
- Remove TRANSACTION_HANDLER_TYPE_* constants and parameterized
  concurrent test; replace with conditional-write-only test
- Add loon_reset_context() FFI for test isolation
- Rewrite column_groups_test to use file-based WriteTo/ReadFrom