### PR TITLE
fix: replace global write mutex with per-file locking in manifest commit

### DIFF
--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -210,7 +211,9 @@ class Transaction {
    */
   Transaction& DropIndex(const std::string& column_name, const std::string& index_type);
 
+#ifndef BUILD_GTEST
   private:
+#endif
   // Private constructor - use Open() factory method instead
   Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
               const std::string& base_path,
@@ -225,6 +228,21 @@ class Transaction {
   arrow::Result<std::shared_ptr<Manifest>> read_manifest(int64_t version);
 
   arrow::Status write_manifest(const std::shared_ptr<Manifest>& manifest, int64_t old_version, int64_t new_version);
+
+  // Write manifest file, dispatches to conditional_write or unsafe_write
+  static arrow::Status write_manifest_file(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                           const std::string& path,
+                                           std::string_view data);
+
+  // Atomic write via UploadConditional (e.g. S3 conditional put)
+  static arrow::Status conditional_write(const std::shared_ptr<UploadConditional>& fs,
+                                         const std::string& path,
+                                         std::string_view data);
+
+  // Non-atomic write with per-file mutex for same-process safety
+  static arrow::Status unsafe_write(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                    const std::string& path,
+                                    std::string_view data);
 
   int64_t read_version_;
   std::shared_ptr<Manifest> read_manifest_;

--- a/cpp/src/filesystem/local_fs_producer.cpp
+++ b/cpp/src/filesystem/local_fs_producer.cpp
@@ -14,6 +14,7 @@
 
 #include "milvus-storage/filesystem/local_fs_producer.h"
 
+#include <mutex>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
@@ -21,6 +22,7 @@
 
 #include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/filesystem/upload_conditional.h"
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage {
 
@@ -126,7 +128,10 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(
       const std::string& path, std::shared_ptr<arrow::KeyValueMetadata> metadata) override {
-    // Check if file already exists, this is NOT thread safe.
+    // This lock is only for testing purposes.
+    static std::mutex local_conditional_write_mutex;
+    std::scoped_lock lock(local_conditional_write_mutex);
+
     auto file_info_result = arrow::fs::LocalFileSystem::GetFileInfo(path);
     if (!file_info_result.ok()) {
       metrics_->IncrementFailedCount();
@@ -135,7 +140,7 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
     auto file_info = file_info_result.ValueOrDie();
     if (file_info.type() == arrow::fs::FileType::File) {
       metrics_->IncrementFailedCount();
-      return arrow::Status::IOError("File already exists: ", path);
+      return MakeExtendError(ExtendStatusCode::AwsErrorConflict, "File already exists: " + path, "");
     }
     return OpenOutputStream(path, metadata);
   }

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -215,9 +215,9 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() 
 
   if (IsInCooldown()) {
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Skipping credential reload — in cooldown after previous failure."
-                           << " has_valid_cached=" << hasExisting);
+    AWS_LOGSTREAM_WARN(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Skipping credential reload — in cooldown after previous failure." << " has_valid_cached=" << hasExisting);
     return;
   }
 

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -19,6 +19,7 @@
 #include <string_view>
 #include <sstream>
 #include <mutex>
+#include <unordered_map>
 #include <set>
 #include <fmt/format.h>
 
@@ -33,6 +34,7 @@
 
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/upload_conditional.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/layout.h"
@@ -289,46 +291,93 @@ Resolver FailResolver = [](const std::shared_ptr<Manifest>& /*read_manifest*/,
 
 // ==================== Transaction Implementation ====================
 
-// Helper function that tries conditional write first, falls back to unsafe write if not supported
-arrow::Status write_manifest_file(const std::shared_ptr<arrow::fs::FileSystem>& fs,
-                                  const std::string& path,
-                                  std::string_view data) {
-  static std::mutex write_mutex;
-  std::scoped_lock lock(write_mutex);
-
-  // Try conditional write first if filesystem supports it
-  auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs);
-  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> res;
-  if (conditional_fs) {
-    res = conditional_fs->OpenConditionalOutputStream(path, nullptr);
-  } else {
-    res = arrow::Status::NotImplemented("Filesystem does not support conditional writes");
+// Check if an IOError status indicates a conditional write conflict (file already exists).
+static bool IsConditionalWriteConflict(const arrow::Status& status) {
+  if (!status.IsIOError()) {
+    return false;
   }
-  if (res.ok()) {
-    auto output_stream = res.ValueOrDie();
-    ARROW_RETURN_NOT_OK(output_stream->Write(data.data(), data.size()));
-    auto result = output_stream->Close();
-    if (!result.ok()) {
-      // already exist then return AlreadyExists
-      if (result.code() == arrow::StatusCode::IOError) {
-        return arrow::Status::AlreadyExists("File already exists: ", path);
-      }
-      // others return the error
-      return result;
+  auto detail = milvus_storage::ExtendStatusDetail::UnwrapStatus(status);
+  if (!detail) {
+    return false;
+  }
+  return detail->code() == milvus_storage::ExtendStatusCode::AwsErrorPreConditionFailed ||
+         detail->code() == milvus_storage::ExtendStatusCode::AwsErrorConflict;
+}
+
+arrow::Status Transaction::conditional_write(const std::shared_ptr<UploadConditional>& fs,
+                                             const std::string& path,
+                                             std::string_view data) {
+  auto open_result = fs->OpenConditionalOutputStream(path, nullptr);
+  if (!open_result.ok()) {
+    if (IsConditionalWriteConflict(open_result.status())) {
+      return arrow::Status::AlreadyExists("File already exists: ", path);
     }
-
-    return arrow::Status::OK();
+    return open_result.status();
   }
+  auto output_stream = std::move(open_result).ValueUnsafe();
+  ARROW_RETURN_NOT_OK(output_stream->Write(data.data(), data.size()));
+  auto close_status = output_stream->Close();
+  if (!close_status.ok()) {
+    if (IsConditionalWriteConflict(close_status)) {
+      return arrow::Status::AlreadyExists("File already exists: ", path);
+    }
+    return close_status;
+  }
+  return arrow::Status::OK();
+}
 
-  // Fall back to unsafe write
+// Per-file mutex with reference counting to avoid unbounded map growth.
+struct RefCountedMutex {
+  std::mutex mtx;
+  int ref_count = 0;
+};
+
+static std::mutex file_mutex_map_mutex;
+static std::unordered_map<std::string, std::unique_ptr<RefCountedMutex>> file_mutex_map;
+
+static std::mutex& acquire_file_mutex(const std::string& path) {
+  std::scoped_lock lock(file_mutex_map_mutex);
+  auto& m = file_mutex_map[path];
+  if (!m) {
+    m = std::make_unique<RefCountedMutex>();
+  }
+  m->ref_count++;
+  return m->mtx;
+}
+
+static void release_file_mutex(const std::string& path) {
+  std::scoped_lock lock(file_mutex_map_mutex);
+  auto it = file_mutex_map.find(path);
+  if (it != file_mutex_map.end() && --it->second->ref_count == 0) {
+    file_mutex_map.erase(it);
+  }
+}
+
+// RAII guard: acquires the per-file mutex and releases the ref count on destruction.
+class FileMutexGuard {
+  public:
+  explicit FileMutexGuard(const std::string& path) : path_(path), lock_(acquire_file_mutex(path)) {}
+  ~FileMutexGuard() {
+    lock_.unlock();
+    lock_.release();
+    release_file_mutex(path_);
+  }
+  FileMutexGuard(const FileMutexGuard&) = delete;
+  FileMutexGuard& operator=(const FileMutexGuard&) = delete;
+
+  private:
+  std::string path_;
+  std::unique_lock<std::mutex> lock_;
+};
+
+arrow::Status Transaction::unsafe_write(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                        const std::string& path,
+                                        std::string_view data) {
+  FileMutexGuard guard(path);
+
   ARROW_ASSIGN_OR_RAISE(auto file_info, fs->GetFileInfo(path));
   if (file_info.type() != arrow::fs::FileType::NotFound) {
     return arrow::Status::AlreadyExists("File already exists: ", path);
-  }
-
-  auto [parent, _] = milvus_storage::GetAbstractPathParent(path);
-  if (!parent.empty()) {
-    ARROW_RETURN_NOT_OK(fs->CreateDir(parent));
   }
 
   ARROW_ASSIGN_OR_RAISE(auto output_stream, fs->OpenOutputStream(path));
@@ -336,6 +385,24 @@ arrow::Status write_manifest_file(const std::shared_ptr<arrow::fs::FileSystem>& 
   ARROW_RETURN_NOT_OK(output_stream->Close());
 
   return arrow::Status::OK();
+}
+
+arrow::Status Transaction::write_manifest_file(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                               const std::string& path,
+                                               std::string_view data) {
+  // Local filesystem may not have the parent directory yet
+  if (IsLocalFileSystem(fs)) {
+    auto [parent, _] = milvus_storage::GetAbstractPathParent(path);
+    if (!parent.empty()) {
+      ARROW_RETURN_NOT_OK(fs->CreateDir(parent));
+    }
+  }
+
+  auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs);
+  if (conditional_fs) {
+    return conditional_write(conditional_fs, path, data);
+  }
+  return unsafe_write(fs, path, data);
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> direct_read(const std::shared_ptr<arrow::fs::FileSystem>& fs,

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -697,4 +697,98 @@ TEST_F(TransactionTest, IndexMultipleColumnsDeprecationTest) {
   }
 }
 
+// ==================== write_manifest_file Tests ====================
+
+TEST_F(TransactionTest, UnsafeWriteBasicTest) {
+  std::string file_path = base_path_ + "/test_unsafe_write.bin";
+  std::string data = "hello";
+
+  // First write should succeed
+  ASSERT_STATUS_OK(Transaction::unsafe_write(fs_, file_path, data));
+
+  // Second write to the same path should return AlreadyExists
+  auto status = Transaction::unsafe_write(fs_, file_path, data);
+  ASSERT_TRUE(status.IsAlreadyExists()) << status.ToString();
+}
+
+TEST_F(TransactionTest, WriteManifestFileFallsBackToUnsafeWrite) {
+  // LocalFileSystem does not implement UploadConditional, so write_manifest_file
+  // should fall back to unsafe_write.
+  std::string file_path = base_path_ + "/test_write_manifest.bin";
+  std::string data = "manifest_data";
+
+  ASSERT_STATUS_OK(Transaction::write_manifest_file(fs_, file_path, data));
+
+  // Verify file exists by trying to write again
+  auto status = Transaction::write_manifest_file(fs_, file_path, data);
+  ASSERT_TRUE(status.IsAlreadyExists()) << status.ToString();
+}
+
+TEST_F(TransactionTest, UnsafeWriteConcurrentDifferentFiles) {
+  // Concurrent writes to DIFFERENT files should all succeed (per-file lock, not global).
+  const size_t num_threads = 8;
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+  std::vector<arrow::Status> results(num_threads);
+
+  std::promise<void> start_promise;
+  std::shared_future<void> start_signal(start_promise.get_future());
+
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&, i, start_signal]() {
+      start_signal.wait();
+      std::string path = base_path_ + "/concurrent_diff_" + std::to_string(i) + ".bin";
+      results[i] = Transaction::unsafe_write(fs_, path, "data_" + std::to_string(i));
+    });
+  }
+
+  start_promise.set_value();
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  for (size_t i = 0; i < num_threads; ++i) {
+    ASSERT_STATUS_OK(results[i]);
+  }
+}
+
+TEST_F(TransactionTest, UnsafeWriteConcurrentSameFile) {
+  // Concurrent writes to the SAME file: exactly one should succeed, the rest AlreadyExists.
+  const size_t num_threads = 8;
+  std::string file_path = base_path_ + "/concurrent_same.bin";
+
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+  std::vector<arrow::Status> results(num_threads);
+
+  std::promise<void> start_promise;
+  std::shared_future<void> start_signal(start_promise.get_future());
+
+  for (size_t i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&, i, start_signal]() {
+      start_signal.wait();
+      results[i] = Transaction::unsafe_write(fs_, file_path, "data_" + std::to_string(i));
+    });
+  }
+
+  start_promise.set_value();
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  size_t success_count = 0;
+  size_t already_exists_count = 0;
+  for (size_t i = 0; i < num_threads; ++i) {
+    if (results[i].ok()) {
+      success_count++;
+    } else {
+      ASSERT_TRUE(results[i].IsAlreadyExists()) << "Unexpected error: " << results[i].ToString();
+      already_exists_count++;
+    }
+  }
+
+  ASSERT_EQ(success_count, 1) << "Exactly one thread should succeed writing the file";
+  ASSERT_EQ(already_exists_count, num_threads - 1);
+}
+
 }  // namespace milvus_storage::test


### PR DESCRIPTION
The old write_manifest_file held a single global mutex for all manifest writes, which meant commits to completely independent paths were serialized unnecessarily. This replaces it with per-file reference-counted mutexes so different paths can be written concurrently within the same process.

The write logic is now split into conditional_write (for S3-style atomic puts) and unsafe_write (check-then-write guarded by a per-file mutex). write_manifest_file picks the right one based on whether the filesystem supports UploadConditional.

Also tightened up conflict detection: instead of treating every IOError as "file already exists", we now check for specific ExtendStatusDetail codes (AwsErrorPreConditionFailed / AwsErrorConflict). The local filesystem's OpenConditionalOutputStream was updated to return the same error codes for consistency, and got a mutex to make the existence check safe within a single process.

Added tests for the basic unsafe write path, concurrent writes to different files, and concurrent writes to the same file.