### PR TITLE
fix: deep copy manifest and updates in applyUpdates to prevent mutation bugs

### DIFF
--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -91,6 +91,10 @@ class Manifest final {
                     const std::vector<Index>& indexes = {},
                     uint32_t version = MANIFEST_VERSION);
 
+  // Deep copy constructor (deep-copies ColumnGroups via copy_column_groups)
+  Manifest(const Manifest& other);
+  Manifest& operator=(const Manifest&) = delete;
+
   // Enable move constructor and assignment operator
   Manifest(Manifest&&) = default;
   Manifest& operator=(Manifest&&) = default;
@@ -151,9 +155,6 @@ class Manifest final {
   [[nodiscard]] int32_t version() const { return version_; }
 
   private:
-  Manifest(const Manifest&);
-  Manifest& operator=(const Manifest&);
-
   /**
    * @brief Deserialize legacy MILV format (v1-v3)
    */

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -102,8 +102,9 @@ using Resolver = std::function<arrow::Result<std::shared_ptr<Manifest>>(const st
 /**
  * @brief Apply updates to a manifest
  *
- * Creates a copy of the manifest and applies all updates (appended files, added column groups,
- * delta logs, stats) to it.
+ * Creates a deep copy of the manifest and applies all updates (appended files, added column groups,
+ * delta logs, stats) to it. New column groups and appended files from updates are also deep-copied
+ * to ensure the returned manifest shares no mutable state with the input updates.
  *
  * @param manifest Base manifest to apply updates to
  * @param updates Updates to apply

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -270,17 +270,6 @@ Manifest::Manifest(const Manifest& other)
       stats_(other.stats_),
       indexes_(other.indexes_) {}
 
-Manifest& Manifest::operator=(const Manifest& other) {
-  if (this != &other) {
-    version_ = other.version_;
-    column_groups_ = copy_column_groups(other.column_groups_);
-    delta_logs_ = other.delta_logs_;
-    stats_ = other.stats_;
-    indexes_ = other.indexes_;
-  }
-  return *this;
-}
-
 arrow::Status Manifest::serialize(std::ostream& output_stream, const std::optional<std::string>& base_path) const {
   try {
     if (base_path.has_value()) {

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -83,11 +83,14 @@ const std::vector<std::pair<std::string, std::string>>& Updates::GetDroppedIndex
 
 arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Manifest>& manifest,
                                                       const Updates& updates) {
-  // Get base manifest attributes
-  const auto& base_column_groups = manifest->columnGroups();
-  const auto& base_delta_logs = manifest->deltaLogs();
-  const auto& base_stats = manifest->stats();
-  const auto& base_indexes = manifest->indexes();
+  // Deep copy manifest to avoid mutating the original (copy constructor deep-copies ColumnGroups)
+  auto manifest_copy = std::make_shared<Manifest>(*manifest);
+
+  // Get mutable references to the deep copy's attributes
+  auto& base_column_groups = manifest_copy->columnGroups();
+  auto& base_delta_logs = manifest_copy->deltaLogs();
+  auto& base_stats = manifest_copy->stats();
+  auto& base_indexes = manifest_copy->indexes();
 
   // Validate: Check if adding column groups has existing column names
   // Also need check current column groups is align
@@ -96,7 +99,7 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
       return arrow::Status::Invalid("Cannot add null column group");
     }
     for (const auto& column_name : new_cg->columns) {
-      auto existing_cg = manifest->getColumnGroup(column_name);
+      auto existing_cg = manifest_copy->getColumnGroup(column_name);
       if (existing_cg != nullptr) {
         return arrow::Status::Invalid(fmt::format("Column '{}' already exists in existing column groups", column_name));
       }
@@ -180,64 +183,51 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
     }
   }
 
-  // Prepare indexes: copy from base, excluding those on affected columns
-  std::vector<Index> resolved_indexes;
-  for (const auto& idx : base_indexes) {
-    if (affected_columns.find(idx.column_name) == affected_columns.end()) {
-      resolved_indexes.push_back(idx);
-    }
-    // else: silently drop - column data changed
-  }
+  // Remove indexes on affected columns
+  base_indexes.erase(std::remove_if(base_indexes.begin(), base_indexes.end(),
+                                    [&](const Index& idx) { return affected_columns.count(idx.column_name) > 0; }),
+                     base_indexes.end());
 
   // Apply explicit DropIndex
   for (const auto& [col, type] : updates.GetDroppedIndexes()) {
     const auto& drop_col = col;
     const auto& drop_type = type;
-    resolved_indexes.erase(
-        std::remove_if(resolved_indexes.begin(), resolved_indexes.end(),
+    base_indexes.erase(
+        std::remove_if(base_indexes.begin(), base_indexes.end(),
                        [&](const Index& idx) { return idx.column_name == drop_col && idx.index_type == drop_type; }),
-        resolved_indexes.end());
+        base_indexes.end());
   }
 
   // Apply AddIndex (add or replace)
   for (const auto& new_idx : updates.GetAddedIndexes()) {
-    // Remove existing index with same key if present
-    resolved_indexes.erase(std::remove_if(resolved_indexes.begin(), resolved_indexes.end(),
-                                          [&](const Index& idx) {
-                                            return idx.column_name == new_idx.column_name &&
-                                                   idx.index_type == new_idx.index_type;
-                                          }),
-                           resolved_indexes.end());
-    resolved_indexes.push_back(new_idx);
+    base_indexes.erase(std::remove_if(base_indexes.begin(), base_indexes.end(),
+                                      [&](const Index& idx) {
+                                        return idx.column_name == new_idx.column_name &&
+                                               idx.index_type == new_idx.index_type;
+                                      }),
+                       base_indexes.end());
+    base_indexes.push_back(new_idx);
   }
 
-  // Prepare delta logs (copy from base + add new ones)
-  std::vector<DeltaLog> resolved_delta_logs = base_delta_logs;
+  // Apply delta logs
   for (const auto& delta_log : updates.GetAddedDeltaLogs()) {
-    resolved_delta_logs.push_back(delta_log);
+    base_delta_logs.push_back(delta_log);
   }
 
-  // Prepare stats (copy from base + merge new ones, new values override)
-  std::map<std::string, Statistics> resolved_stats = base_stats;
+  // Apply stats (new values override)
   for (const auto& [key, stat] : updates.GetAddedStats()) {
-    resolved_stats[key] = stat;  // Override existing or add new
+    base_stats[key] = stat;
   }
-
-  // Create a copy of column groups to apply updates
-  ColumnGroups resolved_column_groups = base_column_groups;
 
   // Apply updates: append files (merge files into existing column groups)
   for (const auto& new_cgs : updates.GetAppendedFiles()) {
-    if (resolved_column_groups.empty()) {
-      // If no existing column groups, directly assign
-      resolved_column_groups = new_cgs;
+    if (base_column_groups.empty()) {
+      base_column_groups = copy_column_groups(new_cgs);
     } else {
-      // Merge files into existing column groups
-      for (size_t i = 0; i < resolved_column_groups.size() && i < new_cgs.size(); ++i) {
-        auto& base_cg = resolved_column_groups[i];
+      for (size_t i = 0; i < base_column_groups.size() && i < new_cgs.size(); ++i) {
+        auto& base_cg = base_column_groups[i];
         const auto& new_cg = new_cgs[i];
         if (base_cg && new_cg) {
-          // Append files from new_cg to base_cg
           for (const auto& file : new_cg->files) {
             base_cg->files.push_back(file);
           }
@@ -248,14 +238,10 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
 
   // Apply updates: add column groups
   for (const auto& cg : updates.GetAddedColumnGroups()) {
-    resolved_column_groups.push_back(cg);
+    base_column_groups.push_back(std::make_shared<ColumnGroup>(*cg));
   }
 
-  // Create resolved manifest using the copy constructor with all attributes
-  auto resolved = std::make_shared<Manifest>(std::move(resolved_column_groups), resolved_delta_logs, resolved_stats,
-                                             resolved_indexes);
-
-  return resolved;
+  return manifest_copy;
 }
 
 // ==================== Helper Resolver Functions ====================

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -791,4 +791,149 @@ TEST_F(TransactionTest, UnsafeWriteConcurrentSameFile) {
   ASSERT_EQ(already_exists_count, num_threads - 1);
 }
 
+TEST_F(TransactionTest, ApplyUpdatesDoesNotMutateOriginalManifest) {
+  // Create a manifest with one column group containing one file
+  auto cg = std::make_shared<ColumnGroup>();
+  cg->columns = {"id", "name"};
+  cg->files = {{.path = base_path_ + "/original.parquet"}};
+  cg->format = LOON_FORMAT_PARQUET;
+
+  auto manifest = std::make_shared<Manifest>();
+  manifest->columnGroups().push_back(cg);
+
+  ASSERT_EQ(manifest->columnGroups()[0]->files.size(), 1);
+
+  // Create updates that append files
+  Updates updates;
+  auto append_cg = std::make_shared<ColumnGroup>();
+  append_cg->columns = {"id", "name"};
+  append_cg->files = {{.path = base_path_ + "/appended.parquet"}};
+  append_cg->format = LOON_FORMAT_PARQUET;
+  updates.AppendFiles({append_cg});
+
+  // Apply updates — this should create a NEW manifest without mutating the original
+  ASSERT_AND_ASSIGN(auto resolved, applyUpdates(manifest, updates));
+
+  // The resolved manifest should have 2 files
+  ASSERT_EQ(resolved->columnGroups()[0]->files.size(), 2);
+
+  // The ORIGINAL manifest must still have only 1 file
+  // BUG: applyUpdates shallow-copies the ColumnGroup shared_ptrs, so
+  // base_cg->files.push_back() mutates the original manifest's ColumnGroup.
+  ASSERT_EQ(manifest->columnGroups()[0]->files.size(), 1)
+      << "applyUpdates mutated the original manifest! "
+         "ColumnGroups should be deep-copied (use copy_column_groups).";
+}
+
+TEST_F(TransactionTest, ApplyUpdatesTwiceProducesSameResult) {
+  // This simulates what happens during a retry in Transaction::Commit():
+  // applyUpdates is called twice with the same manifest and updates.
+  // If the first call mutates the manifest, the second call produces wrong results.
+  auto cg = std::make_shared<ColumnGroup>();
+  cg->columns = {"id", "name"};
+  cg->files = {{.path = base_path_ + "/original.parquet"}};
+  cg->format = LOON_FORMAT_PARQUET;
+
+  auto manifest = std::make_shared<Manifest>();
+  manifest->columnGroups().push_back(cg);
+
+  Updates updates;
+  auto append_cg = std::make_shared<ColumnGroup>();
+  append_cg->columns = {"id", "name"};
+  append_cg->files = {{.path = base_path_ + "/appended.parquet"}};
+  append_cg->format = LOON_FORMAT_PARQUET;
+  updates.AppendFiles({append_cg});
+
+  // First call (simulates first commit attempt)
+  ASSERT_AND_ASSIGN(auto resolved1, applyUpdates(manifest, updates));
+  size_t resolved1_file_count = resolved1->columnGroups()[0]->files.size();
+
+  // Second call (simulates retry after write conflict)
+  ASSERT_AND_ASSIGN(auto resolved2, applyUpdates(manifest, updates));
+  size_t resolved2_file_count = resolved2->columnGroups()[0]->files.size();
+
+  // Both calls should produce manifests with the same number of files (2).
+  // BUG: Without deep copy, the first call mutates manifest, so the second
+  // call sees 2 files in the original and produces 3 files (duplicate append).
+  ASSERT_EQ(resolved1_file_count, 2);
+  ASSERT_EQ(resolved2_file_count, 2) << "Second applyUpdates produced " << resolved2_file_count
+                                     << " files instead of 2. This means the first call mutated the input manifest, "
+                                        "causing duplicate files on retry.";
+}
+
+TEST_F(TransactionTest, OverwriteResolverRetryDoesNotDuplicateFiles) {
+  // Simulates what Transaction::Commit does on retry with OverwriteResolver:
+  // the resolver is called multiple times with the same read_manifest and updates.
+  // If applyUpdates mutates the manifest, the second call produces duplicate files.
+
+  auto cg = std::make_shared<ColumnGroup>();
+  cg->columns = {"id", "name"};
+  cg->files = {{.path = base_path_ + "/original.parquet"}};
+  cg->format = LOON_FORMAT_PARQUET;
+
+  auto read_manifest = std::make_shared<Manifest>();
+  read_manifest->columnGroups().push_back(cg);
+
+  // Seen manifest (different from read, simulating concurrent commit)
+  auto seen_cg = std::make_shared<ColumnGroup>();
+  seen_cg->columns = {"id", "name"};
+  seen_cg->files = {{.path = base_path_ + "/original.parquet"}, {.path = base_path_ + "/concurrent.parquet"}};
+  seen_cg->format = LOON_FORMAT_PARQUET;
+
+  auto seen_manifest = std::make_shared<Manifest>();
+  seen_manifest->columnGroups().push_back(seen_cg);
+
+  // Updates: append one file
+  Updates updates;
+  auto append_cg = std::make_shared<ColumnGroup>();
+  append_cg->columns = {"id", "name"};
+  append_cg->files = {{.path = base_path_ + "/new_file.parquet"}};
+  append_cg->format = LOON_FORMAT_PARQUET;
+  updates.AppendFiles({append_cg});
+
+  // First OverwriteResolver call (applies updates to read_manifest, ignoring seen)
+  ASSERT_AND_ASSIGN(auto result1, OverwriteResolver(read_manifest, 1, seen_manifest, 2, updates));
+  ASSERT_EQ(result1->columnGroups()[0]->files.size(), 2);  // original + new_file
+
+  // Second call (retry) — should still produce 2 files, not 3
+  ASSERT_AND_ASSIGN(auto result2, OverwriteResolver(read_manifest, 1, seen_manifest, 3, updates));
+  ASSERT_EQ(result2->columnGroups()[0]->files.size(), 2) << "OverwriteResolver retry produced duplicate files! "
+                                                            "read_manifest was mutated by the first call.";
+
+  // Verify the original read_manifest was not mutated
+  ASSERT_EQ(read_manifest->columnGroups()[0]->files.size(), 1) << "read_manifest was mutated by the resolver.";
+}
+
+TEST_F(TransactionTest, MergeResolverRetryDoesNotDuplicateFiles) {
+  // Same test but for MergeResolver: applies updates to seen_manifest.
+  // On retry with a new seen_manifest, the old one should not be corrupted.
+
+  auto read_cg = std::make_shared<ColumnGroup>();
+  read_cg->columns = {"id", "name"};
+  read_cg->files = {{.path = base_path_ + "/original.parquet"}};
+  read_cg->format = LOON_FORMAT_PARQUET;
+
+  auto read_manifest = std::make_shared<Manifest>();
+  read_manifest->columnGroups().push_back(read_cg);
+
+  // Seen manifest (same as read in this scenario: latest_version == read_version)
+  auto seen_manifest = read_manifest;
+
+  Updates updates;
+  auto append_cg = std::make_shared<ColumnGroup>();
+  append_cg->columns = {"id", "name"};
+  append_cg->files = {{.path = base_path_ + "/new_file.parquet"}};
+  append_cg->format = LOON_FORMAT_PARQUET;
+  updates.AppendFiles({append_cg});
+
+  // First MergeResolver call
+  ASSERT_AND_ASSIGN(auto result1, MergeResolver(read_manifest, 1, seen_manifest, 1, updates));
+  ASSERT_EQ(result1->columnGroups()[0]->files.size(), 2);
+
+  // read_manifest (== seen_manifest) should not have been mutated
+  ASSERT_EQ(read_manifest->columnGroups()[0]->files.size(), 1)
+      << "MergeResolver mutated read_manifest/seen_manifest. "
+         "On retry, Transaction::Commit would pass an already-corrupted manifest.";
+}
+
 }  // namespace milvus_storage::test


### PR DESCRIPTION
applyUpdates was shallow-copying ColumnGroup shared_ptrs, which meant calling it would mutate the original manifest's column groups in place. This caused duplicate files on retry in Transaction::Commit because the second call saw already-appended files from the first call.

The fix deep-copies the entire manifest at the start via the copy constructor (which uses copy_column_groups), and also deep-copies new column groups and appended files coming from Updates, so the returned manifest shares no mutable state with the inputs.

Also made the Manifest copy constructor public since applyUpdates now needs it, deleted the unused copy assignment operator, and added 4 regression tests covering mutation, retry idempotency, and both OverwriteResolver and MergeResolver retry scenarios.