### PR TITLE
enhance: apply clang-format and clang-tidy fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: fix-checks fix-format fix-tidy
 
-fix-checks: fix-format fix-tidy
+fix-checks:
+	$(MAKE) fix-tidy
+	$(MAKE) fix-format
 
 fix-format:
 	$(MAKE) -C cpp fix-format

--- a/cpp/benchmark/benchmark_data_loader.cpp
+++ b/cpp/benchmark/benchmark_data_loader.cpp
@@ -23,8 +23,7 @@
 
 #include "test_env.h"
 
-namespace milvus_storage {
-namespace benchmark {
+namespace milvus_storage::benchmark {
 
 //=============================================================================
 // SyntheticDataLoader Implementation
@@ -72,14 +71,16 @@ std::string SyntheticDataLoader::GetSchemaBasePatterns() const {
 }
 
 int64_t SyntheticDataLoader::GetDataSize() const {
-  if (!table_)
+  if (!table_) {
     return 0;
+  }
   int64_t size = 0;
   for (int i = 0; i < table_->num_columns(); ++i) {
     for (const auto& chunk : table_->column(i)->chunks()) {
       for (const auto& buffer : chunk->data()->buffers) {
-        if (buffer)
+        if (buffer) {
           size += buffer->size();
+        }
       }
     }
   }
@@ -225,14 +226,16 @@ std::string MilvusSegmentLoader::GetSchemaBasePatterns() const {
 }
 
 int64_t MilvusSegmentLoader::GetDataSize() const {
-  if (!merged_table_)
+  if (!merged_table_) {
     return 0;
+  }
   int64_t size = 0;
   for (int i = 0; i < merged_table_->num_columns(); ++i) {
     for (const auto& chunk : merged_table_->column(i)->chunks()) {
       for (const auto& buffer : chunk->data()->buffers) {
-        if (buffer)
+        if (buffer) {
           size += buffer->size();
+        }
       }
     }
   }
@@ -296,5 +299,4 @@ std::unique_ptr<BenchmarkDataLoader> CreateDataLoaderFromEnv(const SyntheticData
   return std::make_unique<SyntheticDataLoader>(fallback_config);
 }
 
-}  // namespace benchmark
-}  // namespace milvus_storage
+}  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_format_read.cpp
+++ b/cpp/benchmark/benchmark_format_read.cpp
@@ -18,8 +18,7 @@
 #include <arrow/table.h>
 #include "milvus-storage/thread_pool.h"
 
-namespace milvus_storage {
-namespace benchmark {
+namespace milvus_storage::benchmark {
 
 using namespace milvus_storage::api;
 
@@ -65,8 +64,9 @@ class FormatReadBenchmark : public FormatBenchFixtureBase<> {
     std::shared_ptr<arrow::RecordBatch> batch;
     while (true) {
       ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
-      if (!batch)
+      if (!batch) {
         break;
+      }
       ARROW_RETURN_NOT_OK(writer->write(batch));
     }
 
@@ -94,9 +94,9 @@ class FormatReadBenchmark : public FormatBenchFixtureBase<> {
 // Full scan benchmark - read all rows and all columns
 // Args: [format_idx, num_threads, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadFullScan)(::benchmark::State& st) {
-  size_t format_idx = static_cast<size_t>(st.range(0));
-  size_t num_threads = static_cast<size_t>(st.range(1));
-  size_t memory_config_idx = static_cast<size_t>(st.range(2));
+  auto format_idx = static_cast<size_t>(st.range(0));
+  auto num_threads = static_cast<size_t>(st.range(1));
+  auto memory_config_idx = static_cast<size_t>(st.range(2));
 
   std::string format = GetFormatByIndex(format_idx);
   if (!CheckFormatAvailable(st, format)) {
@@ -155,10 +155,10 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
 // Column projection benchmark - read subset of columns
 // Args: [format_idx, num_columns, num_threads, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadProjection)(::benchmark::State& st) {
-  size_t format_idx = static_cast<size_t>(st.range(0));
-  size_t num_columns = static_cast<size_t>(st.range(1));
-  size_t num_threads = static_cast<size_t>(st.range(2));
-  size_t memory_config_idx = static_cast<size_t>(st.range(3));
+  auto format_idx = static_cast<size_t>(st.range(0));
+  auto num_columns = static_cast<size_t>(st.range(1));
+  auto num_threads = static_cast<size_t>(st.range(2));
+  auto memory_config_idx = static_cast<size_t>(st.range(3));
 
   std::string format = GetFormatByIndex(format_idx);
   if (!CheckFormatAvailable(st, format)) {
@@ -231,11 +231,11 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
 // Random access benchmark - read specific rows by indices
 // Args: [format_idx, take_count, distribution, num_threads, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadTake)(::benchmark::State& st) {
-  size_t format_idx = static_cast<size_t>(st.range(0));
-  size_t take_count = static_cast<size_t>(st.range(1));
+  auto format_idx = static_cast<size_t>(st.range(0));
+  auto take_count = static_cast<size_t>(st.range(1));
   int distribution = static_cast<int>(st.range(2));
-  size_t num_threads = static_cast<size_t>(st.range(3));
-  size_t memory_config_idx = static_cast<size_t>(st.range(4));
+  auto num_threads = static_cast<size_t>(st.range(3));
+  auto memory_config_idx = static_cast<size_t>(st.range(4));
 
   std::string format = GetFormatByIndex(format_idx);
   if (!CheckFormatAvailable(st, format)) {
@@ -253,7 +253,7 @@ BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadTake)(::benchmark::State& st) {
   BENCH_ASSERT_STATUS_OK(PrepareTestData(format, cgs, path), st);
 
   // Generate indices based on distribution
-  IndexDistribution dist = static_cast<IndexDistribution>(distribution);
+  auto dist = static_cast<IndexDistribution>(distribution);
   auto indices = GenerateIndices(dist, take_count, GetLoaderNumRows());
 
   int64_t total_rows_read = 0;
@@ -338,5 +338,4 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 
-}  // namespace benchmark
-}  // namespace milvus_storage
+}  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_format_write.cpp
+++ b/cpp/benchmark/benchmark_format_write.cpp
@@ -16,8 +16,7 @@
 
 #include <arrow/filesystem/filesystem.h>
 
-namespace milvus_storage {
-namespace benchmark {
+namespace milvus_storage::benchmark {
 
 using namespace milvus_storage::api;
 
@@ -48,8 +47,9 @@ class FormatWriteBenchmark : public FormatBenchFixtureBase<> {
         st.SkipWithError(("Failed to read batch: " + status.ToString()).c_str());
         return;
       }
-      if (!batch)
+      if (!batch) {
         break;
+      }
       batches_.push_back(batch);
       total_bytes_ += CalculateRawDataSize(batch);
       total_rows_ += batch->num_rows();
@@ -74,9 +74,9 @@ class FormatWriteBenchmark : public FormatBenchFixtureBase<> {
 // Write comparison benchmark across formats
 // Args: [format_idx, data_config_idx, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatWriteBenchmark, WriteComparison)(::benchmark::State& st) {
-  size_t format_idx = static_cast<size_t>(st.range(0));
+  auto format_idx = static_cast<size_t>(st.range(0));
   // data_config_idx is ignored - we use data from loader
-  size_t memory_config_idx = static_cast<size_t>(st.range(2));
+  auto memory_config_idx = static_cast<size_t>(st.range(2));
 
   std::string format = GetFormatByIndex(format_idx);
   if (!CheckFormatAvailable(st, format)) {
@@ -185,7 +185,7 @@ static arrow::Result<int64_t> CalculateFileSize(const std::shared_ptr<arrow::fs:
 // The compression ratio is calculated by comparing file size against raw data size from loader
 // Args: [format_idx, data_config_idx]
 BENCHMARK_DEFINE_F(FormatWriteBenchmark, CompressionAnalysis)(::benchmark::State& st) {
-  size_t format_idx = static_cast<size_t>(st.range(0));
+  auto format_idx = static_cast<size_t>(st.range(0));
   // data_config_idx is ignored - we use data from loader
 
   std::string format = GetFormatByIndex(format_idx);
@@ -280,5 +280,4 @@ BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
     ->UseRealTime()
     ->Iterations(3);
 
-}  // namespace benchmark
-}  // namespace milvus_storage
+}  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_storage_layer.cpp
+++ b/cpp/benchmark/benchmark_storage_layer.cpp
@@ -28,8 +28,7 @@
 #include "format/bridge/rust/include/lance_bridge.h"
 #include "milvus-storage/format/lance/lance_common.h"
 
-namespace milvus_storage {
-namespace benchmark {
+namespace milvus_storage::benchmark {
 
 using namespace milvus_storage::api;
 using namespace milvus_storage::api::transaction;
@@ -95,8 +94,9 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
         st.SkipWithError(("Failed to read batch: " + status.ToString()).c_str());
         return;
       }
-      if (!batch)
+      if (!batch) {
         break;
+      }
       batches_.push_back(batch);
       total_bytes_ += CalculateRawDataSize(batch);
       total_rows_ += batch->num_rows();
@@ -128,8 +128,9 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
     ARROW_ASSIGN_OR_RAISE(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
 
     auto writer = Writer::create(path, schema_, std::move(policy), properties_);
-    if (!writer)
+    if (!writer) {
       return arrow::Status::Invalid("Failed to create writer");
+    }
 
     // Write all pre-loaded batches
     for (const auto& batch : batches_) {
@@ -155,8 +156,9 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
     ARROW_ASSIGN_OR_RAISE(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
 
     auto writer = Writer::create(path, schema_, std::move(policy), properties_);
-    if (!writer)
+    if (!writer) {
       return arrow::Status::Invalid("Failed to create writer");
+    }
 
     // Write all pre-loaded batches
     for (const auto& batch : batches_) {
@@ -177,16 +179,18 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
     auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
 
     auto reader = Reader::create(cgs, schema_, nullptr, properties_);
-    if (!reader)
+    if (!reader) {
       return arrow::Status::Invalid("Failed to create reader");
+    }
 
     ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader->get_record_batch_reader());
 
     std::shared_ptr<arrow::RecordBatch> batch;
     while (true) {
       ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
-      if (!batch)
+      if (!batch) {
         break;
+      }
       out_rows += batch->num_rows();
       out_bytes += CalculateRawDataSize(batch);
     }
@@ -202,16 +206,18 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
     auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
 
     auto reader = Reader::create(cgs, schema_, nullptr, properties_);
-    if (!reader)
+    if (!reader) {
       return arrow::Status::Invalid("Failed to create reader");
+    }
 
     ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader->get_record_batch_reader());
 
     std::shared_ptr<arrow::RecordBatch> batch;
     while (true) {
       ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
-      if (!batch)
+      if (!batch) {
         break;
+      }
       // No stats collection in benchmark loop
     }
     return arrow::Status::OK();
@@ -229,16 +235,18 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
     auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
 
     auto reader = Reader::create(cgs, schema_, nullptr, properties_);
-    if (!reader)
+    if (!reader) {
       return arrow::Status::Invalid("Failed to create reader");
+    }
 
     ARROW_ASSIGN_OR_RAISE(auto table, reader->take(indices));
     out_rows += table->num_rows();
     for (int i = 0; i < table->num_columns(); ++i) {
       for (const auto& chunk : table->column(i)->chunks()) {
         for (const auto& buffer : chunk->data()->buffers) {
-          if (buffer)
+          if (buffer) {
             out_bytes += buffer->size();
+          }
         }
       }
     }
@@ -254,8 +262,9 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
     auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
 
     auto reader = Reader::create(cgs, schema_, nullptr, properties_);
-    if (!reader)
+    if (!reader) {
       return arrow::Status::Invalid("Failed to create reader");
+    }
 
     ARROW_ASSIGN_OR_RAISE(auto table, reader->take(indices));
     // No stats collection in benchmark loop
@@ -323,8 +332,9 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_WriteCommit)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
 
-  if (!CheckStorageFormatAvailable(st, format_type))
+  if (!CheckStorageFormatAvailable(st, format_type)) {
     return;
+  }
 
   ConfigureThreadPool(1);
 
@@ -357,8 +367,9 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_WriteOnly)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
 
-  if (!CheckStorageFormatAvailable(st, format_type))
+  if (!CheckStorageFormatAvailable(st, format_type)) {
     return;
+  }
 
   ConfigureThreadPool(1);
 
@@ -393,8 +404,9 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_OpenRead)(::benchmark::Sta
   auto format_type = static_cast<StorageFormatType>(st.range(0));
   int num_threads = static_cast<int>(st.range(1));
 
-  if (!CheckStorageFormatAvailable(st, format_type))
+  if (!CheckStorageFormatAvailable(st, format_type)) {
     return;
+  }
 
   ConfigureThreadPool(num_threads);
 
@@ -435,11 +447,12 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
 // Args: [format_type, take_count, num_threads]
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_Take)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
-  size_t take_count = static_cast<size_t>(st.range(1));
+  auto take_count = static_cast<size_t>(st.range(1));
   int num_threads = static_cast<int>(st.range(2));
 
-  if (!CheckStorageFormatAvailable(st, format_type))
+  if (!CheckStorageFormatAvailable(st, format_type)) {
     return;
+  }
 
   ConfigureThreadPool(num_threads);
 
@@ -539,8 +552,9 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_OpenRead)(::benchmark::State
     std::shared_ptr<arrow::RecordBatch> rb;
     while (true) {
       ARROW_RETURN_NOT_OK(reader->ReadNext(&rb));
-      if (!rb)
+      if (!rb) {
         break;
+      }
       if (collect_stats) {
         out_rows += rb->num_rows();
         out_bytes += CalculateRawDataSize(rb);
@@ -580,7 +594,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_OpenRead)
 
 // Args: [take_count, num_threads]
 BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_Take)(::benchmark::State& st) {
-  size_t take_count = static_cast<size_t>(st.range(0));
+  auto take_count = static_cast<size_t>(st.range(0));
   int num_threads = static_cast<int>(st.range(1));
 
   lance::ReplaceLanceRuntime(static_cast<uint32_t>(num_threads));
@@ -610,8 +624,9 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_Take)(::benchmark::State& st
     std::shared_ptr<arrow::RecordBatch> rb;
     while (true) {
       ARROW_RETURN_NOT_OK(reader->ReadNext(&rb));
-      if (!rb)
+      if (!rb) {
         break;
+      }
       if (collect_stats) {
         out_rows += rb->num_rows();
         out_bytes += CalculateRawDataSize(rb);
@@ -699,6 +714,7 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_MultiReader)(::benchmark::St
     std::atomic<bool> has_error{false};
 
     // Launch N reader threads
+    reader_threads.reserve(num_readers);
     for (int i = 0; i < num_readers; ++i) {
       reader_threads.emplace_back([&, i]() {
         auto read_all = [&]() -> arrow::Status {
@@ -715,8 +731,9 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_MultiReader)(::benchmark::St
           std::shared_ptr<arrow::RecordBatch> rb;
           while (true) {
             ARROW_RETURN_NOT_OK(reader->ReadNext(&rb));
-            if (!rb)
+            if (!rb) {
               break;
+            }
             rows_read += rb->num_rows();
             bytes_read += CalculateRawDataSize(rb);
           }
@@ -772,8 +789,9 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_MultiReader)(::benchmark::
   int num_readers = static_cast<int>(st.range(1));
   int thread_pool_size = static_cast<int>(st.range(2));
 
-  if (!CheckStorageFormatAvailable(st, format_type))
+  if (!CheckStorageFormatAvailable(st, format_type)) {
     return;
+  }
 
   ConfigureThreadPool(thread_pool_size);
 
@@ -795,6 +813,7 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_MultiReader)(::benchmark::
     std::atomic<bool> has_error{false};
 
     // Launch N reader threads, each opens its own transaction
+    reader_threads.reserve(num_readers);
     for (int i = 0; i < num_readers; ++i) {
       reader_threads.emplace_back([&, i]() {
         auto read_all = [&]() -> arrow::Status {
@@ -803,16 +822,18 @@ BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_MultiReader)(::benchmark::
           auto cgs = std::make_shared<ColumnGroups>(manifest->columnGroups());
 
           auto reader = Reader::create(cgs, schema_, nullptr, properties_);
-          if (!reader)
+          if (!reader) {
             return arrow::Status::Invalid("Failed to create reader");
+          }
 
           ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader->get_record_batch_reader());
 
           std::shared_ptr<arrow::RecordBatch> rb;
           while (true) {
             ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&rb));
-            if (!rb)
+            if (!rb) {
               break;
+            }
             rows_read += rb->num_rows();
             bytes_read += CalculateRawDataSize(rb);
           }
@@ -926,5 +947,4 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 
-}  // namespace benchmark
-}  // namespace milvus_storage
+}  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_v2_v3.cpp
+++ b/cpp/benchmark/benchmark_v2_v3.cpp
@@ -26,8 +26,7 @@
 #include "milvus-storage/packed/reader.h"
 #include "milvus-storage/thread_pool.h"
 
-namespace milvus_storage {
-namespace benchmark {
+namespace milvus_storage::benchmark {
 
 using namespace milvus_storage::api;
 
@@ -66,8 +65,9 @@ class V2V3BenchFixture : public FormatBenchFixtureBase<> {
         st.SkipWithError(("Failed to read batch: " + status.ToString()).c_str());
         return;
       }
-      if (!batch)
+      if (!batch) {
         break;
+      }
       batches_.push_back(batch);
       total_bytes_ += CalculateRawDataSize(batch);
       total_rows_ += batch->num_rows();
@@ -94,6 +94,7 @@ class V2V3BenchFixture : public FormatBenchFixtureBase<> {
     // Build column groups based on schema
     std::vector<std::vector<int>> column_groups;
     std::vector<int> all_cols;
+    all_cols.reserve(schema_->num_fields());
     for (int i = 0; i < schema_->num_fields(); ++i) {
       all_cols.push_back(i);
     }
@@ -161,8 +162,9 @@ BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchReader)(::benchmark::St
     std::shared_ptr<arrow::RecordBatch> batch;
     while (true) {
       BENCH_ASSERT_STATUS_OK(reader.ReadNext(&batch), st);
-      if (batch == nullptr)
+      if (batch == nullptr) {
         break;
+      }
       total_rows_read += batch->num_rows();
       total_bytes_read += CalculateRawDataSize(batch);
     }
@@ -253,6 +255,7 @@ BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)(::benchmark::St
   // Build column groups based on schema
   std::vector<std::vector<int>> column_groups;
   std::vector<int> all_cols;
+  all_cols.reserve(schema_->num_fields());
   for (int i = 0; i < schema_->num_fields(); ++i) {
     all_cols.push_back(i);
   }
@@ -345,5 +348,4 @@ BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_Writer)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 
-}  // namespace benchmark
-}  // namespace milvus_storage
+}  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_wr.cpp
+++ b/cpp/benchmark/benchmark_wr.cpp
@@ -93,7 +93,7 @@ struct WriteDataConfig {
 };
 
 static void APIWriteBenchmark(benchmark::State& st,
-                              std::shared_ptr<arrow::fs::FileSystem> fs,
+                              const std::shared_ptr<arrow::fs::FileSystem>& fs,
                               std::string& base_path,
                               const api::Properties& properties,
                               size_t loop_times,
@@ -107,7 +107,7 @@ static void APIWriteBenchmark(benchmark::State& st,
 
   for (auto _ : st) {
     GBENCH_ASSERT_AND_ASSIGN(auto policy, ColumnGroupPolicy::create_column_group_policy(properties, schema), st);
-    auto writer = Writer::create(base_path, schema, std::move(policy), std::move(properties));
+    auto writer = Writer::create(base_path, schema, std::move(policy), properties);
     for (size_t i = 0; i < loop_times; ++i) {
       GBENCH_ASSERT_STATUS_OK(writer->write(record_batch), st);
     }
@@ -132,7 +132,7 @@ static std::shared_ptr<std::vector<std::string>> GetProjection(std::array<bool, 
 }
 
 static void APIFullReadBenchmark(benchmark::State& st,
-                                 std::shared_ptr<arrow::fs::FileSystem> fs,
+                                 const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                  std::string& base_path,
                                  const api::Properties& properties,
                                  size_t loop_times,
@@ -147,7 +147,7 @@ static void APIFullReadBenchmark(benchmark::State& st,
       st);
 
   GBENCH_ASSERT_AND_ASSIGN(auto policy, ColumnGroupPolicy::create_column_group_policy(properties, schema), st);
-  auto writer = Writer::create(base_path, schema, std::move(policy), std::move(properties));
+  auto writer = Writer::create(base_path, schema, std::move(policy), properties);
   for (size_t i = 0; i < loop_times; ++i) {
     GBENCH_ASSERT_STATUS_OK(writer->write(record_batch), st);
   }
@@ -172,7 +172,7 @@ static void APIFullReadBenchmark(benchmark::State& st,
 }
 
 static void APIWriteLargeBenchmark(benchmark::State& st,
-                                   std::shared_ptr<arrow::fs::FileSystem> fs,
+                                   const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                    std::string& base_path,
                                    const api::Properties& properties,
                                    size_t target_row,
@@ -195,7 +195,7 @@ static void APIWriteLargeBenchmark(benchmark::State& st,
 
   for (auto _ : st) {
     GBENCH_ASSERT_AND_ASSIGN(auto policy, ColumnGroupPolicy::create_column_group_policy(properties, schema), st);
-    auto writer = Writer::create(base_path, schema, std::move(policy), std::move(properties));
+    auto writer = Writer::create(base_path, schema, std::move(policy), properties);
     for (size_t i = 0; i < target_write_times; ++i) {
       auto rb = batches[i % multi_random_rb_counts];
       GBENCH_ASSERT_STATUS_OK(writer->write(rb), st);

--- a/cpp/include/milvus-storage/common/metadata.h
+++ b/cpp/include/milvus-storage/common/metadata.h
@@ -139,7 +139,8 @@ class PackedFileMetadata {
                               const GroupFieldIDList& group_field_id_list,
                               const std::string& storage_version);
 
-  static arrow::Result<std::shared_ptr<PackedFileMetadata>> Make(std::shared_ptr<::parquet::FileMetaData> metadata);
+  static arrow::Result<std::shared_ptr<PackedFileMetadata>> Make(
+      const std::shared_ptr<::parquet::FileMetaData>& metadata);
 
   const RowGroupMetadataVector GetRowGroupMetadataVector();
 

--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -54,8 +54,8 @@ class ColumnGroupReader {
    * @return Unique pointer to the created chunk reader
    */
   [[nodiscard]] static arrow::Result<std::unique_ptr<ColumnGroupReader>> create(
-      std::shared_ptr<arrow::Schema> schema,
-      std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
+      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
       const std::vector<std::string>& needed_columns,
       const milvus_storage::api::Properties& properties,
       const std::function<std::string(const std::string&)>& key_retriever);

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -25,7 +25,7 @@ namespace milvus_storage::lance {
 
 class LanceTableReader final : public FormatReader, public std::enable_shared_from_this<LanceTableReader> {
   public:
-  LanceTableReader(const std::shared_ptr<BlockingDataset> dataset,
+  LanceTableReader(const std::shared_ptr<BlockingDataset>& dataset,
                    uint64_t fragment_id,
                    const std::shared_ptr<arrow::Schema>& schema,
                    const milvus_storage::api::Properties& properties,

--- a/cpp/include/milvus-storage/format/parquet/file_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/file_reader.h
@@ -23,17 +23,17 @@ namespace milvus_storage {
 class FileRowGroupReader {
   public:
   static arrow::Result<std::shared_ptr<FileRowGroupReader>> Make(
-      std::shared_ptr<arrow::fs::FileSystem> fs,
+      const std::shared_ptr<arrow::fs::FileSystem>& fs,
       const std::string& path,
       const int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE,
-      ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties());
+      const ::parquet::ReaderProperties& reader_props = ::parquet::default_reader_properties());
 
   static arrow::Result<std::shared_ptr<FileRowGroupReader>> Make(
-      std::shared_ptr<arrow::fs::FileSystem> fs,
+      const std::shared_ptr<arrow::fs::FileSystem>& fs,
       const std::string& path,
-      const std::shared_ptr<arrow::Schema> schema,
+      const std::shared_ptr<arrow::Schema>& schema,
       const int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE,
-      ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties());
+      const ::parquet::ReaderProperties& reader_props = ::parquet::default_reader_properties());
 
   arrow::Status SetRowGroupOffsetAndCount(int row_group_offset, int row_group_num);
 
@@ -68,10 +68,10 @@ class FileRowGroupReader {
    * @param buffer_size Memory limit for reading row groups.
    * @param reader_props The reader properties.
    */
-  FileRowGroupReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+  FileRowGroupReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                      const std::string& path,
                      const int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE,
-                     ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties());
+                     const ::parquet::ReaderProperties& reader_props = ::parquet::default_reader_properties());
 
   /**
    * @brief FileRowGroupReader reads specified row groups with memory constraints and schema.
@@ -82,18 +82,18 @@ class FileRowGroupReader {
    * @param buffer_size Memory limit for reading row groups.
    * @param reader_props The reader properties.
    */
-  FileRowGroupReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+  FileRowGroupReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                      const std::string& path,
-                     const std::shared_ptr<arrow::Schema> schema,
+                     const std::shared_ptr<arrow::Schema>& schema,
                      const int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE,
-                     ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties());
+                     const ::parquet::ReaderProperties& reader_props = ::parquet::default_reader_properties());
 
   private:
   arrow::Status init(std::shared_ptr<arrow::fs::FileSystem> fs,
                      const std::string& path,
                      const int64_t buffer_size,
-                     const std::shared_ptr<arrow::Schema> schema = nullptr,
-                     ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties());
+                     const std::shared_ptr<arrow::Schema>& schema = nullptr,
+                     const ::parquet::ReaderProperties& reader_props = ::parquet::default_reader_properties());
 
   /**
    * @brief Slices a row group from the table and updates the buffer state.

--- a/cpp/include/milvus-storage/format/parquet/parquet_writer.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_writer.h
@@ -42,14 +42,15 @@ class ParquetFileWriter : public FormatWriter {
       std::shared_ptr<arrow::fs::FileSystem> fs,
       const std::string& file_path,
       const milvus_storage::StorageConfig& storage_config,
-      std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
+      const std::shared_ptr<::parquet::WriterProperties>& writer_props = ::parquet::default_writer_properties());
 
   protected:
-  ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
-                    std::shared_ptr<arrow::fs::FileSystem> fs,
-                    const std::string& file_path,
-                    const milvus_storage::StorageConfig& storage_config,
-                    std::shared_ptr<::parquet::WriterProperties> writer_props = ::parquet::default_writer_properties());
+  ParquetFileWriter(
+      std::shared_ptr<arrow::Schema> schema,
+      std::shared_ptr<arrow::fs::FileSystem> fs,
+      const std::string& file_path,
+      const milvus_storage::StorageConfig& storage_config,
+      const std::shared_ptr<::parquet::WriterProperties>& writer_props = ::parquet::default_writer_properties());
 
   arrow::Status init();
 

--- a/cpp/include/milvus-storage/format/vortex/vortex_writer.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_writer.h
@@ -28,7 +28,7 @@ namespace milvus_storage::vortex {
 
 class VortexFileWriter final : public FormatWriter {
   public:
-  VortexFileWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
+  VortexFileWriter(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                    std::shared_ptr<arrow::Schema> schema,
                    const std::string& file_path,
                    const api::Properties& properties);

--- a/cpp/include/milvus-storage/packed/reader.h
+++ b/cpp/include/milvus-storage/packed/reader.h
@@ -46,9 +46,9 @@ class PackedRecordBatchReader : public arrow::RecordBatchReader {
    * @param buffer_size The max buffer size of the packed reader.
    * @param reader_props The reader properties.
    */
-  PackedRecordBatchReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+  PackedRecordBatchReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                           std::vector<std::string>& paths,
-                          std::shared_ptr<arrow::Schema> schema,
+                          const std::shared_ptr<arrow::Schema>& schema,
                           int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE,
                           ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties());
 
@@ -76,13 +76,13 @@ class PackedRecordBatchReader : public arrow::RecordBatchReader {
   arrow::Status Close() override;
 
   private:
-  arrow::Status init(std::shared_ptr<arrow::fs::FileSystem> fs,
+  arrow::Status init(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                      std::vector<std::string>& paths,
-                     std::shared_ptr<arrow::Schema> origin_schema,
+                     const std::shared_ptr<arrow::Schema>& origin_schema,
                      ::parquet::ReaderProperties& reader_props);
 
-  arrow::Status schemaMatching(std::shared_ptr<arrow::fs::FileSystem> fs,
-                               std::shared_ptr<arrow::Schema> schema,
+  arrow::Status schemaMatching(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                               const std::shared_ptr<arrow::Schema>& schema,
                                std::vector<std::string>& paths,
                                ::parquet::ReaderProperties& reader_props);
 

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -211,9 +211,7 @@ class Transaction {
    */
   Transaction& DropIndex(const std::string& column_name, const std::string& index_type);
 
-#ifndef BUILD_GTEST
   private:
-#endif
   // Private constructor - use Open() factory method instead
   Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
               const std::string& base_path,

--- a/cpp/src/common/arrow_util.cpp
+++ b/cpp/src/common/arrow_util.cpp
@@ -62,8 +62,9 @@ arrow::Result<std::unique_ptr<parquet::arrow::FileReader>> MakeArrowFileReader(
 
 size_t CalculateArrayDataMemorySize(const std::shared_ptr<arrow::ArrayData>& array_data,
                                     std::unordered_set<const void*>& seen_buffers) {
-  if (!array_data)
+  if (!array_data) {
     return 0;
+  }
   size_t size = 0;
 
   for (const auto& buffer : array_data->buffers) {
@@ -83,8 +84,9 @@ size_t CalculateArrayDataMemorySize(const std::shared_ptr<arrow::ArrayData>& arr
 
 size_t CalculateArrayMemorySize(const std::shared_ptr<arrow::Array>& array,
                                 std::unordered_set<const void*>& seen_buffers) {
-  if (!array)
+  if (!array) {
     return 0;
+  }
   return CalculateArrayDataMemorySize(array->data(), seen_buffers);
 }
 

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -61,8 +61,7 @@ std::shared_ptr<ExtendStatusDetail> ExtendStatusDetail::UnwrapStatus(const arrow
 
 arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info) {
   arrow::StatusCode arrow_code = arrow::StatusCode::IOError;
-  return arrow::Status(arrow_code, std::move(message),
-                       std::make_shared<ExtendStatusDetail>(code, std::move(extra_info)));
+  return {arrow_code, std::move(message), std::make_shared<ExtendStatusDetail>(code, std::move(extra_info))};
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/common/metadata.cpp
+++ b/cpp/src/common/metadata.cpp
@@ -28,7 +28,7 @@
 namespace milvus_storage {
 
 // Implementation of FieldIDList
-FieldIDList::FieldIDList(const std::vector<FieldID>& field_ids) : field_ids_(std::move(field_ids)) {}
+FieldIDList::FieldIDList(const std::vector<FieldID>& field_ids) : field_ids_(field_ids) {}
 
 bool FieldIDList::operator==(const FieldIDList& other) const { return field_ids_ == other.field_ids_; }
 
@@ -94,7 +94,7 @@ GroupFieldIDList::GroupFieldIDList(const std::vector<std::vector<int>>& list) {
   }
 }
 
-GroupFieldIDList::GroupFieldIDList(const std::vector<FieldIDList>& list) : list_(std::move(list)) {}
+GroupFieldIDList::GroupFieldIDList(const std::vector<FieldIDList>& list) : list_(list) {}
 
 GroupFieldIDList GroupFieldIDList::Make(const std::vector<std::vector<int>>& column_groups,
                                         FieldIDList& field_id_list) {
@@ -281,14 +281,14 @@ PackedFileMetadata::PackedFileMetadata(const std::shared_ptr<parquet::FileMetaDa
                                        const std::map<FieldID, ColumnOffset>& field_id_mapping,
                                        const GroupFieldIDList& group_field_id_list,
                                        const std::string& storage_version)
-    : parquet_metadata_(std::move(metadata)),
-      row_group_metadata_(std::move(row_group_metadata)),
-      field_id_mapping_(std::move(field_id_mapping)),
-      group_field_id_list_(std::move(group_field_id_list)),
+    : parquet_metadata_(metadata),
+      row_group_metadata_(row_group_metadata),
+      field_id_mapping_(field_id_mapping),
+      group_field_id_list_(group_field_id_list),
       storage_version_(storage_version) {}
 
 arrow::Result<std::shared_ptr<PackedFileMetadata>> PackedFileMetadata::Make(
-    std::shared_ptr<parquet::FileMetaData> metadata) {
+    const std::shared_ptr<parquet::FileMetaData>& metadata) {
   // deserialize row group metadata
   auto key_value_metadata = metadata->key_value_metadata();
   auto row_group_meta = key_value_metadata->Get(ROW_GROUP_META_KEY);

--- a/cpp/src/ffi/column_groups_c.cpp
+++ b/cpp/src/ffi/column_groups_c.cpp
@@ -70,8 +70,9 @@ LoonFFIResult loon_column_groups_create(const char** columns,
 }
 
 static void destroy_column_group_file(LoonColumnGroupFile* ccgf) {
-  if (!ccgf)
+  if (!ccgf) {
     return;
+  }
 
   // Free path
   if (ccgf->path) {
@@ -88,8 +89,9 @@ static void destroy_column_group_file(LoonColumnGroupFile* ccgf) {
 }
 
 void destroy_column_group(LoonColumnGroup* ccg) {
-  if (!ccg)
+  if (!ccg) {
     return;
+  }
 
   // Free column names
   if (ccg->columns) {
@@ -122,8 +124,9 @@ void destroy_column_group(LoonColumnGroup* ccg) {
 
 // Helper function to destroy embedded column groups (used by loon_manifest_destroy)
 void destroy_column_groups_contents(LoonColumnGroups* cgroups) {
-  if (!cgroups)
+  if (!cgroups) {
     return;
+  }
 
   // Destroy column groups
   if (cgroups->column_group_array) {
@@ -137,8 +140,9 @@ void destroy_column_groups_contents(LoonColumnGroups* cgroups) {
 }
 
 void loon_column_groups_destroy(LoonColumnGroups* cgroups) {
-  if (!cgroups)
+  if (!cgroups) {
     return;
+  }
 
   // Destroy contents
   destroy_column_groups_contents(cgroups);

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -445,10 +445,12 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
 
     // Initialize outputs
     *out_size = 0;
-    if (out_meta_array)
+    if (out_meta_array) {
       *out_meta_array = nullptr;
-    if (out_meta_count)
+    }
+    if (out_meta_count) {
       *out_meta_count = 0;
+    }
 
     auto fs = reinterpret_cast<FileSystemWrapper*>(handle)->get();
     std::string path(path_ptr, path_len);
@@ -475,10 +477,10 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
         if (metadata && metadata->size() > 0) {
           const auto& keys = metadata->keys();
           const auto& values = metadata->values();
-          uint32_t count = static_cast<uint32_t>(keys.size());
+          auto count = static_cast<uint32_t>(keys.size());
 
           // Allocate array of LoonFileSystemMeta structs
-          *out_meta_array = (LoonFileSystemMeta*)malloc(count * sizeof(LoonFileSystemMeta));
+          *out_meta_array = static_cast<LoonFileSystemMeta*>(malloc(count * sizeof(LoonFileSystemMeta)));
 
           if (!*out_meta_array) {
             RETURN_ERROR(LOON_LOGICAL_ERROR, "Failed to allocate memory for metadata array");
@@ -498,10 +500,12 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
             if (!(*out_meta_array)[i].key || !(*out_meta_array)[i].value) {
               // Clean up on error
               for (uint32_t j = 0; j <= i; j++) {
-                if ((*out_meta_array)[j].key)
+                if ((*out_meta_array)[j].key) {
                   free((*out_meta_array)[j].key);
-                if ((*out_meta_array)[j].value)
+                }
+                if ((*out_meta_array)[j].value) {
                   free((*out_meta_array)[j].value);
+                }
               }
               free(*out_meta_array);
               *out_meta_array = nullptr;
@@ -517,20 +521,24 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
     RETURN_SUCCESS();
   } catch (const std::exception& e) {
     // Clean up on error
-    if (out_size)
+    if (out_size) {
       *out_size = 0;
+    }
     if (out_meta_array && *out_meta_array) {
       for (uint32_t i = 0; i < (out_meta_count && *out_meta_count ? *out_meta_count : 0); i++) {
-        if ((*out_meta_array)[i].key)
+        if ((*out_meta_array)[i].key) {
           free((*out_meta_array)[i].key);
-        if ((*out_meta_array)[i].value)
+        }
+        if ((*out_meta_array)[i].value) {
           free((*out_meta_array)[i].value);
+        }
       }
       free(*out_meta_array);
       *out_meta_array = nullptr;
     }
-    if (out_meta_count)
+    if (out_meta_count) {
       *out_meta_count = 0;
+    }
     RETURN_EXCEPTION(e.what());
   }
 
@@ -586,7 +594,7 @@ LoonFFIResult loon_filesystem_read_file_all(
 
     // Allocate memory for file content
     *out_size = static_cast<uint64_t>(file_size);
-    *out_data = (uint8_t*)malloc(file_size);
+    *out_data = static_cast<uint8_t*>(malloc(file_size));
     if (!*out_data) {
       *out_size = 0;
       RETURN_ERROR(LOON_LOGICAL_ERROR, "Failed to allocate memory for file data");
@@ -738,10 +746,12 @@ LoonFFIResult loon_filesystem_get_path_info(FileSystemHandle handle,
 
     // Initialize outputs
     *out_exists = false;
-    if (out_is_dir)
+    if (out_is_dir) {
       *out_is_dir = false;
-    if (out_mtime_ns)
+    }
+    if (out_mtime_ns) {
       *out_mtime_ns = 0;
+    }
 
     auto fs = reinterpret_cast<FileSystemWrapper*>(handle)->get();
     std::string path(path_ptr, path_len);
@@ -778,12 +788,15 @@ LoonFFIResult loon_filesystem_get_path_info(FileSystemHandle handle,
 
     RETURN_SUCCESS();
   } catch (const std::exception& e) {
-    if (out_exists)
+    if (out_exists) {
       *out_exists = false;
-    if (out_is_dir)
+    }
+    if (out_is_dir) {
       *out_is_dir = false;
-    if (out_mtime_ns)
+    }
+    if (out_mtime_ns) {
       *out_mtime_ns = 0;
+    }
     RETURN_EXCEPTION(e.what());
   }
 
@@ -859,14 +872,14 @@ LoonFFIResult loon_filesystem_list_dir(
     }
 
     auto file_infos = file_info_result.ValueOrDie();
-    uint32_t count = static_cast<uint32_t>(file_infos.size());
+    auto count = static_cast<uint32_t>(file_infos.size());
 
     if (count == 0) {
       RETURN_SUCCESS();
     }
 
     // Allocate entries array
-    out_list->entries = (LoonFileInfo*)malloc(count * sizeof(LoonFileInfo));
+    out_list->entries = static_cast<LoonFileInfo*>(malloc(count * sizeof(LoonFileInfo)));
     if (!out_list->entries) {
       RETURN_ERROR(LOON_LOGICAL_ERROR, "Failed to allocate memory for file info list");
     }

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -272,8 +272,9 @@ LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle handle,
 }
 
 void loon_manifest_destroy(LoonManifest* cmanifest) {
-  if (!cmanifest)
+  if (!cmanifest) {
     return;
+  }
 
   // Destroy column groups (embedded structure, not a pointer)
   destroy_column_groups_contents(&cmanifest->column_groups);

--- a/cpp/src/ffi/reader_c.cpp
+++ b/cpp/src/ffi/reader_c.cpp
@@ -62,7 +62,7 @@ LoonFFIResult loon_get_chunk_indices(LoonChunkReaderHandle reader,
     auto* cpp_reader = reinterpret_cast<ChunkReader*>(reader);
     std::vector<int64_t> input_indices(row_indices, row_indices + num_indices);
 
-    auto result = cpp_reader->get_chunk_indices(std::move(input_indices));
+    auto result = cpp_reader->get_chunk_indices(input_indices);
     if (!result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
     }
@@ -272,8 +272,9 @@ LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
                  "must be > 0");
   }
 
-  if (parallelism == 0)
+  if (parallelism == 0) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: parallelism must be > 0");
+  }
 
   try {
     auto* cpp_reader = reinterpret_cast<ChunkReader*>(reader);
@@ -299,13 +300,13 @@ LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
           // Free previously allocated arrays
           loon_free_chunk_arrays(*arrays, i);
           *num_arrays = 0;
-          *arrays = NULL;
+          *arrays = nullptr;
           RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
         }
       }
     } else {
       *num_arrays = 0;
-      *arrays = NULL;
+      *arrays = nullptr;
       RETURN_ERROR(LOON_MEMORY_ERROR, "Fail to alloc for chunk arrays [rb size=", record_batches.size(), "]");
     }
 
@@ -314,7 +315,7 @@ LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
       if (!status.ok()) {
         loon_free_chunk_arrays(*arrays, *num_arrays);
         *num_arrays = 0;
-        *arrays = NULL;
+        *arrays = nullptr;
         RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
       }
     }
@@ -436,8 +437,9 @@ void loon_reader_set_keyretriever(LoonReaderHandle reader, const char* (*key_ret
 LoonFFIResult loon_get_record_batch_reader(LoonReaderHandle reader,
                                            const char* predicate,
                                            ArrowArrayStream* out_array_stream) {
-  if (!reader || !out_array_stream)
+  if (!reader || !out_array_stream) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: reader and out_array_stream must not be null");
+  }
 
   try {
     auto* cpp_reader = reinterpret_cast<Reader*>(reader);
@@ -467,15 +469,17 @@ LoonFFIResult loon_get_chunk_reader(LoonReaderHandle reader,
                                     const char* const* needed_columns,
                                     size_t num_columns,
                                     LoonChunkReaderHandle* out_handle) {
-  if (!reader || !out_handle)
+  if (!reader || !out_handle) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: reader and out_handle must not be null");
+  }
 
   try {
     auto* cpp_reader = reinterpret_cast<Reader*>(reader);
     auto cpp_needed_columns = convert_needed_columns(needed_columns, num_columns);
     auto result = cpp_reader->get_chunk_reader(column_group_id, cpp_needed_columns);
-    if (!result.ok())
+    if (!result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+    }
 
     // Transfer ownership to a raw pointer for C interface
     auto* chunk_reader = result.ValueOrDie().release();
@@ -498,13 +502,15 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
                         ArrowArray** arrays,
                         size_t* num_arrays,
                         ArrowSchema* out_schema) {
-  if (!reader || !row_indices || num_indices == 0 || !arrays || !num_arrays)
+  if (!reader || !row_indices || num_indices == 0 || !arrays || !num_arrays) {
     RETURN_ERROR(
         LOON_INVALID_ARGS,
         "Invalid arguments: reader, row_indices, and out_arrays must not be null, and num_indices must be > 0");
+  }
 
-  if (parallelism == 0)
+  if (parallelism == 0) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: parallelism must be > 0");
+  }
 
   try {
     auto* cpp_reader = reinterpret_cast<Reader*>(reader);
@@ -512,13 +518,15 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
     auto cpp_needed_columns = convert_needed_columns(needed_columns, num_columns);
 
     auto result = cpp_reader->take(indices, parallelism, cpp_needed_columns);
-    if (!result.ok())
+    if (!result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+    }
 
     auto table = result.ValueOrDie();
     auto rbs_result = ConvertTableToRecordBatchs(table);
-    if (!rbs_result.ok())
+    if (!rbs_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, rbs_result.status().ToString());
+    }
     auto record_batches = rbs_result.ValueOrDie();
 
     // Convert RecordBatches to Arrow C ABI arrays
@@ -531,7 +539,7 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
           // Free previously allocated arrays
           loon_free_chunk_arrays(*arrays, i);
           *num_arrays = 0;
-          *arrays = NULL;
+          *arrays = nullptr;
           RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
         }
       }
@@ -542,13 +550,13 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
         if (!status.ok()) {
           loon_free_chunk_arrays(*arrays, *num_arrays);
           *num_arrays = 0;
-          *arrays = NULL;
+          *arrays = nullptr;
           RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
         }
       }
     } else {
       *num_arrays = 0;
-      *arrays = NULL;
+      *arrays = nullptr;
       RETURN_ERROR(LOON_MEMORY_ERROR, "Fail to alloc for chunk arrays [rb size=", record_batches.size(), "]");
     }
 

--- a/cpp/src/ffi/result_c.cpp
+++ b/cpp/src/ffi/result_c.cpp
@@ -46,7 +46,7 @@ int loon_ffi_is_success(LoonFFIResult* result) {
 const char* loon_ffi_get_errmsg(LoonFFIResult* result) {
   assert(result);
   if (loon_ffi_is_success(result)) {
-    return NULL;
+    return nullptr;
   }
   return result->message;
 }

--- a/cpp/src/ffi/writer_c.cpp
+++ b/cpp/src/ffi/writer_c.cpp
@@ -51,8 +51,7 @@ LoonFFIResult loon_writer_new(const char* base_path,
       RETURN_ERROR(LOON_ARROW_ERROR, policy_status.ToString());
     }
 
-    auto cpp_writer =
-        Writer::create(std::move(std::string(base_path)), schema, std::move(policy), std::move(properties_map));
+    auto cpp_writer = Writer::create(std::move(std::string(base_path)), schema, std::move(policy), properties_map);
 
     auto raw_cpp_writer = reinterpret_cast<LoonWriterHandle>(cpp_writer.release());
     assert(raw_cpp_writer);
@@ -137,8 +136,8 @@ LoonFFIResult loon_writer_close(LoonWriterHandle handle,
                      "]");
       }
 
-      meta_keys_vec.emplace_back(std::string_view(meta_keys[i]));
-      meta_vals_vec.emplace_back(std::string_view(meta_vals[i]));
+      meta_keys_vec.emplace_back(meta_keys[i]);
+      meta_vals_vec.emplace_back(meta_vals[i]);
     }
 
     auto* cpp_writer = reinterpret_cast<Writer*>(handle);
@@ -163,8 +162,9 @@ LoonFFIResult loon_writer_close(LoonWriterHandle handle,
 }
 
 void loon_free_cstr(char* cstr) {
-  if (cstr)
+  if (cstr) {
     free(cstr);
+  }
 }
 
 void loon_writer_destroy(LoonWriterHandle handle) {

--- a/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
@@ -18,7 +18,7 @@
 
 #include <cstdlib>
 #include <fstream>
-#include <string.h>
+#include <cstring>
 #include <climits>
 
 #include <aws/core/config/AWSProfileConfigLoader.h>
@@ -110,8 +110,8 @@ AliyunSTSAssumeRoleWebIdentityCredentialsProvider::AliyunSTSAssumeRoleWebIdentit
   // config.region = tmpRegion;
 
   Aws::Vector<Aws::String> retryableErrors;
-  retryableErrors.push_back("IDPCommunicationError");
-  retryableErrors.push_back("InvalidIdentityToken");
+  retryableErrors.emplace_back("IDPCommunicationError");
+  retryableErrors.emplace_back("InvalidIdentityToken");
 
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
@@ -125,7 +125,7 @@ Aws::Auth::AWSCredentials AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Get
   // A valid client means required information like role arn and token file were constructed correctly.
   // We can use this provider to load creds, otherwise, we can just return empty creds.
   if (!m_initialized) {
-    return Aws::Auth::AWSCredentials();
+    return {};
   }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);

--- a/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
@@ -16,7 +16,7 @@
 
 #include "milvus-storage/filesystem/s3/provider/AliyunSTSClient.h"
 
-#include <limits.h>
+#include <climits>
 #include <mutex>
 #include <sstream>
 #include <random>

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -80,8 +80,8 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   config.region = m_region;
 
   Aws::Vector<Aws::String> retryableErrors;
-  retryableErrors.push_back("IDPCommunicationError");
-  retryableErrors.push_back("InvalidIdentityToken");
+  retryableErrors.emplace_back("IDPCommunicationError");
+  retryableErrors.emplace_back("InvalidIdentityToken");
 
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
@@ -98,7 +98,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
 
 Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
   if (!m_initialized) {
-    return Aws::Auth::AWSCredentials();
+    return {};
   }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
@@ -109,7 +109,7 @@ Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider
     AWS_LOGSTREAM_WARN(
         STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
         "Cached credentials have fully expired; returning empty credentials to avoid silent auth failures.");
-    return Aws::Auth::AWSCredentials();
+    return {};
   }
   return m_credentials;
 }
@@ -215,9 +215,9 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() 
 
   if (IsInCooldown()) {
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    AWS_LOGSTREAM_WARN(
-        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-        "Skipping credential reload — in cooldown after previous failure." << " has_valid_cached=" << hasExisting);
+    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+                       "Skipping credential reload — in cooldown after previous failure."
+                           << " has_valid_cached=" << hasExisting);
     return;
   }
 

--- a/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
@@ -96,8 +96,8 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   config.region = m_region;
 
   Aws::Vector<Aws::String> retryableErrors;
-  retryableErrors.push_back("IDPCommunicationError");
-  retryableErrors.push_back("InvalidIdentityToken");
+  retryableErrors.emplace_back("IDPCommunicationError");
+  retryableErrors.emplace_back("InvalidIdentityToken");
 
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
@@ -111,7 +111,7 @@ Aws::Auth::AWSCredentials TencentCloudSTSAssumeRoleWebIdentityCredentialsProvide
   // A valid client means required information like role arn and token file were constructed correctly.
   // We can use this provider to load creds, otherwise, we can just return empty creds.
   if (!m_initialized) {
-    return Aws::Auth::AWSCredentials();
+    return {};
   }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);

--- a/cpp/src/filesystem/s3/s3_auth_signer.cpp
+++ b/cpp/src/filesystem/s3/s3_auth_signer.cpp
@@ -35,8 +35,8 @@ static std::string SHA256Hex(const std::string& data) {
   SHA256(reinterpret_cast<const unsigned char*>(data.c_str()), data.length(), hash);
 
   std::stringstream ss;
-  for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
+  for (unsigned char i : hash) {
+    ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(i);
   }
   return ss.str();
 }
@@ -76,7 +76,7 @@ static std::string URLEncode(const std::string& value) {
     }
     // Any other characters are percent-encoded
     escaped << std::uppercase;
-    escaped << '%' << std::setw(2) << int((unsigned char)c);
+    escaped << '%' << std::setw(2) << static_cast<int>(static_cast<unsigned char>(c));
     escaped << std::nouppercase;
   }
 
@@ -97,14 +97,16 @@ static std::string BuildCanonicalQueryString(const Aws::Http::URI& uri) {
   std::sort(sorted_params.begin(), sorted_params.end());
 
   std::vector<std::string> parts;
+  parts.reserve(sorted_params.size());
   for (const auto& [key, val] : sorted_params) {
     parts.push_back(URLEncode(key) + "=" + URLEncode(val));
   }
 
   std::string result;
   for (size_t i = 0; i < parts.size(); i++) {
-    if (i > 0)
+    if (i > 0) {
       result += "&";
+    }
     result += parts[i];
   }
   return result;
@@ -139,8 +141,9 @@ static std::string GetSignedHeaders(const std::shared_ptr<Aws::Http::HttpRequest
 
   std::string result;
   for (size_t i = 0; i < headers.size(); i++) {
-    if (i > 0)
+    if (i > 0) {
       result += ";";
+    }
     result += headers[i];
   }
   return result;

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -133,8 +133,8 @@ class WrappedRetryStrategy : public Aws::Client::RetryStrategy {
   explicit WrappedRetryStrategy(const std::shared_ptr<S3RetryStrategy>& s3_retry_strategy)
       : s3_retry_strategy_(s3_retry_strategy) {}
 
-  bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
-                   long attempted_retries) const override {  // NOLINT runtime/int
+  [[nodiscard]] bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
+                                 long attempted_retries) const override {  // NOLINT runtime/int
     S3RetryStrategy::AWSErrorDetail detail = ErrorToDetail(error);
     return s3_retry_strategy_->ShouldRetry(detail, static_cast<int64_t>(attempted_retries));
   }
@@ -167,7 +167,7 @@ std::string S3Client::GetBucketRegionFromHeaders(const Aws::Http::HeaderValueCol
   if (it != headers.end()) {
     return std::string(FromAwsString(it->second));
   }
-  return std::string();
+  return {};
 }
 
 template <typename ErrorType>
@@ -259,12 +259,12 @@ S3Model::CompleteMultipartUploadOutcome S3Client::CompleteMultipartUploadWithErr
   // (m_retryStrategy is a private member of AwsClient), so don't use that.
   std::unique_ptr<Aws::Client::RetryStrategy> retry_strategy;
   if (s3_retry_strategy_) {
-    retry_strategy.reset(new WrappedRetryStrategy(s3_retry_strategy_));
+    retry_strategy = std::make_unique<WrappedRetryStrategy>(s3_retry_strategy_);
   } else {
     // Note that DefaultRetryStrategy, unlike StandardRetryStrategy,
     // has empty definitions for RequestBookkeeping() and GetSendToken(),
     // which simplifies the code below.
-    retry_strategy.reset(new Aws::Client::DefaultRetryStrategy());
+    retry_strategy = std::make_unique<Aws::Client::DefaultRetryStrategy>();
   }
 
   for (int32_t retries = 0;; retries++) {
@@ -426,7 +426,7 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> S3ClientFinalizer::AddClient(std:
 
   // Remove expired entries before adding new one
   auto end = std::remove_if(holders_.begin(), holders_.end(),
-                            [](std::weak_ptr<S3ClientHolder> holder) { return holder.expired(); });
+                            [](const std::weak_ptr<S3ClientHolder>& holder) { return holder.expired(); });
   holders_.erase(end, holders_.end());
   holders_.emplace_back(holder);
   return holder;

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -23,6 +23,7 @@
 #include <optional>
 #include <shared_mutex>
 #include <thread>
+#include <utility>
 
 #include <arrow/util/async_generator.h>
 #include <arrow/util/logging.h>
@@ -282,7 +283,7 @@ struct S3Path {
     return arrow::Status::OK();
   }
 
-  Aws::String ToAwsString() const {
+  [[nodiscard]] Aws::String ToAwsString() const {
     Aws::String res(bucket.begin(), bucket.end());
     res.reserve(bucket.size() + key.size() + 1);
     res += kSep;
@@ -290,7 +291,7 @@ struct S3Path {
     return res;
   }
 
-  S3Path parent() const {
+  [[nodiscard]] S3Path parent() const {
     DCHECK(!key_parts.empty());
     auto parent = S3Path{"", bucket, "", key_parts};
     parent.key_parts.pop_back();
@@ -299,9 +300,9 @@ struct S3Path {
     return parent;
   }
 
-  bool has_parent() const { return !key.empty(); }
+  [[nodiscard]] bool has_parent() const { return !key.empty(); }
 
-  bool empty() const { return bucket.empty() && key.empty(); }
+  [[nodiscard]] bool empty() const { return bucket.empty() && key.empty(); }
 
   bool operator==(const S3Path& other) const { return bucket == other.bucket && key == other.key; }
 };
@@ -636,8 +637,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         default_metadata_(options.default_metadata),
         background_writes_(options.background_writes),
         use_crc32c_checksum_(options.use_crc32c_checksum),
-        part_upload_size_(part_size),
-        allow_delayed_open_(true) {}
+        part_upload_size_(part_size) {}
 
   template <typename ObjectRequest>
   arrow::Status SetMetadataInRequest(ObjectRequest* request) {
@@ -807,8 +807,9 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   arrow::Status Close() override {
-    if (closed_)
+    if (closed_) {
       return arrow::Status::OK();
+    }
 
     ARROW_RETURN_NOT_OK(CleanupIfFailed(EnsureReadyToFlushFromClose()));
 
@@ -822,8 +823,9 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   Future<> CloseAsync() override {
-    if (closed_)
+    if (closed_) {
       return arrow::Status::OK();
+    }
 
     ARROW_RETURN_NOT_OK(CleanupIfFailed(EnsureReadyToFlushFromClose()));
 
@@ -851,12 +853,12 @@ class CustomOutputStream final : public arrow::io::OutputStream {
 
   arrow::Status Write(const void* data, int64_t nbytes) override { return DoWrite(data, nbytes); }
 
-  arrow::Status DoWrite(const void* data, int64_t nbytes, std::shared_ptr<Buffer> owned_buffer = nullptr) {
+  arrow::Status DoWrite(const void* data, int64_t nbytes, const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
     if (closed_) {
       return arrow::Status::Invalid("Operation on closed stream");
     }
 
-    const int8_t* data_ptr = reinterpret_cast<const int8_t*>(data);
+    const auto* data_ptr = reinterpret_cast<const int8_t*>(data);
     auto advance_ptr = [&data_ptr, &nbytes](const int64_t offset) {
       data_ptr += offset;
       nbytes -= offset;
@@ -1031,23 +1033,25 @@ class CustomOutputStream final : public arrow::io::OutputStream {
                          "PutObject", outcome.GetError());
   }
 
-  arrow::Status UploadUsingSingleRequest(std::shared_ptr<Buffer> buffer) {
+  arrow::Status UploadUsingSingleRequest(const std::shared_ptr<Buffer>& buffer) {
     return UploadUsingSingleRequest(buffer->data(), buffer->size(), buffer);
   }
 
   arrow::Status UploadUsingSingleRequest(const void* data,
                                          int64_t nbytes,
                                          std::shared_ptr<Buffer> owned_buffer = nullptr) {
-    auto sync_result_callback = [](const Aws::S3::Model::PutObjectRequest& request, std::shared_ptr<UploadState> state,
-                                   int32_t part_number, Aws::S3::Model::PutObjectOutcome outcome) {
+    auto sync_result_callback = [](const Aws::S3::Model::PutObjectRequest& request,
+                                   const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                   const Aws::S3::Model::PutObjectOutcome& outcome) {
       if (!outcome.IsSuccess()) {
         return UploadUsingSingleRequestError(request, outcome);
       }
       return arrow::Status::OK();
     };
 
-    auto async_result_callback = [](const Aws::S3::Model::PutObjectRequest& request, std::shared_ptr<UploadState> state,
-                                    int32_t part_number, Aws::S3::Model::PutObjectOutcome outcome) {
+    auto async_result_callback = [](const Aws::S3::Model::PutObjectRequest& request,
+                                    const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                    const Aws::S3::Model::PutObjectOutcome& outcome) {
       HandleUploadUsingSingleRequestOutcome(state, request, outcome);
       return arrow::Status::OK();
     };
@@ -1060,7 +1064,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         std::move(owned_buffer));
   }
 
-  arrow::Status UploadPart(std::shared_ptr<Buffer> buffer) {
+  arrow::Status UploadPart(const std::shared_ptr<Buffer>& buffer) {
     return UploadPart(buffer->data(), buffer->size(), buffer);
   }
 
@@ -1080,8 +1084,9 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     req.SetPartNumber(part_number_);
     req.SetUploadId(multipart_upload_id_);
 
-    auto sync_result_callback = [](const Aws::S3::Model::UploadPartRequest& request, std::shared_ptr<UploadState> state,
-                                   int32_t part_number, Aws::S3::Model::UploadPartOutcome outcome) {
+    auto sync_result_callback = [](const Aws::S3::Model::UploadPartRequest& request,
+                                   const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                   Aws::S3::Model::UploadPartOutcome outcome) {
       if (!outcome.IsSuccess()) {
         return UploadPartError(request, outcome);
       } else {
@@ -1092,8 +1097,8 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     };
 
     auto async_result_callback = [](const Aws::S3::Model::UploadPartRequest& request,
-                                    std::shared_ptr<UploadState> state, int32_t part_number,
-                                    Aws::S3::Model::UploadPartOutcome outcome) {
+                                    const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                    const Aws::S3::Model::UploadPartOutcome& outcome) {
       HandleUploadPartOutcome(state, part_number, request, outcome);
       return arrow::Status::OK();
     };
@@ -1173,7 +1178,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   const std::shared_ptr<const arrow::KeyValueMetadata> default_metadata_;
   const bool background_writes_;
   const bool use_crc32c_checksum_;
-  const bool allow_delayed_open_;
+  const bool allow_delayed_open_{true};
 
   int64_t part_upload_size_;
 
@@ -1210,7 +1215,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
   static constexpr int32_t kMultipleDeleteMaxKeys = 1000;
 
   explicit Impl(S3Options options, arrow::io::IOContext io_context)
-      : builder_(std::move(options)), io_context_(io_context) {}
+      : builder_(std::move(options)), io_context_(std::move(io_context)) {}
 
   arrow::Status Init() {
     auto result = builder_.BuildClient(io_context_);
@@ -1427,6 +1432,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
 
   static std::vector<FileInfo> MakeDirectoryInfos(std::vector<std::string> dirnames) {
     std::vector<FileInfo> dir_infos;
+    dir_infos.reserve(dirnames.size());
     for (auto& dirname : dirnames) {
       dir_infos.push_back(MakeDirectoryInfo(std::move(dirname)));
     }
@@ -1448,7 +1454,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     bool empty = true;
 
     FileListerState(arrow::PushGenerator<std::vector<FileInfo>>::Producer files_queue,
-                    FileSelector select,
+                    const FileSelector& select,
                     const std::string& bucket,
                     const std::string& key,
                     bool include_implicit_dirs,
@@ -1510,7 +1516,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
           break;
         }
         if (directories.insert(parent_dir).second) {
-          new_directories.push_back(std::move(parent_dir));
+          new_directories.push_back(parent_dir);
         }
       }
       return new_directories;
@@ -1659,7 +1665,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
         return arrow::Status::OK();
       });
     }
-    std::string_view name() const override { return "S3ListFiles"; }
+    [[nodiscard]] std::string_view name() const override { return "S3ListFiles"; }
   };
 
   // Lists all file, potentially recursively, in a bucket
@@ -1675,7 +1681,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
                  const std::string& key,
                  bool include_implicit_dirs,
                  arrow::util::AsyncTaskScheduler* scheduler,
-                 FileInfoSink sink) {
+                 const FileInfoSink& sink) {
     // We can only fetch kListObjectsMaxKeys files at a time and so we create a
     // scheduler and schedule a task to grab the first batch.  Once that's done we
     // schedule a new task for the next batch.  All of these tasks share the same

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -20,6 +20,7 @@
 #include <google/cloud/options.h>
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
@@ -66,14 +67,18 @@ static const char* TLS_FACTORY_ALLOCATION_TAG = "TlsHttpClientFactory";
 // Convert tls_min_version string to CURLOPT_SSLVERSION value.
 // Returns CURL_SSLVERSION_DEFAULT (0) if the version string is empty or unrecognized.
 static long TlsVersionToCurlOpt(const std::string& tls_min_version) {
-  if (tls_min_version == "1.0")
+  if (tls_min_version == "1.0") {
     return CURL_SSLVERSION_TLSv1_0;
-  if (tls_min_version == "1.1")
+  }
+  if (tls_min_version == "1.1") {
     return CURL_SSLVERSION_TLSv1_1;
-  if (tls_min_version == "1.2")
+  }
+  if (tls_min_version == "1.2") {
     return CURL_SSLVERSION_TLSv1_2;
-  if (tls_min_version == "1.3")
+  }
+  if (tls_min_version == "1.3") {
     return CURL_SSLVERSION_TLSv1_3;
+  }
 
   return CURL_SSLVERSION_DEFAULT;
 }
@@ -100,7 +105,7 @@ class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
   public:
   explicit TlsHttpClientFactory(const std::string& tls_min_version) : tls_min_version_(tls_min_version) {}
 
-  std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
       const Aws::Client::ClientConfiguration& config) const override {
 #ifdef BUILD_GTEST
     // Enable curl verbose tracing in test builds so that TLS handshake details
@@ -113,15 +118,15 @@ class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
 #endif
   }
 
-  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String& uri,
-                                                            Aws::Http::HttpMethod method,
-                                                            const Aws::IOStreamFactory& streamFactory) const override {
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
     return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
   }
 
-  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::Http::URI& uri,
-                                                            Aws::Http::HttpMethod method,
-                                                            const Aws::IOStreamFactory& streamFactory) const override {
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri,
+      Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override {
     auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(TLS_FACTORY_ALLOCATION_TAG, uri, method);
     request->SetResponseStreamFactory(streamFactory);
     return request;
@@ -233,17 +238,17 @@ class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
                           const std::string& access_key = "",
                           const std::string& secret_key = "",
                           const std::string& tls_min_version = "")
-      : credentials_(credentials),
+      : credentials_(std::move(credentials)),
         use_iam_(use_iam),
         access_key_(access_key),
         secret_key_(secret_key),
         tls_min_version_(tls_min_version) {}
 
   void SetCredentials(std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials) {
-    credentials_ = credentials;
+    credentials_ = std::move(credentials);
   }
 
-  std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
       const Aws::Client::ClientConfiguration& clientConfiguration) const override {
     // Create GoogleHttpClientDelegator with use_iam and ak/sk.
     // Delegator will decide whether to use GOOG4 signing based on use_iam
@@ -251,15 +256,15 @@ class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
                                                       use_iam_, access_key_, secret_key_, tls_min_version_);
   }
 
-  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String& uri,
-                                                            Aws::Http::HttpMethod method,
-                                                            const Aws::IOStreamFactory& streamFactory) const override {
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
     return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
   }
 
-  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::Http::URI& uri,
-                                                            Aws::Http::HttpMethod method,
-                                                            const Aws::IOStreamFactory& streamFactory) const override {
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri,
+      Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override {
     auto request =
         Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, uri, method);
     request->SetResponseStreamFactory(streamFactory);

--- a/cpp/src/filesystem/s3/util_internal.cpp
+++ b/cpp/src/filesystem/s3/util_internal.cpp
@@ -16,8 +16,7 @@ namespace arrow {
 using internal::StatusDetailFromErrno;
 using util::Uri;
 
-namespace fs {
-namespace internal {
+namespace fs::internal {
 
 TimePoint CurrentTimePoint() {
   auto now = std::chrono::system_clock::now();
@@ -231,6 +230,5 @@ arrow::Result<FileInfoVector> GlobFiles(const std::shared_ptr<FileSystem>& files
 
 FileSystemGlobalOptions global_options;
 
-}  // namespace internal
-}  // namespace fs
+}  // namespace fs::internal
 }  // namespace arrow

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -77,7 +77,7 @@ std::unique_ptr<BlockingDataset> BlockingDataset::WriteDataset(const std::string
 std::vector<uint64_t> BlockingDataset::GetAllFragmentIds() const {
   try {
     auto fragment_ids = impl_->get_all_fragment_ids();
-    return std::vector<uint64_t>(fragment_ids.begin(), fragment_ids.end());
+    return {fragment_ids.begin(), fragment_ids.end()};
   } catch (const rust::cxxbridge1::Error& e) {
     throw LanceException(e.what());
   }

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -54,7 +54,7 @@ DType from_arrow(struct ArrowSchema& schema, bool non_nullable) {
 // Methods
 std::string DType::ToString() const {
   auto rust_str = impl_->to_string();
-  return std::string(rust_str.data(), rust_str.length());
+  return {rust_str.data(), rust_str.length()};
 }
 }  // namespace dtype
 
@@ -199,7 +199,7 @@ std::vector<uint64_t> VortexFile::Splits() const {
   try {
     ::rust::Vec<::rust::u64> rs_splits = impl_->splits();
 
-    return std::vector<uint64_t>(rs_splits.begin(), rs_splits.end());
+    return {rs_splits.begin(), rs_splits.end()};
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }
@@ -208,7 +208,7 @@ std::vector<uint64_t> VortexFile::Splits() const {
 std::vector<uint64_t> VortexFile::GetUncompressedSizes() const {
   ::rust::Vec<::rust::u64> rs_sizes = impl_->uncompressed_sizes();
 
-  return std::vector<uint64_t>(rs_sizes.begin(), rs_sizes.end());
+  return {rs_sizes.begin(), rs_sizes.end()};
 }
 
 ScanBuilder& ScanBuilder::WithFilter(expr::Expr&& expr) & {

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -47,7 +47,7 @@ class ColumnGroupLazyReaderImpl : public ColumnGroupLazyReader {
                             const std::vector<std::string>& needed_columns,
                             const std::function<std::string(const std::string&)>& key_retriever);
 
-  ~ColumnGroupLazyReaderImpl() = default;
+  ~ColumnGroupLazyReaderImpl() override = default;
 
   arrow::Result<std::shared_ptr<arrow::Table>> take(const std::vector<int64_t>& row_indices,
                                                     size_t parallelism = 1) override;
@@ -218,6 +218,7 @@ arrow::Result<std::shared_ptr<arrow::Table>> ColumnGroupLazyReaderImpl::take(con
   // Wait for all futures to complete before checking errors,
   // to avoid early return while tasks still hold `this`.
   std::vector<arrow::Result<std::shared_ptr<arrow::Table>>> all_results;
+  all_results.reserve(futures.size());
   for (auto& future : futures) {
     all_results.emplace_back(future.get());
   }

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -44,7 +44,7 @@
 namespace milvus_storage::api {
 
 using milvus_storage::RowGroupInfo;
-typedef arrow::Result<std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>> ChunkRBMapResult;
+using ChunkRBMapResult = arrow::Result<std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>>;
 struct ChunkInfo {
   public:
   size_t file_index;               // current chunk belong which file
@@ -56,7 +56,7 @@ struct ChunkInfo {
   size_t avg_memory_size;          // average memory usage of this row group
 
   ChunkInfo() = default;
-  std::string ToString() const;
+  [[nodiscard]] std::string ToString() const;
 };
 
 class ColumnGroupReaderImpl : public ColumnGroupReader {
@@ -67,7 +67,7 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
                         const std::vector<std::string>& needed_columns,
                         const std::function<std::string(const std::string&)>& key_retriever);
 
-  ~ColumnGroupReaderImpl() = default;
+  ~ColumnGroupReaderImpl() override = default;
 
   [[nodiscard]] arrow::Status open() override;
   [[nodiscard]] size_t total_number_of_chunks() const override;
@@ -103,8 +103,8 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
 };  // ColumnGroupReaderImpl
 
 arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
-    std::shared_ptr<arrow::Schema> schema,
-    std::shared_ptr<milvus_storage::api::ColumnGroup> column_group,
+    const std::shared_ptr<arrow::Schema>& schema,
+    const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
     const std::vector<std::string>& needed_columns,
     const milvus_storage::api::Properties& properties,
     const std::function<std::string(const std::string&)>& key_retriever) {
@@ -195,8 +195,8 @@ arrow::Status ColumnGroupReaderImpl::open() {
         size_t rg_end = row_group_in_file[j].end_offset;
 
         // calculate the overlap range
-        size_t overlap_start = std::max((size_t)start_index, rg_start);
-        size_t overlap_end = std::min((size_t)end_index, rg_end);
+        size_t overlap_start = std::max(static_cast<size_t>(start_index), rg_start);
+        size_t overlap_end = std::min(static_cast<size_t>(end_index), rg_end);
 
         // if the overlap range is valid, create the chunk info
         if (overlap_start < overlap_end) {
@@ -397,8 +397,8 @@ ChunkRBMapResult ColumnGroupReaderImpl::read_chunks_from_files(const std::vector
     // generate chunk_rb_map
     size_t rbs_idx = 0;
     size_t rbs_offset = 0;
-    for (size_t i = 0; i < chunk_idxs.size(); ++i) {
-      const auto& chunk_info = chunk_infos_[chunk_idxs[i]];
+    for (long long chunk_idx : chunk_idxs) {
+      const auto& chunk_info = chunk_infos_[chunk_idx];
       if (UNLIKELY(((rbs_in_file[rbs_idx]->num_rows() - rbs_offset) < chunk_info.number_of_rows))) {
         return arrow::Status::Invalid(
             fmt::format("Invalid slice of record batchs: {} out of {}, [chunk info={}]", chunk_info.number_of_rows,
@@ -406,7 +406,7 @@ ChunkRBMapResult ColumnGroupReaderImpl::read_chunks_from_files(const std::vector
       }
 
       auto rb = rbs_in_file[rbs_idx]->Slice(rbs_offset, chunk_info.number_of_rows);
-      chunk_rb_map[chunk_idxs[i]] = rb;
+      chunk_rb_map[chunk_idx] = rb;
       rbs_offset += chunk_info.number_of_rows;
 
       assert(rbs_offset <= rbs_in_file[rbs_idx]->num_rows());
@@ -452,6 +452,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> ColumnGroupReade
     // Wait for all futures to complete before checking errors,
     // to avoid early return while tasks still hold `this`.
     std::vector<ChunkRBMapResult> all_results;
+    all_results.reserve(futures.size());
     for (auto& future : futures) {
       all_results.emplace_back(future.get());
     }

--- a/cpp/src/format/column_group_writer.cpp
+++ b/cpp/src/format/column_group_writer.cpp
@@ -48,9 +48,7 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
         column_group_(column_group),
         schema_(schema),
         properties_(properties),
-        format_writer_(nullptr),
-        max_bytes_limit_(0),
-        written_bytes_(0) {}
+        format_writer_(nullptr) {}
 
   [[nodiscard]] arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) override {
     // Fault injection point for testing
@@ -129,9 +127,9 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
     }
 
     if (format == LOON_FORMAT_PARQUET) {
-      ARROW_ASSIGN_OR_RAISE(writer, parquet::ParquetFileWriter::Make(
-                                        file_system, schema,
-                                        std::move(get_data_filepath(base_path, column_group_id, format)), properties));
+      ARROW_ASSIGN_OR_RAISE(
+          writer, parquet::ParquetFileWriter::Make(file_system, schema,
+                                                   get_data_filepath(base_path, column_group_id, format), properties));
     } else if (format == LOON_FORMAT_VORTEX) {
       writer = std::make_unique<vortex::VortexFileWriter>(
           file_system, schema, std::move(get_data_filepath(base_path, column_group_id, format)), properties);
@@ -158,8 +156,8 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
 
   std::unique_ptr<FormatWriter> format_writer_;
 
-  uint64_t max_bytes_limit_;
-  uint64_t written_bytes_;
+  uint64_t max_bytes_limit_{0};
+  uint64_t written_bytes_{0};
 
   std::vector<ColumnGroupFile> written_files_;
 };

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -31,7 +31,7 @@
 
 namespace milvus_storage::lance {
 
-LanceTableReader::LanceTableReader(const std::shared_ptr<BlockingDataset> dataset,
+LanceTableReader::LanceTableReader(const std::shared_ptr<BlockingDataset>& dataset,
                                    uint64_t fragment_id,
                                    const std::shared_ptr<arrow::Schema>& schema,
                                    const milvus_storage::api::Properties& properties,
@@ -57,7 +57,7 @@ LanceTableReader::LanceTableReader(const std::string& uri,
 
 static std::vector<RowGroupInfo> create_row_group_infos(uint64_t rows_in_file, uint64_t logical_chunk_rows) {
   if (rows_in_file == 0) {
-    return std::vector<RowGroupInfo>();
+    return {};
   }
 
   std::vector<RowGroupInfo> result;

--- a/cpp/src/format/lance/lance_table_writer.cpp
+++ b/cpp/src/format/lance/lance_table_writer.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <iostream>
 #include <unordered_set>
+#include <utility>
 
 #include <arrow/chunked_array.h>  // keep this line before other arrow header
 #include <arrow/c/abi.h>
@@ -37,7 +38,7 @@ namespace milvus_storage::lance {
 LanceTableWriter::LanceTableWriter(const std::string& base_path,
                                    std::shared_ptr<arrow::Schema> schema,
                                    const api::Properties& properties)
-    : closed_(false), base_path_(base_path), schema_(schema), properties_(properties), dataset_(nullptr) {
+    : closed_(false), base_path_(base_path), schema_(std::move(schema)), properties_(properties), dataset_(nullptr) {
   assert(schema_);
 }
 
@@ -45,9 +46,9 @@ class BatchIterator : public arrow::RecordBatchReader {
   public:
   BatchIterator(const std::shared_ptr<arrow::Schema>& schema,
                 const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches)
-      : schema_(schema), batches_(batches), position_(0) {}
+      : schema_(schema), batches_(batches) {}
 
-  std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
+  [[nodiscard]] std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
 
   arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override {
     if (position_ >= batches_.size()) {
@@ -61,7 +62,7 @@ class BatchIterator : public arrow::RecordBatchReader {
   private:
   std::shared_ptr<arrow::Schema> schema_;
   std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
-  size_t position_;
+  size_t position_{0};
 };
 
 arrow::Status LanceTableWriter::Write(const std::shared_ptr<arrow::RecordBatch> batch) {

--- a/cpp/src/format/parquet/file_reader.cpp
+++ b/cpp/src/format/parquet/file_reader.cpp
@@ -40,31 +40,33 @@
 
 namespace milvus_storage {
 
-FileRowGroupReader::FileRowGroupReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+FileRowGroupReader::FileRowGroupReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                        const std::string& path,
                                        const int64_t buffer_size,
-                                       parquet::ReaderProperties reader_props) {}
+                                       const parquet::ReaderProperties& reader_props) {}
 
-FileRowGroupReader::FileRowGroupReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+FileRowGroupReader::FileRowGroupReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                        const std::string& path,
-                                       const std::shared_ptr<arrow::Schema> schema,
+                                       const std::shared_ptr<arrow::Schema>& schema,
                                        const int64_t buffer_size,
-                                       parquet::ReaderProperties reader_props) {}
+                                       const parquet::ReaderProperties& reader_props) {}
 
-arrow::Result<std::shared_ptr<FileRowGroupReader>> FileRowGroupReader::Make(std::shared_ptr<arrow::fs::FileSystem> fs,
-                                                                            const std::string& path,
-                                                                            const int64_t buffer_size,
-                                                                            parquet::ReaderProperties reader_props) {
+arrow::Result<std::shared_ptr<FileRowGroupReader>> FileRowGroupReader::Make(
+    const std::shared_ptr<arrow::fs::FileSystem>& fs,
+    const std::string& path,
+    const int64_t buffer_size,
+    const parquet::ReaderProperties& reader_props) {
   auto reader = std::shared_ptr<FileRowGroupReader>(new FileRowGroupReader(fs, path, buffer_size, reader_props));
   ARROW_RETURN_NOT_OK(reader->init(fs, path, buffer_size, nullptr, reader_props));
   return reader;
 }
 
-arrow::Result<std::shared_ptr<FileRowGroupReader>> FileRowGroupReader::Make(std::shared_ptr<arrow::fs::FileSystem> fs,
-                                                                            const std::string& path,
-                                                                            const std::shared_ptr<arrow::Schema> schema,
-                                                                            const int64_t buffer_size,
-                                                                            parquet::ReaderProperties reader_props) {
+arrow::Result<std::shared_ptr<FileRowGroupReader>> FileRowGroupReader::Make(
+    const std::shared_ptr<arrow::fs::FileSystem>& fs,
+    const std::string& path,
+    const std::shared_ptr<arrow::Schema>& schema,
+    const int64_t buffer_size,
+    const parquet::ReaderProperties& reader_props) {
   auto reader =
       std::shared_ptr<FileRowGroupReader>(new FileRowGroupReader(fs, path, schema, buffer_size, reader_props));
   ARROW_RETURN_NOT_OK(reader->init(fs, path, buffer_size, schema, reader_props));
@@ -74,8 +76,8 @@ arrow::Result<std::shared_ptr<FileRowGroupReader>> FileRowGroupReader::Make(std:
 arrow::Status FileRowGroupReader::init(std::shared_ptr<arrow::fs::FileSystem> fs,
                                        const std::string& path,
                                        const int64_t buffer_size,
-                                       const std::shared_ptr<arrow::Schema> schema,
-                                       parquet::ReaderProperties reader_props) {
+                                       const std::shared_ptr<arrow::Schema>& schema,
+                                       const parquet::ReaderProperties& reader_props) {
   fs_ = std::move(fs);
   path_ = path;
   buffer_size_limit_ = buffer_size <= 0 ? INT64_MAX : buffer_size;

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -98,10 +98,10 @@ ParquetFormatReader::ParquetFormatReader(const std::shared_ptr<arrow::fs::FileSy
                                          const std::vector<std::string>& needed_columns,
                                          const std::function<std::string(const std::string&)>& key_retriever)
     : path_(path),
-      fs_(std::move(fs)),
+      fs_(fs),
       schema_(nullptr),
-      properties_(std::move(properties)),
-      needed_columns_(std::move(needed_columns)),
+      properties_(properties),
+      needed_columns_(needed_columns),
       key_retriever_(key_retriever),
       file_reader_(nullptr) {}
 
@@ -109,7 +109,7 @@ static arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> create_parqu
     const std::shared_ptr<arrow::fs::FileSystem>& fs,
     const std::string& file_path,
     const std::function<std::string(const std::string&)>& key_retriever,
-    std::shared_ptr<::parquet::FileMetaData> metadata = nullptr) {
+    const std::shared_ptr<::parquet::FileMetaData>& metadata = nullptr) {
   std::unique_ptr<::parquet::arrow::FileReader> result;
 
   ::parquet::arrow::FileReaderBuilder builder;
@@ -309,9 +309,7 @@ class RangeRecordBatchReader : public arrow::RecordBatchReader {
         rg_indices_(std::move(rg_indices)),
         column_indices_(std::move(column_indices)),
         first_rg_slice_offset_(first_rg_slice_offset),
-        total_rows_(total_rows),
-        loaded_(false),
-        current_batch_index_(0) {}
+        total_rows_(total_rows) {}
 
   ~RangeRecordBatchReader() override = default;
 
@@ -330,7 +328,7 @@ class RangeRecordBatchReader : public arrow::RecordBatchReader {
     return arrow::Status::OK();
   }
 
-  std::shared_ptr<::arrow::Schema> schema() const override { return schema_; }
+  [[nodiscard]] std::shared_ptr<::arrow::Schema> schema() const override { return schema_; }
 
   private:
   arrow::Status LoadData() {
@@ -361,9 +359,9 @@ class RangeRecordBatchReader : public arrow::RecordBatchReader {
   uint64_t first_rg_slice_offset_;
   uint64_t total_rows_;
 
-  bool loaded_;
+  bool loaded_{false};
   std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
-  size_t current_batch_index_;
+  size_t current_batch_index_{0};
 };
 
 arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> ParquetFormatReader::read_with_range(
@@ -403,6 +401,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> ParquetFormatReader::re
 
   // Build projected schema for the reader
   std::vector<std::shared_ptr<arrow::Field>> projected_fields;
+  projected_fields.reserve(needed_column_indices_.size());
   for (int col_idx : needed_column_indices_) {
     projected_fields.push_back(schema_->field(col_idx));
   }

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -20,6 +20,7 @@
 #include <boost/variant.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -59,9 +60,9 @@ static std::shared_ptr<::parquet::WriterProperties> convert_write_properties(
 
   bool enc_enable = api::GetValueNoError<bool>(properties, PROPERTY_WRITER_ENC_ENABLE);
   if (enc_enable) {
-    std::string enc_key = api::GetValueNoError<std::string>(properties, PROPERTY_WRITER_ENC_KEY);
-    std::string enc_meta = api::GetValueNoError<std::string>(properties, PROPERTY_WRITER_ENC_META);
-    std::string enc_algorithm = api::GetValueNoError<std::string>(properties, PROPERTY_WRITER_ENC_ALGORITHM);
+    auto enc_key = api::GetValueNoError<std::string>(properties, PROPERTY_WRITER_ENC_KEY);
+    auto enc_meta = api::GetValueNoError<std::string>(properties, PROPERTY_WRITER_ENC_META);
+    auto enc_algorithm = api::GetValueNoError<std::string>(properties, PROPERTY_WRITER_ENC_ALGORITHM);
 
     // create builder with key
     ::parquet::FileEncryptionProperties::Builder file_encryption_builder(enc_key);
@@ -104,17 +105,16 @@ ParquetFileWriter::ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
                                      std::shared_ptr<arrow::fs::FileSystem> fs,
                                      const std::string& file_path,
                                      const milvus_storage::StorageConfig& storage_config,
-                                     std::shared_ptr<::parquet::WriterProperties> writer_props)
+                                     const std::shared_ptr<::parquet::WriterProperties>& writer_props)
     : schema_(std::move(schema)),
       fs_(std::move(fs)),
       file_path_(file_path),
       storage_config_(storage_config),
       sink_(nullptr),
       writer_(nullptr),
-      cached_size_(0),
+
       cached_batches_(),
-      cached_batch_sizes_(),
-      written_rows_(0) {
+      cached_batch_sizes_() {
   auto builder = ::parquet::WriterProperties::Builder(*writer_props);
   builder.max_row_group_length(
       std::numeric_limits<int64_t>::max());  // no limit on row group size, let the writer handle it
@@ -152,8 +152,8 @@ arrow::Result<std::unique_ptr<ParquetFileWriter>> ParquetFileWriter::Make(
     const milvus_storage::api::Properties& properties) {
   ARROW_ASSIGN_OR_RAISE(auto part_size,
                         milvus_storage::api::GetValue<int64_t>(properties, PROPERTY_FS_MULTI_PART_UPLOAD_SIZE));
-  return ParquetFileWriter::Make(schema, fs, file_path, milvus_storage::StorageConfig{part_size},
-                                 std::move(convert_write_properties(properties)));
+  return ParquetFileWriter::Make(std::move(schema), std::move(fs), file_path, milvus_storage::StorageConfig{part_size},
+                                 convert_write_properties(properties));
 }
 
 arrow::Result<std::unique_ptr<ParquetFileWriter>> ParquetFileWriter::Make(
@@ -161,9 +161,9 @@ arrow::Result<std::unique_ptr<ParquetFileWriter>> ParquetFileWriter::Make(
     std::shared_ptr<arrow::fs::FileSystem> fs,
     const std::string& file_path,
     const milvus_storage::StorageConfig& storage_config,
-    std::shared_ptr<::parquet::WriterProperties> writer_props) {
-  auto writer =
-      std::unique_ptr<ParquetFileWriter>(new ParquetFileWriter(schema, fs, file_path, storage_config, writer_props));
+    const std::shared_ptr<::parquet::WriterProperties>& writer_props) {
+  auto writer = std::unique_ptr<ParquetFileWriter>(
+      new ParquetFileWriter(std::move(schema), std::move(fs), file_path, storage_config, writer_props));
   ARROW_RETURN_NOT_OK(writer->init());
   return writer;
 }

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -42,7 +42,7 @@ static void remove_metadata_from_schema(ArrowSchema* schema) {
   schema->metadata = nullptr;
 }
 
-static inline arrow::Result<ArrowSchema> export_c_arrow_schema(std::shared_ptr<arrow::Schema> schema) {
+static inline arrow::Result<ArrowSchema> export_c_arrow_schema(const std::shared_ptr<arrow::Schema>& schema) {
   ArrowSchema c_arrow_schema;
 
   ARROW_RETURN_NOT_OK(arrow::ExportSchema(*schema, &c_arrow_schema));
@@ -60,7 +60,7 @@ static std::vector<RowGroupInfo> create_row_group_infos(uint64_t memory_usage_in
                                                         uint64_t rows_in_file,
                                                         const std::vector<uint64_t>& row_ranges) {
   if (rows_in_file == 0) {
-    return std::vector<RowGroupInfo>();
+    return {};
   }
 
   std::vector<RowGroupInfo> result(row_ranges.size());
@@ -102,7 +102,7 @@ VortexFormatReader::VortexFormatReader(const std::shared_ptr<arrow::fs::FileSyst
                                        const milvus_storage::api::Properties& properties,
                                        const std::vector<std::string>& needed_columns)
     : fs_holder_(std::make_shared<FileSystemWrapper>(fs)),
-      proj_cols_(std::move(needed_columns)),
+      proj_cols_(needed_columns),
       path_(path),
       read_schema_(schema),
       properties_(properties),
@@ -115,7 +115,7 @@ arrow::Status VortexFormatReader::open() {
   if (read_schema_ && read_schema_->num_fields() == 0) {
     read_schema_ = nullptr;
   }
-  vxfile_ = VortexFile::OpenUnique((uint8_t*)fs_holder_.get(), path_);
+  vxfile_ = VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder_.get()), path_);
 
   // Always derive full file schema from file metadata
   {
@@ -239,7 +239,7 @@ arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std:
     scan_builder.WithOutputSchema(c_arrow_schema);
   }
 
-  scan_builder.WithIncludeByIndex((const uint64_t*)row_indices.data(), row_indices.size());
+  scan_builder.WithIncludeByIndex(reinterpret_cast<const uint64_t*>(row_indices.data()), row_indices.size());
 
   ArrowArrayStream array_stream = std::move(scan_builder).IntoStream();
   ARROW_ASSIGN_OR_RAISE(auto chunkedarray, arrow::ImportChunkedArray(&array_stream));

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -17,6 +17,7 @@
 #include <arrow/chunked_array.h>
 #include <arrow/array.h>
 #include <string>
+#include <utility>
 
 #include "milvus-storage/properties.h"
 #include "milvus-storage/common/arrow_util.h"
@@ -26,7 +27,7 @@ namespace milvus_storage::vortex {
 
 using namespace milvus_storage::api;
 
-VortexFileWriter::VortexFileWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
+VortexFileWriter::VortexFileWriter(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                    std::shared_ptr<arrow::Schema> schema,
                                    const std::string& file_path,
                                    const api::Properties& properties)
@@ -34,12 +35,11 @@ VortexFileWriter::VortexFileWriter(std::shared_ptr<arrow::fs::FileSystem> fs,
       file_path_(file_path),
       fs_holder_(std::make_unique<FileSystemWrapper>(fs)),
       vx_writer_(
-          std::move(VortexWriter::Open((uint8_t*)fs_holder_.get(),
+          std::move(VortexWriter::Open(reinterpret_cast<uint8_t*>(fs_holder_.get()),
                                        file_path_,
                                        GetValueNoError<bool>(properties, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS)))),
-      schema_(schema),
-      properties_(properties),
-      written_rows_(0) {}
+      schema_(std::move(schema)),
+      properties_(properties) {}
 
 arrow::Status VortexFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> batch) {
   assert(!closed_);

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <algorithm>
+#include <utility>
 
 #include <arrow/array/data.h>
 #include <arrow/array/util.h>
@@ -36,9 +37,9 @@
 
 namespace milvus_storage {
 
-PackedRecordBatchReader::PackedRecordBatchReader(std::shared_ptr<arrow::fs::FileSystem> fs,
+PackedRecordBatchReader::PackedRecordBatchReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                                  std::vector<std::string>& paths,
-                                                 std::shared_ptr<arrow::Schema> schema,
+                                                 const std::shared_ptr<arrow::Schema>& schema,
                                                  int64_t buffer_size,
                                                  parquet::ReaderProperties reader_props)
     : memory_limit_(buffer_size <= 0 ? INT64_MAX : buffer_size),
@@ -53,9 +54,9 @@ PackedRecordBatchReader::PackedRecordBatchReader(std::shared_ptr<arrow::fs::File
   }
 }
 
-arrow::Status PackedRecordBatchReader::init(std::shared_ptr<arrow::fs::FileSystem> fs,
+arrow::Status PackedRecordBatchReader::init(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                             std::vector<std::string>& paths,
-                                            std::shared_ptr<arrow::Schema> schema,
+                                            const std::shared_ptr<arrow::Schema>& schema,
                                             parquet::ReaderProperties& reader_props) {
   // read first file metadata to get field id mapping and do schema matching
   ARROW_RETURN_NOT_OK(schemaMatching(fs, schema, paths, reader_props));
@@ -94,8 +95,8 @@ arrow::Status PackedRecordBatchReader::init(std::shared_ptr<arrow::fs::FileSyste
   return arrow::Status::OK();
 }
 
-arrow::Status PackedRecordBatchReader::schemaMatching(std::shared_ptr<arrow::fs::FileSystem> fs,
-                                                      std::shared_ptr<arrow::Schema> schema,
+arrow::Status PackedRecordBatchReader::schemaMatching(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                                      const std::shared_ptr<arrow::Schema>& schema,
                                                       std::vector<std::string>& paths,
                                                       parquet::ReaderProperties& reader_props) {
   // read first file metadata to get field id mapping

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 
 #include <arrow/type.h>
 #include <arrow/util/logging.h>
@@ -61,8 +62,8 @@ arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> PackedRecordBatchWriter:
     std::vector<std::vector<int>>& column_groups,
     size_t buffer_size,
     std::shared_ptr<::parquet::WriterProperties> writer_props) {
-  auto writer = std::shared_ptr<PackedRecordBatchWriter>(
-      new PackedRecordBatchWriter(fs, paths, schema, storage_config, column_groups, buffer_size, writer_props));
+  auto writer = std::shared_ptr<PackedRecordBatchWriter>(new PackedRecordBatchWriter(
+      std::move(fs), paths, std::move(schema), storage_config, column_groups, buffer_size, std::move(writer_props)));
   ARROW_RETURN_NOT_OK(writer->init());
   return writer;
 }
@@ -89,8 +90,8 @@ arrow::Status PackedRecordBatchWriter::init() {
 
   // Validate column group indices are within bounds
   int num_fields = schema_->num_fields();
-  for (size_t i = 0; i < group_indices_.size(); ++i) {
-    for (int col_index : group_indices_[i]) {
+  for (const auto& group_indice : group_indices_) {
+    for (int col_index : group_indice) {
       if (col_index < 0 || col_index >= num_fields) {
         return arrow::Status::Invalid(fmt::format("Column index out of range: {} (schema has {} fields), [schema={}]",
                                                   col_index, num_fields, schema_->ToString(true)));

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -103,8 +103,9 @@ PropertiesValidator::PropertiesValidator(ValidatorFunc f) : fn(std::move(f)) {}
 
 std::optional<std::string> PropertiesValidator::operator()(const PropertyInfo& property_info,
                                                            const std::string& v) const {
-  if (!fn)
+  if (!fn) {
     return std::nullopt;
+  }
   return fn(property_info, v);
 }
 
@@ -275,14 +276,16 @@ static PropertiesValidator ValidatePropertyEnum(Allowed&&... allowed) {
         T val = GetPropertyValue<T>(property_info, v);
 
         for (const auto& a : allowed_values) {
-          if (val == a)
+          if (val == a) {
             return std::nullopt;  // valid
+          }
         }
 
         std::ostringstream oss;
         for (size_t i = 0; i < allowed_values.size(); ++i) {
-          if (i)
+          if (i) {
             oss << ", ";
+          }
           oss << allowed_values[i];
         }
 

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -68,9 +68,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
         key_retriever_callback_(key_retriever),
         number_of_chunks_per_cg_(column_groups.size()),
         chunk_readers_(column_groups.size()),
-        // above is immutable after open
-        memory_used_(0),
-        current_offset_(0),
+
         current_rbs_(column_groups.size()),
         current_cg_offsets_(column_groups.size(), 0),
         current_cg_chunk_indices_(column_groups.size(), 0),
@@ -133,9 +131,9 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
 
       for (int i = 0; i < column_groups_.size(); ++i) {
         const auto& cg = column_groups_[i];
-        for (int j = 0; j < cg->columns.size(); ++j) {
-          if (unique_needed_columns.count(cg->columns[j]) != 0) {
-            columns_after_projection[i].emplace_back(cg->columns[j]);
+        for (auto& column : cg->columns) {
+          if (unique_needed_columns.count(column) != 0) {
+            columns_after_projection[i].emplace_back(column);
           }
         }
       }
@@ -162,8 +160,8 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
     // When schema is nullptr, derive field types from the column group readers' schemas.
     std::unordered_map<std::string, std::shared_ptr<arrow::Field>> cg_field_map;
     if (!schema_) {
-      for (size_t i = 0; i < chunk_readers_.size(); ++i) {
-        auto cg_schema = chunk_readers_[i]->get_schema();
+      for (const auto& chunk_reader : chunk_readers_) {
+        auto cg_schema = chunk_reader->get_schema();
         if (cg_schema) {
           for (int j = 0; j < cg_schema->num_fields(); ++j) {
             cg_field_map[cg_schema->field(j)->name()] = cg_schema->field(j);
@@ -212,7 +210,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
   /**
    * @brief Return the schema of needed columns.
    */
-  std::shared_ptr<arrow::Schema> schema() const override { return out_schema_; }
+  [[nodiscard]] std::shared_ptr<arrow::Schema> schema() const override { return out_schema_; }
 
   /**
    * @brief Read next batch of arrow record batch to the specifed pointer.
@@ -408,8 +406,8 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
   size_t parallelism_;
   // above is immutable after open
 
-  int64_t memory_used_;     // current memory usage
-  int64_t current_offset_;  // current read offset
+  int64_t memory_used_{0};     // current memory usage
+  int64_t current_offset_{0};  // current read offset
   std::vector<std::queue<std::shared_ptr<arrow::RecordBatch>>>
       current_rbs_;                                // current read arrays for each column group
   std::vector<size_t> current_cg_offsets_;         // current read offset for each column group
@@ -537,8 +535,7 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> ChunkReaderImpl:
 
   size_t curr_rb_index = 0;
   size_t curr_rb_offset = 0;
-  for (size_t i = 0; i < chunk_indices.size(); ++i) {
-    int64_t target_chunk_index = chunk_indices[i];
+  for (long long target_chunk_index : chunk_indices) {
     ARROW_ASSIGN_OR_RAISE(auto target_number_of_rows, chunk_reader_->get_chunk_rows(target_chunk_index));
 
     if (curr_rb_index >= results.size()) {
@@ -638,7 +635,7 @@ class ReaderImpl : public Reader {
     assert(cgs_);
   }
 
-  std::shared_ptr<ColumnGroups> get_column_groups() const override {
+  [[nodiscard]] std::shared_ptr<ColumnGroups> get_column_groups() const override {
     assert(cgs_);
     return cgs_;
   }
@@ -745,8 +742,8 @@ class ReaderImpl : public Reader {
                                                           resolved_columns, key_retriever_callback_));
     }
 
-    for (size_t i = 0; i < lazy_readers.size(); ++i) {
-      ARROW_ASSIGN_OR_RAISE(auto table, lazy_readers[i]->take(row_indices, parallelism));
+    for (const auto& lazy_reader : lazy_readers) {
+      ARROW_ASSIGN_OR_RAISE(auto table, lazy_reader->take(row_indices, parallelism));
       tables.emplace_back(table);
     }
 
@@ -811,7 +808,7 @@ class ReaderImpl : public Reader {
   /**
    * @brief Returns the per-call needed_columns if non-null and non-empty, otherwise falls back to the default.
    */
-  const std::shared_ptr<std::vector<std::string>>& effective_needed_columns(
+  [[nodiscard]] const std::shared_ptr<std::vector<std::string>>& effective_needed_columns(
       const std::shared_ptr<std::vector<std::string>>& per_call) const {
     return (per_call != nullptr && !per_call->empty()) ? per_call : needed_columns_;
   }
@@ -839,8 +836,9 @@ class ReaderImpl : public Reader {
       // No schema provided: collect all unique column names from column groups
       std::unordered_set<std::string> seen;
       for (const auto& cg : *cgs_) {
-        if (!cg)
+        if (!cg) {
           continue;
+        }
         for (const auto& col : cg->columns) {
           if (seen.insert(col).second) {
             resolved.emplace_back(col);
@@ -861,7 +859,7 @@ class ReaderImpl : public Reader {
   /**
    * @brief Collects unique column groups for the requested columns
    */
-  std::vector<std::shared_ptr<ColumnGroup>> collect_required_column_groups(
+  [[nodiscard]] std::vector<std::shared_ptr<ColumnGroup>> collect_required_column_groups(
       const std::vector<std::string>& needed_columns) const {
     std::unordered_set<std::shared_ptr<ColumnGroup>> unique_groups;
 

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -289,7 +289,7 @@ class WriterImpl : public Writer {
    *
    * @return Shared pointer to the Arrow schema
    */
-  std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
+  [[nodiscard]] std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
 
   /**
    * @brief Writes a record batch to the dataset

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include <thread>
 #include <future>
@@ -66,7 +67,7 @@ class TransactionTest : public ::testing::Test {
                                                   std::vector<std::string> cols = {"id", "name"}) {
     ManifestPtr manifest = std::make_shared<Manifest>();
     auto cg1 = std::make_shared<ColumnGroup>();
-    cg1->columns = cols;
+    cg1->columns = std::move(cols);
     cg1->files = {
         {.path = base_path_ + dummy_name},
     };
@@ -431,8 +432,9 @@ TEST_F(TransactionTest, ConcurrentCommitsWithConditionalWrite) {
   start_promise.set_value();
 
   for (auto& t : threads) {
-    if (t.joinable())
+    if (t.joinable()) {
       t.join();
+    }
   }
 
   size_t success_count =

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -193,7 +193,7 @@ TEST_P(APIWriterReaderTest, SizeBasedColumnGroupPolicy) {
 }
 
 TEST_P(APIWriterReaderTest, TestWriteNotExistPath) {
-  auto verify_writer = [&](std::string base_path, api::Properties& properties) {
+  auto verify_writer = [&](const std::string& base_path, api::Properties& properties) {
     ASSERT_AND_ASSIGN(auto temp_fs, GetFileSystem(properties));
     ASSERT_STATUS_OK(DeleteTestDir(temp_fs, base_path));
 
@@ -931,8 +931,8 @@ TEST_P(APIWriterReaderTest, TakeWithMultiFiles) {
   ASSERT_EQ(written_rows, 2250);
   std::vector<std::vector<int64_t>> test_row_indices = {
       // take single row
-      {(int64_t)written_rows - 1},
-      {(int64_t)written_rows / 2},
+      {static_cast<int64_t>(written_rows) - 1},
+      {static_cast<int64_t>(written_rows) / 2},
       {0},
       // take multiple rows
       {10, 500, 900},

--- a/cpp/test/common/parallelism_test.cpp
+++ b/cpp/test/common/parallelism_test.cpp
@@ -50,7 +50,7 @@ TEST_P(ParallelismTest, ThreadPoolTest) {
   std::vector<std::packaged_task<size_t()>> tasks;
   std::vector<std::future<size_t>> futures;
   for (int i = 0; i < num_of_tasks; ++i) {
-    tasks.emplace_back(std::packaged_task<size_t()>(std::bind(taskFunction, i)));
+    tasks.emplace_back([i] { return taskFunction(i); });
     futures.emplace_back(tasks.back().get_future());
   }
 

--- a/cpp/test/ffi/arrow_c_wrapper.c
+++ b/cpp/test/ffi/arrow_c_wrapper.c
@@ -236,8 +236,9 @@ void release_root_array(struct ArrowArray* array) {
     free(array->children);
   }
 
-  if (array->buffers != NULL)
+  if (array->buffers != NULL) {
     free(array->buffers);
+  }
   array->release = NULL;
 }
 
@@ -246,8 +247,9 @@ struct ArrowArray* create_int64_array(const int64_t* data,
                                       const uint8_t* null_bitmap,
                                       int64_t null_count) {
   struct ArrowArray* array = malloc(sizeof(struct ArrowArray));
-  if (array == NULL)
+  if (array == NULL) {
     return NULL;
+  }
 
   array->length = length;
   array->null_count = null_count;
@@ -283,8 +285,9 @@ struct ArrowArray* create_int32_array(const int32_t* data,
                                       const uint8_t* null_bitmap,
                                       int64_t null_count) {
   struct ArrowArray* array = malloc(sizeof(struct ArrowArray));
-  if (array == NULL)
+  if (array == NULL) {
     return NULL;
+  }
 
   array->length = length;
   array->null_count = null_count;
@@ -316,8 +319,9 @@ struct ArrowArray* create_string_array(const char** data,
                                        const uint8_t* null_bitmap,
                                        int64_t null_count) {
   struct ArrowArray* array = malloc(sizeof(struct ArrowArray));
-  if (array == NULL)
+  if (array == NULL) {
     return NULL;
+  }
 
   array->length = length;
   array->null_count = null_count;
@@ -366,8 +370,9 @@ struct ArrowArray* create_string_array(const char** data,
 
 struct ArrowArray* create_struct_array(struct ArrowArray** children, int64_t n_children, int64_t length) {
   struct ArrowArray* array = malloc(sizeof(struct ArrowArray));
-  if (array == NULL)
+  if (array == NULL) {
     return NULL;
+  }
 
   array->length = length;
   array->null_count = 0;

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -24,7 +24,7 @@
 
 #define TEST_ROOT_PATH "test_filesystem_ffi"
 #define TEST_FILE_NAME "test_filesystem_file"
-#define TEST_BUFFER_SIZE 4096
+enum { TEST_BUFFER_SIZE = 4096 };
 
 int remove_directory(const char* root_path, const char* path);
 int make_directory(const char* root_path, const char* sub_dir);

--- a/cpp/test/ffi/ffi_property_test.c
+++ b/cpp/test/ffi/ffi_property_test.c
@@ -20,8 +20,7 @@
 #include <assert.h>
 #include <unistd.h>
 
-#define PROPERTIES_TEST_COUNT 10
-#define PROPERTIES_TEST_KVSIZE 10
+enum { PROPERTIES_TEST_COUNT = 10, PROPERTIES_TEST_KVSIZE = 10 };
 
 void create_properties_test_kvs_internal(char*** out_test_key,
                                          char*** out_test_val,
@@ -70,7 +69,7 @@ static void test_basic(void) {
   rc = loon_properties_create(&test_key, &test_val, 1, &rp);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-  const char* test_val_got = loon_properties_get(&rp, (const char*)test_key);
+  const char* test_val_got = loon_properties_get(&rp, test_key);
   ck_assert(test_val_got != NULL && strcmp(test_val_got, test_val) == 0);
   loon_properties_free(&rp);
 }

--- a/cpp/test/filesystem/s3_client_test.cpp
+++ b/cpp/test/filesystem/s3_client_test.cpp
@@ -131,6 +131,7 @@ TEST_F(S3ClientTest, TestConcurrent) {
   std::vector<std::thread> threads;
 
   auto start = std::chrono::high_resolution_clock::now();
+  threads.reserve(num_threads);
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([this]() {
       ASSERT_AND_ASSIGN(auto client_lock, client_holder_->Lock());

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -1021,6 +1021,7 @@ TEST_F(S3FsTest, BackgroundWritesConcurrent) {
     std::vector<std::thread> threads;
     std::vector<arrow::Status> statuses(kNumThreads);
 
+    threads.reserve(kNumThreads);
     for (int i = 0; i < kNumThreads; ++i) {
       threads.emplace_back([&, i]() {
         std::string path = dir + "/file_" + std::to_string(i) + ".txt";

--- a/cpp/test/filesystem/s3_provider_test.cpp
+++ b/cpp/test/filesystem/s3_provider_test.cpp
@@ -115,7 +115,7 @@ class TempFile {
 
   ~TempFile() { std::remove(path_.c_str()); }
 
-  const std::string& path() const { return path_; }
+  [[nodiscard]] const std::string& path() const { return path_; }
 
   TempFile(const TempFile&) = delete;
   TempFile& operator=(const TempFile&) = delete;
@@ -197,22 +197,22 @@ class MockHttpClientFactory : public Aws::Http::HttpClientFactory {
   public:
   explicit MockHttpClientFactory(std::shared_ptr<MockHttpClient> client) : mock_client_(std::move(client)) {}
 
-  std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
       const Aws::Client::ClientConfiguration& clientConfiguration) const override {
     return mock_client_;
   }
 
-  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String& uri,
-                                                            Aws::Http::HttpMethod method,
-                                                            const Aws::IOStreamFactory& streamFactory) const override {
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
     auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("MockHttpClientFactory", uri, method);
     request->SetResponseStreamFactory(streamFactory);
     return request;
   }
 
-  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::Http::URI& uri,
-                                                            Aws::Http::HttpMethod method,
-                                                            const Aws::IOStreamFactory& streamFactory) const override {
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri,
+      Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override {
     auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("MockHttpClientFactory", uri, method);
     request->SetResponseStreamFactory(streamFactory);
     return request;
@@ -970,6 +970,7 @@ TEST_F(S3ProviderTest, TestHuaweiProviderConcurrentAccessNoStorm) {
   std::vector<std::thread> threads;
   std::vector<Aws::Auth::AWSCredentials> results(NUM_THREADS);
 
+  threads.reserve(NUM_THREADS);
   for (int i = 0; i < NUM_THREADS; i++) {
     threads.emplace_back([&provider, &results, i]() { results[i] = provider.GetAWSCredentials(); });
   }

--- a/cpp/test/format/column_groups_wr_test.cpp
+++ b/cpp/test/format/column_groups_wr_test.cpp
@@ -62,7 +62,7 @@ class ColumnGroupsWRTest : public ::testing::TestWithParam<std::tuple<std::strin
   }
 
   arrow::Result<std::vector<std::shared_ptr<ColumnGroups>>> generate_25600_rows_data(
-      const std::string& format, std::shared_ptr<arrow::Schema> schema, std::array<bool, 4> projection) {
+      const std::string& format, const std::shared_ptr<arrow::Schema>& schema, std::array<bool, 4> projection) {
     // Test writing with SinglePolicy
     // make sure parquet will make new column group for each write
     ARROW_ASSIGN_OR_RAISE(auto rb_256_rows,
@@ -220,7 +220,7 @@ TEST_P(ColumnGroupsWRTest, TestGetChunksSliced) {
       std::vector<int64_t> chunkidx_samples;
 
       float fraction = static_cast<float>(i) / random_times;
-      size_t samples_size = static_cast<size_t>(chunk_indices.size() * fraction);
+      auto samples_size = static_cast<size_t>(chunk_indices.size() * fraction);
 
       std::sample(chunk_indices.begin(), chunk_indices.end(), std::back_inserter(chunkidx_samples), samples_size, gen);
 
@@ -281,8 +281,8 @@ TEST_P(ColumnGroupsWRTest, TestStartEndIndex) {
     }
     ASSERT_AND_ASSIGN(auto chunks, chunk_reader->get_chunks(chunk_indices, parallelism_));
     size_t total_rows = 0;
-    for (size_t i = 0; i < chunks.size(); ++i) {
-      total_rows += chunks[i]->num_rows();
+    for (const auto& chunk : chunks) {
+      total_rows += chunk->num_rows();
     }
 
     for (size_t i = 0; i < chunks.size(); ++i) {

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -113,8 +113,8 @@ TEST_P(FormatReaderTest, ReadParquetWithoutMeta) {
   ASSERT_AND_ASSIGN(auto rbs, format_reader->get_chunks(rg_indices_in_file));
 
   size_t total_size = 0;
-  for (size_t i = 0; i < rbs.size(); i++) {
-    total_size += rbs[i]->num_rows();
+  for (const auto& rb : rbs) {
+    total_size += rb->num_rows();
   }
   ASSERT_EQ(total_size, test_batch_->num_rows() * 10);
 }

--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -84,11 +84,11 @@ class VortexBasicTest : public ::testing::Test {
     return rbs;
   }
 
-  inline int64_t recordBatchsRows() const {
+  [[nodiscard]] inline int64_t recordBatchsRows() const {
     return (count_each_loop_ * (record_batch_len_ - 1)) * record_batch_len_ / 2;
   }
 
-  inline size_t recordBatchsSize() const { return record_bacths_.size(); }
+  [[nodiscard]] inline size_t recordBatchsSize() const { return record_bacths_.size(); }
 
   template <typename T>
   std::vector<T> randomNumbers(T maxVal, T size) {
@@ -389,13 +389,13 @@ TEST_F(VortexBasicTest, TestBasicTake) {
                                               std::vector<std::string>{"int32"});
   ASSERT_STATUS_OK(vx_reader.open());
   // take single row
-  take_verify(vx_reader, std::move(randomNumbers<int64_t>(recordBatchsRows() - 1, 1)), 1);
+  take_verify(vx_reader, randomNumbers<int64_t>(recordBatchsRows() - 1, 1), 1);
   // 100 randowm rows
-  take_verify(vx_reader, std::move(randomNumbers<int64_t>(recordBatchsRows() - 1, 100)), 100);
+  take_verify(vx_reader, randomNumbers<int64_t>(recordBatchsRows() - 1, 100), 100);
   // boundary Testing
-  take_verify(vx_reader, {0, (int64_t)recordBatchsRows() - 1}, 2);
+  take_verify(vx_reader, {0, recordBatchsRows() - 1}, 2);
   // take all range
-  take_verify(vx_reader, rangeNumbers<int64_t>(0, recordBatchsRows()), (int64_t)recordBatchsRows());
+  take_verify(vx_reader, rangeNumbers<int64_t>(0, recordBatchsRows()), recordBatchsRows());
   // Note: vortex 0.56+ does not gracefully handle out-of-range indices (panics instead of returning error),
   // so we removed the out-of-range index tests.
 }

--- a/cpp/test/packed/packed_integration_test.cpp
+++ b/cpp/test/packed/packed_integration_test.cpp
@@ -35,8 +35,9 @@ TEST_F(PackedIntegrationTest, TestOneFile) {
   while (true) {
     std::shared_ptr<arrow::RecordBatch> batch;
     ASSERT_STATUS_OK(pr.ReadNext(&batch));
-    if (!batch)
+    if (!batch) {
       break;
+    }
     batches.push_back(batch);
   }
   ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatches(pr.schema(), batches));
@@ -62,8 +63,9 @@ TEST_F(PackedIntegrationTest, TestSplitColumnGroup) {
   while (true) {
     std::shared_ptr<arrow::RecordBatch> batch;
     ASSERT_STATUS_OK(pr.ReadNext(&batch));
-    if (!batch)
+    if (!batch) {
       break;
+    }
     batches.push_back(batch);
   }
   ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatches(pr.schema(), batches));
@@ -154,8 +156,9 @@ TEST_F(PackedIntegrationTest, TestMultipleRowGroups) {
   while (true) {
     std::shared_ptr<arrow::RecordBatch> batch;
     ASSERT_STATUS_OK(pr.ReadNext(&batch));
-    if (!batch)
+    if (!batch) {
       break;
+    }
     batches.push_back(batch);
   }
   ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatches(pr.schema(), batches));

--- a/cpp/test/s3_tls_version_test.cpp
+++ b/cpp/test/s3_tls_version_test.cpp
@@ -362,8 +362,9 @@ TEST_F(S3TlsVersionTest, EnforceMinTlsTest) {
   auto parse_tls_version = [](const std::string& ver) -> double {
     // "TLSv1.3" -> 1.3, "TLSv1.2" -> 1.2, etc.
     auto pos = ver.find("TLSv");
-    if (pos == std::string::npos)
+    if (pos == std::string::npos) {
       return 0.0;
+    }
     return std::stod(ver.substr(pos + 4));
   };
 
@@ -473,8 +474,9 @@ TEST_F(S3TlsVersionTest, EnforceMinTlsArrowFsTest) {
 
   auto parse_tls_version = [](const std::string& ver) -> double {
     auto pos = ver.find("TLSv");
-    if (pos == std::string::npos)
+    if (pos == std::string::npos) {
       return 0.0;
+    }
     return std::stod(ver.substr(pos + 4));
   };
 

--- a/cpp/test/test_env.cpp
+++ b/cpp/test/test_env.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <random>
 #include <iostream>
+#include <utility>
 
 #include <arrow/type_fwd.h>
 #include <arrow/api.h>
@@ -197,7 +198,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateTestData(std::shared_pt
   std::vector<std::shared_ptr<arrow::Array>> arrays;
   std::shared_ptr<arrow::Array> id_array, name_array, value_array, vector_array;
 
-  srand(static_cast<unsigned>(time(0)));
+  srand(static_cast<unsigned>(time(nullptr)));
   for (int64_t i = start_offset; i < start_offset + num_rows; ++i) {
     if (needed_columns[0]) {
       ARROW_RETURN_NOT_OK(randdata ? id_builder.Append(generateRandomInt<int64_t>()) : id_builder.Append(i));
@@ -245,7 +246,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateTestData(std::shared_pt
     arrays.emplace_back(vector_array);
   }
 
-  return arrow::RecordBatch::Make(schema, num_rows, arrays);
+  return arrow::RecordBatch::Make(std::move(schema), num_rows, arrays);
 }
 
 arrow::Status ValidateRowAlignment(const std::shared_ptr<arrow::RecordBatch>& batch) {
@@ -406,8 +407,8 @@ arrow::Result<std::vector<int64_t>> GenerateSortedUniqueArray(int rand_counts,
 
   if (print_out) {
     std::cout << "Random array: " << std::endl;
-    for (int i = 0; i < result.size(); ++i) {
-      std::cout << result[i] << " ";
+    for (long long i : result) {
+      std::cout << i << " ";
     }
     std::cout << std::endl;
   }


### PR DESCRIPTION
Apply automated code style fixes from `make fix-checks`
(clang-format + clang-tidy) across the codebase. No functional
changes.

Test plan:
- All changes are formatting-only (whitespace, line breaks,
  brace placement)
- Verified by running `make fix-checks` which produced no
  further changes