### PR TITLE
feat: support schema-less reading in Reader API

### DIFF
--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -41,6 +41,9 @@ class ColumnGroupReader {
   virtual arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) = 0;
   virtual arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) = 0;
 
+  // get the file schema of this column group (always derived from file metadata, not projected)
+  virtual std::shared_ptr<arrow::Schema> get_schema() const = 0;
+
   /**
    * @brief Create a chunk reader for a column group
    *

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -83,9 +83,12 @@ class FormatReader {
   // if the reader is thread-safe, then return itself
   [[nodiscard]] virtual arrow::Result<std::shared_ptr<FormatReader>> clone_reader() = 0;
 
+  // get the file schema of this reader (always derived from file metadata, not projected)
+  [[nodiscard]] virtual std::shared_ptr<arrow::Schema> get_schema() const = 0;
+
   // create format reader
   static arrow::Result<std::shared_ptr<FormatReader>> create(
-      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<arrow::Schema>& read_schema,
       const std::string& format,
       const api::ColumnGroupFile& file,
       const api::Properties& properties,

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -28,12 +28,14 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
   LanceTableReader(const std::shared_ptr<BlockingDataset> dataset,
                    uint64_t fragment_id,
                    const std::shared_ptr<arrow::Schema>& schema,
-                   const milvus_storage::api::Properties& properties);
+                   const milvus_storage::api::Properties& properties,
+                   const std::vector<std::string>& needed_columns = {});
 
   LanceTableReader(const std::string& uri,
                    uint64_t fragment_id,
                    const std::shared_ptr<arrow::Schema>& schema,
-                   const milvus_storage::api::Properties& properties);
+                   const milvus_storage::api::Properties& properties,
+                   const std::vector<std::string>& needed_columns = {});
 
   [[nodiscard]] arrow::Status open() override;
 
@@ -56,12 +58,17 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
 
   [[nodiscard]] arrow::Result<std::shared_ptr<FormatReader>> clone_reader() override;
 
+  [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
+
   private:
   std::shared_ptr<BlockingDataset> dataset_;
   std::string uri_;
   uint64_t fragment_id_;
-  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<arrow::Schema> read_schema_;
   milvus_storage::api::Properties properties_;
+  std::vector<std::string> needed_columns_;
+
+  std::shared_ptr<arrow::Schema> file_schema_;  // always derived from fragment metadata in open()
 
   uint64_t logical_chunk_rows_;
   std::vector<RowGroupInfo> row_group_infos_;

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -60,6 +60,8 @@ class ParquetFormatReader final : public FormatReader {
 
   [[nodiscard]] arrow::Result<std::shared_ptr<FormatReader>> clone_reader() override;
 
+  [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
+
   private:
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::Table>> get_chunks_internal(
       const std::vector<int>& rg_indices_in_file);

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -53,6 +53,8 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
 
   [[nodiscard]] arrow::Result<std::shared_ptr<FormatReader>> clone_reader() override;
 
+  [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
+
   // get the row ranges(splits) of the file
   inline std::vector<uint64_t> row_ranges() const { return vxfile_->Splits(); }
 
@@ -74,8 +76,10 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   std::shared_ptr<FileSystemWrapper> fs_holder_;
   std::vector<std::string> proj_cols_;
   std::string path_;
-  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<arrow::Schema> read_schema_;
   milvus_storage::api::Properties properties_;
+
+  std::shared_ptr<arrow::Schema> file_schema_;  // always derived from file in open()
 
   uint64_t logical_chunk_rows_;
   std::vector<RowGroupInfo> row_group_infos_;

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -116,7 +116,8 @@ class Reader {
    * readers without exposing the concrete implementation details.
    *
    * @param cgs Dataset column group information
-   * @param schema Arrow schema defining the logical structure of the data
+   * @param schema Arrow schema defining the logical structure of the data.
+   *        If nullptr, the schema is derived from the underlying file metadata.
    * @param properties Read configuration properties including encryption settings
    * @return Unique pointer to a Reader instance
    *
@@ -140,8 +141,24 @@ class Reader {
    * }
    * @endcode
    *
+   * About schema:
+   *  - If `schema` is provided, it defines the logical structure: field types are taken from
+   *    the schema, column validation is performed against it, and missing columns are filled
+   *    with NULL values.
+   *  - If `schema` is nullptr, field types are derived from the underlying files (e.g. Parquet
+   *    file metadata, Lance fragment schema, Vortex file schema). In this mode, all output
+   *    columns must exist in the column group files; NULL filling for missing columns is not
+   *    supported (since types are unknown).
+   *
+   *  Empty column groups behavior:
+   *  - If `schema` is provided and column groups are empty, `get_record_batch_reader()` and
+   *    `take()` return an empty result (empty RecordBatchReader / empty Table) with the given
+   *    schema.
+   *  - If `schema` is nullptr and column groups are empty, these methods return an Invalid
+   *    error, since no schema can be derived to construct the result.
+   *
    * About projection (set via `needed_columns` in create, or per-call on `get_chunk_reader`/`take`):
-   *  Top Reader:
+   *  Top Reader (when schema is provided):
    *  - All column names in `needed_columns` must exist as field names in the schema.
    *    Example:
    *      - schema{a,b,c}, needed_columns{a,b,c,d} or {d}
@@ -168,6 +185,11 @@ class Reader {
    *           - ChunkReader(column_group_id=0), columns{a,b}, needed_columns{a,c}
    *           - The output is {a}.
    *
+   *  Top Reader (when schema is nullptr):
+   *  - If `needed_columns` is nullptr, all columns from all column groups will be read.
+   *  - If `needed_columns` is provided, only those columns will be read (no validation).
+   *  - The output schema is derived from the file metadata (e.g. Parquet schema).
+   *
    *  Column Group Reader: Uses the `columns` in the current column group to filter
    *    `needed_columns` and build the `out_schema`. The filtered
    *    projection must match the `out_schema`.
@@ -176,7 +198,7 @@ class Reader {
    *    `needed_columns`. If `needed_columns` is also empty or nullptr, it reads all columns.
    */
   static std::unique_ptr<Reader> create(const std::shared_ptr<ColumnGroups>& cgs,
-                                        const std::shared_ptr<arrow::Schema>& schema,
+                                        const std::shared_ptr<arrow::Schema>& schema = nullptr,
                                         const std::shared_ptr<std::vector<std::string>>& needed_columns = nullptr,
                                         const Properties& properties = {});
 

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -87,6 +87,9 @@ class BlockingDataset {
 
   uint64_t GetFragmentRowCount(uint64_t fragment_id) const;
 
+  // Get the schema of a specific fragment, exported as Arrow C schema
+  void GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const;
+
   // Dataset-level scan: create a scanner for projected columns
   std::unique_ptr<BlockingScanner> Scan(ArrowSchema& schema, uint32_t batch_size);
 

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -193,6 +193,9 @@ class VortexFile {
   /// Get the number of rows in the file.
   uint64_t RowCount() const;
 
+  /// Get the file schema, exported as Arrow C schema.
+  void GetFileSchema(ArrowSchema& out_schema) const;
+
   /// Create a scan builder for the file.
   /// The scan builder can be used to scan the file.
   ScanBuilder CreateScanBuilder() const;

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -91,6 +91,14 @@ uint64_t BlockingDataset::GetFragmentRowCount(uint64_t fragment_id) const {
   }
 }
 
+void BlockingDataset::GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const {
+  try {
+    ffi::get_fragment_schema(*impl_, fragment_id, reinterpret_cast<uint8_t*>(&out_schema));
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw LanceException(e.what());
+  }
+}
+
 void BlockingDataset::WriteArrowArrayStream(struct ArrowArrayStream* stream) {
   try {
     impl_->write_stream(reinterpret_cast<uint8_t*>(stream));

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -616,6 +616,36 @@ pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Re
         })
 }
 
+pub unsafe fn get_fragment_schema(
+    dataset: &BlockingDataset,
+    fragment_id: u64,
+    out_schema_ptr: *mut u8,
+) -> Result<()> {
+    let fragment_meta = dataset
+        .get_fragment(fragment_id)
+        .ok_or_else(|| LanceError::InvalidInput {
+            source: format!("Fragment {} not found", fragment_id).into(),
+            location: snafu::location!(),
+        })?;
+
+    // Lance only exposes fragment schema via FileFragment::schema(), which requires an
+    // Arc<Dataset>. The clone here is cheap — Dataset internally wraps state in Arcs, so
+    // this is essentially a ref-count bump rather than a deep copy.
+    let file_fragment = FileFragment::new(Arc::new(dataset.inner.clone()), fragment_meta);
+    let lance_schema = file_fragment.schema();
+    let arrow_schema: ArrowSchema = lance_schema.into();
+
+    let ffi_schema = arrow::ffi::FFI_ArrowSchema::try_from(&arrow_schema)
+        .map_err(|e| LanceError::InvalidInput {
+            source: format!("Failed to export fragment schema: {}", e).into(),
+            location: snafu::location!(),
+        })?;
+
+    let out_ptr = out_schema_ptr as *mut arrow::ffi::FFI_ArrowSchema;
+    unsafe { std::ptr::write(out_ptr, ffi_schema) };
+    Ok(())
+}
+
 //=============================================================================
 // BlockingScanner: dataset-level scan support
 //=============================================================================

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -73,6 +73,11 @@ pub mod lance_ffi {
         pub unsafe fn write_stream(self: &mut BlockingDataset, stream_ptr: *mut u8) -> Result<()>;
         pub fn get_all_fragment_ids(self: &BlockingDataset) -> Vec<u64>;
         pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64>;
+        pub unsafe fn get_fragment_schema(
+            dataset: &BlockingDataset,
+            fragment_id: u64,
+            out_schema_ptr: *mut u8,
+        ) -> Result<()>;
 
         type BlockingFragmentReader;
         pub unsafe fn open_fragment_reader(
@@ -195,6 +200,7 @@ pub mod vortex_ffi {
         // reader
         type VortexFile;
         fn row_count(self: &VortexFile) -> u64;
+        unsafe fn get_schema(self: &VortexFile, out_schema: *mut u8) -> Result<()>;
         fn scan_builder(self: &VortexFile) -> Result<Box<VortexScanBuilder>>;
         unsafe fn scan_builder_with_schema(self: &VortexFile, in_schema: *mut u8) -> Result<Box<VortexScanBuilder>>;
         fn splits(self: &VortexFile) -> Result<Vec<u64>>;

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -181,6 +181,14 @@ std::unique_ptr<VortexFile> VortexFile::OpenUnique(uint8_t* fs_rawptr, const std
 
 uint64_t VortexFile::RowCount() const { return impl_->row_count(); }
 
+void VortexFile::GetFileSchema(ArrowSchema& out_schema) const {
+  try {
+    impl_->get_schema(reinterpret_cast<uint8_t*>(&out_schema));
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw VortexException(e.what());
+  }
+}
+
 ScanBuilder VortexFile::CreateScanBuilder() const { return ScanBuilder(impl_->scan_builder()); }
 
 ScanBuilder VortexFile::CreateScanBuilderWithSchema(ArrowSchema& in_schema) const {

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -539,6 +539,14 @@ impl VortexFile {
         }))
     }
 
+    pub(crate) unsafe fn get_schema(&self, out_schema: *mut u8) -> Result<()> {
+        let dtype = self.inner.dtype();
+        let arrow_schema = dtype.to_arrow_schema()?;
+        let ffi_schema = FFI_ArrowSchema::try_from(&arrow_schema)?;
+        unsafe { std::ptr::write(out_schema as *mut FFI_ArrowSchema, ffi_schema) };
+        Ok(())
+    }
+
     pub(crate) fn splits(&self) -> Result<Vec<u64>> {
         // get the Vec<Range<u64>> from the inner file
         let ranges = self.inner.splits()

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -273,18 +273,24 @@ arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> ColumnGroupLazyReader::cre
     const std::function<std::string(const std::string&)>& key_retriever) {
   std::shared_ptr<arrow::Schema> out_schema;
   std::vector<std::string> filtered_columns;
-  std::vector<std::shared_ptr<arrow::Field>> fields;
   for (const auto& col_name : needed_columns) {
     if (std::find(column_group->columns.begin(), column_group->columns.end(), col_name) !=
         column_group->columns.end()) {
       filtered_columns.emplace_back(col_name);
+    }
+  }
+
+  if (schema) {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (const auto& col_name : filtered_columns) {
       auto field = schema->GetFieldByName(col_name);
       assert(field);
       fields.emplace_back(field);
     }
+    out_schema = std::make_shared<arrow::Schema>(fields);
   }
-
-  out_schema = std::make_shared<arrow::Schema>(fields);
+  // When schema is nullptr, out_schema stays nullptr;
+  // the RecordBatches returned by the format reader will carry the file schema.
 
   return std::make_unique<ColumnGroupLazyReaderImpl>(out_schema, column_group, properties, filtered_columns,
                                                      key_retriever);

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -82,6 +82,8 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) override;
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
 
+  [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
+
   private:
   ChunkRBMapResult read_chunks_from_files(const std::vector<int64_t>& task_indices);
 
@@ -111,21 +113,29 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     return arrow::Status::Invalid("Column group cannot be null");
   }
 
-  // Generate the output schema with only the needed columns
-  std::shared_ptr<arrow::Schema> out_schema;
+  // Filter needed_columns to only those present in this column group
   std::vector<std::string> filtered_columns;
-  std::vector<std::shared_ptr<arrow::Field>> fields;
   for (const auto& col_name : needed_columns) {
     if (std::find(column_group->columns.begin(), column_group->columns.end(), col_name) !=
         column_group->columns.end()) {
       filtered_columns.emplace_back(col_name);
+    }
+  }
+
+  // Build output schema from the provided schema if available
+  std::shared_ptr<arrow::Schema> out_schema;
+  if (schema) {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (const auto& col_name : filtered_columns) {
       auto field = schema->GetFieldByName(col_name);
       assert(field);
       fields.emplace_back(field);
     }
+    out_schema = std::make_shared<arrow::Schema>(fields);
   }
+  // When schema is nullptr, out_schema stays nullptr;
+  // the RecordBatches returned by the format reader will carry the file schema.
 
-  out_schema = std::make_shared<arrow::Schema>(fields);
   reader = std::make_unique<milvus_storage::api::ColumnGroupReaderImpl>(out_schema, column_group, properties,
                                                                         filtered_columns, key_retriever);
   ARROW_RETURN_NOT_OK(reader->open());
@@ -479,6 +489,13 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl::get_chunk_rows(int64_t chunk_inde
         fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
   }
   return chunk_infos_[chunk_index].number_of_rows;
+}
+
+std::shared_ptr<arrow::Schema> ColumnGroupReaderImpl::get_schema() const {
+  if (!format_readers_.empty()) {
+    return format_readers_[0]->get_schema();
+  }
+  return nullptr;
 }
 
 }  // namespace milvus_storage::api

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -32,7 +32,7 @@ std::string RowGroupInfo::ToString() const {
 }
 
 arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
-    const std::shared_ptr<arrow::Schema>& schema,
+    const std::shared_ptr<arrow::Schema>& read_schema,
     const std::string& format,
     const api::ColumnGroupFile& file,
     const api::Properties& properties,
@@ -49,13 +49,14 @@ arrow::Result<std::shared_ptr<FormatReader>> FormatReader::create(
     ARROW_ASSIGN_OR_RAISE(auto file_system, FilesystemCache::getInstance().get(properties, file.path));
     ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(file.path));
     std::string resolved_path = uri.scheme.empty() ? file.path : uri.key;
-    format_reader =
-        std::make_shared<vortex::VortexFormatReader>(file_system, schema, resolved_path, properties, needed_columns);
+    format_reader = std::make_shared<vortex::VortexFormatReader>(file_system, read_schema, resolved_path, properties,
+                                                                 needed_columns);
   } else if (format == LOON_FORMAT_LANCE_TABLE) {
     std::string base_path;
     uint64_t fragment_id;
     ARROW_ASSIGN_OR_RAISE(std::tie(base_path, fragment_id), lance::ParseLanceUri(file.path));
-    format_reader = std::make_shared<lance::LanceTableReader>(base_path, fragment_id, schema, properties);
+    format_reader =
+        std::make_shared<lance::LanceTableReader>(base_path, fragment_id, read_schema, properties, needed_columns);
   } else {
     return arrow::Status::Invalid(fmt::format("Unknown file format: {}", format));
   }

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -34,22 +34,26 @@ namespace milvus_storage::lance {
 LanceTableReader::LanceTableReader(const std::shared_ptr<BlockingDataset> dataset,
                                    uint64_t fragment_id,
                                    const std::shared_ptr<arrow::Schema>& schema,
-                                   const milvus_storage::api::Properties& properties)
+                                   const milvus_storage::api::Properties& properties,
+                                   const std::vector<std::string>& needed_columns)
     : dataset_(dataset),
       fragment_id_(fragment_id),
-      schema_(schema),
+      read_schema_(schema),
       properties_(properties),
-      fragment_reader_(nullptr) {
-  assert(schema_);
-}
+      needed_columns_(needed_columns),
+      fragment_reader_(nullptr) {}
 
 LanceTableReader::LanceTableReader(const std::string& uri,
                                    uint64_t fragment_id,
                                    const std::shared_ptr<arrow::Schema>& schema,
-                                   const milvus_storage::api::Properties& properties)
-    : uri_(uri), fragment_id_(fragment_id), schema_(schema), properties_(properties), fragment_reader_(nullptr) {
-  assert(schema_);
-}
+                                   const milvus_storage::api::Properties& properties,
+                                   const std::vector<std::string>& needed_columns)
+    : uri_(uri),
+      fragment_id_(fragment_id),
+      read_schema_(schema),
+      properties_(properties),
+      needed_columns_(needed_columns),
+      fragment_reader_(nullptr) {}
 
 static std::vector<RowGroupInfo> create_row_group_infos(uint64_t rows_in_file, uint64_t logical_chunk_rows) {
   if (rows_in_file == 0) {
@@ -83,14 +87,45 @@ arrow::Status LanceTableReader::open() {
     dataset_ = BlockingDataset::Open(uri_, ToLanceStorageOptions(fs_config));
   }
 
+  // Always derive file schema from fragment metadata
+  {
+    ArrowSchema c_fragment_schema;
+    try {
+      dataset_->GetFragmentSchema(fragment_id_, c_fragment_schema);
+    } catch (const LanceException& e) {
+      return arrow::Status::IOError(fmt::format("Failed to get fragment schema: {}", e.what()));
+    }
+    ARROW_ASSIGN_OR_RAISE(file_schema_, arrow::ImportSchema(&c_fragment_schema));
+  }
+
+  // Build the read schema for fragment reader:
+  // use user-provided schema if available, otherwise project file schema by needed_columns
+  std::shared_ptr<arrow::Schema> read_schema;
+  if (read_schema_) {
+    read_schema = read_schema_;
+  } else if (!needed_columns_.empty()) {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    for (const auto& col : needed_columns_) {
+      auto field = file_schema_->GetFieldByName(col);
+      if (field) {
+        fields.push_back(field);
+      }
+    }
+    read_schema = arrow::schema(fields);
+  } else {
+    read_schema = file_schema_;
+  }
+  ARROW_RETURN_NOT_OK(arrow::ExportSchema(*read_schema, &c_arrow_schema));
+
   ARROW_ASSIGN_OR_RAISE(logical_chunk_rows_, api::GetValue<uint64_t>(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
-  ARROW_RETURN_NOT_OK(arrow::ExportSchema(*schema_, &c_arrow_schema));
 
   fragment_reader_ = BlockingFragmentReader::Open(*dataset_, fragment_id_, c_arrow_schema);
   row_group_infos_ = create_row_group_infos(fragment_reader_->RowCount(), logical_chunk_rows_);
 
   return arrow::Status::OK();
 }
+
+std::shared_ptr<arrow::Schema> LanceTableReader::get_schema() const { return file_schema_; }
 
 arrow::Result<std::vector<RowGroupInfo>> LanceTableReader::get_row_group_infos() {
   assert(fragment_reader_);

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -169,6 +169,11 @@ arrow::Status ParquetFormatReader::open() {
   return arrow::Status::OK();
 }
 
+// Parquet uses a single schema_ (always derived from the file footer) rather than
+// separate read_schema_/file_schema_ like Lance/Vortex. Projection is handled via
+// needed_column_indices_ instead of a separate read schema.
+std::shared_ptr<arrow::Schema> ParquetFormatReader::get_schema() const { return schema_; }
+
 arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::get_row_group_infos() { return row_group_infos_; }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> ParquetFormatReader::get_chunk(const int& row_group_index) {

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -104,7 +104,7 @@ VortexFormatReader::VortexFormatReader(const std::shared_ptr<arrow::fs::FileSyst
     : fs_holder_(std::make_shared<FileSystemWrapper>(fs)),
       proj_cols_(std::move(needed_columns)),
       path_(path),
-      schema_(schema),
+      read_schema_(schema),
       properties_(properties),
       vxfile_(nullptr) {}
 
@@ -112,16 +112,29 @@ arrow::Status VortexFormatReader::open() {
   assert(!vxfile_);
 
   ARROW_ASSIGN_OR_RAISE(logical_chunk_rows_, api::GetValue<uint64_t>(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
-  if (schema_ && schema_->num_fields() == 0) {
-    schema_ = nullptr;
+  if (read_schema_ && read_schema_->num_fields() == 0) {
+    read_schema_ = nullptr;
   }
   vxfile_ = VortexFile::OpenUnique((uint8_t*)fs_holder_.get(), path_);
+
+  // Always derive full file schema from file metadata
+  {
+    ArrowSchema c_schema;
+    try {
+      vxfile_->GetFileSchema(c_schema);
+    } catch (const VortexException& e) {
+      return arrow::Status::IOError(fmt::format("Failed to get vortex file schema: {}", e.what()));
+    }
+    ARROW_ASSIGN_OR_RAISE(file_schema_, arrow::ImportSchema(&c_schema));
+  }
 
   row_group_infos_ =
       create_row_group_infos(total_mem_usage(), rows(), recalc_row_ranges(row_ranges(), logical_chunk_rows_));
 
   return arrow::Status::OK();
 }
+
+std::shared_ptr<arrow::Schema> VortexFormatReader::get_schema() const { return file_schema_; }
 
 arrow::Result<std::vector<RowGroupInfo>> VortexFormatReader::get_row_group_infos() {
   assert(vxfile_);
@@ -193,8 +206,8 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start, uin
     scan_builder.WithProjection(build_projection(proj_cols_));
   }
 
-  if (schema_) {
-    ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(schema_));
+  if (read_schema_) {
+    ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(read_schema_));
     scan_builder.WithOutputSchema(c_arrow_schema);
   }
 
@@ -221,8 +234,8 @@ arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std:
     scan_builder.WithProjection(build_projection(proj_cols_));
   }
 
-  if (schema_) {
-    ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(schema_));
+  if (read_schema_) {
+    ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(read_schema_));
     scan_builder.WithOutputSchema(c_arrow_schema);
   }
 

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -159,15 +159,29 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
       }
     }
 
+    // When schema is nullptr, derive field types from the column group readers' schemas.
+    std::unordered_map<std::string, std::shared_ptr<arrow::Field>> cg_field_map;
+    if (!schema_) {
+      for (size_t i = 0; i < chunk_readers_.size(); ++i) {
+        auto cg_schema = chunk_readers_[i]->get_schema();
+        if (cg_schema) {
+          for (int j = 0; j < cg_schema->num_fields(); ++j) {
+            cg_field_map[cg_schema->field(j)->name()] = cg_schema->field(j);
+          }
+        }
+      }
+    }
+
     std::vector<std::shared_ptr<arrow::Field>> out_fields(needed_columns_.size());
     // build output schema and field map
     for (size_t i = 0; i < needed_columns_.size(); ++i) {
       const auto& col_name = needed_columns_[i];
       if (columnMap.count(col_name) == 0) {
-        // no found in any column group, missing column should fill with nulls(maybe use the default value?)
-        auto field_index = schema_->GetFieldIndex(col_name);
-        assert(field_index != -1);  // already verified in collect_required_column_groups
-
+        // not found in any column group, missing column should fill with nulls
+        if (schema_) {
+          auto field_index = schema_->GetFieldIndex(col_name);
+          assert(field_index != -1);  // already verified in collect_required_column_groups
+        }
         out_field_map_[i] = std::make_pair(-1, -1);
       } else {
         assert(columnMap.find(col_name) != columnMap.end());
@@ -176,7 +190,19 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
         // find the field index in schema
         out_field_map_[i] = std::make_pair(cg_index, idx_in_columns);
       }
-      out_fields[i] = schema_->field(schema_->GetFieldIndex(col_name));
+
+      // Get the field from schema or from RecordBatch schema
+      if (schema_) {
+        out_fields[i] = schema_->field(schema_->GetFieldIndex(col_name));
+      } else {
+        auto it = cg_field_map.find(col_name);
+        if (it != cg_field_map.end()) {
+          out_fields[i] = it->second;
+        } else {
+          return arrow::Status::Invalid(
+              fmt::format("Column '{}' not found in any column group and no schema provided", col_name));
+        }
+      }
     }
     out_schema_ = arrow::schema(out_fields);
 
@@ -307,7 +333,9 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
     // Reset memory tracking for this batch
     memory_used_ = 0;
 
-    // Load chunks up to memory limit using min-heap for row offset alignment
+    // Load chunks up to memory limit using min-heap for row offset alignment.
+    // Each column group is guaranteed at least one chunk per load round,
+    // regardless of memory limit, to avoid leaving any CG with an empty queue.
     RowOffsetMinHeap sorted_offsets;
     for (size_t i = 0; i < column_groups_.size(); ++i) {
       if (current_cg_chunk_indices_[i] < number_of_chunks_per_cg_[i]) {
@@ -315,7 +343,17 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
       }
     }
 
-    while (!sorted_offsets.empty() && memory_used_ < memory_usage_limit_) {
+    auto all_cgs_have_data = [&]() {
+      for (size_t i = 0; i < column_groups_.size(); ++i) {
+        if (current_rbs_[i].empty() && loaded_chunk_indices_[i].empty() &&
+            current_cg_chunk_indices_[i] < number_of_chunks_per_cg_[i]) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    while (!sorted_offsets.empty() && (memory_used_ < memory_usage_limit_ || !all_cgs_have_data())) {
       auto [cg_index, cg_offset] = sorted_offsets.top();
       sorted_offsets.pop();
 
@@ -440,10 +478,7 @@ ChunkReaderImpl::ChunkReaderImpl(const std::shared_ptr<arrow::Schema>& schema,
       column_group_(column_group),
       needed_columns_(needed_columns),
       properties_(properties),
-      key_retriever_callback_(key_retriever) {
-  // create schema from column group
-  assert(schema != nullptr);
-}
+      key_retriever_callback_(key_retriever) {}
 
 arrow::Status ChunkReaderImpl::open() {
   // The case is:
@@ -600,7 +635,7 @@ class ReaderImpl : public Reader {
         properties_(properties),
         key_retriever_callback_(nullptr) {
     // Validate required parameters
-    assert(cgs_ && schema_);
+    assert(cgs_);
   }
 
   std::shared_ptr<ColumnGroups> get_column_groups() const override {
@@ -615,9 +650,12 @@ class ReaderImpl : public Reader {
       const std::string& /*predicate*/) const override {
     // empty column groups
     if (cgs_->size() == 0) {
-      // direct return empty record batch reader
-      ARROW_ASSIGN_OR_RAISE(auto empty_table, arrow::Table::MakeEmpty(schema_));
-      return std::make_shared<arrow::TableBatchReader>(std::move(empty_table));
+      if (schema_) {
+        ARROW_ASSIGN_OR_RAISE(auto empty_table, arrow::Table::MakeEmpty(schema_));
+        return std::make_shared<arrow::TableBatchReader>(std::move(empty_table));
+      }
+
+      return arrow::Status::Invalid("Cannot read from empty column groups without a schema");
     }
 
     ARROW_ASSIGN_OR_RAISE(auto resolved_columns, resolve_needed_columns(schema_, needed_columns_));
@@ -625,15 +663,18 @@ class ReaderImpl : public Reader {
     // Collect required column groups
     auto needed_column_groups = collect_required_column_groups(resolved_columns);
 
-    // Create schema with only needed columns for projection
-    std::vector<std::shared_ptr<arrow::Field>> needed_fields;
-    for (const auto& column_name : resolved_columns) {
-      auto field = schema_->GetFieldByName(column_name);
-      if (field != nullptr) {
-        needed_fields.emplace_back(field);
+    // Build projected schema: from user-provided schema or nullptr
+    std::shared_ptr<arrow::Schema> projected_schema = nullptr;
+    if (schema_) {
+      std::vector<std::shared_ptr<arrow::Field>> needed_fields;
+      for (const auto& column_name : resolved_columns) {
+        auto field = schema_->GetFieldByName(column_name);
+        if (field != nullptr) {
+          needed_fields.emplace_back(field);
+        }
       }
+      projected_schema = arrow::schema(needed_fields);
     }
-    auto projected_schema = arrow::schema(needed_fields);
 
     auto reader = std::make_shared<PackedRecordBatchReader>(needed_column_groups, projected_schema, resolved_columns,
                                                             properties_, key_retriever_callback_);
@@ -677,7 +718,10 @@ class ReaderImpl : public Reader {
     std::vector<std::shared_ptr<arrow::Table>> tables;
     // empty input row indices
     if (row_indices.empty()) {
-      return arrow::Table::MakeEmpty(schema_);
+      if (schema_) {
+        return arrow::Table::MakeEmpty(schema_);
+      }
+      return arrow::Status::Invalid("Cannot create empty table without a schema");
     }
 
     // empty column groups
@@ -736,7 +780,11 @@ class ReaderImpl : public Reader {
     for (const auto& colname : resolved_columns) {
       auto it = colname_to_index.find(colname);
       if (it == colname_to_index.end()) {
-        // fill null column
+        // fill null column (requires schema for type information)
+        if (!schema_) {
+          return arrow::Status::Invalid(fmt::format(
+              "Column '{}' not found in any column group and no schema provided for null filling", colname));
+        }
         auto missing_field = schema_->GetFieldByName(colname);
         ARROW_ASSIGN_OR_RAISE(auto null_array,
                               arrow::MakeArrayOfNull(missing_field->type(), static_cast<int64_t>(row_indices.size())));
@@ -771,23 +819,40 @@ class ReaderImpl : public Reader {
   /**
    * @brief Resolve needed columns and verify they exist in schema.
    *
-   * If needed_columns is nullptr or empty, returns all schema field names.
-   * Otherwise returns the provided columns after verifying each exists in the schema.
+   * If needed_columns is nullptr or empty:
+   *   - When schema is provided, returns all schema field names.
+   *   - When schema is nullptr, returns all column names from column groups.
+   * Otherwise returns the provided columns after verifying each exists in the schema (if schema is provided).
    */
-  static arrow::Result<std::vector<std::string>> resolve_needed_columns(
-      const std::shared_ptr<arrow::Schema>& schema, const std::shared_ptr<std::vector<std::string>>& needed_columns) {
+  arrow::Result<std::vector<std::string>> resolve_needed_columns(
+      const std::shared_ptr<arrow::Schema>& schema,
+      const std::shared_ptr<std::vector<std::string>>& needed_columns) const {
     std::vector<std::string> resolved;
     if (needed_columns != nullptr && !needed_columns->empty()) {
       resolved = *needed_columns;
-    } else {
+    } else if (schema) {
       resolved.reserve(schema->num_fields());
       for (int i = 0; i < schema->num_fields(); ++i) {
         resolved.emplace_back(schema->field(i)->name());
       }
+    } else {
+      // No schema provided: collect all unique column names from column groups
+      std::unordered_set<std::string> seen;
+      for (const auto& cg : *cgs_) {
+        if (!cg)
+          continue;
+        for (const auto& col : cg->columns) {
+          if (seen.insert(col).second) {
+            resolved.emplace_back(col);
+          }
+        }
+      }
     }
-    for (const auto& col_name : resolved) {
-      if (schema->GetFieldIndex(col_name) == -1) {
-        return arrow::Status::Invalid("Column [name=", col_name, "] not found in schema");
+    if (schema) {
+      for (const auto& col_name : resolved) {
+        if (schema->GetFieldIndex(col_name) == -1) {
+          return arrow::Status::Invalid("Column [name=", col_name, "] not found in schema");
+        }
       }
     }
     return resolved;

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -1420,6 +1420,89 @@ TEST_P(APIWriterReaderTest, TestFileRolling) {
   }
 }
 
+TEST_P(APIWriterReaderTest, ReadWithoutSchema) {
+  // Test reading without providing a schema (schema=nullptr).
+  // The reader should derive field types from the underlying file metadata.
+
+  auto verify_read = [&](const std::shared_ptr<ColumnGroups>& cgs,
+                         const std::shared_ptr<std::vector<std::string>>& needed_columns, size_t expected_columns,
+                         const api::Properties& props = {}) {
+    auto read_props = props.empty() ? properties_ : props;
+    auto reader = Reader::create(cgs, nullptr, needed_columns, read_props);
+    ASSERT_NE(reader, nullptr);
+
+    // get_record_batch_reader
+    {
+      ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader());
+      ASSERT_AND_ASSIGN(auto table, batch_reader->ToTable());
+      EXPECT_EQ(table->num_rows(), 100);
+      EXPECT_EQ(table->num_columns(), expected_columns);
+    }
+
+    // get_chunk_reader / get_chunk / get_chunks
+    {
+      ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+      ASSERT_GT(chunk_reader->total_number_of_chunks(), 0);
+
+      ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
+      ASSERT_NE(chunk, nullptr);
+      EXPECT_GT(chunk->num_rows(), 0);
+
+      ASSERT_AND_ASSIGN(auto chunks, chunk_reader->get_chunks({0}, parallelism_));
+      ASSERT_EQ(chunks.size(), 1);
+      EXPECT_EQ(chunks[0]->num_rows(), chunk->num_rows());
+    }
+
+    // take
+    {
+      std::vector<int64_t> row_indices = {0, 10, 50, 99};
+      ASSERT_AND_ASSIGN(auto table, reader->take(row_indices, parallelism_));
+      ASSERT_AND_ASSIGN(auto batch, table->CombineChunksToBatch());
+      ASSERT_EQ(batch->num_rows(), row_indices.size());
+      EXPECT_EQ(batch->num_columns(), expected_columns);
+    }
+  };
+
+  // Single CG
+  {
+    ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
+    auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+    ASSERT_OK(writer->write(test_batch_));
+    ASSERT_AND_ASSIGN(auto cgs, writer->close());
+
+    // nc=nullptr: read all columns
+    verify_read(cgs, nullptr, 4);
+
+    // nc={"id","value"}: projection
+    auto nc = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"id", "value"});
+    verify_read(cgs, nc, 2);
+  }
+
+  ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+  ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
+
+  // Multi CG: "id, name | value, vector"
+  {
+    std::string patterns = "id, name|value, vector";
+    ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
+    auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+    ASSERT_OK(writer->write(test_batch_));
+    ASSERT_AND_ASSIGN(auto cgs, writer->close());
+
+    // nc=nullptr: read all columns across CGs
+    verify_read(cgs, nullptr, 4);
+
+    // nc={"id","value"}: projection across CGs (id from CG0, value from CG1)
+    auto nc = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"id", "value"});
+    verify_read(cgs, nc, 2);
+
+    // tiny memory budget (1 byte): verify schema derivation still works
+    auto small_budget_props = properties_;
+    SetValue(small_budget_props, PROPERTY_READER_RECORD_BATCH_MAX_SIZE, "1");
+    verify_read(cgs, nullptr, 4, small_budget_props);
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(APIWriterReaderTestP,
                          APIWriterReaderTest,
                          ::testing::Combine(::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX),

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -169,6 +169,56 @@ TEST_P(FormatReaderTest, TestReadWithRange) {
   }
 }
 
+TEST_P(FormatReaderTest, ReadWithoutSchema) {
+  std::string format = GetParam();
+
+  // Write a file using the Writer API
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  for (size_t i = 0; i < 3; i++) {
+    ASSERT_OK(writer->write(test_batch_));
+  }
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+  ASSERT_EQ(cgs->size(), 1);
+  ASSERT_FALSE((*cgs)[0]->files.empty());
+  auto cg_file = (*cgs)[0]->files[0];
+
+  // schema=nullptr, needed_columns=empty → read all columns
+  {
+    ASSERT_AND_ASSIGN(auto reader,
+                      FormatReader::create(nullptr, format, cg_file, properties_, std::vector<std::string>{}, nullptr));
+    ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
+    ASSERT_GT(rg_infos.size(), 0);
+
+    ASSERT_AND_ASSIGN(auto rb, reader->get_chunk(0));
+    EXPECT_GT(rb->num_rows(), 0);
+    EXPECT_EQ(rb->num_columns(), 4);
+  }
+
+  // schema=nullptr, needed_columns={"id","value"} → read projected columns
+  {
+    ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, format, cg_file, properties_,
+                                                        std::vector<std::string>{"id", "value"}, nullptr));
+    ASSERT_AND_ASSIGN(auto rb, reader->get_chunk(0));
+    EXPECT_GT(rb->num_rows(), 0);
+    EXPECT_EQ(rb->num_columns(), 2);
+    EXPECT_EQ(rb->schema()->field(0)->name(), "id");
+    EXPECT_EQ(rb->schema()->field(1)->name(), "value");
+
+    // read_with_range
+    ASSERT_AND_ASSIGN(auto rb_reader, reader->read_with_range(0, 50));
+    ASSERT_AND_ASSIGN(auto rbs, rb_reader->ToRecordBatches());
+    ASSERT_AND_ASSIGN(auto combined, arrow::ConcatenateRecordBatches(rbs));
+    EXPECT_EQ(combined->num_rows(), 50);
+    EXPECT_EQ(combined->num_columns(), 2);
+
+    // take
+    ASSERT_AND_ASSIGN(auto table, reader->take({0, 10, 50}));
+    EXPECT_EQ(table->num_rows(), 3);
+    EXPECT_EQ(table->num_columns(), 2);
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(FormatReaderTestP,
                          FormatReaderTest,
                          ::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX, LOON_FORMAT_LANCE_TABLE));


### PR DESCRIPTION
Make the schema parameter optional in Reader::create(). When nullptr is passed, field types are derived from the underlying file metadata instead of a user-provided schema.

Added get_schema() to the FormatReader hierarchy so we can grab the file schema without reading any actual data. Parquet already has it from the file footer, Lance now fetches it from fragment metadata via a new GetFragmentSchema FFI bridge call, and Vortex gets it from the file's DType via a new GetFileSchema bridge call. ColumnGroupReader delegates to the first format reader.

In PackedRecordBatchReader::open(), when no schema is provided, we call get_schema() on each column group reader to build the output schema from file metadata. This avoids pre-loading data just to peek at RecordBatch schemas.

The schema parameter in FormatReader::create() is renamed to read_schema to distinguish it from the file-derived schema. Lance and Vortex format readers now store both a read_schema_ (user-provided, used for projection) and a file_schema_ (always derived from file metadata). resolve_needed_columns() is no longer static since it needs access to column groups to collect column names when no schema is available.