### PR TITLE
enhance: port Azure FS implementation from Arrow v23 

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -153,7 +153,18 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/build/Release:$(pwd)/build/Release/libs
           source ./scripts/minio_env.sh && ./build/Release/test/milvus_test
-          
+
+      - name: Setup Azurite
+        run: |
+          chmod +x ./cpp/scripts/setup_azurite.sh
+          ./cpp/scripts/setup_azurite.sh
+
+      - name: Run unittest with azurite
+        working-directory: ./cpp
+        run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/build/Release:$(pwd)/build/Release/libs
+          source ./scripts/azurite_env.sh && ./build/Release/test/milvus_test
+
       - name: coverage-report
         working-directory: ./cpp
         run: |

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,23 +9,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(WITH_UT "Build the testing tree." OFF)
 option(WITH_ASAN "Build with address sanitizer." OFF)
 option(WITH_BENCHMARK "Build with micro benchmark." ON)
-option(WITH_AZURE_FS "Build with azure file system." ON)
 option(WITH_JNI "Build with JNI library." OFF)
 option(WITH_PYTHON_BINDING "Build for Python bindings with hidden symbols." OFF)
 option(WITH_FIU "Build with fault injection support (libfiu)." OFF)
-
-# Disable Azure FS on macOS since the Arrow library is built without Azure support
-if(APPLE)
-  set(WITH_AZURE_FS OFF)
-  message(STATUS "Azure filesystem disabled on macOS (Arrow built without Azure support)")
-endif()
 option(ARROW_WITH_JEMALLOC "Build with jemalloc." OFF)
 
 include(GNUInstallDirs)
-
-if (WITH_AZURE_FS)
-  add_compile_definitions(MILVUS_AZURE_FS)
-endif()
 
 
 find_package(Boost REQUIRED)
@@ -38,6 +27,8 @@ if(NOT Arrow_INCLUDE_DIRS AND arrow_INCLUDE_DIRS)
 endif()
 include_directories(${Arrow_INCLUDE_DIRS})
 
+
+find_package(Azure REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(google-cloud-cpp REQUIRED)
 find_package(libavrocpp QUIET)
@@ -69,7 +60,7 @@ list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/jni/.*\\.cpp$")
 
 add_library(milvus-storage SHARED ${ALL_SRC_FILES})
 
-list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management google-cloud-cpp::storage ${AVRO_TARGET} Folly::folly fmt::fmt)
+list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management google-cloud-cpp::storage ${AVRO_TARGET} Folly::folly fmt::fmt azure-sdk-for-cpp::azure-sdk-for-cpp)
 list(APPEND INCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Fault injection support using libfiu

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -52,7 +52,7 @@ python-lib:
 	mkdir -p build && cd build && \
 	${CONAN_BASE} \
 	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=False -o with_jemalloc=False \
-	-o with_python_binding=True -o with_azure=False -o with_fiu=${with_fiu} && \
+	-o with_python_binding=True -o with_fiu=${with_fiu} && \
 	conan build ..
 
 java-lib:
@@ -60,7 +60,7 @@ java-lib:
 	mkdir -p build && cd build && \
 	${CONAN_BASE} \
 	-o with_ut=False -o with_benchmark=False -o with_asan=False -o with_jni=True -o with_jemalloc=False \
-	-o with_python_binding=False -o with_azure=True -o with_fiu=${with_fiu} && \
+	-o with_python_binding=False -o with_fiu=${with_fiu} && \
 	conan build ..
 
 clean:
@@ -73,10 +73,14 @@ test-all: build
 	# running milvus_test and Test_FFI without minio
 	./build/${build_type}/test/milvus_test && ./build/${build_type}/test/Test_FFI
 
-	# running milvus_test and Test_FFI with minio
+	# running milvus_test with minio
 	./scripts/setup_minio.sh
 	source ./scripts/minio_env.sh && ./build/${build_type}/test/milvus_test
 
+	# running milvus_test with azurite
+	./scripts/setup_azurite.sh
+	source ./scripts/azurite_env.sh && ./build/${build_type}/test/milvus_test
+	
 # Test cloud storage with all providers or a specific one
 # Usage: make test-cloud-storage     # Test all cloud providers
 #        make test-cloud-storage aws  # Test AWS only

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -28,7 +28,6 @@ class StorageConan(ConanFile):
         "with_ut": [True, False],
         "with_benchmark": [True, False],
         "with_jemalloc": [True, False],
-        "with_azure": [True, False],
         "with_jni": [True, False],
         "with_python_binding": [True, False],
         "with_fiu": [True, False],
@@ -40,7 +39,6 @@ class StorageConan(ConanFile):
         "with_profiler": False,
         "with_ut": True,
         "with_benchmark": True,
-        "with_azure": True,
         "with_jemalloc": True,
         "with_jni": False,
         "with_python_binding": False,
@@ -109,7 +107,7 @@ class StorageConan(ConanFile):
         if self.settings.arch not in ("x86_64", "x86"):
             del self.options["folly"].use_sse4_2
         self.options["arrow"].with_jemalloc = self.options.with_jemalloc
-        self.options["arrow"].with_azure = self.options.with_azure
+        self.options["arrow"].with_azure = True
         if self.options.with_jni and self.settings.os != "Macos":
             self.options["arrow"].shared = True
             self.options["arrow"].acero = True
@@ -151,8 +149,7 @@ class StorageConan(ConanFile):
         if self.options.with_ut:
             self.requires("gtest/1.15.0")
         if self.settings.os == "Macos":
-            # Macos M1 cannot use jemalloc and arrow azure fs
-            self.options["arrow"].with_azure = False
+            # Macos M1 cannot use jemalloc
             self.options["arrow"].with_jemalloc = False
         else:
             self.requires("libunwind/1.8.1")
@@ -206,7 +203,6 @@ class StorageConan(ConanFile):
         tc.variables["WITH_PROFILER"] = self.options.with_profiler
         tc.variables["WITH_UT"] = self.options.with_ut
         tc.variables["WITH_BENCHMARK"] = self.options.with_benchmark
-        tc.variables["WITH_AZURE_FS"] = self.options.with_azure
         tc.variables["ARROW_WITH_JEMALLOC"] = self.options.with_jemalloc
         tc.variables["WITH_JNI"] = self.options.with_jni
         tc.variables["WITH_PYTHON_BINDING"] = self.options.with_python_binding

--- a/cpp/include/milvus-storage/filesystem/azure/azure_fs_producer.h
+++ b/cpp/include/milvus-storage/filesystem/azure/azure_fs_producer.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #pragma once
-#ifdef MILVUS_AZURE_FS
 
 #include "milvus-storage/filesystem/fs.h"
 
@@ -30,4 +29,3 @@ class AzureFileSystemProducer : public FileSystemProducer {
 };
 
 }  // namespace milvus_storage
-#endif

--- a/cpp/include/milvus-storage/filesystem/azure/azurefs.h
+++ b/cpp/include/milvus-storage/filesystem/azure/azurefs.h
@@ -1,0 +1,380 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/filesystem/filesystem.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/uri.h"
+
+namespace Azure::Core::Credentials {
+class TokenCredential;
+}
+
+namespace Azure::Storage {
+class StorageSharedKeyCredential;
+}
+
+namespace Azure::Storage::Blobs {
+class BlobServiceClient;
+}
+
+namespace Azure::Storage::Files::DataLake {
+class DataLakeFileSystemClient;
+class DataLakeServiceClient;
+}  // namespace Azure::Storage::Files::DataLake
+
+namespace milvus_storage::fs {
+
+// Bridge arrow types into this namespace so the v23 Azure FS code compiles
+// with minimal changes from upstream.
+using arrow::KeyValueMetadata;
+using arrow::Result;
+using arrow::Status;
+using arrow::util::Uri;
+
+using arrow::fs::FileInfo;
+using arrow::fs::FileInfoVector;
+using arrow::fs::FileSelector;
+using arrow::fs::FileSystem;
+using arrow::fs::FileType;
+
+namespace io = arrow::io;
+
+class TestAzureFileSystem;
+class TestAzureOptions;
+
+/// Options for the AzureFileSystem implementation.
+///
+/// By default, authentication is handled by the Azure SDK's credential chain
+/// which may read from multiple environment variables, such as:
+/// - `AZURE_TENANT_ID`
+/// - `AZURE_CLIENT_ID`
+/// - `AZURE_CLIENT_SECRET`
+/// - `AZURE_AUTHORITY_HOST`
+/// - `AZURE_CLIENT_CERTIFICATE_PATH`
+/// - `AZURE_FEDERATED_TOKEN_FILE`
+///
+/// Functions are provided for explicit configuration of credentials if that is preferred.
+struct ARROW_EXPORT AzureOptions {
+  friend class TestAzureOptions;
+
+  /// \brief The name of the Azure Storage Account being accessed.
+  ///
+  /// All service URLs will be constructed using this storage account name.
+  /// `ConfigureAccountKeyCredential` assumes the user wants to authenticate
+  /// this account.
+  std::string account_name;
+
+  /// \brief hostname[:port] of the Azure Blob Storage Service.
+  ///
+  /// If the hostname is a relative domain name (one that starts with a '.'), then storage
+  /// account URLs will be constructed by prepending the account name to the hostname.
+  /// If the hostname is a fully qualified domain name, then the hostname will be used
+  /// as-is and the account name will follow the hostname in the URL path.
+  ///
+  /// Default: ".blob.core.windows.net"
+  std::string blob_storage_authority = ".blob.core.windows.net";
+
+  /// \brief hostname[:port] of the Azure Data Lake Storage Gen 2 Service.
+  ///
+  /// If the hostname is a relative domain name (one that starts with a '.'), then storage
+  /// account URLs will be constructed by prepending the account name to the hostname.
+  /// If the hostname is a fully qualified domain name, then the hostname will be used
+  /// as-is and the account name will follow the hostname in the URL path.
+  ///
+  /// Default: ".dfs.core.windows.net"
+  std::string dfs_storage_authority = ".dfs.core.windows.net";
+
+  /// \brief Azure Blob Storage connection transport.
+  ///
+  /// Default: "https"
+  std::string blob_storage_scheme = "https";
+
+  /// \brief Azure Data Lake Storage Gen 2 connection transport.
+  ///
+  /// Default: "https"
+  std::string dfs_storage_scheme = "https";
+
+  // TODO(GH-38598): Add support for more auth methods.
+  // std::string connection_string;
+  // std::string sas_token;
+
+  /// \brief Default metadata for OpenOutputStream.
+  ///
+  /// This will be ignored if non-empty metadata is passed to OpenOutputStream.
+  std::shared_ptr<const KeyValueMetadata> default_metadata;
+
+  /// Whether OutputStream writes will be issued in the background, without blocking.
+  bool background_writes = true;
+
+  private:
+  enum class CredentialKind {
+    kDefault,
+    kAnonymous,
+    kStorageSharedKey,
+    kSASToken,
+    kClientSecret,
+    kManagedIdentity,
+    kCLI,
+    kWorkloadIdentity,
+    kEnvironment,
+  } credential_kind_ = CredentialKind::kDefault;
+
+  std::shared_ptr<Azure::Storage::StorageSharedKeyCredential> storage_shared_key_credential_;
+  std::string sas_token_;
+  mutable std::shared_ptr<Azure::Core::Credentials::TokenCredential> token_credential_;
+
+  public:
+  AzureOptions();
+  ~AzureOptions();
+
+  private:
+  void ExtractFromUriSchemeAndHierPart(const Uri& uri, std::string* out_path);
+  Status ExtractFromUriQuery(const Uri& uri);
+
+  public:
+  /// \brief Construct a new AzureOptions from an URI.
+  ///
+  /// Supported formats:
+  ///
+  /// 1. abfs[s]://\<account\>.blob.core.windows.net[/\<container\>[/\<path\>]]
+  /// 2. abfs[s]://\<container\>\@\<account\>.dfs.core.windows.net[/path]
+  /// 3. abfs[s]://[\<account@]\<host[.domain]\>[\<:port\>][/\<container\>[/path]]
+  /// 4. abfs[s]://[\<account@]\<container\>[/path]
+  ///
+  /// (1) and (2) are compatible with the Azure Data Lake Storage Gen2 URIs
+  /// [1], (3) is for Azure Blob Storage compatible service including Azurite,
+  /// and (4) is a shorter version of (1) and (2).
+  ///
+  /// Note that there is no difference between abfs and abfss. HTTPS is
+  /// used with abfs by default. You can force to use HTTP by specifying
+  /// "enable_tls=false" query.
+  ///
+  /// Supported query parameters:
+  ///
+  /// * blob_storage_authority: Set AzureOptions::blob_storage_authority
+  /// * dfs_storage_authority: Set AzureOptions::dfs_storage_authority
+  /// * enable_tls: If it's "false" or "0", HTTP not HTTPS is used.
+  /// * credential_kind: One of "default", "anonymous", "workload_identity",
+  ///   "environment" or "cli". If "default" is specified, it's
+  ///   just ignored.  If "anonymous" is specified,
+  ///   AzureOptions::ConfigureAnonymousCredential() is called. If
+  ///   "workload_identity" is specified,
+  ///   AzureOptions::ConfigureWorkloadIdentityCredential() is called. If
+  ///   "environment" is specified,
+  ///   AzureOptions::ConfigureEnvironmentCredential() is called. If "cli" is
+  ///   specified, AzureOptions::ConfigureCLICredential() is called.
+  /// * tenant_id: You must specify "client_id" and "client_secret"
+  ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
+  /// * client_id: If you don't specify "tenant_id" and
+  ///   "client_secret",
+  ///   AzureOptions::ConfigureManagedIdentityCredential() is
+  ///   called. If you specify "tenant_id" and "client_secret" too,
+  ///   AzureOptions::ConfigureClientSecretCredential() is called.
+  /// * client_secret: You must specify "tenant_id" and "client_id"
+  ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
+  /// * A SAS token is made up of several query parameters. Appending a SAS
+  ///   token to the URI configures SAS token auth by calling
+  ///   AzureOptions::ConfigureSASCredential().
+  ///
+  /// [1]:
+  /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri
+  static Result<AzureOptions> FromUri(const Uri& uri, std::string* out_path);
+  static Result<AzureOptions> FromUri(const std::string& uri, std::string* out_path);
+
+  Status ConfigureDefaultCredential();
+  Status ConfigureAnonymousCredential();
+  Status ConfigureAccountKeyCredential(const std::string& account_key);
+  Status ConfigureSASCredential(const std::string& sas_token);
+  Status ConfigureClientSecretCredential(const std::string& tenant_id,
+                                         const std::string& client_id,
+                                         const std::string& client_secret);
+  Status ConfigureManagedIdentityCredential(const std::string& client_id = std::string());
+  Status ConfigureCLICredential();
+  Status ConfigureWorkloadIdentityCredential();
+  Status ConfigureEnvironmentCredential();
+
+  bool Equals(const AzureOptions& other) const;
+
+  std::string AccountBlobUrl(const std::string& account_name) const;
+  std::string AccountDfsUrl(const std::string& account_name) const;
+
+  Result<std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient>> MakeBlobServiceClient() const;
+
+  Result<std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>> MakeDataLakeServiceClient() const;
+};
+
+/// \brief FileSystem implementation backed by Azure Blob Storage (ABS) [1] and
+/// Azure Data Lake Storage Gen2 (ADLS Gen2) [2].
+///
+/// ADLS Gen2 isn't a dedicated service or account type. It's a set of capabilities that
+/// support high throughput analytic workloads, built on Azure Blob Storage. All the data
+/// ingested via the ADLS Gen2 APIs is persisted as blobs in the storage account.
+/// ADLS Gen2 provides filesystem semantics, file-level security, and Hadoop
+/// compatibility. ADLS Gen1 exists as a separate object that will retired on 2024-02-29
+/// and new ADLS accounts use Gen2 instead.
+///
+/// ADLS Gen2 and Blob APIs can operate on the same data, but there are
+/// some limitations [3]. The ones that are relevant to this
+/// implementation are listed here:
+///
+/// - You can't use Blob APIs, and ADLS APIs to write to the same instance of a file. If
+///   you write to a file by using ADLS APIs then that file's blocks won't be visible
+///   to calls to the GetBlockList Blob API. The only exception is when you're
+///   overwriting.
+/// - When you use the ListBlobs operation without specifying a delimiter, the results
+///   include both directories and blobs. If you choose to use a delimiter, use only a
+///   forward slash (/) \--- the only supported delimiter.
+/// - If you use the DeleteBlob API to delete a directory, that directory is deleted only
+///   if it's empty. This means that you can't use the Blob API delete directories
+///   recursively.
+///
+/// [1]: https://azure.microsoft.com/en-us/products/storage/blobs
+/// [2]: https://azure.microsoft.com/en-us/products/storage/data-lake-storage
+/// [3]:
+/// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-known-issues
+class ARROW_EXPORT AzureFileSystem : public FileSystem {
+  private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+
+  explicit AzureFileSystem(std::unique_ptr<Impl>&& impl);
+
+  friend class TestAzureFileSystem;
+  void ForceCachedHierarchicalNamespaceSupport(int hns_support);
+
+  public:
+  ~AzureFileSystem() override = default;
+
+  static Result<std::shared_ptr<AzureFileSystem>> Make(const AzureOptions& options,
+                                                       const io::IOContext& = io::default_io_context());
+
+  std::string type_name() const override { return "abfs"; }
+
+  /// Return the original Azure options when constructing the filesystem
+  const AzureOptions& options() const;
+
+  bool Equals(const FileSystem& other) const override;
+
+  /// \cond FALSE
+  using FileSystem::CreateDir;
+  using FileSystem::DeleteDirContents;
+  using FileSystem::GetFileInfo;
+  using FileSystem::OpenAppendStream;
+  using FileSystem::OpenOutputStream;
+  /// \endcond
+
+  Result<FileInfo> GetFileInfo(const std::string& path) override;
+
+  Result<FileInfoVector> GetFileInfo(const FileSelector& select) override;
+
+  Status CreateDir(const std::string& path, bool recursive) override;
+
+  /// \brief Delete a directory and its contents recursively.
+  ///
+  /// Atomicity is guaranteed only on Hierarchical Namespace Storage accounts.
+  Status DeleteDir(const std::string& path) override;
+
+  /// \brief Non-atomically deletes the contents of a directory.
+  ///
+  /// This function can return a bad Status after only partially deleting the
+  /// contents of the directory.
+  Status DeleteDirContents(const std::string& path, bool missing_dir_ok) override;
+
+  /// \brief Deletion of all the containers in the storage account (not
+  /// implemented for safety reasons).
+  ///
+  /// \return Status::NotImplemented
+  Status DeleteRootDirContents() override;
+
+  /// \brief Deletes a file.
+  ///
+  /// Supported on both flat namespace and Hierarchical Namespace storage
+  /// accounts. A check is made to guarantee the parent directory doesn't
+  /// disappear after the blob is deleted and while this operation is running,
+  /// no other client can delete the parent directory due to the use of leases.
+  ///
+  /// This means applications can safely retry this operation without coordination to
+  /// guarantee only one client/process is trying to delete the same file.
+  Status DeleteFile(const std::string& path) override;
+
+  /// \brief Move/rename a file or directory.
+  ///
+  /// There are no files immediately at the root directory, so paths like
+  /// "/segment" always refer to a container of the storage account and are
+  /// treated as directories.
+  ///
+  /// If `dest` exists but the operation fails for some reason, `Move`
+  /// guarantees `dest` is not lost.
+  ///
+  /// Conditions for a successful move:
+  ///
+  /// 1. `src` must exist.
+  /// 2. `dest` can't contain a strict path prefix of `src`. More generally,
+  ///    a directory can't be made a subdirectory of itself.
+  /// 3. If `dest` already exists and it's a file, `src` must also be a file.
+  ///    `dest` is then replaced by `src`.
+  /// 4. All components of `dest` must exist, except for the last.
+  /// 5. If `dest` already exists and it's a directory, `src` must also be a
+  ///    directory and `dest` must be empty. `dest` is then replaced by `src`
+  ///    and its contents.
+  ///
+  /// Leases are used to guarantee the pre-condition checks and the rename
+  /// operation are atomic: other clients can't invalidate the pre-condition in
+  /// the time between the checks and the actual rename operation.
+  ///
+  /// This is possible because Move() is only support on storage accounts with
+  /// Hierarchical Namespace Support enabled.
+  ///
+  /// ## Limitations
+  ///
+  /// - Moves are not supported on storage accounts without
+  ///   Hierarchical Namespace support enabled
+  /// - Moves across different containers are not supported
+  /// - Moving a path of the form `/container` is not supported as it would
+  ///   require moving all the files in a container to another container.
+  ///   The only exception is a `Move("/container_a", "/container_b")` where
+  ///   both containers are empty or `container_b` doesn't even exist.
+  ///   The atomicity of the emptiness checks followed by the renaming operation
+  ///   is guaranteed by the use of leases.
+  Status Move(const std::string& src, const std::string& dest) override;
+
+  Status CopyFile(const std::string& src, const std::string& dest) override;
+
+  Result<std::shared_ptr<io::InputStream>> OpenInputStream(const std::string& path) override;
+
+  Result<std::shared_ptr<io::InputStream>> OpenInputStream(const FileInfo& info) override;
+
+  Result<std::shared_ptr<io::RandomAccessFile>> OpenInputFile(const std::string& path) override;
+
+  Result<std::shared_ptr<io::RandomAccessFile>> OpenInputFile(const FileInfo& info) override;
+
+  Result<std::shared_ptr<io::OutputStream>> OpenOutputStream(
+      const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) override;
+
+  Result<std::shared_ptr<io::OutputStream>> OpenAppendStream(
+      const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) override;
+
+  Result<std::string> PathFromUri(const std::string& uri_string) const override;
+};
+
+}  // namespace milvus_storage::fs

--- a/cpp/include/milvus-storage/filesystem/azure/azurefs_internal.h
+++ b/cpp/include/milvus-storage/filesystem/azure/azurefs_internal.h
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/result.h"
+
+namespace Azure::Storage::Files::DataLake {
+class DataLakeFileSystemClient;
+class DataLakeServiceClient;
+}  // namespace Azure::Storage::Files::DataLake
+
+namespace milvus_storage::fs {
+
+using arrow::Result;
+
+struct AzureOptions;
+
+namespace internal {
+
+enum class HierarchicalNamespaceSupport {
+  kUnknown = 0,
+  kContainerNotFound = 1,
+  kDisabled = 2,
+  kEnabled = 3,
+};
+
+/// \brief Performs a request to check if the storage account has Hierarchical
+/// Namespace support enabled.
+///
+/// This check requires a DataLakeFileSystemClient for any container of the
+/// storage account. If the container doesn't exist yet, we just forward that
+/// error to the caller (kContainerNotFound) since that's a proper error to the operation
+/// on that container anyways -- no need to try again with or without the knowledge of
+/// Hierarchical Namespace support.
+///
+/// Hierarchical Namespace support can't easily be changed after the storage account is
+/// created and the feature is shared by all containers in the storage account.
+/// This means the result of this check can (and should!) be cached as soon as
+/// it returns a successful result on any container of the storage account (see
+/// AzureFileSystem::Impl).
+///
+/// The check consists of a call to DataLakeFileSystemClient::GetAccessControlList()
+/// on the root directory of the container. An approach taken by the Hadoop Azure
+/// project [1]. A more obvious approach would be to call
+/// BlobServiceClient::GetAccountInfo(), but that endpoint requires elevated
+/// permissions [2] that we can't generally rely on.
+///
+/// [1]:
+/// https://github.com/apache/hadoop/blob/7c6af6a5f626d18d68b656d085cc23e4c1f7a1ef/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java#L356.
+/// [2]:
+/// https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties?tabs=azure-ad#authorization
+///
+/// IMPORTANT: If the result is kEnabled or kDisabled, it doesn't necessarily mean that
+/// the container exists.
+///
+/// \param adlfs_client A DataLakeFileSystemClient for a container of the storage
+/// account.
+/// \return kEnabled/kDisabled/kContainerNotFound (kUnknown is never
+/// returned).
+ARROW_EXPORT Result<HierarchicalNamespaceSupport> CheckIfHierarchicalNamespaceIsEnabled(
+    const Azure::Storage::Files::DataLake::DataLakeFileSystemClient& adlfs_client,
+    const milvus_storage::fs::AzureOptions& options);
+
+}  // namespace internal
+}  // namespace milvus_storage::fs

--- a/cpp/include/milvus-storage/filesystem/util_internal.h
+++ b/cpp/include/milvus-storage/filesystem/util_internal.h
@@ -2,12 +2,14 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string_view>
 
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/status.h"
+#include "arrow/util/thread_pool.h"
 #include "arrow/util/uri.h"
 #include "arrow/util/visibility.h"
 
@@ -105,4 +107,19 @@ arrow::Status PathNotFound(std::string_view path);
 
 }  // namespace internal
 }  // namespace fs
+
+namespace io {
+namespace internal {
+
+template <typename... SubmitArgs>
+auto SubmitIO(arrow::io::IOContext io_context, SubmitArgs&&... submit_args)
+    -> decltype(std::declval<::arrow::internal::Executor*>()->Submit(submit_args...)) {
+  arrow::internal::TaskHints hints;
+  hints.external_id = io_context.external_id();
+  return io_context.executor()->Submit(hints, io_context.stop_token(), std::forward<SubmitArgs>(submit_args)...);
+}
+
+}  // namespace internal
+}  // namespace io
+
 }  // namespace arrow

--- a/cpp/scripts/azurite_env.sh
+++ b/cpp/scripts/azurite_env.sh
@@ -1,0 +1,8 @@
+# https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string 
+# azurite defualt AK/SK
+export ACCESS_KEY="devstoreaccount1"
+export SECRET_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+export ADDRESS="127.0.0.1:10000"
+export CLOUD_PROVIDER="azure"
+export BUCKET_NAME="test-container"
+export STORAGE_TYPE="remote"

--- a/cpp/scripts/setup_azurite.sh
+++ b/cpp/scripts/setup_azurite.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Azurite well-known test credentials (not real secrets):
+# https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+AZURITE_ACCOUNT="devstoreaccount1"
+AZURITE_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+AZURITE_BLOB_PORT=10000
+AZURITE_BLOB_HOST="127.0.0.1"
+AZURITE_CONTAINER="test-container"
+
+# Check if Azurite is already running locally
+if curl -s "http://${AZURITE_BLOB_HOST}:${AZURITE_BLOB_PORT}/${AZURITE_ACCOUNT}?comp=list" &> /dev/null; then
+    echo "Azurite is already running locally."
+else
+    # Check if Azurite container exists in docker
+    if [ "$(docker ps -aq -f name=azurite)" ]; then
+        if [ ! "$(docker ps -q -f name=azurite)" ]; then
+            echo "Starting existing azurite container..."
+            docker start azurite
+        else
+            echo "Azurite container is already running."
+        fi
+    else
+        echo "Creating and starting new azurite container..."
+        docker run -d -p ${AZURITE_BLOB_PORT}:${AZURITE_BLOB_PORT} --name azurite \
+          mcr.microsoft.com/azure-storage/azurite \
+          azurite-blob --blobHost 0.0.0.0 --blobPort ${AZURITE_BLOB_PORT} --skipApiVersionCheck
+    fi
+fi
+
+# Wait for Azurite to be ready
+echo "Waiting for Azurite to be ready..."
+max_retries=10
+count=0
+while [ $count -lt $max_retries ]; do
+  if curl -s "http://${AZURITE_BLOB_HOST}:${AZURITE_BLOB_PORT}/${AZURITE_ACCOUNT}?comp=list" &> /dev/null; then
+    echo "Azurite is ready"
+    break
+  fi
+  echo "Still waiting for Azurite... ($((count + 1))/$max_retries)"
+  sleep 2
+  count=$((count + 1))
+done
+
+if [ $count -eq $max_retries ]; then
+    echo "Azurite failed to start in time"
+    exit 1
+fi
+
+# Install az CLI if not present
+if ! command -v az &> /dev/null; then
+    echo "Installing Azure CLI..."
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &> /dev/null; then
+            brew install azure-cli
+        else
+            echo "Homebrew not found. Please install Azure CLI manually: https://aka.ms/InstallAzureCli"
+            exit 1
+        fi
+    else
+        echo "Unsupported OS. Please install Azure CLI manually: https://aka.ms/InstallAzureCli"
+        exit 1
+    fi
+fi
+
+# Create test container using az CLI
+AZURITE_CONN_STR="DefaultEndpointsProtocol=http;AccountName=${AZURITE_ACCOUNT};AccountKey=${AZURITE_KEY};BlobEndpoint=http://${AZURITE_BLOB_HOST}:${AZURITE_BLOB_PORT}/${AZURITE_ACCOUNT};"
+
+if az storage container show -n "${AZURITE_CONTAINER}" --connection-string "${AZURITE_CONN_STR}" &> /dev/null; then
+    echo "Container ${AZURITE_CONTAINER} already exists"
+else
+    echo "Creating container ${AZURITE_CONTAINER}..."
+    az storage container create -n "${AZURITE_CONTAINER}" --connection-string "${AZURITE_CONN_STR}" --output none
+    echo "Container created"
+fi
+
+echo ""
+echo "Azurite is ready. Use these env vars for tests:"
+echo "  export ACCESS_KEY=${AZURITE_ACCOUNT}"
+echo "  export SECRET_KEY=${AZURITE_KEY}"
+echo "  export ADDRESS=${AZURITE_BLOB_HOST}:${AZURITE_BLOB_PORT}"
+echo "  export CLOUD_PROVIDER=azure"
+echo "  export BUCKET_NAME=${AZURITE_CONTAINER}"
+echo "  export STORAGE_TYPE=remote"

--- a/cpp/src/common/cloud_storage_options.cpp
+++ b/cpp/src/common/cloud_storage_options.cpp
@@ -34,21 +34,26 @@ EndpointInfo BuildEndpointUrl(const std::string& address) {
   return {"https://" + address, false};
 }
 
-std::string BuildAzureEndpointAddress(const std::string& address, const std::string& account_name) {
+// Build Azure endpoint URL from authority and account name.
+// Uses the same convention as azurefs.cc BuildBaseUrl:
+//   '.' prefix → virtual-hosted: https://account.blob.core.windows.net
+//   otherwise  → path-style:     http://127.0.0.1:10000/account
+static std::string BuildAzureEndpointAddress(const std::string& address,
+                                             const std::string& account_name,
+                                             bool use_ssl) {
   std::string host = address;
-  std::string scheme_prefix;
 
-  size_t scheme_pos = host.find("://");
-  if (scheme_pos != std::string::npos) {
-    scheme_prefix = host.substr(0, scheme_pos + 3);
-    host = host.substr(scheme_pos + 3);
+  // Strip scheme if present; use_ssl determines the actual scheme
+  auto pos = host.find("://");
+  if (pos != std::string::npos) {
+    host = host.substr(pos + 3);
   }
 
-  if (!account_name.empty() && host.find(account_name + ".") != 0) {
-    host = account_name + "." + host;
+  std::string scheme = use_ssl ? "https" : "http";
+  if (!host.empty() && host[0] == '.') {
+    return scheme + "://" + account_name + host;
   }
-
-  return scheme_prefix + host;
+  return scheme + "://" + host + "/" + account_name;
 }
 
 void SetOptionIfNotEmpty(CloudStorageOptions& options, const std::string& key, const std::string& value) {
@@ -80,8 +85,10 @@ void ConfigureAzureOptions(CloudStorageOptions& options, const ArrowFileSystemCo
   SetOptionIfNotEmpty(options, "azure_storage_account_key", config.access_key_value);
 
   if (!config.address.empty()) {
-    auto azure_address = BuildAzureEndpointAddress(config.address, config.access_key_id);
-    SetEndpointOptions(options, "azure_endpoint", azure_address);
+    options["azure_endpoint"] = BuildAzureEndpointAddress(config.address, config.access_key_id, config.use_ssl);
+    if (!config.use_ssl) {
+      options["allow_http"] = "true";
+    }
   }
 }
 

--- a/cpp/src/filesystem/azure/azure_fs_producer.cpp
+++ b/cpp/src/filesystem/azure/azure_fs_producer.cpp
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef MILVUS_AZURE_FS
-
 #include <cstdlib>
 #include <cassert>
 
-#include "arrow/filesystem/azurefs.h"
+#include "milvus-storage/filesystem/azure/azurefs.h"
 #include <arrow/util/logging.h>
 
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/fs.h"
-#include "milvus-storage/filesystem/azure/azure_fs.h"
+#include "milvus-storage/filesystem/azure/azure_fs_producer.h"
 
 namespace milvus_storage {
 
@@ -32,21 +30,37 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
                        << "Requested version: " << config_.tls_min_version << ". Ignoring.";
   }
 
-  arrow::fs::AzureOptions options;
+  milvus_storage::fs::AzureOptions options;
   assert(!config_.access_key_id.empty());
   options.account_name = config_.access_key_id;
+
+  if (!config_.address.empty()) {
+    options.blob_storage_authority = config_.address;
+    options.dfs_storage_authority = config_.address;
+  }
+  if (!config_.use_ssl) {
+    options.blob_storage_scheme = "http";
+    options.dfs_storage_scheme = "http";
+  }
+
   if (config_.use_iam) {
     const char* federated_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
     if (federated_token != nullptr && strlen(federated_token) > 0) {
       // Workload Identity
-      assert(getenv("AZURE_CLIENT_ID") != NULL);
-      assert(getenv("AZURE_TENANT_ID") != NULL);
+      if (std::getenv("AZURE_CLIENT_ID") == nullptr) {
+        return arrow::Status::Invalid("AZURE_CLIENT_ID environment variable is not set");
+      }
+      if (std::getenv("AZURE_TENANT_ID") == nullptr) {
+        return arrow::Status::Invalid("AZURE_TENANT_ID environment variable is not set");
+      }
       ARROW_RETURN_NOT_OK(options.ConfigureWorkloadIdentityCredential());
     } else {
       // Managed Identity
-      assert(getenv("AZURE_CLIENT_ID") != NULL);
-      std::string clientId(std::getenv("AZURE_CLIENT_ID"));
-      ARROW_RETURN_NOT_OK(options.ConfigureManagedIdentityCredential(clientId));
+      const char* client_id = std::getenv("AZURE_CLIENT_ID");
+      if (client_id == nullptr) {
+        return arrow::Status::Invalid("AZURE_CLIENT_ID environment variable is not set");
+      }
+      ARROW_RETURN_NOT_OK(options.ConfigureManagedIdentityCredential(std::string(client_id)));
     }
   } else {
     // need azure secret key without iam
@@ -54,9 +68,8 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
     ARROW_RETURN_NOT_OK(options.ConfigureAccountKeyCredential(config_.access_key_value));
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto fs, arrow::fs::AzureFileSystem::Make(options));
+  ARROW_ASSIGN_OR_RAISE(auto fs, milvus_storage::fs::AzureFileSystem::Make(options));
   return std::make_shared<FileSystemProxy>(config_.bucket_name, fs);
 }
 
 }  // namespace milvus_storage
-#endif

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -1,0 +1,3538 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <optional>
+
+#include "milvus-storage/filesystem/azure/azurefs.h"
+#include "milvus-storage/filesystem/azure/azurefs_internal.h"
+#include "arrow/io/memory.h"
+
+// idenfity.hpp triggers -Wattributes warnings cause -Werror builds to fail,
+// so disable it for this file with pragmas.
+#if defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wattributes"
+#endif
+#include <azure/identity.hpp>
+#if defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
+#include <azure/storage/blobs.hpp>
+#include <azure/storage/files/datalake.hpp>
+
+#include <arrow/buffer.h>
+#include <arrow/filesystem/path_util.h>
+
+#include <arrow/result.h>
+#include <arrow/util/checked_cast.h>
+#include <arrow/util/formatting.h>
+#include <arrow/util/future.h>
+#include <arrow/util/key_value_metadata.h>
+#include <arrow/util/logging.h>
+#include <arrow/util/string.h>
+
+#include "milvus-storage/filesystem/util_internal.h"
+
+namespace milvus_storage::fs {
+
+// --- Begin namespace bridge ---
+// Import arrow types so the v23 Azure FS code compiles with minimal changes
+// from upstream. These were previously resolved via enclosing namespace lookup
+// when the code lived in arrow::fs.
+
+// Arrow core types
+using arrow::BooleanType;
+using arrow::Buffer;
+using arrow::Future;
+using arrow::HexEncode;
+using arrow::Int32Type;
+using arrow::Int64Type;
+using arrow::KeyValueMetadata;
+using arrow::Result;
+using arrow::Status;
+using arrow::TypeTraits;
+using arrow::util::Uri;
+
+// Arrow filesystem types
+using arrow::fs::FileInfo;
+using arrow::fs::FileInfoVector;
+using arrow::fs::FileSelector;
+using arrow::fs::FileSystem;
+using arrow::fs::FileType;
+using arrow::fs::kNoSize;
+
+// Arrow IO namespace (referenced as io::* throughout)
+namespace io = arrow::io;
+
+// Import arrow::fs::internal utilities into our internal namespace.
+// Our own internal types (HierarchicalNamespaceSupport, etc. from
+// azurefs_internal.h) coexist here without conflict.
+namespace internal {
+using arrow::fs::internal::AssertNoTrailingSlash;
+using arrow::fs::internal::ConcatAbstractPath;
+using arrow::fs::internal::EnsureTrailingSlash;
+using arrow::fs::internal::GetAbstractPathDepth;
+using arrow::fs::internal::HasTrailingSlash;
+using arrow::fs::internal::InvalidDeleteDirContents;
+using arrow::fs::internal::IsADir;
+using arrow::fs::internal::IsEmptyPath;
+using arrow::fs::internal::IsLikelyUri;
+using arrow::fs::internal::JoinAbstractPath;
+using arrow::fs::internal::kSep;
+using arrow::fs::internal::NotADir;
+using arrow::fs::internal::NotAFile;
+using arrow::fs::internal::NotEmpty;
+using arrow::fs::internal::PathNotFound;
+using arrow::fs::internal::RemoveLeadingSlash;
+using arrow::fs::internal::RemoveTrailingSlash;
+using arrow::fs::internal::SplitAbstractPath;
+using arrow::fs::internal::ValidateAbstractPathParts;
+}  // namespace internal
+// --- End namespace bridge ---
+
+namespace Blobs = Azure::Storage::Blobs;
+namespace Core = Azure::Core;
+namespace DataLake = Azure::Storage::Files::DataLake;
+namespace Http = Azure::Core::Http;
+namespace Storage = Azure::Storage;
+
+using HNSSupport = internal::HierarchicalNamespaceSupport;
+
+// -----------------------------------------------------------------------
+// AzureOptions Implementation
+
+AzureOptions::AzureOptions() = default;
+
+AzureOptions::~AzureOptions() = default;
+
+void AzureOptions::ExtractFromUriSchemeAndHierPart(const Uri& uri,
+                                                   std::string* out_path) {
+  const auto host = uri.host();
+  std::string path;
+  if (arrow::internal::EndsWith(host, blob_storage_authority)) {
+    account_name = host.substr(0, host.size() - blob_storage_authority.size());
+    path = internal::RemoveLeadingSlash(uri.path());
+  } else if (arrow::internal::EndsWith(host, dfs_storage_authority)) {
+    account_name = host.substr(0, host.size() - dfs_storage_authority.size());
+    path = internal::ConcatAbstractPath(uri.username(), uri.path());
+  } else {
+    account_name = uri.username();
+    const auto port_text = uri.port_text();
+    if (host.find(".") == std::string::npos && port_text.empty()) {
+      // abfs://container/dir/file
+      path = internal::ConcatAbstractPath(host, uri.path());
+    } else {
+      // abfs://host.domain/container/dir/file
+      // abfs://host.domain:port/container/dir/file
+      // abfs://host:port/container/dir/file
+      std::string host_port = host;
+      if (!port_text.empty()) {
+        host_port += ":" + port_text;
+      }
+      blob_storage_authority = host_port;
+      dfs_storage_authority = host_port;
+      path = internal::RemoveLeadingSlash(uri.path());
+    }
+  }
+  if (out_path != nullptr) {
+    *out_path = path;
+  }
+}
+
+Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
+  std::optional<CredentialKind> credential_kind;
+  std::optional<std::string> credential_kind_value;
+  std::string tenant_id;
+  std::string client_id;
+  std::string client_secret;
+
+  // These query parameters are the union of the following docs:
+  // https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters
+  // https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#construct-a-service-sas
+  // (excluding parameters for table storage only)
+  // https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#construct-a-user-delegation-sas
+  static const std::set<std::string> sas_token_query_parameters = {
+      "sv",    "ss",    "sr",  "st",  "se",   "sp",   "si",   "sip",   "spr",
+      "skoid", "sktid", "srt", "skt", "ske",  "skv",  "sks",  "saoid", "suoid",
+      "scid",  "sdd",   "ses", "sig", "rscc", "rscd", "rsce", "rscl",  "rsct",
+  };
+
+  ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
+  for (const auto& kv : options_items) {
+    if (kv.first == "blob_storage_authority") {
+      blob_storage_authority = kv.second;
+    } else if (kv.first == "dfs_storage_authority") {
+      dfs_storage_authority = kv.second;
+    } else if (kv.first == "credential_kind") {
+      if (kv.second == "default") {
+        credential_kind = CredentialKind::kDefault;
+      } else if (kv.second == "anonymous") {
+        credential_kind = CredentialKind::kAnonymous;
+      } else if (kv.second == "cli") {
+        credential_kind = CredentialKind::kCLI;
+      } else if (kv.second == "workload_identity") {
+        credential_kind = CredentialKind::kWorkloadIdentity;
+      } else if (kv.second == "environment") {
+        credential_kind = CredentialKind::kEnvironment;
+      } else {
+        // Other credential kinds should be inferred from the given
+        // parameters automatically.
+        return Status::Invalid("Unexpected credential_kind: '", kv.second, "'");
+      }
+      credential_kind_value = kv.second;
+    } else if (kv.first == "tenant_id") {
+      tenant_id = kv.second;
+    } else if (kv.first == "client_id") {
+      client_id = kv.second;
+    } else if (kv.first == "client_secret") {
+      client_secret = kv.second;
+    } else if (kv.first == "enable_tls") {
+      ARROW_ASSIGN_OR_RAISE(auto enable_tls, ::arrow::internal::ParseBoolean(kv.second));
+      if (enable_tls) {
+        blob_storage_scheme = "https";
+        dfs_storage_scheme = "https";
+      } else {
+        blob_storage_scheme = "http";
+        dfs_storage_scheme = "http";
+      }
+    } else if (kv.first == "background_writes") {
+      ARROW_ASSIGN_OR_RAISE(background_writes,
+                            ::arrow::internal::ParseBoolean(kv.second));
+    } else if (sas_token_query_parameters.find(kv.first) !=
+               sas_token_query_parameters.end()) {
+      credential_kind = CredentialKind::kSASToken;
+    } else {
+      return Status::Invalid(
+          "Unexpected query parameter in Azure Blob File System URI: '", kv.first, "'");
+    }
+  }
+
+  if (credential_kind) {
+    if (!tenant_id.empty()) {
+      return Status::Invalid("tenant_id must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
+    if (!client_id.empty()) {
+      return Status::Invalid("client_id must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
+    if (!client_secret.empty()) {
+      return Status::Invalid("client_secret must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
+
+    switch (*credential_kind) {
+      case CredentialKind::kAnonymous:
+        RETURN_NOT_OK(ConfigureAnonymousCredential());
+        break;
+      case CredentialKind::kCLI:
+        RETURN_NOT_OK(ConfigureCLICredential());
+        break;
+      case CredentialKind::kWorkloadIdentity:
+        RETURN_NOT_OK(ConfigureWorkloadIdentityCredential());
+        break;
+      case CredentialKind::kEnvironment:
+        RETURN_NOT_OK(ConfigureEnvironmentCredential());
+        break;
+      case CredentialKind::kSASToken:
+        // Reconstructing the SAS token without the other URI query parameters is awkward
+        // because some parts are URI escaped and some parts are not. Instead we just
+        // pass through the entire query string and Azure ignores the extra query
+        // parameters.
+        RETURN_NOT_OK(ConfigureSASCredential("?" + uri.query_string()));
+        break;
+      default:
+        // Default credential
+        break;
+    }
+  } else {
+    if (tenant_id.empty() && client_id.empty() && client_secret.empty()) {
+      // No related parameters
+      if (account_name.empty()) {
+        RETURN_NOT_OK(ConfigureAnonymousCredential());
+      } else {
+        // Default credential
+      }
+    } else {
+      // One or more tenant_id, client_id or client_secret are specified
+      if (client_id.empty()) {
+        return Status::Invalid("client_id must be specified");
+      }
+      if (tenant_id.empty() && client_secret.empty()) {
+        RETURN_NOT_OK(ConfigureManagedIdentityCredential(client_id));
+      } else if (!tenant_id.empty() && !client_secret.empty()) {
+        RETURN_NOT_OK(
+            ConfigureClientSecretCredential(tenant_id, client_id, client_secret));
+      } else {
+        return Status::Invalid("Both of tenant_id and client_secret must be specified");
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Result<AzureOptions> AzureOptions::FromUri(const Uri& uri, std::string* out_path) {
+  AzureOptions options;
+  options.ExtractFromUriSchemeAndHierPart(uri, out_path);
+  RETURN_NOT_OK(options.ExtractFromUriQuery(uri));
+  return options;
+}
+
+Result<AzureOptions> AzureOptions::FromUri(const std::string& uri_string,
+                                           std::string* out_path) {
+  Uri uri;
+  RETURN_NOT_OK(uri.Parse(uri_string));
+  return FromUri(uri, out_path);
+}
+
+bool AzureOptions::Equals(const AzureOptions& other) const {
+  const bool equals = blob_storage_authority == other.blob_storage_authority &&
+                      dfs_storage_authority == other.dfs_storage_authority &&
+                      blob_storage_scheme == other.blob_storage_scheme &&
+                      dfs_storage_scheme == other.dfs_storage_scheme &&
+                      default_metadata == other.default_metadata &&
+                      account_name == other.account_name &&
+                      credential_kind_ == other.credential_kind_;
+  if (!equals) {
+    return false;
+  }
+  switch (credential_kind_) {
+    case CredentialKind::kDefault:
+    case CredentialKind::kAnonymous:
+      return true;
+    case CredentialKind::kStorageSharedKey:
+      return storage_shared_key_credential_->AccountName ==
+             other.storage_shared_key_credential_->AccountName;
+    case CredentialKind::kSASToken:
+      return sas_token_ == other.sas_token_;
+    case CredentialKind::kClientSecret:
+    case CredentialKind::kCLI:
+    case CredentialKind::kManagedIdentity:
+    case CredentialKind::kWorkloadIdentity:
+    case CredentialKind::kEnvironment:
+      return token_credential_->GetCredentialName() ==
+             other.token_credential_->GetCredentialName();
+  }
+  DCHECK(false);
+  return false;
+}
+
+namespace {
+std::string BuildBaseUrl(const std::string& scheme, const std::string& authority,
+                         const std::string& account_name) {
+  std::string url;
+  url += scheme + "://";
+  if (!authority.empty()) {
+    if (authority[0] == '.') {
+      url += account_name;
+      url += authority;
+    } else {
+      url += authority;
+      url += "/";
+      url += account_name;
+    }
+  }
+  url += "/";
+  return url;
+}
+
+template <typename... PrefixArgs>
+Status ExceptionToStatus(const Azure::Core::RequestFailedException& exception,
+                         PrefixArgs&&... prefix_args) {
+  return Status::IOError(std::forward<PrefixArgs>(prefix_args)..., " Azure Error: [",
+                         exception.ErrorCode, "] ", exception.what());
+}
+}  // namespace
+
+std::string AzureOptions::AccountBlobUrl(const std::string& account_name) const {
+  return BuildBaseUrl(blob_storage_scheme, blob_storage_authority, account_name);
+}
+
+std::string AzureOptions::AccountDfsUrl(const std::string& account_name) const {
+  return BuildBaseUrl(dfs_storage_scheme, dfs_storage_authority, account_name);
+}
+
+Status AzureOptions::ConfigureDefaultCredential() {
+  credential_kind_ = CredentialKind::kDefault;
+  token_credential_ = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureAnonymousCredential() {
+  credential_kind_ = CredentialKind::kAnonymous;
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureAccountKeyCredential(const std::string& account_key) {
+  credential_kind_ = CredentialKind::kStorageSharedKey;
+  if (account_name.empty()) {
+    return Status::Invalid("AzureOptions doesn't contain a valid account name");
+  }
+  storage_shared_key_credential_ =
+      std::make_shared<Storage::StorageSharedKeyCredential>(account_name, account_key);
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureSASCredential(const std::string& sas_token) {
+  credential_kind_ = CredentialKind::kSASToken;
+  if (account_name.empty()) {
+    return Status::Invalid("AzureOptions doesn't contain a valid account name");
+  }
+  sas_token_ = sas_token;
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureClientSecretCredential(const std::string& tenant_id,
+                                                     const std::string& client_id,
+                                                     const std::string& client_secret) {
+  credential_kind_ = CredentialKind::kClientSecret;
+  token_credential_ = std::make_shared<Azure::Identity::ClientSecretCredential>(
+      tenant_id, client_id, client_secret);
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& client_id) {
+  credential_kind_ = CredentialKind::kManagedIdentity;
+  token_credential_ =
+      std::make_shared<Azure::Identity::ManagedIdentityCredential>(client_id);
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureCLICredential() {
+  credential_kind_ = CredentialKind::kCLI;
+  token_credential_ = std::make_shared<Azure::Identity::AzureCliCredential>();
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureWorkloadIdentityCredential() {
+  credential_kind_ = CredentialKind::kWorkloadIdentity;
+  token_credential_ = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
+  return Status::OK();
+}
+
+Status AzureOptions::ConfigureEnvironmentCredential() {
+  credential_kind_ = CredentialKind::kEnvironment;
+  token_credential_ = std::make_shared<Azure::Identity::EnvironmentCredential>();
+  return Status::OK();
+}
+
+Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceClient()
+    const {
+  if (account_name.empty()) {
+    return Status::Invalid("AzureOptions doesn't contain a valid account name");
+  }
+  if (!(blob_storage_scheme == "http" || blob_storage_scheme == "https")) {
+    return Status::Invalid("AzureOptions::blob_storage_scheme must be http or https: ",
+                           blob_storage_scheme);
+  }
+  switch (credential_kind_) {
+    case CredentialKind::kAnonymous:
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name));
+    case CredentialKind::kDefault:
+      if (!token_credential_) {
+        token_credential_ = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+      }
+      [[fallthrough]];
+    case CredentialKind::kClientSecret:
+    case CredentialKind::kManagedIdentity:
+    case CredentialKind::kCLI:
+    case CredentialKind::kWorkloadIdentity:
+    case CredentialKind::kEnvironment:
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name),
+                                                        token_credential_);
+    case CredentialKind::kStorageSharedKey:
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name),
+                                                        storage_shared_key_credential_);
+    case CredentialKind::kSASToken:
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name) +
+                                                        sas_token_);
+  }
+  return Status::Invalid("AzureOptions doesn't contain a valid auth configuration");
+}
+
+Result<std::unique_ptr<DataLake::DataLakeServiceClient>>
+AzureOptions::MakeDataLakeServiceClient() const {
+  if (account_name.empty()) {
+    return Status::Invalid("AzureOptions doesn't contain a valid account name");
+  }
+  if (!(dfs_storage_scheme == "http" || dfs_storage_scheme == "https")) {
+    return Status::Invalid("AzureOptions::dfs_storage_scheme must be http or https: ",
+                           dfs_storage_scheme);
+  }
+  switch (credential_kind_) {
+    case CredentialKind::kAnonymous:
+      return std::make_unique<DataLake::DataLakeServiceClient>(
+          AccountDfsUrl(account_name));
+    case CredentialKind::kDefault:
+      if (!token_credential_) {
+        token_credential_ = std::make_shared<Azure::Identity::DefaultAzureCredential>();
+      }
+      [[fallthrough]];
+    case CredentialKind::kClientSecret:
+    case CredentialKind::kManagedIdentity:
+    case CredentialKind::kCLI:
+    case CredentialKind::kWorkloadIdentity:
+    case CredentialKind::kEnvironment:
+      return std::make_unique<DataLake::DataLakeServiceClient>(
+          AccountDfsUrl(account_name), token_credential_);
+    case CredentialKind::kStorageSharedKey:
+      return std::make_unique<DataLake::DataLakeServiceClient>(
+          AccountDfsUrl(account_name), storage_shared_key_credential_);
+    case CredentialKind::kSASToken:
+      return std::make_unique<DataLake::DataLakeServiceClient>(
+          AccountBlobUrl(account_name) + sas_token_);
+  }
+  return Status::Invalid("AzureOptions doesn't contain a valid auth configuration");
+}
+
+namespace {
+
+// An AzureFileSystem represents an Azure storage account. An AzureLocation describes a
+// container in that storage account and a path within that container.
+struct AzureLocation {
+  std::string all;
+  std::string container;
+  std::string path;
+  std::vector<std::string> path_parts;
+
+  static Result<AzureLocation> FromString(const std::string& origin_string) {
+    // Example expected string format: testcontainer/testdir/testfile.txt
+    // container = testcontainer
+    // path = testdir/testfile.txt
+    // path_parts = [testdir, testfile.txt]
+    auto string = std::filesystem::path(origin_string).lexically_normal().string();
+    if (internal::IsLikelyUri(string)) {
+      return Status::Invalid(
+          "Expected an Azure object location of the form 'container/path...',"
+          " got a URI: '",
+          string, "'");
+    }
+    auto first_sep = string.find_first_of(internal::kSep);
+    if (first_sep == 0) {
+      return Status::Invalid("Location cannot start with a separator ('", string, "')");
+    }
+    if (first_sep == std::string::npos) {
+      return AzureLocation{string, string, "", {}};
+    }
+    AzureLocation location;
+    location.all = string;
+    location.container = string.substr(0, first_sep);
+    location.path = string.substr(first_sep + 1);
+    location.path_parts = internal::SplitAbstractPath(location.path);
+    RETURN_NOT_OK(location.Validate());
+    return location;
+  }
+
+  AzureLocation parent() const {
+    DCHECK(has_parent());
+    AzureLocation parent{"", container, "", path_parts};
+    parent.path_parts.pop_back();
+    parent.path = internal::JoinAbstractPath(parent.path_parts);
+    if (parent.path.empty()) {
+      parent.all = parent.container;
+    } else {
+      parent.all = parent.container + internal::kSep + parent.path;
+    }
+    return parent;
+  }
+
+  Result<AzureLocation> join(const std::string& stem) const {
+    return FromString(internal::ConcatAbstractPath(all, stem));
+  }
+
+  bool has_parent() const { return !path.empty(); }
+
+  bool empty() const { return container.empty() && path.empty(); }
+
+  bool operator==(const AzureLocation& other) const {
+    return container == other.container && path == other.path;
+  }
+
+ private:
+  Status Validate() {
+    auto status = internal::ValidateAbstractPathParts(path_parts);
+    return status.ok() ? status : Status::Invalid(status.message(), " in location ", all);
+  }
+};
+
+Status PathNotFound(const AzureLocation& location) {
+  return ::arrow::fs::internal::PathNotFound(location.all);
+}
+
+Status NotADir(const AzureLocation& location) {
+  return ::arrow::fs::internal::NotADir(location.all);
+}
+
+Status NotAFile(const AzureLocation& location) {
+  return ::arrow::fs::internal::NotAFile(location.all);
+}
+
+Status NotEmpty(const AzureLocation& location) {
+  return ::arrow::fs::internal::NotEmpty(location.all);
+}
+
+Status ValidateFileLocation(const AzureLocation& location) {
+  if (location.container.empty()) {
+    return PathNotFound(location);
+  }
+  if (location.path.empty()) {
+    return NotAFile(location);
+  }
+  return internal::AssertNoTrailingSlash(location.path);
+}
+
+Status InvalidDirMoveToSubdir(const AzureLocation& src, const AzureLocation& dest) {
+  return Status::Invalid("Cannot Move to '", dest.all, "' and make '", src.all,
+                         "' a sub-directory of itself.");
+}
+
+Status DestinationParentPathNotFound(const AzureLocation& dest) {
+  return Status::IOError("The parent directory of the destination path '", dest.all,
+                         "' does not exist.");
+}
+
+Status CrossContainerMoveNotImplemented(const AzureLocation& src,
+                                        const AzureLocation& dest) {
+  return Status::NotImplemented(
+      "Move of '", src.all, "' to '", dest.all,
+      "' requires moving data between containers, which is not implemented.");
+}
+
+bool IsContainerNotFound(const Storage::StorageException& e) {
+  // In some situations, only the ReasonPhrase is set and the
+  // ErrorCode is empty, so we check both.
+  if (e.ErrorCode == "ContainerNotFound" ||
+      e.ReasonPhrase == "The specified container does not exist." ||
+      e.ReasonPhrase == "The specified filesystem does not exist.") {
+    DCHECK_EQ(e.StatusCode, Http::HttpStatusCode::NotFound);
+    return true;
+  }
+  return false;
+}
+
+const auto kHierarchicalNamespaceIsDirectoryMetadataKey = "hdi_isFolder";
+const auto kFlatNamespaceIsDirectoryMetadataKey = "is_directory";
+
+bool MetadataIndicatesIsDirectory(const Storage::Metadata& metadata) {
+  // Inspired by
+  // https://github.com/Azure/azure-sdk-for-cpp/blob/12407e8bfcb9bc1aa43b253c1d0ec93bf795ae3b/sdk/storage/azure-storage-files-datalake/src/datalake_utilities.cpp#L86-L91
+  auto hierarchical_directory_metadata =
+      metadata.find(kHierarchicalNamespaceIsDirectoryMetadataKey);
+  if (hierarchical_directory_metadata != metadata.end()) {
+    return hierarchical_directory_metadata->second == "true";
+  }
+  auto flat_directory_metadata = metadata.find(kFlatNamespaceIsDirectoryMetadataKey);
+  return flat_directory_metadata != metadata.end() &&
+         flat_directory_metadata->second == "true";
+}
+
+template <typename ArrowType>
+std::string FormatValue(typename TypeTraits<ArrowType>::CType value) {
+  struct StringAppender {
+    std::string string;
+    Status operator()(std::string_view view) {
+      string.append(view.data(), view.size());
+      return Status::OK();
+    }
+  } appender;
+  arrow::internal::StringFormatter<ArrowType> formatter;
+  ARROW_UNUSED(formatter(value, appender));
+  return appender.string;
+}
+
+std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
+    const Blobs::Models::BlobProperties& properties) {
+  auto metadata = std::make_shared<KeyValueMetadata>();
+  // Not supported yet:
+  // * properties.ObjectReplicationSourceProperties
+  //
+  // They may have the same key defined in the following
+  // metadata->Append() list. If we have duplicated key in metadata,
+  // the first value may be only used by users because
+  // KeyValueMetadata::Get() returns the first found value. Note that
+  // users can use all values by using KeyValueMetadata::keys() and
+  // KeyValueMetadata::values().
+  if (properties.ImmutabilityPolicy.HasValue()) {
+    metadata->Append("Immutability-Policy-Expires-On",
+                     properties.ImmutabilityPolicy.Value().ExpiresOn.ToString());
+    metadata->Append("Immutability-Policy-Mode",
+                     properties.ImmutabilityPolicy.Value().PolicyMode.ToString());
+  }
+  metadata->Append("Content-Type", properties.HttpHeaders.ContentType);
+  metadata->Append("Content-Encoding", properties.HttpHeaders.ContentEncoding);
+  metadata->Append("Content-Language", properties.HttpHeaders.ContentLanguage);
+  const auto& content_hash = properties.HttpHeaders.ContentHash.Value;
+  metadata->Append("Content-Hash", HexEncode(content_hash.data(), content_hash.size()));
+  metadata->Append("Content-Disposition", properties.HttpHeaders.ContentDisposition);
+  metadata->Append("Cache-Control", properties.HttpHeaders.CacheControl);
+  metadata->Append("Last-Modified", properties.LastModified.ToString());
+  metadata->Append("Created-On", properties.CreatedOn.ToString());
+  if (properties.ObjectReplicationDestinationPolicyId.HasValue()) {
+    metadata->Append("Object-Replication-Destination-Policy-Id",
+                     properties.ObjectReplicationDestinationPolicyId.Value());
+  }
+  metadata->Append("Blob-Type", properties.BlobType.ToString());
+  if (properties.CopyCompletedOn.HasValue()) {
+    metadata->Append("Copy-Completed-On", properties.CopyCompletedOn.Value().ToString());
+  }
+  if (properties.CopyStatusDescription.HasValue()) {
+    metadata->Append("Copy-Status-Description", properties.CopyStatusDescription.Value());
+  }
+  if (properties.CopyId.HasValue()) {
+    metadata->Append("Copy-Id", properties.CopyId.Value());
+  }
+  if (properties.CopyProgress.HasValue()) {
+    metadata->Append("Copy-Progress", properties.CopyProgress.Value());
+  }
+  if (properties.CopySource.HasValue()) {
+    metadata->Append("Copy-Source", properties.CopySource.Value());
+  }
+  if (properties.CopyStatus.HasValue()) {
+    metadata->Append("Copy-Status", properties.CopyStatus.Value().ToString());
+  }
+  if (properties.IsIncrementalCopy.HasValue()) {
+    metadata->Append("Is-Incremental-Copy",
+                     FormatValue<BooleanType>(properties.IsIncrementalCopy.Value()));
+  }
+  if (properties.IncrementalCopyDestinationSnapshot.HasValue()) {
+    metadata->Append("Incremental-Copy-Destination-Snapshot",
+                     properties.IncrementalCopyDestinationSnapshot.Value());
+  }
+  if (properties.LeaseDuration.HasValue()) {
+    metadata->Append("Lease-Duration", properties.LeaseDuration.Value().ToString());
+  }
+  if (properties.LeaseState.HasValue()) {
+    metadata->Append("Lease-State", properties.LeaseState.Value().ToString());
+  }
+  if (properties.LeaseStatus.HasValue()) {
+    metadata->Append("Lease-Status", properties.LeaseStatus.Value().ToString());
+  }
+  metadata->Append("Content-Length", FormatValue<Int64Type>(properties.BlobSize));
+  if (properties.ETag.HasValue()) {
+    metadata->Append("ETag", properties.ETag.ToString());
+  }
+  if (properties.SequenceNumber.HasValue()) {
+    metadata->Append("Sequence-Number",
+                     FormatValue<Int64Type>(properties.SequenceNumber.Value()));
+  }
+  if (properties.CommittedBlockCount.HasValue()) {
+    metadata->Append("Committed-Block-Count",
+                     FormatValue<Int32Type>(properties.CommittedBlockCount.Value()));
+  }
+  metadata->Append("IsServerEncrypted",
+                   FormatValue<BooleanType>(properties.IsServerEncrypted));
+  if (properties.EncryptionKeySha256.HasValue()) {
+    const auto& sha256 = properties.EncryptionKeySha256.Value();
+    metadata->Append("Encryption-Key-Sha-256", HexEncode(sha256.data(), sha256.size()));
+  }
+  if (properties.EncryptionScope.HasValue()) {
+    metadata->Append("Encryption-Scope", properties.EncryptionScope.Value());
+  }
+  if (properties.AccessTier.HasValue()) {
+    metadata->Append("Access-Tier", properties.AccessTier.Value().ToString());
+  }
+  if (properties.IsAccessTierInferred.HasValue()) {
+    metadata->Append("Is-Access-Tier-Inferred",
+                     FormatValue<BooleanType>(properties.IsAccessTierInferred.Value()));
+  }
+  if (properties.ArchiveStatus.HasValue()) {
+    metadata->Append("Archive-Status", properties.ArchiveStatus.Value().ToString());
+  }
+  if (properties.AccessTierChangedOn.HasValue()) {
+    metadata->Append("Access-Tier-Changed-On",
+                     properties.AccessTierChangedOn.Value().ToString());
+  }
+  if (properties.VersionId.HasValue()) {
+    metadata->Append("Version-Id", properties.VersionId.Value());
+  }
+  if (properties.IsCurrentVersion.HasValue()) {
+    metadata->Append("Is-Current-Version",
+                     FormatValue<BooleanType>(properties.IsCurrentVersion.Value()));
+  }
+  if (properties.TagCount.HasValue()) {
+    metadata->Append("Tag-Count", FormatValue<Int32Type>(properties.TagCount.Value()));
+  }
+  if (properties.ExpiresOn.HasValue()) {
+    metadata->Append("Expires-On", properties.ExpiresOn.Value().ToString());
+  }
+  if (properties.IsSealed.HasValue()) {
+    metadata->Append("Is-Sealed", FormatValue<BooleanType>(properties.IsSealed.Value()));
+  }
+  if (properties.RehydratePriority.HasValue()) {
+    metadata->Append("Rehydrate-Priority",
+                     properties.RehydratePriority.Value().ToString());
+  }
+  if (properties.LastAccessedOn.HasValue()) {
+    metadata->Append("Last-Accessed-On", properties.LastAccessedOn.Value().ToString());
+  }
+  metadata->Append("Has-Legal-Hold", FormatValue<BooleanType>(properties.HasLegalHold));
+  for (const auto& [key, value] : properties.Metadata) {
+    metadata->Append(key, value);
+  }
+  return metadata;
+}
+
+void ArrowMetadataToCommitBlockListOptions(
+    const std::shared_ptr<const KeyValueMetadata>& arrow_metadata,
+    Blobs::CommitBlockListOptions& options) {
+  using ::arrow::internal::AsciiEqualsCaseInsensitive;
+  for (auto& [key, value] : arrow_metadata->sorted_pairs()) {
+    if (AsciiEqualsCaseInsensitive(key, "Content-Type")) {
+      options.HttpHeaders.ContentType = value;
+    } else if (AsciiEqualsCaseInsensitive(key, "Content-Encoding")) {
+      options.HttpHeaders.ContentEncoding = value;
+    } else if (AsciiEqualsCaseInsensitive(key, "Content-Language")) {
+      options.HttpHeaders.ContentLanguage = value;
+    } else if (AsciiEqualsCaseInsensitive(key, "Content-Hash")) {
+      // Ignore: auto-generated value
+    } else if (AsciiEqualsCaseInsensitive(key, "Content-Disposition")) {
+      options.HttpHeaders.ContentDisposition = value;
+    } else if (AsciiEqualsCaseInsensitive(key, "Cache-Control")) {
+      options.HttpHeaders.CacheControl = value;
+    } else {
+      options.Metadata[key] = value;
+    }
+  }
+}
+
+class ObjectInputFile final : public io::RandomAccessFile {
+ public:
+  ObjectInputFile(std::shared_ptr<Blobs::BlobClient> blob_client,
+                  const io::IOContext& io_context, AzureLocation location,
+                  int64_t size = kNoSize)
+      : blob_client_(std::move(blob_client)),
+        io_context_(io_context),
+        location_(std::move(location)),
+        content_length_(size) {}
+
+  Status Init() {
+    if (content_length_ != kNoSize) {
+      // When the user provides the file size we don't validate that its a file. This is
+      // only a read so its not a big deal if the user makes a mistake.
+      DCHECK_GE(content_length_, 0);
+      return Status::OK();
+    }
+    try {
+      // To open an ObjectInputFile the Blob must exist and it must not represent
+      // a directory. Additionally we need to know the file size.
+      auto properties = blob_client_->GetProperties();
+      if (MetadataIndicatesIsDirectory(properties.Value.Metadata)) {
+        return NotAFile(location_);
+      }
+      content_length_ = properties.Value.BlobSize;
+      metadata_ = PropertiesToMetadata(properties.Value);
+      return Status::OK();
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        return PathNotFound(location_);
+      }
+      return ExceptionToStatus(
+          exception, "GetProperties failed for '", blob_client_->GetUrl(),
+          "'. Cannot initialise an ObjectInputFile without knowing the file size.");
+    }
+  }
+
+  Status CheckClosed(const char* action) const {
+    if (closed_) {
+      return Status::Invalid("Cannot ", action, " on closed file.");
+    }
+    return Status::OK();
+  }
+
+  Status CheckPosition(int64_t position, const char* action) const {
+    DCHECK_GE(content_length_, 0);
+    if (position < 0) {
+      return Status::Invalid("Cannot ", action, " from negative position");
+    }
+    if (position > content_length_) {
+      return Status::IOError("Cannot ", action, " past end of file");
+    }
+    return Status::OK();
+  }
+
+  // RandomAccessFile APIs
+
+  Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata() override {
+    return metadata_;
+  }
+
+  Future<std::shared_ptr<const KeyValueMetadata>> ReadMetadataAsync(
+      const io::IOContext& io_context) override {
+    return metadata_;
+  }
+
+  Status Close() override {
+    blob_client_ = nullptr;
+    closed_ = true;
+    return Status::OK();
+  }
+
+  bool closed() const override { return closed_; }
+
+  Result<int64_t> Tell() const override {
+    RETURN_NOT_OK(CheckClosed("tell"));
+    return pos_;
+  }
+
+  Result<int64_t> GetSize() override {
+    RETURN_NOT_OK(CheckClosed("size"));
+    return content_length_;
+  }
+
+  Status Seek(int64_t position) override {
+    RETURN_NOT_OK(CheckClosed("seek"));
+    RETURN_NOT_OK(CheckPosition(position, "seek"));
+
+    pos_ = position;
+    return Status::OK();
+  }
+
+  Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    RETURN_NOT_OK(CheckClosed("read"));
+    RETURN_NOT_OK(CheckPosition(position, "read"));
+
+    nbytes = std::min(nbytes, content_length_ - position);
+    if (nbytes == 0) {
+      return 0;
+    }
+
+    // Read the desired range of bytes
+    Http::HttpRange range{position, nbytes};
+    Storage::Blobs::DownloadBlobToOptions download_options;
+    download_options.Range = range;
+    try {
+      return blob_client_
+          ->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options)
+          .Value.ContentRange.Length.Value();
+    } catch (const Storage::StorageException& exception) {
+      return ExceptionToStatus(
+          exception, "DownloadTo from '", blob_client_->GetUrl(), "' at position ",
+          position, " for ", nbytes,
+          " bytes failed. ReadAt failed to read the required byte range.");
+    }
+  }
+
+  Result<std::shared_ptr<Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
+    RETURN_NOT_OK(CheckClosed("read"));
+    RETURN_NOT_OK(CheckPosition(position, "read"));
+
+    // No need to allocate more than the remaining number of bytes
+    nbytes = std::min(nbytes, content_length_ - position);
+
+    ARROW_ASSIGN_OR_RAISE(auto buffer,
+                          AllocateResizableBuffer(nbytes, io_context_.pool()));
+    if (nbytes > 0) {
+      ARROW_ASSIGN_OR_RAISE(int64_t bytes_read,
+                            ReadAt(position, nbytes, buffer->mutable_data()));
+      DCHECK_LE(bytes_read, nbytes);
+      RETURN_NOT_OK(buffer->Resize(bytes_read));
+    }
+    return buffer;
+  }
+
+  Result<int64_t> Read(int64_t nbytes, void* out) override {
+    ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(pos_, nbytes, out));
+    pos_ += bytes_read;
+    return bytes_read;
+  }
+
+  Result<std::shared_ptr<Buffer>> Read(int64_t nbytes) override {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, ReadAt(pos_, nbytes));
+    pos_ += buffer->size();
+    return buffer;
+  }
+
+ private:
+  std::shared_ptr<Blobs::BlobClient> blob_client_;
+  const io::IOContext io_context_;
+  AzureLocation location_;
+
+  bool closed_ = false;
+  int64_t pos_ = 0;
+  int64_t content_length_ = kNoSize;
+  std::shared_ptr<const KeyValueMetadata> metadata_;
+};
+
+Status CreateEmptyBlockBlob(const Blobs::BlockBlobClient& block_blob_client) {
+  try {
+    block_blob_client.UploadFrom(nullptr, 0);
+  } catch (const Storage::StorageException& exception) {
+    return ExceptionToStatus(
+        exception, "UploadFrom failed for '", block_blob_client.GetUrl(),
+        "'. There is no existing blob at this location or the existing blob must be "
+        "replaced so ObjectAppendStream must create a new empty block blob.");
+  }
+  return Status::OK();
+}
+
+Result<Blobs::Models::GetBlockListResult> GetBlockList(
+    std::shared_ptr<Blobs::BlockBlobClient> block_blob_client) {
+  try {
+    return block_blob_client->GetBlockList().Value;
+  } catch (Storage::StorageException& exception) {
+    return ExceptionToStatus(
+        exception, "GetBlockList failed for '", block_blob_client->GetUrl(),
+        "'. Cannot write to a file without first fetching the existing block list.");
+  }
+}
+
+Status CommitBlockList(std::shared_ptr<Storage::Blobs::BlockBlobClient> block_blob_client,
+                       const std::vector<std::string>& block_ids,
+                       const Blobs::CommitBlockListOptions& options) {
+  try {
+    // CommitBlockList puts all block_ids in the latest element. That means in the case
+    // of overlapping block_ids the newly staged block ids will always replace the
+    // previously committed blocks.
+    // https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list?tabs=microsoft-entra-id#request-body
+    block_blob_client->CommitBlockList(block_ids, options);
+  } catch (const Storage::StorageException& exception) {
+    return ExceptionToStatus(
+        exception, "CommitBlockList failed for '", block_blob_client->GetUrl(),
+        "'. Committing is required to flush an output/append stream.");
+  }
+  return Status::OK();
+}
+
+Status StageBlock(Blobs::BlockBlobClient* block_blob_client, const std::string& id,
+                  Core::IO::MemoryBodyStream& content) {
+  try {
+    block_blob_client->StageBlock(id, content);
+  } catch (const Storage::StorageException& exception) {
+    return ExceptionToStatus(
+        exception, "StageBlock failed for '", block_blob_client->GetUrl(),
+        "' new_block_id: '", id,
+        "'. Staging new blocks is fundamental to streaming writes to blob storage.");
+  }
+
+  return Status::OK();
+}
+
+/// Writes will be buffered up to this size (in bytes) before actually uploading them.
+static constexpr int64_t kBlockUploadSizeBytes = 10 * 1024 * 1024;
+/// The maximum size of a block in Azure Blob (as per docs).
+static constexpr int64_t kMaxBlockSizeBytes = 4UL * 1024 * 1024 * 1024;
+
+/// This output stream, similar to other arrow OutputStreams, is not thread-safe.
+class ObjectAppendStream final : public io::OutputStream {
+ private:
+  struct UploadState;
+
+  std::shared_ptr<ObjectAppendStream> Self() {
+    return std::dynamic_pointer_cast<ObjectAppendStream>(shared_from_this());
+  }
+
+ public:
+  ObjectAppendStream(std::shared_ptr<Blobs::BlockBlobClient> block_blob_client,
+                     const io::IOContext& io_context, const AzureLocation& location,
+                     const std::shared_ptr<const KeyValueMetadata>& metadata,
+                     const AzureOptions& options)
+      : block_blob_client_(std::move(block_blob_client)),
+        io_context_(io_context),
+        location_(location),
+        background_writes_(options.background_writes) {
+    if (metadata && metadata->size() != 0) {
+      ArrowMetadataToCommitBlockListOptions(metadata, commit_block_list_options_);
+    } else if (options.default_metadata && options.default_metadata->size() != 0) {
+      ArrowMetadataToCommitBlockListOptions(options.default_metadata,
+                                            commit_block_list_options_);
+    }
+  }
+
+  Status Init(const bool truncate,
+              std::function<Status()> ensure_not_flat_namespace_directory) {
+    if (truncate) {
+      content_length_ = 0;
+      pos_ = 0;
+      // We need to create an empty file overwriting any existing file, but
+      // fail if there is an existing directory.
+      RETURN_NOT_OK(ensure_not_flat_namespace_directory());
+      // On hierarchical namespace CreateEmptyBlockBlob will fail if there is an existing
+      // directory so we don't need to check like we do on flat namespace.
+      RETURN_NOT_OK(CreateEmptyBlockBlob(*block_blob_client_));
+    } else {
+      try {
+        auto properties = block_blob_client_->GetProperties();
+        if (MetadataIndicatesIsDirectory(properties.Value.Metadata)) {
+          return NotAFile(location_);
+        }
+        content_length_ = properties.Value.BlobSize;
+        pos_ = content_length_;
+      } catch (const Storage::StorageException& exception) {
+        if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+          // No file exists but on flat namespace its possible there is a directory
+          // marker or an implied directory. Ensure there is no directory before starting
+          // a new empty file.
+          RETURN_NOT_OK(ensure_not_flat_namespace_directory());
+          RETURN_NOT_OK(CreateEmptyBlockBlob(*block_blob_client_));
+        } else {
+          return ExceptionToStatus(
+              exception, "GetProperties failed for '", block_blob_client_->GetUrl(),
+              "'. Cannot initialise an ObjectAppendStream without knowing whether a "
+              "file already exists at this path, and if it exists, its size.");
+        }
+        content_length_ = 0;
+      }
+    }
+
+    upload_state_ = std::make_shared<UploadState>();
+
+    if (content_length_ > 0) {
+      ARROW_ASSIGN_OR_RAISE(auto block_list, GetBlockList(block_blob_client_));
+      for (auto block : block_list.CommittedBlocks) {
+        upload_state_->block_ids.push_back(block.Name);
+      }
+    }
+    initialised_ = true;
+    return Status::OK();
+  }
+
+  Status Abort() override {
+    if (closed_) {
+      return Status::OK();
+    }
+    block_blob_client_ = nullptr;
+    closed_ = true;
+    return Status::OK();
+  }
+
+  Status Close() override {
+    if (closed_) {
+      return Status::OK();
+    }
+
+    if (current_block_) {
+      // Upload remaining buffer
+      RETURN_NOT_OK(AppendCurrentBlock());
+    }
+
+    RETURN_NOT_OK(Flush());
+    block_blob_client_ = nullptr;
+    closed_ = true;
+    return Status::OK();
+  }
+
+  Future<> CloseAsync() override {
+    if (closed_) {
+      return Status::OK();
+    }
+
+    if (current_block_) {
+      // Upload remaining buffer
+      RETURN_NOT_OK(AppendCurrentBlock());
+    }
+
+    return FlushAsync().Then([self = Self()]() {
+      self->block_blob_client_ = nullptr;
+      self->closed_ = true;
+    });
+  }
+
+  bool closed() const override { return closed_; }
+
+  Status CheckClosed(const char* action) const {
+    if (closed_) {
+      return Status::Invalid("Cannot ", action, " on closed stream.");
+    }
+    return Status::OK();
+  }
+
+  Result<int64_t> Tell() const override {
+    RETURN_NOT_OK(CheckClosed("tell"));
+    return pos_;
+  }
+
+  Status Write(const std::shared_ptr<Buffer>& buffer) override {
+    return DoWrite(buffer->data(), buffer->size(), buffer);
+  }
+
+  Status Write(const void* data, int64_t nbytes) override {
+    return DoWrite(data, nbytes);
+  }
+
+  Status Flush() override {
+    RETURN_NOT_OK(CheckClosed("flush"));
+    if (!initialised_) {
+      // If the stream has not been successfully initialized then there is nothing to
+      // flush. This also avoids some unhandled errors when flushing in the destructor.
+      return Status::OK();
+    }
+
+    Future<> pending_blocks_completed;
+    {
+      std::unique_lock<std::mutex> lock(upload_state_->mutex);
+      pending_blocks_completed = upload_state_->pending_blocks_completed;
+    }
+
+    RETURN_NOT_OK(pending_blocks_completed.status());
+    std::unique_lock<std::mutex> lock(upload_state_->mutex);
+    return CommitBlockList(block_blob_client_, upload_state_->block_ids,
+                           commit_block_list_options_);
+  }
+
+  Future<> FlushAsync() {
+    RETURN_NOT_OK(CheckClosed("flush async"));
+    if (!initialised_) {
+      // If the stream has not been successfully initialized then there is nothing to
+      // flush. This also avoids some unhandled errors when flushing in the destructor.
+      return Status::OK();
+    }
+
+    Future<> pending_blocks_completed;
+    {
+      std::unique_lock<std::mutex> lock(upload_state_->mutex);
+      pending_blocks_completed = upload_state_->pending_blocks_completed;
+    }
+
+    return pending_blocks_completed.Then([self = Self()] {
+      std::unique_lock<std::mutex> lock(self->upload_state_->mutex);
+      return CommitBlockList(self->block_blob_client_, self->upload_state_->block_ids,
+                             self->commit_block_list_options_);
+    });
+  }
+
+ private:
+  Status AppendCurrentBlock() {
+    ARROW_ASSIGN_OR_RAISE(auto buf, current_block_->Finish());
+    current_block_.reset();
+    current_block_size_ = 0;
+    return AppendBlock(buf);
+  }
+
+  Status DoWrite(const void* data, int64_t nbytes,
+                 std::shared_ptr<Buffer> owned_buffer = nullptr) {
+    if (closed_) {
+      return Status::Invalid("Operation on closed stream");
+    }
+
+    const auto* data_ptr = reinterpret_cast<const int8_t*>(data);
+    auto advance_ptr = [this, &data_ptr, &nbytes](const int64_t offset) {
+      data_ptr += offset;
+      nbytes -= offset;
+      pos_ += offset;
+      content_length_ += offset;
+    };
+
+    // Handle case where we have some bytes buffered from prior calls.
+    if (current_block_size_ > 0) {
+      // Try to fill current buffer
+      const int64_t to_copy =
+          std::min(nbytes, kBlockUploadSizeBytes - current_block_size_);
+      RETURN_NOT_OK(current_block_->Write(data_ptr, to_copy));
+      current_block_size_ += to_copy;
+      advance_ptr(to_copy);
+
+      // If buffer isn't full, break
+      if (current_block_size_ < kBlockUploadSizeBytes) {
+        return Status::OK();
+      }
+
+      // Upload current buffer
+      RETURN_NOT_OK(AppendCurrentBlock());
+    }
+
+    // We can upload chunks without copying them into a buffer
+    while (nbytes >= kBlockUploadSizeBytes) {
+      const auto upload_size = std::min(nbytes, kMaxBlockSizeBytes);
+      RETURN_NOT_OK(AppendBlock(data_ptr, upload_size));
+      advance_ptr(upload_size);
+    }
+
+    // Buffer remaining bytes
+    if (nbytes > 0) {
+      current_block_size_ = nbytes;
+
+      if (current_block_ == nullptr) {
+        ARROW_ASSIGN_OR_RAISE(
+            current_block_,
+            io::BufferOutputStream::Create(kBlockUploadSizeBytes, io_context_.pool()));
+      } else {
+        // Re-use the allocation from before.
+        RETURN_NOT_OK(current_block_->Reset(kBlockUploadSizeBytes, io_context_.pool()));
+      }
+
+      RETURN_NOT_OK(current_block_->Write(data_ptr, current_block_size_));
+      pos_ += current_block_size_;
+      content_length_ += current_block_size_;
+    }
+
+    return Status::OK();
+  }
+
+  std::string CreateBlock() {
+    std::unique_lock<std::mutex> lock(upload_state_->mutex);
+    const auto n_block_ids = upload_state_->block_ids.size();
+
+    // New block ID must always be distinct from the existing block IDs. Otherwise we
+    // will accidentally replace the content of existing blocks, causing corruption.
+    // We will use monotonically increasing integers.
+    auto new_block_id = std::to_string(n_block_ids);
+
+    // Pad to 5 digits, because Azure allows a maximum of 50,000 blocks.
+    const size_t target_number_of_digits = 5;
+    const auto required_padding_digits =
+        target_number_of_digits - std::min(target_number_of_digits, new_block_id.size());
+    new_block_id.insert(0, required_padding_digits, '0');
+    // There is a small risk when appending to a blob created by another client that
+    // `new_block_id` may overlapping with an existing block id. Adding the `-arrow`
+    // suffix significantly reduces the risk, but does not 100% eliminate it. For
+    // example if the blob was previously created with one block, with id `00001-arrow`
+    // then the next block we append will conflict with that, and cause corruption.
+    new_block_id += "-arrow";
+    new_block_id = Core::Convert::Base64Encode(
+        std::vector<uint8_t>(new_block_id.begin(), new_block_id.end()));
+
+    upload_state_->block_ids.push_back(new_block_id);
+
+    // We only use the future if we have background writes enabled. Without background
+    // writes the future is initialized as finished and not mutated any more.
+    if (background_writes_ && upload_state_->blocks_in_progress++ == 0) {
+      upload_state_->pending_blocks_completed = Future<>::Make();
+    }
+
+    return new_block_id;
+  }
+
+  Status AppendBlock(const void* data, int64_t nbytes,
+                     std::shared_ptr<Buffer> owned_buffer = nullptr) {
+    RETURN_NOT_OK(CheckClosed("append"));
+
+    if (nbytes == 0) {
+      return Status::OK();
+    }
+
+    const auto block_id = CreateBlock();
+
+    if (background_writes_) {
+      if (owned_buffer == nullptr) {
+        ARROW_ASSIGN_OR_RAISE(owned_buffer, AllocateBuffer(nbytes, io_context_.pool()));
+        memcpy(owned_buffer->mutable_data(), data, nbytes);
+      } else {
+        DCHECK_EQ(data, owned_buffer->data());
+        DCHECK_EQ(nbytes, owned_buffer->size());
+      }
+
+      // The closure keeps the buffer and the upload state alive
+      auto deferred = [owned_buffer, block_id, block_blob_client = block_blob_client_,
+                       state = upload_state_]() mutable -> Status {
+        Core::IO::MemoryBodyStream block_content(owned_buffer->data(),
+                                                 owned_buffer->size());
+
+        auto status = StageBlock(block_blob_client.get(), block_id, block_content);
+        HandleUploadOutcome(state, status);
+        return Status::OK();
+      };
+      RETURN_NOT_OK(io::internal::SubmitIO(io_context_, std::move(deferred)));
+    } else {
+      auto append_data = reinterpret_cast<const uint8_t*>(data);
+      Core::IO::MemoryBodyStream block_content(append_data, nbytes);
+
+      RETURN_NOT_OK(StageBlock(block_blob_client_.get(), block_id, block_content));
+    }
+
+    return Status::OK();
+  }
+
+  Status AppendBlock(std::shared_ptr<Buffer> buffer) {
+    return AppendBlock(buffer->data(), buffer->size(), buffer);
+  }
+
+  static void HandleUploadOutcome(const std::shared_ptr<UploadState>& state,
+                                  const Status& status) {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    if (!status.ok()) {
+      state->status &= status;
+    }
+    // Notify completion
+    if (--state->blocks_in_progress == 0) {
+      auto fut = state->pending_blocks_completed;
+      lock.unlock();
+      fut.MarkFinished(state->status);
+    }
+  }
+
+  std::shared_ptr<Blobs::BlockBlobClient> block_blob_client_;
+  const io::IOContext io_context_;
+  const AzureLocation location_;
+  const bool background_writes_;
+  int64_t content_length_ = kNoSize;
+
+  std::shared_ptr<io::BufferOutputStream> current_block_;
+  int64_t current_block_size_ = 0;
+
+  bool closed_ = false;
+  bool initialised_ = false;
+  int64_t pos_ = 0;
+
+  // This struct is kept alive through background writes to avoid problems
+  // in the completion handler.
+  struct UploadState {
+    std::mutex mutex;
+    std::vector<std::string> block_ids;
+    int64_t blocks_in_progress = 0;
+    Status status;
+    Future<> pending_blocks_completed = Future<>::MakeFinished(Status::OK());
+  };
+  std::shared_ptr<UploadState> upload_state_;
+
+  Blobs::CommitBlockListOptions commit_block_list_options_;
+};
+
+bool IsDfsEmulator(const AzureOptions& options) {
+  return options.dfs_storage_authority != ".dfs.core.windows.net";
+}
+
+}  // namespace
+
+// -----------------------------------------------------------------------
+// internal implementation
+
+namespace internal {
+
+Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
+    const DataLake::DataLakeFileSystemClient& adlfs_client, const AzureOptions& options) {
+  try {
+    auto directory_client = adlfs_client.GetDirectoryClient("");
+    // GetAccessControlList will fail on storage accounts
+    // without hierarchical namespace enabled.
+    directory_client.GetAccessControlList();
+    return HNSSupport::kEnabled;
+  } catch (std::out_of_range& exception) {
+    // Azurite issue detected.
+    DCHECK(IsDfsEmulator(options));
+    return HNSSupport::kDisabled;
+  } catch (const Storage::StorageException& exception) {
+    // Flat namespace storage accounts with "soft delete" enabled return
+    //
+    //   "Conflict - This endpoint does not support BlobStorageEvents
+    //   or SoftDelete. [...]" [1],
+    //
+    // otherwise it returns:
+    //
+    //   "BadRequest - This operation is only supported on a hierarchical namespace
+    //   account."
+    //
+    // [1]:
+    // https://learn.microsoft.com/en-us/answers/questions/1069779/this-endpoint-does-not-support-blobstorageevents-o
+    switch (exception.StatusCode) {
+      case Http::HttpStatusCode::BadRequest:
+      case Http::HttpStatusCode::Conflict:
+        return HNSSupport::kDisabled;
+      case Http::HttpStatusCode::NotFound:
+        if (IsDfsEmulator(options)) {
+          return HNSSupport::kDisabled;
+        }
+        // Did we get an error because of the container not existing?
+        if (IsContainerNotFound(exception)) {
+          return HNSSupport::kContainerNotFound;
+        }
+        [[fallthrough]];
+      default:
+        if (exception.ErrorCode == "HierarchicalNamespaceNotEnabled") {
+          return HNSSupport::kDisabled;
+        }
+        return ExceptionToStatus(exception,
+                                 "Check for Hierarchical Namespace support on '",
+                                 adlfs_client.GetUrl(), "' failed.");
+    }
+  } catch (const Azure::Core::Http::TransportException& exception) {
+    return ExceptionToStatus(exception, "Check for Hierarchical Namespace support on '",
+                             adlfs_client.GetUrl(), "' failed.");
+  } catch (const std::exception& exception) {
+    return Status::UnknownError(
+        "Check for Hierarchical Namespace support on '", adlfs_client.GetUrl(),
+        "' failed: ", typeid(exception).name(), ": ", exception.what());
+  }
+}
+
+}  // namespace internal
+
+// -----------------------------------------------------------------------
+// AzureFilesystem Implementation
+
+namespace {
+
+// In Azure Storage terminology, a "container" and a "filesystem" are the same
+// kind of object, but it can be accessed using different APIs. The Blob Storage
+// API calls it a "container", the Data Lake Storage Gen 2 API calls it a
+// "filesystem". Creating a container using the Blob Storage API will make it
+// accessible using the Data Lake Storage Gen 2 API and vice versa.
+
+const char kDelimiter[] = {internal::kSep, '\0'};
+
+/// \pre location.container is not empty.
+template <class ContainerClient>
+Result<FileInfo> GetContainerPropsAsFileInfo(const AzureLocation& location,
+                                             const ContainerClient& container_client) {
+  DCHECK(!location.container.empty());
+  FileInfo info{location.path.empty() ? location.all : location.container};
+  try {
+    auto properties = container_client.GetProperties();
+    info.set_type(FileType::Directory);
+    info.set_mtime(std::chrono::system_clock::time_point{properties.Value.LastModified});
+    return info;
+  } catch (const Storage::StorageException& exception) {
+    if (IsContainerNotFound(exception)) {
+      info.set_type(FileType::NotFound);
+      return info;
+    }
+    return ExceptionToStatus(exception, "GetProperties for '", container_client.GetUrl(),
+                             "' failed.");
+  }
+}
+
+template <class ContainerClient>
+Status CreateContainerIfNotExists(const std::string& container_name,
+                                  const ContainerClient& container_client) {
+  try {
+    container_client.CreateIfNotExists();
+    return Status::OK();
+  } catch (const Storage::StorageException& exception) {
+    return ExceptionToStatus(exception, "Failed to create a container: ", container_name,
+                             ": ", container_client.GetUrl());
+  }
+}
+
+FileInfo FileInfoFromPath(std::string_view container,
+                          const DataLake::Models::PathItem& path) {
+  FileInfo info{internal::ConcatAbstractPath(container, path.Name),
+                path.IsDirectory ? FileType::Directory : FileType::File};
+  info.set_size(path.FileSize);
+  info.set_mtime(std::chrono::system_clock::time_point{path.LastModified});
+  return info;
+}
+
+FileInfo DirectoryFileInfoFromPath(std::string_view path) {
+  return FileInfo{std::string{internal::RemoveTrailingSlash(path)}, FileType::Directory};
+}
+
+FileInfo FileInfoFromBlob(std::string_view container,
+                          const Blobs::Models::BlobItem& blob) {
+  auto path = internal::ConcatAbstractPath(container, blob.Name);
+  if (internal::HasTrailingSlash(blob.Name)) {
+    return DirectoryFileInfoFromPath(path);
+  }
+  FileInfo info{std::move(path), FileType::File};
+  info.set_size(blob.BlobSize);
+  info.set_mtime(std::chrono::system_clock::time_point{blob.Details.LastModified});
+  return info;
+}
+
+/// \brief RAII-style guard for releasing a lease on a blob or container.
+///
+/// The guard should be constructed right after a successful BlobLeaseClient::Acquire()
+/// call. Use std::optional<LeaseGuard> to declare a guard in outer scope and construct it
+/// later with std::optional::emplace(...).
+///
+/// Leases expire automatically, but explicit release means concurrent clients or
+/// ourselves when trying new operations on the same blob or container don't have
+/// to wait for the lease to expire by itself.
+///
+/// Learn more about leases at
+/// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob
+class LeaseGuard {
+ public:
+  using SteadyClock = std::chrono::steady_clock;
+
+ private:
+  /// \brief The time when the lease expires or is broken.
+  ///
+  /// The lease is not guaranteed to be valid until this time, but it is guaranteed to
+  /// be expired after this time. In other words, this is an overestimation of
+  /// the true time_point.
+  SteadyClock::time_point break_or_expires_at_;
+  const std::unique_ptr<Blobs::BlobLeaseClient> lease_client_;
+  bool release_attempt_pending_ = true;
+
+  /// \brief The latest known expiry time of a lease guarded by this class
+  /// that failed to be released or was forgotten by calling Forget().
+  static std::atomic<SteadyClock::time_point> latest_known_expiry_time_;
+
+  /// \brief The maximum lease duration supported by Azure Storage.
+  static constexpr std::chrono::seconds kMaxLeaseDuration{60};
+
+ public:
+  LeaseGuard(std::unique_ptr<Blobs::BlobLeaseClient> lease_client,
+             std::chrono::seconds lease_duration)
+      : break_or_expires_at_(SteadyClock::now() +
+                             std::min(kMaxLeaseDuration, lease_duration)),
+        lease_client_(std::move(lease_client)) {
+    DCHECK(lease_duration <= kMaxLeaseDuration);
+    DCHECK(this->lease_client_);
+  }
+
+  ARROW_DISALLOW_COPY_AND_ASSIGN(LeaseGuard);
+
+  ~LeaseGuard() {
+    // No point in trying any error handling here other than the debug checking. The lease
+    // will eventually expire on the backend without any intervention from us (just much
+    // later than if we released it).
+    [[maybe_unused]] auto status = Release();
+    ARROW_LOG(DEBUG) << status;
+  }
+
+  bool PendingRelease() const {
+    return release_attempt_pending_ && SteadyClock::now() <= break_or_expires_at_;
+  }
+
+ private:
+  Status DoRelease() {
+    DCHECK(release_attempt_pending_);
+    try {
+      lease_client_->Release();
+    } catch (const Storage::StorageException& exception) {
+      return ExceptionToStatus(exception, "Failed to release the ",
+                               lease_client_->GetLeaseId(), " lease");
+    }
+    return Status::OK();
+  }
+
+ public:
+  std::string LeaseId() const { return lease_client_->GetLeaseId(); }
+
+  bool StillValidFor(SteadyClock::duration expected_time_left) const {
+    return SteadyClock::now() + expected_time_left < break_or_expires_at_;
+  }
+
+  /// \brief Break the lease.
+  ///
+  /// The lease will stay in the "Breaking" state for break_period seconds or
+  /// less if the lease is expiring before that.
+  ///
+  /// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-container#outcomes-of-use-attempts-on-containers-by-lease-state
+  /// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob#outcomes-of-use-attempts-on-blobs-by-lease-state
+  Status Break(Azure::Nullable<std::chrono::seconds> break_period = {}) {
+    auto remaining_time_ms = [this]() {
+      const auto remaining_time = break_or_expires_at_ - SteadyClock::now();
+      return std::chrono::duration_cast<std::chrono::milliseconds>(remaining_time);
+    };
+#ifndef NDEBUG
+    if (break_period.HasValue() && !StillValidFor(*break_period)) {
+      ARROW_LOG(WARNING)
+          << "Azure Storage: requested break_period ("
+          << break_period.ValueOr(std::chrono::seconds{0}).count()
+          << "s) is too long or lease duration is too short for all the operations "
+             "performed so far (lease expires in "
+          << remaining_time_ms().count() << "ms)";
+    }
+#endif
+    Blobs::BreakLeaseOptions options;
+    options.BreakPeriod = break_period;
+    try {
+      lease_client_->Break(options);
+      break_or_expires_at_ =
+          std::min(break_or_expires_at_,
+                   SteadyClock::now() + break_period.ValueOr(std::chrono::seconds{0}));
+    } catch (const Storage::StorageException& exception) {
+      return ExceptionToStatus(exception, "Failed to break the ",
+                               lease_client_->GetLeaseId(), " lease expiring in ",
+                               remaining_time_ms().count(), "ms");
+    }
+    return Status::OK();
+  }
+
+  /// \brief Break the lease before deleting or renaming the resource via the
+  /// DataLakeFileSystemClient API.
+  ///
+  /// NOTE: When using the Blobs API, this is not necessary -- you can release a
+  /// lease on a path after it's deleted with a lease on it.
+  ///
+  /// Calling this is recommended when the resource for which the lease was acquired is
+  /// about to be deleted as there is no way of releasing the lease after that, we can
+  /// only forget about it. The break_period should be a conservative estimate of the time
+  /// it takes to delete/rename the resource.
+  ///
+  /// If break_period is too small, the delete/rename will fail with a lease conflict,
+  /// and if it's too large the only consequence is that a lease on a non-existent
+  /// resource will remain in the "Breaking" state for a while blocking others
+  /// from recreating the resource.
+  void BreakBeforeDeletion(std::chrono::seconds break_period) {
+    ARROW_CHECK_OK(Break(break_period));
+  }
+
+  // These functions are marked ARROW_NOINLINE because they are called from
+  // multiple locations, but are not performance-critical.
+
+  ARROW_NOINLINE Status Release() {
+    if (!PendingRelease()) {
+      return Status::OK();
+    }
+    auto status = DoRelease();
+    if (!status.ok()) {
+      Forget();
+      return status;
+    }
+    release_attempt_pending_ = false;
+    return Status::OK();
+  }
+
+  /// \brief Prevent any release attempts in the destructor.
+  ///
+  /// When it's known they would certainly fail.
+  /// \see LeaseGuard::BreakBeforeDeletion()
+  ARROW_NOINLINE void Forget() {
+    if (!PendingRelease()) {
+      release_attempt_pending_ = false;
+      return;
+    }
+    release_attempt_pending_ = false;
+    // Remember the latest known expiry time so we can gracefully handle lease
+    // acquisition failures by waiting until the latest forgotten lease.
+    auto latest = latest_known_expiry_time_.load(std::memory_order_relaxed);
+    while (
+        latest < break_or_expires_at_ &&
+        !latest_known_expiry_time_.compare_exchange_weak(latest, break_or_expires_at_)) {
+    }
+    DCHECK_GE(latest_known_expiry_time_.load(), break_or_expires_at_);
+  }
+
+  ARROW_NOINLINE static void WaitUntilLatestKnownExpiryTime() {
+    auto remaining_time = latest_known_expiry_time_.load() - SteadyClock::now();
+#ifndef NDEBUG
+    int64_t remaining_time_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(remaining_time).count();
+    ARROW_LOG(WARNING) << "LeaseGuard::WaitUntilLatestKnownExpiryTime for "
+                       << remaining_time_ms << "ms...";
+#endif
+    DCHECK(remaining_time <= kMaxLeaseDuration);
+    if (remaining_time > SteadyClock::duration::zero()) {
+      std::this_thread::sleep_for(remaining_time);
+    }
+  }
+};
+
+}  // namespace
+
+class AzureFileSystem::Impl {
+ private:
+  io::IOContext io_context_;
+  AzureOptions options_;
+
+  std::unique_ptr<DataLake::DataLakeServiceClient> datalake_service_client_;
+  std::unique_ptr<Blobs::BlobServiceClient> blob_service_client_;
+  HNSSupport cached_hns_support_ = HNSSupport::kUnknown;
+
+  Impl(AzureOptions options, io::IOContext io_context)
+      : io_context_(std::move(io_context)), options_(std::move(options)) {}
+
+ public:
+  static Result<std::unique_ptr<AzureFileSystem::Impl>> Make(AzureOptions options,
+                                                             io::IOContext io_context) {
+    auto self = std::unique_ptr<AzureFileSystem::Impl>(
+        new AzureFileSystem::Impl(std::move(options), std::move(io_context)));
+    ARROW_ASSIGN_OR_RAISE(self->blob_service_client_,
+                          self->options_.MakeBlobServiceClient());
+    ARROW_ASSIGN_OR_RAISE(self->datalake_service_client_,
+                          self->options_.MakeDataLakeServiceClient());
+    return self;
+  }
+
+  io::IOContext& io_context() { return io_context_; }
+  const AzureOptions& options() const { return options_; }
+
+  Blobs::BlobContainerClient GetBlobContainerClient(const std::string& container_name) {
+    return blob_service_client_->GetBlobContainerClient(container_name);
+  }
+
+  Blobs::BlobClient GetBlobClient(const std::string& container_name,
+                                  const std::string& blob_name) {
+    return GetBlobContainerClient(container_name).GetBlobClient(blob_name);
+  }
+
+  /// \param container_name Also known as "filesystem" in the ADLS Gen2 API.
+  DataLake::DataLakeFileSystemClient GetFileSystemClient(
+      const std::string& container_name) {
+    return datalake_service_client_->GetFileSystemClient(container_name);
+  }
+
+  /// \brief Memoized version of CheckIfHierarchicalNamespaceIsEnabled.
+  ///
+  /// \return kEnabled/kDisabled/kContainerNotFound (kUnknown is never returned).
+  Result<HNSSupport> HierarchicalNamespaceSupport(
+      const DataLake::DataLakeFileSystemClient& adlfs_client) {
+    switch (cached_hns_support_) {
+      case HNSSupport::kEnabled:
+      case HNSSupport::kDisabled:
+        return cached_hns_support_;
+      case HNSSupport::kUnknown:
+      case HNSSupport::kContainerNotFound:
+        // Try the check again because the support is still unknown or the container
+        // that didn't exist before may exist now.
+        break;
+    }
+    ARROW_ASSIGN_OR_RAISE(
+        auto hns_support,
+        internal::CheckIfHierarchicalNamespaceIsEnabled(adlfs_client, options_));
+    DCHECK_NE(hns_support, HNSSupport::kUnknown);
+    if (hns_support == HNSSupport::kContainerNotFound) {
+      // Caller should handle kContainerNotFound case appropriately as it knows the
+      // container this refers to, but the cached value in that case should remain
+      // kUnknown before we get a CheckIfHierarchicalNamespaceIsEnabled result that
+      // is not kContainerNotFound.
+      cached_hns_support_ = HNSSupport::kUnknown;
+    } else {
+      cached_hns_support_ = hns_support;
+    }
+    return hns_support;
+  }
+
+  /// This is used from unit tests to ensure we perform operations on all the
+  /// possible states of cached_hns_support_.
+  void ForceCachedHierarchicalNamespaceSupport(int support) {
+    auto hns_support = static_cast<HNSSupport>(support);
+    switch (hns_support) {
+      case HNSSupport::kUnknown:
+      case HNSSupport::kContainerNotFound:
+      case HNSSupport::kDisabled:
+      case HNSSupport::kEnabled:
+        cached_hns_support_ = hns_support;
+        return;
+    }
+    // This is reachable if an invalid int is cast to enum class HNSSupport.
+    DCHECK(false) << "Invalid enum HierarchicalNamespaceSupport value.";
+  }
+
+  /// \pre location.path is not empty.
+  Result<FileInfo> GetFileInfo(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                               const AzureLocation& location,
+                               Azure::Nullable<std::string> lease_id = {}) {
+    auto file_client = adlfs_client.GetFileClient(location.path);
+    DataLake::GetPathPropertiesOptions options;
+    options.AccessConditions.LeaseId = std::move(lease_id);
+    try {
+      FileInfo info{location.all};
+      auto properties = file_client.GetProperties(options);
+      if (properties.Value.IsDirectory) {
+        info.set_type(FileType::Directory);
+      } else if (internal::HasTrailingSlash(location.path)) {
+        // For a path with a trailing slash, a Hierarchical Namespace storage account
+        // may recognize a file (path with trailing slash removed). For consistency
+        // with other arrow::FileSystem implementations we chose to return NotFound
+        // because the trailing slash means the user was looking for a directory.
+        info.set_type(FileType::NotFound);
+        return info;
+      } else {
+        info.set_type(FileType::File);
+        info.set_size(properties.Value.FileSize);
+      }
+      info.set_mtime(
+          std::chrono::system_clock::time_point{properties.Value.LastModified});
+      return info;
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        return FileInfo{location.all, FileType::NotFound};
+      }
+      return ExceptionToStatus(
+          exception, "GetProperties for '", file_client.GetUrl(),
+          "' failed. GetFileInfo is unable to determine whether the path exists.");
+    }
+  }
+
+  /// On flat namespace accounts there are no real directories. Directories are
+  /// implied by empty directory marker blobs with names ending in "/" or there
+  /// being blobs with names starting with the directory path.
+  ///
+  /// \pre location.path is not empty.
+  Result<FileInfo> GetFileInfo(const Blobs::BlobContainerClient& container_client,
+                               const AzureLocation& location) {
+    DCHECK(!location.path.empty());
+    Blobs::ListBlobsOptions options;
+    options.Prefix = internal::RemoveTrailingSlash(location.path);
+    options.PageSizeHint = 1;
+
+    try {
+      FileInfo info{location.all};
+      auto list_response = container_client.ListBlobsByHierarchy(kDelimiter, options);
+      // Since PageSizeHint=1, we expect at most one entry in either Blobs or
+      // BlobPrefixes. A BlobPrefix always ends with kDelimiter ("/"), so we can
+      // distinguish between a directory and a file by checking if we received a
+      // prefix or a blob.
+      // This strategy allows us to implement GetFileInfo with just 1 blob storage
+      // operation in almost every case.
+      if (!list_response.BlobPrefixes.empty()) {
+        // Ensure the returned BlobPrefixes[0] string doesn't contain more characters than
+        // the requested Prefix. For instance, if we request with Prefix="dir/abra" and
+        // the container contains "dir/abracadabra/" but not "dir/abra/", we will get back
+        // "dir/abracadabra/" in the BlobPrefixes list. If "dir/abra/" existed,
+        // it would be returned instead because it comes before "dir/abracadabra/" in the
+        // lexicographic order guaranteed by ListBlobsByHierarchy.
+        const auto& blob_prefix = list_response.BlobPrefixes[0];
+        if (blob_prefix == internal::EnsureTrailingSlash(location.path)) {
+          info.set_type(FileType::Directory);
+          return info;
+        }
+      }
+      if (!list_response.Blobs.empty()) {
+        const auto& blob = list_response.Blobs[0];
+        if (blob.Name == location.path) {
+          info.set_type(FileType::File);
+          info.set_size(blob.BlobSize);
+          info.set_mtime(
+              std::chrono::system_clock::time_point{blob.Details.LastModified});
+          return info;
+        } else if (blob.Name[options.Prefix.Value().length()] < internal::kSep) {
+          // First list result did not indicate a directory and there is definitely no
+          // exactly matching blob. However, there may still be a directory that we
+          // initially missed because the first list result came before
+          // `options.Prefix + internal::kSep` lexigraphically.
+          // For example the flat namespace storage account has the following blobs:
+          // - container/dir.txt
+          // - container/dir/file.txt
+          // GetFileInfo(container/dir) should return FileType::Directory but in this
+          // edge case `blob = "dir.txt"`, so without further checks we would incorrectly
+          // return FileType::NotFound.
+          // Therefore we make an extra list operation with the trailing slash to confirm
+          // whether the path is a directory.
+          options.Prefix = internal::EnsureTrailingSlash(location.path);
+          auto list_with_trailing_slash_response = container_client.ListBlobs(options);
+          if (!list_with_trailing_slash_response.Blobs.empty()) {
+            info.set_type(FileType::Directory);
+            return info;
+          }
+        }
+      }
+      info.set_type(FileType::NotFound);
+      return info;
+    } catch (const Storage::StorageException& exception) {
+      if (IsContainerNotFound(exception)) {
+        return FileInfo{location.all, FileType::NotFound};
+      }
+      return ExceptionToStatus(
+          exception, "ListBlobsByHierarchy failed for prefix='", *options.Prefix,
+          "'. GetFileInfo is unable to determine whether the path exists.");
+    }
+  }
+
+  Result<FileInfo> GetFileInfoOfPathWithinContainer(const AzureLocation& location) {
+    DCHECK(!location.container.empty() && !location.path.empty());
+    // There is a path to search within the container. Check HNS support to proceed.
+    auto adlfs_client = GetFileSystemClient(location.container);
+    ARROW_ASSIGN_OR_RAISE(auto hns_support, HierarchicalNamespaceSupport(adlfs_client));
+    if (hns_support == HNSSupport::kContainerNotFound) {
+      return FileInfo{location.all, FileType::NotFound};
+    }
+    if (hns_support == HNSSupport::kEnabled) {
+      return GetFileInfo(adlfs_client, location);
+    }
+    DCHECK_EQ(hns_support, HNSSupport::kDisabled);
+    auto container_client = GetBlobContainerClient(location.container);
+    return GetFileInfo(container_client, location);
+  }
+
+ private:
+  /// \pre location.container is not empty.
+  template <typename ContainerClient>
+  Status CheckDirExists(const ContainerClient& container_client,
+                        const AzureLocation& location) {
+    DCHECK(!location.container.empty());
+    FileInfo info;
+    if (location.path.empty()) {
+      ARROW_ASSIGN_OR_RAISE(info,
+                            GetContainerPropsAsFileInfo(location, container_client));
+    } else {
+      ARROW_ASSIGN_OR_RAISE(info, GetFileInfo(container_client, location));
+    }
+    if (info.type() == FileType::NotFound) {
+      return PathNotFound(location);
+    }
+    if (info.type() != FileType::Directory) {
+      return NotADir(location);
+    }
+    return Status::OK();
+  }
+
+  template <typename OnContainer>
+  Status VisitContainers(const Core::Context& context, OnContainer&& on_container) const {
+    Blobs::ListBlobContainersOptions options;
+    try {
+      auto container_list_response =
+          blob_service_client_->ListBlobContainers(options, context);
+      for (; container_list_response.HasPage();
+           container_list_response.MoveToNextPage(context)) {
+        for (const auto& container : container_list_response.BlobContainers) {
+          RETURN_NOT_OK(on_container(container));
+        }
+      }
+    } catch (const Storage::StorageException& exception) {
+      return ExceptionToStatus(exception, "Failed to list account containers.");
+    }
+    return Status::OK();
+  }
+
+  static std::string_view BasenameView(std::string_view s) {
+    DCHECK(!internal::HasTrailingSlash(s));
+    auto offset = s.find_last_of(internal::kSep);
+    auto result = (offset == std::string_view::npos) ? s : s.substr(offset);
+    DCHECK(!result.empty() && result.back() != internal::kSep);
+    return result;
+  }
+
+  /// \brief List the paths at the root of a filesystem or some dir in a filesystem.
+  ///
+  /// \pre adlfs_client is the client for the filesystem named like the first
+  /// segment of select.base_dir. The filesystem is know to exist.
+  Status GetFileInfoWithSelectorFromFileSystem(
+      const DataLake::DataLakeFileSystemClient& adlfs_client,
+      const Core::Context& context, Azure::Nullable<int32_t> page_size_hint,
+      const FileSelector& select, FileInfoVector* acc_results) {
+    ARROW_ASSIGN_OR_RAISE(auto base_location, AzureLocation::FromString(select.base_dir));
+
+    // The filesystem a.k.a. the container is known to exist so if the path is empty then
+    // we have already found the base_location, so initialize found to true.
+    bool found = base_location.path.empty();
+
+    auto directory_client = adlfs_client.GetDirectoryClient(base_location.path);
+    DataLake::ListPathsOptions options;
+    options.PageSizeHint = page_size_hint;
+
+    auto base_path_depth = internal::GetAbstractPathDepth(base_location.path);
+    try {
+      auto list_response = directory_client.ListPaths(select.recursive, options, context);
+      for (; list_response.HasPage(); list_response.MoveToNextPage(context)) {
+        if (list_response.Paths.empty()) {
+          continue;
+        }
+        found = true;
+        for (const auto& path : list_response.Paths) {
+          if (path.Name == base_location.path && !path.IsDirectory) {
+            return NotADir(base_location);
+          }
+          // Subtract 1 because with `max_recursion=0` we want to list the base path,
+          // which will produce results with depth 1 greater that the base path's depth.
+          // NOTE: `select.max_recursion` + anything will cause integer overflows because
+          // `select.max_recursion` defaults to `INT32_MAX`. Therefore, options to
+          // rewrite this condition in a more readable way are limited.
+          if (internal::GetAbstractPathDepth(path.Name) - base_path_depth - 1 <=
+              select.max_recursion) {
+            acc_results->push_back(FileInfoFromPath(base_location.container, path));
+          }
+        }
+      }
+    } catch (const Storage::StorageException& exception) {
+      if (IsContainerNotFound(exception) || exception.ErrorCode == "PathNotFound") {
+        found = false;
+      } else {
+        return ExceptionToStatus(exception,
+                                 "Failed to list paths in a directory: ", select.base_dir,
+                                 ": ", directory_client.GetUrl());
+      }
+    }
+
+    return found || select.allow_not_found
+               ? Status::OK()
+               : ::arrow::fs::internal::PathNotFound(select.base_dir);
+  }
+
+  /// \brief List the blobs at the root of a container or some dir in a container.
+  ///
+  /// \pre container_client is the client for the container named like the first
+  /// segment of select.base_dir.
+  Status GetFileInfoWithSelectorFromContainer(
+      const Blobs::BlobContainerClient& container_client, const Core::Context& context,
+      Azure::Nullable<int32_t> page_size_hint, const FileSelector& select,
+      FileInfoVector* acc_results) {
+    ARROW_ASSIGN_OR_RAISE(auto base_location, AzureLocation::FromString(select.base_dir));
+
+    bool found = false;
+    Blobs::ListBlobsOptions options;
+    if (internal::IsEmptyPath(base_location.path)) {
+      // If the base_dir is the root of the container, then we want to list all blobs in
+      // the container and the Prefix should be empty and not even include the trailing
+      // slash because the container itself represents the `<container>/` directory.
+      options.Prefix = {};
+      found = true;  // Unless the container itself is not found later!
+    } else {
+      options.Prefix = internal::EnsureTrailingSlash(base_location.path);
+    }
+    options.PageSizeHint = page_size_hint;
+    options.Include = Blobs::Models::ListBlobsIncludeFlags::Metadata;
+
+    auto recurse = [&](const std::string& blob_prefix) noexcept -> Status {
+      if (select.recursive && select.max_recursion > 0) {
+        FileSelector sub_select;
+        sub_select.base_dir = internal::ConcatAbstractPath(
+            base_location.container, internal::RemoveTrailingSlash(blob_prefix));
+        sub_select.allow_not_found = true;
+        sub_select.recursive = true;
+        sub_select.max_recursion = select.max_recursion - 1;
+        return GetFileInfoWithSelectorFromContainer(
+            container_client, context, page_size_hint, sub_select, acc_results);
+      }
+      return Status::OK();
+    };
+
+    auto process_blob = [&](const Blobs::Models::BlobItem& blob) noexcept {
+      // blob.Name has trailing slash only when Prefix is an empty
+      // directory marker blob for the directory we're listing
+      // from, and we should skip it.
+      if (!internal::HasTrailingSlash(blob.Name)) {
+        acc_results->push_back(FileInfoFromBlob(base_location.container, blob));
+      }
+    };
+    auto process_prefix = [&](const std::string& prefix) noexcept -> Status {
+      const auto path = internal::ConcatAbstractPath(base_location.container, prefix);
+      acc_results->push_back(DirectoryFileInfoFromPath(path));
+      return recurse(prefix);
+    };
+
+    try {
+      auto list_response =
+          container_client.ListBlobsByHierarchy(/*delimiter=*/"/", options, context);
+      for (; list_response.HasPage(); list_response.MoveToNextPage(context)) {
+        if (list_response.Blobs.empty() && list_response.BlobPrefixes.empty()) {
+          continue;
+        }
+        found = true;
+        // Blob and BlobPrefixes are sorted by name, so we can merge-iterate
+        // them to ensure returned results are all sorted.
+        size_t blob_index = 0;
+        size_t blob_prefix_index = 0;
+        while (blob_index < list_response.Blobs.size() &&
+               blob_prefix_index < list_response.BlobPrefixes.size()) {
+          const auto& blob = list_response.Blobs[blob_index];
+          const auto& prefix = list_response.BlobPrefixes[blob_prefix_index];
+          const int cmp = blob.Name.compare(prefix);
+          if (cmp < 0) {
+            process_blob(blob);
+            blob_index += 1;
+          } else if (cmp > 0) {
+            RETURN_NOT_OK(process_prefix(prefix));
+            blob_prefix_index += 1;
+          } else {
+            DCHECK_EQ(blob.Name, prefix);
+            RETURN_NOT_OK(process_prefix(prefix));
+            blob_index += 1;
+            blob_prefix_index += 1;
+            // If the container has an empty dir marker blob and another blob starting
+            // with this blob name as a prefix, the blob doesn't appear in the listing
+            // that also contains the prefix, so AFAICT this branch in unreachable. The
+            // code above is kept just in case, but if this DCHECK(false) is ever reached,
+            // we should refactor this loop to ensure no duplicate entries are ever
+            // reported.
+            DCHECK(false)
+                << "Unexpected blob/prefix name collision on the same listing request";
+          }
+        }
+        for (; blob_index < list_response.Blobs.size(); blob_index++) {
+          process_blob(list_response.Blobs[blob_index]);
+        }
+        for (; blob_prefix_index < list_response.BlobPrefixes.size();
+             blob_prefix_index++) {
+          RETURN_NOT_OK(process_prefix(list_response.BlobPrefixes[blob_prefix_index]));
+        }
+      }
+    } catch (const Storage::StorageException& exception) {
+      if (IsContainerNotFound(exception)) {
+        found = false;
+      } else {
+        return ExceptionToStatus(exception,
+                                 "Failed to list blobs in a directory: ", select.base_dir,
+                                 ": ", container_client.GetUrl());
+      }
+    }
+
+    return found || select.allow_not_found
+               ? Status::OK()
+               : ::arrow::fs::internal::PathNotFound(select.base_dir);
+  }
+
+ public:
+  Status GetFileInfoWithSelector(const Core::Context& context,
+                                 Azure::Nullable<int32_t> page_size_hint,
+                                 const FileSelector& select,
+                                 FileInfoVector* acc_results) {
+    ARROW_ASSIGN_OR_RAISE(auto base_location, AzureLocation::FromString(select.base_dir));
+
+    if (base_location.container.empty()) {
+      // Without a container, the base_location is equivalent to the filesystem
+      // root -- `/`. FileSelector::allow_not_found doesn't matter in this case
+      // because the root always exists.
+      auto on_container = [&](const Blobs::Models::BlobContainerItem& container) {
+        // Deleted containers are not listed by ListContainers.
+        DCHECK(!container.IsDeleted);
+
+        // Every container is considered a directory.
+        FileInfo info{container.Name, FileType::Directory};
+        info.set_mtime(
+            std::chrono::system_clock::time_point{container.Details.LastModified});
+        acc_results->push_back(std::move(info));
+
+        // Recurse into containers (subdirectories) if requested.
+        if (select.recursive && select.max_recursion > 0) {
+          FileSelector sub_select;
+          sub_select.base_dir = container.Name;
+          sub_select.allow_not_found = true;
+          sub_select.recursive = true;
+          sub_select.max_recursion = select.max_recursion - 1;
+          ARROW_RETURN_NOT_OK(
+              GetFileInfoWithSelector(context, page_size_hint, sub_select, acc_results));
+        }
+        return Status::OK();
+      };
+      return VisitContainers(context, std::move(on_container));
+    }
+
+    auto adlfs_client = GetFileSystemClient(base_location.container);
+    ARROW_ASSIGN_OR_RAISE(auto hns_support, HierarchicalNamespaceSupport(adlfs_client));
+    if (hns_support == HNSSupport::kContainerNotFound) {
+      if (select.allow_not_found) {
+        return Status::OK();
+      } else {
+        return ::arrow::fs::internal::PathNotFound(select.base_dir);
+      }
+    }
+    if (hns_support == HNSSupport::kEnabled) {
+      return GetFileInfoWithSelectorFromFileSystem(adlfs_client, context, page_size_hint,
+                                                   select, acc_results);
+    }
+    DCHECK_EQ(hns_support, HNSSupport::kDisabled);
+    auto container_client =
+        blob_service_client_->GetBlobContainerClient(base_location.container);
+    return GetFileInfoWithSelectorFromContainer(container_client, context, page_size_hint,
+                                                select, acc_results);
+  }
+
+  Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const AzureLocation& location,
+                                                         AzureFileSystem* fs) {
+    RETURN_NOT_OK(ValidateFileLocation(location));
+    auto blob_client = std::make_shared<Blobs::BlobClient>(
+        GetBlobClient(location.container, location.path));
+
+    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(),
+                                                 std::move(location));
+    RETURN_NOT_OK(ptr->Init());
+    return ptr;
+  }
+
+  Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const FileInfo& info,
+                                                         AzureFileSystem* fs) {
+    if (info.type() == FileType::NotFound) {
+      return ::arrow::fs::internal::PathNotFound(info.path());
+    }
+    if (info.type() != FileType::File && info.type() != FileType::Unknown) {
+      return ::arrow::fs::internal::NotAFile(info.path());
+    }
+    ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(info.path()));
+    RETURN_NOT_OK(ValidateFileLocation(location));
+    auto blob_client = std::make_shared<Blobs::BlobClient>(
+        GetBlobClient(location.container, location.path));
+
+    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(),
+                                                 std::move(location), info.size());
+    RETURN_NOT_OK(ptr->Init());
+    return ptr;
+  }
+
+ private:
+  /// This function cannot assume the filesystem/container already exists.
+  ///
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  template <class ContainerClient, class CreateDirIfNotExists>
+  Status CreateDirTemplate(const ContainerClient& container_client,
+                           CreateDirIfNotExists&& create_if_not_exists,
+                           const AzureLocation& location, bool recursive) {
+    DCHECK(!location.container.empty());
+    DCHECK(!location.path.empty());
+    if (recursive) {
+      // Recursive CreateDir calls require that all path segments be
+      // either a directory or not found.
+
+      // Check each path segment is a directory or not
+      // found. Nonexistent segments are collected to
+      // nonexistent_locations. We'll create directories for
+      // nonexistent segments later.
+      std::vector<AzureLocation> nonexistent_locations;
+      for (auto prefix = location; !prefix.path.empty(); prefix = prefix.parent()) {
+        ARROW_ASSIGN_OR_RAISE(auto info, GetFileInfo(container_client, prefix));
+        if (info.type() == FileType::File) {
+          return NotADir(prefix);
+        }
+        if (info.type() == FileType::NotFound) {
+          nonexistent_locations.push_back(prefix);
+        }
+      }
+      // Ensure container exists
+      ARROW_ASSIGN_OR_RAISE(auto container,
+                            AzureLocation::FromString(location.container));
+      ARROW_ASSIGN_OR_RAISE(auto container_info,
+                            GetContainerPropsAsFileInfo(container, container_client));
+      if (container_info.type() == FileType::NotFound) {
+        try {
+          container_client.CreateIfNotExists();
+        } catch (const Storage::StorageException& exception) {
+          return ExceptionToStatus(exception, "Failed to create directory '",
+                                   location.all, "': ", container_client.GetUrl());
+        }
+      }
+      // Create nonexistent directories from shorter to longer:
+      //
+      // Example:
+      //
+      // * location: /container/a/b/c/d/
+      // * Nonexistent path segments:
+      //   * /container/a/
+      //   * /container/a/c/
+      //   * /container/a/c/d/
+      // * target_locations:
+      //   1. /container/a/c/d/
+      //   2. /container/a/c/
+      //   3. /container/a/
+      //
+      // Create order:
+      //   1. /container/a/
+      //   2. /container/a/c/
+      //   3. /container/a/c/d/
+      for (size_t i = nonexistent_locations.size(); i > 0; --i) {
+        const auto& nonexistent_location = nonexistent_locations[i - 1];
+        try {
+          create_if_not_exists(container_client, nonexistent_location);
+        } catch (const Storage::StorageException& exception) {
+          return ExceptionToStatus(exception, "Failed to create directory '",
+                                   location.all, "': ", container_client.GetUrl());
+        }
+      }
+      return Status::OK();
+    } else {
+      // Non-recursive CreateDir calls require the parent directory to exist.
+      auto parent = location.parent();
+      if (!parent.path.empty()) {
+        RETURN_NOT_OK(CheckDirExists(container_client, parent));
+      }
+      // If the parent location is just the container, we don't need to check if it
+      // exists because the operation we perform below will fail if the container
+      // doesn't exist and we can handle that error according to the recursive flag.
+      try {
+        create_if_not_exists(container_client, location);
+        return Status::OK();
+      } catch (const Storage::StorageException& exception) {
+        if (IsContainerNotFound(exception)) {
+          auto parent = location.parent();
+          return PathNotFound(parent);
+        }
+        return ExceptionToStatus(exception, "Failed to create directory '", location.all,
+                                 "': ", container_client.GetUrl());
+      }
+    }
+  }
+
+ public:
+  /// This function cannot assume the filesystem already exists.
+  ///
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  Status CreateDirOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                               const AzureLocation& location, bool recursive) {
+    return CreateDirTemplate(
+        adlfs_client,
+        [](const auto& adlfs_client, const auto& location) {
+          auto directory_client = adlfs_client.GetDirectoryClient(
+              std::string(internal::RemoveTrailingSlash(location.path)));
+          directory_client.CreateIfNotExists();
+        },
+        location, recursive);
+  }
+
+  /// This function cannot assume the container already exists.
+  ///
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  Status CreateDirOnContainer(const Blobs::BlobContainerClient& container_client,
+                              const AzureLocation& location, bool recursive) {
+    return CreateDirTemplate(
+        container_client,
+        [this](const auto& container_client, const auto& location) {
+          EnsureEmptyDirExistsImplThatThrows(container_client, location.path);
+        },
+        location, recursive);
+  }
+
+  Result<std::shared_ptr<ObjectAppendStream>> OpenAppendStream(
+      const AzureLocation& location,
+      const std::shared_ptr<const KeyValueMetadata>& metadata, const bool truncate,
+      AzureFileSystem* fs) {
+    RETURN_NOT_OK(ValidateFileLocation(location));
+
+    const auto blob_container_client = GetBlobContainerClient(location.container);
+    auto block_blob_client = std::make_shared<Blobs::BlockBlobClient>(
+        blob_container_client.GetBlockBlobClient(location.path));
+
+    auto ensure_not_flat_namespace_directory = [this, location,
+                                                blob_container_client]() -> Status {
+      ARROW_ASSIGN_OR_RAISE(
+          auto hns_support,
+          HierarchicalNamespaceSupport(GetFileSystemClient(location.container)));
+      if (hns_support == HNSSupport::kDisabled) {
+        // Flat namespace so we need to GetFileInfo in-case its a directory.
+        ARROW_ASSIGN_OR_RAISE(auto status, GetFileInfo(blob_container_client, location))
+        if (status.type() == FileType::Directory) {
+          return NotAFile(location);
+        }
+      }
+      // kContainerNotFound - it doesn't exist, so no need to check if its a directory.
+      // kEnabled - hierarchical namespace so Azure APIs will fail if its a directory. We
+      // don't need to explicitly check.
+      return Status::OK();
+    };
+
+    std::shared_ptr<ObjectAppendStream> stream;
+    stream = std::make_shared<ObjectAppendStream>(block_blob_client, fs->io_context(),
+                                                  location, metadata, options_);
+    RETURN_NOT_OK(stream->Init(truncate, ensure_not_flat_namespace_directory));
+    return stream;
+  }
+
+ private:
+  void EnsureEmptyDirExistsImplThatThrows(
+      const Blobs::BlobContainerClient& container_client,
+      const std::string& path_within_container) {
+    auto dir_marker_blob_path = internal::EnsureTrailingSlash(path_within_container);
+    auto block_blob_client =
+        container_client.GetBlobClient(dir_marker_blob_path).AsBlockBlobClient();
+    // Attach metadata that other filesystem implementations expect to be present
+    // on directory marker blobs.
+    // https://github.com/fsspec/adlfs/blob/32132c4094350fca2680155a5c236f2e9f991ba5/adlfs/spec.py#L855-L870
+    Blobs::UploadBlockBlobFromOptions blob_options;
+    blob_options.Metadata.emplace(kFlatNamespaceIsDirectoryMetadataKey, "true");
+    block_blob_client.UploadFrom(nullptr, 0, blob_options);
+  }
+
+ public:
+  /// This function assumes the container already exists. So it can only be
+  /// called after that has been verified.
+  ///
+  /// \pre location.container is not empty.
+  /// \pre The location.container container already exists.
+  Status EnsureEmptyDirExists(const Blobs::BlobContainerClient& container_client,
+                              const AzureLocation& location, const char* operation_name) {
+    DCHECK(!location.container.empty());
+    if (location.path.empty()) {
+      // Nothing to do. The container already exists per the preconditions.
+      return Status::OK();
+    }
+    try {
+      EnsureEmptyDirExistsImplThatThrows(container_client, location.path);
+      return Status::OK();
+    } catch (const Storage::StorageException& exception) {
+      return ExceptionToStatus(
+          exception, operation_name, " failed to ensure empty directory marker '",
+          location.path, "' exists in container: ", container_client.GetUrl());
+    }
+  }
+
+  /// \pre location.container is not empty.
+  /// \pre location.path is empty.
+  Status DeleteContainer(const Blobs::BlobContainerClient& container_client,
+                         const AzureLocation& location) {
+    DCHECK(!location.container.empty());
+    DCHECK(location.path.empty());
+    try {
+      auto response = container_client.Delete();
+      // Only the "*IfExists" functions ever set Deleted to false.
+      // All the others either succeed or throw an exception.
+      DCHECK(response.Value.Deleted);
+    } catch (const Storage::StorageException& exception) {
+      if (IsContainerNotFound(exception)) {
+        return PathNotFound(location);
+      }
+      return ExceptionToStatus(exception,
+                               "Failed to delete a container: ", location.container, ": ",
+                               container_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
+  /// Deletes contents of a directory and possibly the directory itself
+  /// depending on the value of preserve_dir_marker_blob.
+  ///
+  /// \pre location.container is not empty.
+  /// \pre preserve_dir_marker_blob=false implies location.path is not empty
+  /// because we can't *not preserve* the root directory of a container.
+  ///
+  /// \param require_dir_to_exist Require the directory to exist *before* this
+  /// operation, otherwise return PathNotFound.
+  /// \param preserve_dir_marker_blob Ensure the empty directory marker blob
+  /// is preserved (not deleted) or created (before the contents are deleted) if it
+  /// doesn't exist explicitly but is implied by the existence of blobs with names
+  /// starting with the directory path.
+  /// \param operation_name Used in error messages to accurately describe the operation
+  Status DeleteDirContentsOnContainer(const Blobs::BlobContainerClient& container_client,
+                                      const AzureLocation& location,
+                                      bool require_dir_to_exist,
+                                      bool preserve_dir_marker_blob,
+                                      const char* operation_name) {
+    using DeleteBlobResponse = Storage::DeferredResponse<Blobs::Models::DeleteBlobResult>;
+    DCHECK(!location.container.empty());
+    DCHECK(preserve_dir_marker_blob || !location.path.empty())
+        << "Must pass preserve_dir_marker_blob=true when location.path is empty "
+           "(i.e. deleting the contents of a container).";
+    Blobs::ListBlobsOptions options;
+    if (!location.path.empty()) {
+      options.Prefix = internal::EnsureTrailingSlash(location.path);
+    }
+    // https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch#remarks
+    //
+    // Only supports up to 256 subrequests in a single batch. The
+    // size of the body for a batch request can't exceed 4 MB.
+    const int32_t kNumMaxRequestsInBatch = 256;
+    options.PageSizeHint = kNumMaxRequestsInBatch;
+    // trusted only if preserve_dir_marker_blob is true.
+    bool found_dir_marker_blob = false;
+    try {
+      auto list_response = container_client.ListBlobs(options);
+      if (list_response.Blobs.empty()) {
+        if (require_dir_to_exist) {
+          return PathNotFound(location);
+        } else {
+          ARROW_ASSIGN_OR_RAISE(auto info, GetFileInfo(container_client, location));
+          if (info.type() == FileType::File) {
+            return NotADir(location);
+          }
+        }
+      }
+      for (; list_response.HasPage(); list_response.MoveToNextPage()) {
+        if (list_response.Blobs.empty()) {
+          continue;
+        }
+        auto batch = container_client.CreateBatch();
+        std::vector<std::pair<std::string_view, DeleteBlobResponse>> deferred_responses;
+        for (const auto& blob_item : list_response.Blobs) {
+          if (preserve_dir_marker_blob && !found_dir_marker_blob) {
+            const bool is_dir_marker_blob =
+                options.Prefix.HasValue() && blob_item.Name == *options.Prefix;
+            if (is_dir_marker_blob) {
+              // Skip deletion of the existing directory marker blob,
+              // but take note that it exists.
+              found_dir_marker_blob = true;
+              continue;
+            }
+          }
+          deferred_responses.emplace_back(blob_item.Name,
+                                          batch.DeleteBlob(blob_item.Name));
+        }
+        try {
+          // Before submitting the batch deleting directory contents, ensure
+          // the empty directory marker blob exists. Doing this first, means that
+          // directory doesn't "stop existing" during the duration of the batch delete
+          // operation.
+          if (preserve_dir_marker_blob && !found_dir_marker_blob) {
+            // Only create an empty directory marker blob if the directory's
+            // existence is implied by the existence of blobs with names
+            // starting with the directory path.
+            if (!deferred_responses.empty()) {
+              RETURN_NOT_OK(
+                  EnsureEmptyDirExists(container_client, location, operation_name));
+            }
+          }
+          if (!deferred_responses.empty()) {
+            container_client.SubmitBatch(batch);
+          }
+        } catch (const Storage::StorageException& exception) {
+          return ExceptionToStatus(exception, "Failed to delete blobs in a directory: ",
+                                   location.path, ": ", container_client.GetUrl());
+        }
+        std::vector<std::string> failed_blob_names;
+        for (auto& [blob_name_view, deferred_response] : deferred_responses) {
+          bool success = true;
+          try {
+            auto delete_result = deferred_response.GetResponse();
+            success = delete_result.Value.Deleted;
+          } catch (const Storage::StorageException& exception) {
+            success = false;
+          }
+          if (!success) {
+            failed_blob_names.emplace_back(blob_name_view);
+          }
+        }
+        if (!failed_blob_names.empty()) {
+          if (failed_blob_names.size() == 1) {
+            return Status::IOError("Failed to delete a blob: ", failed_blob_names[0],
+                                   ": " + container_client.GetUrl());
+          } else {
+            return Status::IOError("Failed to delete blobs: [",
+                                   arrow::internal::JoinStrings(failed_blob_names, ", "),
+                                   "]: " + container_client.GetUrl());
+          }
+        }
+      }
+      return Status::OK();
+    } catch (const Storage::StorageException& exception) {
+      return ExceptionToStatus(exception,
+                               "Failed to list blobs in a directory: ", location.path,
+                               ": ", container_client.GetUrl());
+    }
+  }
+
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  Status DeleteDirOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                               const AzureLocation& location, bool recursive,
+                               bool require_dir_to_exist,
+                               Azure::Nullable<std::string> lease_id = {}) {
+    DCHECK(!location.container.empty());
+    DCHECK(!location.path.empty());
+    ARROW_ASSIGN_OR_RAISE(auto file_info, GetFileInfo(adlfs_client, location, lease_id));
+    if (file_info.type() == FileType::NotFound) {
+      if (require_dir_to_exist) {
+        return PathNotFound(location);
+      } else {
+        return Status::OK();
+      }
+    }
+    if (file_info.type() != FileType::Directory) {
+      return NotADir(location);
+    }
+    auto directory_client = adlfs_client.GetDirectoryClient(
+        std::string(internal::RemoveTrailingSlash(location.path)));
+    DataLake::DeleteDirectoryOptions options;
+    options.AccessConditions.LeaseId = std::move(lease_id);
+    try {
+      auto response = recursive ? directory_client.DeleteRecursive(options)
+                                : directory_client.DeleteEmpty(options);
+      // Only the "*IfExists" functions ever set Deleted to false.
+      // All the others either succeed or throw an exception.
+      DCHECK(response.Value.Deleted);
+    } catch (const Storage::StorageException& exception) {
+      if (exception.ErrorCode == "FilesystemNotFound" ||
+          exception.ErrorCode == "PathNotFound") {
+        if (require_dir_to_exist) {
+          return PathNotFound(location);
+        }
+        return Status::OK();
+      }
+      return ExceptionToStatus(exception, "Failed to delete a directory: ", location.path,
+                               ": ", directory_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
+  /// \pre location.container is not empty.
+  Status DeleteDirContentsOnFileSystem(
+      const DataLake::DataLakeFileSystemClient& adlfs_client,
+      const AzureLocation& location, bool missing_dir_ok) {
+    auto directory_client = adlfs_client.GetDirectoryClient(location.path);
+    try {
+      auto list_response = directory_client.ListPaths(false);
+      for (; list_response.HasPage(); list_response.MoveToNextPage()) {
+        for (const auto& path : list_response.Paths) {
+          if (path.IsDirectory) {
+            auto sub_directory_client = adlfs_client.GetDirectoryClient(path.Name);
+            try {
+              sub_directory_client.DeleteRecursive();
+            } catch (const Storage::StorageException& exception) {
+              return ExceptionToStatus(
+                  exception, "Failed to delete a sub directory: ", location.container,
+                  kDelimiter, path.Name, ": ", sub_directory_client.GetUrl());
+            }
+          } else {
+            if (path.Name == location.path) {
+              return NotADir(location);
+            }
+            auto sub_file_client = adlfs_client.GetFileClient(path.Name);
+            try {
+              sub_file_client.Delete();
+            } catch (const Storage::StorageException& exception) {
+              return ExceptionToStatus(
+                  exception, "Failed to delete a sub file: ", location.container,
+                  kDelimiter, path.Name, ": ", sub_file_client.GetUrl());
+            }
+          }
+        }
+      }
+      return Status::OK();
+    } catch (const Storage::StorageException& exception) {
+      if (missing_dir_ok && exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        return Status::OK();
+      }
+      return ExceptionToStatus(exception,
+                               "Failed to delete directory contents: ", location.path,
+                               ": ", directory_client.GetUrl());
+    }
+  }
+
+ private:
+  /// \brief Create a BlobLeaseClient and acquire a lease on the container.
+  ///
+  /// \param allow_missing_container if true, a nullptr may be returned when the container
+  /// doesn't exist, otherwise a PathNotFound(location) error is produced right away
+  /// \return A BlobLeaseClient is wrapped as a unique_ptr so it's moveable and
+  /// optional (nullptr denotes container not found)
+  Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireContainerLease(
+      const AzureLocation& location, std::chrono::seconds lease_duration,
+      bool allow_missing_container = false, bool retry_allowed = true) {
+    DCHECK(!location.container.empty());
+    auto container_client = GetBlobContainerClient(location.container);
+    auto lease_id = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+    auto container_url = container_client.GetUrl();
+    auto lease_client = std::make_unique<Blobs::BlobLeaseClient>(
+        std::move(container_client), std::move(lease_id));
+    try {
+      [[maybe_unused]] auto result = lease_client->Acquire(lease_duration);
+      DCHECK_EQ(result.Value.LeaseId, lease_client->GetLeaseId());
+    } catch (const Storage::StorageException& exception) {
+      if (IsContainerNotFound(exception)) {
+        if (allow_missing_container) {
+          return nullptr;
+        }
+        return PathNotFound(location);
+      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict &&
+                 exception.ErrorCode == "LeaseAlreadyPresent") {
+        if (retry_allowed) {
+          LeaseGuard::WaitUntilLatestKnownExpiryTime();
+          return AcquireContainerLease(location, lease_duration, allow_missing_container,
+                                       /*retry_allowed=*/false);
+        }
+      }
+      return ExceptionToStatus(exception, "Failed to acquire a lease on container '",
+                               location.container, "': ", container_url);
+    }
+    return lease_client;
+  }
+
+  /// \brief Create a BlobLeaseClient and acquire a lease on a blob/file (or
+  /// directory if Hierarchical Namespace is supported).
+  ///
+  /// \param allow_missing if true, a nullptr may be returned when the blob
+  /// doesn't exist, otherwise a PathNotFound(location) error is produced right away
+  /// \return A BlobLeaseClient is wrapped as a unique_ptr so it's moveable and
+  /// optional (nullptr denotes blob not found)
+  Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireBlobLease(
+      const AzureLocation& location, std::chrono::seconds lease_duration,
+      bool allow_missing, bool retry_allowed = true) {
+    DCHECK(!location.container.empty() && !location.path.empty());
+    auto path = std::string{internal::RemoveTrailingSlash(location.path)};
+    auto blob_client = GetBlobClient(location.container, std::move(path));
+    auto lease_id = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
+    auto blob_url = blob_client.GetUrl();
+    auto lease_client = std::make_unique<Blobs::BlobLeaseClient>(std::move(blob_client),
+                                                                 std::move(lease_id));
+    try {
+      [[maybe_unused]] auto result = lease_client->Acquire(lease_duration);
+      DCHECK_EQ(result.Value.LeaseId, lease_client->GetLeaseId());
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        if (allow_missing) {
+          return nullptr;
+        }
+        return PathNotFound(location);
+      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict &&
+                 exception.ErrorCode == "LeaseAlreadyPresent") {
+        if (retry_allowed) {
+          LeaseGuard::WaitUntilLatestKnownExpiryTime();
+          return AcquireBlobLease(location, lease_duration, allow_missing,
+                                  /*retry_allowed=*/false);
+        }
+      }
+      return ExceptionToStatus(exception, "Failed to acquire a lease on file '",
+                               location.all, "': ", blob_url);
+    }
+    return lease_client;
+  }
+
+  /// \brief The default lease duration used for acquiring a lease on a container or blob.
+  ///
+  /// Azure Storage leases can be acquired for a duration of 15 to 60 seconds.
+  ///
+  /// Operations consisting of an unpredictable number of sub-operations should
+  /// renew the lease periodically (heartbeat pattern) instead of acquiring an
+  /// infinite lease (very bad idea for a library like Arrow).
+  static constexpr auto kLeaseDuration = std::chrono::seconds{15};
+
+  // These are conservative estimates of how long it takes for the client
+  // request to reach the server counting from the moment the Azure SDK function
+  // issuing the request is called. See their usage for more context.
+  //
+  // If the client connection to the server is unpredictably slow, operations
+  // may fail, but due to the use of leases, the entire arrow::FileSystem
+  // operation can be retried without risk of data loss. Thus, unexpected network
+  // slow downs can be fixed with retries (either by some system using Arrow or
+  // an user interactively retrying a failed operation).
+  //
+  // If a network is permanently slow, the lease time and these numbers should be
+  // increased but not so much so that the client gives up an operation because the
+  // values say it takes more time to reach the server than the remaining lease
+  // time on the resources.
+  //
+  // NOTE: The initial constant values were chosen conservatively. If we learn,
+  // from experience, that they are causing issues, we can increase them. And if
+  // broadly applicable values aren't possible, we can make them configurable.
+  static constexpr auto kTimeNeededForContainerDeletion = std::chrono::seconds{3};
+  static constexpr auto kTimeNeededForContainerRename = std::chrono::seconds{3};
+  static constexpr auto kTimeNeededForFileOrDirectoryRename = std::chrono::seconds{3};
+
+ public:
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  Status DeleteFileOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                                const AzureLocation& location,
+                                bool require_file_to_exist) {
+    DCHECK(!location.container.empty());
+    DCHECK(!location.path.empty());
+    auto path_no_trailing_slash =
+        std::string{internal::RemoveTrailingSlash(location.path)};
+    auto file_client = adlfs_client.GetFileClient(path_no_trailing_slash);
+    try {
+      // This is necessary to avoid deletion of directories via DeleteFile.
+      auto properties = file_client.GetProperties();
+      if (properties.Value.IsDirectory) {
+        return internal::NotAFile(location.all);
+      }
+      if (internal::HasTrailingSlash(location.path)) {
+        return internal::NotADir(location.all);
+      }
+      auto response = file_client.Delete();
+      // Only the "*IfExists" functions ever set Deleted to false.
+      // All the others either succeed or throw an exception.
+      DCHECK(response.Value.Deleted);
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        // ErrorCode can be "FilesystemNotFound", "PathNotFound"...
+        if (require_file_to_exist) {
+          return PathNotFound(location);
+        }
+        return Status::OK();
+      }
+      return ExceptionToStatus(exception, "Failed to delete a file: ", location.path,
+                               ": ", file_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  Status DeleteFileOnContainer(const Blobs::BlobContainerClient& container_client,
+                               const AzureLocation& location, bool require_file_to_exist,
+                               const char* operation) {
+    DCHECK(!location.container.empty());
+    DCHECK(!location.path.empty());
+    constexpr auto kFileBlobLeaseTime = std::chrono::seconds{15};
+
+    // When it's known that the blob doesn't exist as a file, check if it exists as a
+    // directory to generate the appropriate error message.
+    auto check_if_location_exists_as_dir = [&]() -> Status {
+      auto no_trailing_slash = location;
+      no_trailing_slash.path = internal::RemoveTrailingSlash(location.path);
+      no_trailing_slash.all = internal::RemoveTrailingSlash(location.all);
+      ARROW_ASSIGN_OR_RAISE(auto file_info,
+                            GetFileInfo(container_client, no_trailing_slash));
+      if (file_info.type() == FileType::NotFound) {
+        return require_file_to_exist ? PathNotFound(location) : Status::OK();
+      }
+      if (file_info.type() == FileType::Directory) {
+        return internal::NotAFile(location.all);
+      }
+      return internal::HasTrailingSlash(location.path) ? internal::NotADir(location.all)
+                                                       : internal::NotAFile(location.all);
+    };
+
+    // Paths ending with trailing slashes are never leading to a deletion,
+    // but the correct error message requires a check of the path.
+    if (internal::HasTrailingSlash(location.path)) {
+      return check_if_location_exists_as_dir();
+    }
+
+    // If the parent directory of a file is not the container itself, there is a
+    // risk that deleting the file also deletes the *implied directory* -- the
+    // directory that is implied by the existence of the file path.
+    //
+    // In this case, we must ensure that the deletion is not semantically
+    // equivalent to also deleting the directory. This is done by ensuring the
+    // directory marker blob exists before the file is deleted.
+    std::optional<LeaseGuard> file_blob_lease_guard;
+    const auto parent = location.parent();
+    if (!parent.path.empty()) {
+      // We have to check the existence of the file before checking the
+      // existence of the parent directory marker, so we acquire a lease on the
+      // file first.
+      ARROW_ASSIGN_OR_RAISE(auto file_blob_lease_client,
+                            AcquireBlobLease(location, kFileBlobLeaseTime,
+                                             /*allow_missing=*/true));
+      if (file_blob_lease_client) {
+        file_blob_lease_guard.emplace(std::move(file_blob_lease_client),
+                                      kFileBlobLeaseTime);
+        // Ensure the empty directory marker blob of the parent exists before the file is
+        // deleted.
+        //
+        // There is not need to hold a lease on the directory marker because if
+        // a concurrent client deletes the directory marker right after we
+        // create it, the file deletion itself won't be the cause of the directory
+        // deletion. Additionally, the fact that a lease is held on the blob path
+        // semantically preserves the directory -- its existence is implied
+        // until the blob representing the file is deleted -- even if another
+        // client deletes the directory marker.
+        RETURN_NOT_OK(EnsureEmptyDirExists(container_client, parent, operation));
+      } else {
+        return check_if_location_exists_as_dir();
+      }
+    }
+
+    auto blob_client = container_client.GetBlobClient(location.path);
+    Blobs::DeleteBlobOptions options;
+    if (file_blob_lease_guard) {
+      options.AccessConditions.LeaseId = file_blob_lease_guard->LeaseId();
+    }
+    try {
+      auto response = blob_client.Delete(options);
+      // Only the "*IfExists" functions ever set Deleted to false.
+      // All the others either succeed or throw an exception.
+      DCHECK(response.Value.Deleted);
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        return check_if_location_exists_as_dir();
+      }
+      return ExceptionToStatus(exception, "Failed to delete a file: ", location.all, ": ",
+                               blob_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
+  /// The conditions for a successful container rename are derived from the
+  /// conditions for a successful `Move("/$src.container", "/$dest.container")`.
+  /// The numbers here match the list in `Move`.
+  ///
+  /// 1. `src.container` must exist.
+  /// 2. If `src.container` and `dest.container` are the same, do nothing and
+  ///    return OK.
+  /// 3. N/A.
+  /// 4. N/A.
+  /// 5. `dest.container` doesn't exist or is empty.
+  ///    NOTE: one exception related to container Move is that when the
+  ///    destination is empty we also require the source container to be empty,
+  ///    because the only way to perform the "Move" is by deleting the source
+  ///    instead of deleting the destination and renaming the source.
+  Status RenameContainer(const AzureLocation& src, const AzureLocation& dest) {
+    DCHECK(!src.container.empty() && src.path.empty());
+    DCHECK(!dest.container.empty() && dest.path.empty());
+    auto src_container_client = GetBlobContainerClient(src.container);
+
+    // If src and dest are the same, we only have to check src exists.
+    if (src.container == dest.container) {
+      ARROW_ASSIGN_OR_RAISE(auto info,
+                            GetContainerPropsAsFileInfo(src, src_container_client));
+      if (info.type() == FileType::NotFound) {
+        return PathNotFound(src);
+      }
+      DCHECK(info.type() == FileType::Directory);
+      return Status::OK();
+    }
+
+    // Acquire a lease on the source container because (1) we need the lease
+    // before rename and (2) it works as a way of checking the container exists.
+    ARROW_ASSIGN_OR_RAISE(auto src_lease_client,
+                          AcquireContainerLease(src, kLeaseDuration));
+    LeaseGuard src_lease_guard{std::move(src_lease_client), kLeaseDuration};
+    // Check dest.container doesn't exist or is empty.
+    auto dest_container_client = GetBlobContainerClient(dest.container);
+    std::optional<LeaseGuard> dest_lease_guard;
+    bool dest_exists = false;
+    bool dest_is_empty = false;
+    ARROW_ASSIGN_OR_RAISE(
+        auto dest_lease_client,
+        AcquireContainerLease(dest, kLeaseDuration, /*allow_missing_container*/ true));
+    if (dest_lease_client) {
+      dest_lease_guard.emplace(std::move(dest_lease_client), kLeaseDuration);
+      dest_exists = true;
+      // Emptiness check after successful acquisition of the lease.
+      Blobs::ListBlobsOptions list_blobs_options;
+      list_blobs_options.PageSizeHint = 1;
+      try {
+        auto dest_list_response = dest_container_client.ListBlobs(list_blobs_options);
+        dest_is_empty = dest_list_response.Blobs.empty();
+        if (!dest_is_empty) {
+          return NotEmpty(dest);
+        }
+      } catch (const Storage::StorageException& exception) {
+        return ExceptionToStatus(exception, "Failed to check that '", dest.container,
+                                 "' is empty: ", dest_container_client.GetUrl());
+      }
+    }
+    DCHECK(!dest_exists || dest_is_empty);
+
+    if (!dest_exists) {
+      // Rename the source container.
+      Blobs::RenameBlobContainerOptions options;
+      options.SourceAccessConditions.LeaseId = src_lease_guard.LeaseId();
+      try {
+        src_lease_guard.BreakBeforeDeletion(kTimeNeededForContainerRename);
+        blob_service_client_->RenameBlobContainer(src.container, dest.container, options);
+        src_lease_guard.Forget();
+      } catch (const Storage::StorageException& exception) {
+        if (exception.StatusCode == Http::HttpStatusCode::BadRequest &&
+            exception.ErrorCode == "InvalidQueryParameterValue") {
+          auto param_name = exception.AdditionalInformation.find("QueryParameterName");
+          if (param_name != exception.AdditionalInformation.end() &&
+              param_name->second == "comp") {
+            return ExceptionToStatus(
+                exception, "The 'rename' operation is not supported on containers. ",
+                "Attempting a rename of '", src.container, "' to '", dest.container,
+                "': ", blob_service_client_->GetUrl());
+          }
+        }
+        return ExceptionToStatus(exception, "Failed to rename container '", src.container,
+                                 "' to '", dest.container,
+                                 "': ", blob_service_client_->GetUrl());
+      }
+    } else if (dest_is_empty) {
+      // Even if we deleted the empty dest.container, RenameBlobContainer() would still
+      // fail because containers are not immediately deleted by the service -- they are
+      // deleted asynchronously based on retention policies and non-deterministic behavior
+      // of the garbage collection process.
+      //
+      // One way to still match POSIX rename semantics is to delete the src.container if
+      // and only if it's empty because the final state would be equivalent to replacing
+      // the dest.container with the src.container and its contents (which happens
+      // to also be empty).
+      Blobs::ListBlobsOptions list_blobs_options;
+      list_blobs_options.PageSizeHint = 1;
+      try {
+        auto src_list_response = src_container_client.ListBlobs(list_blobs_options);
+        if (!src_list_response.Blobs.empty()) {
+          // Reminder: dest is used here because we're semantically replacing dest
+          // with src. By deleting src if it's empty just like dest.
+          return Status::IOError("Unable to replace empty container: '", dest.all, "'");
+        }
+        // Delete the source container now that we know it's empty.
+        Blobs::DeleteBlobContainerOptions options;
+        options.AccessConditions.LeaseId = src_lease_guard.LeaseId();
+        DCHECK(dest_lease_guard.has_value());
+        // Make sure lease on dest is still valid before deleting src. This is to ensure
+        // the destination container is not deleted by another process/client before
+        // Move() returns.
+        if (!dest_lease_guard->StillValidFor(kTimeNeededForContainerDeletion)) {
+          return Status::IOError("Unable to replace empty container: '", dest.all, "'. ",
+                                 "Preparation for the operation took too long and a "
+                                 "container lease expired.");
+        }
+        try {
+          src_lease_guard.BreakBeforeDeletion(kTimeNeededForContainerDeletion);
+          src_container_client.Delete(options);
+          src_lease_guard.Forget();
+        } catch (const Storage::StorageException& exception) {
+          return ExceptionToStatus(exception, "Failed to delete empty container: '",
+                                   src.container, "': ", src_container_client.GetUrl());
+        }
+      } catch (const Storage::StorageException& exception) {
+        return ExceptionToStatus(exception, "Unable to replace empty container: '",
+                                 dest.all, "': ", dest_container_client.GetUrl());
+      }
+    }
+    return Status::OK();
+  }
+
+  Status MoveContainerToPath(const AzureLocation& src, const AzureLocation& dest) {
+    DCHECK(!src.container.empty() && src.path.empty());
+    DCHECK(!dest.container.empty() && !dest.path.empty());
+    // Check Move pre-condition 1 -- `src` must exist.
+    auto container_client = GetBlobContainerClient(src.container);
+    ARROW_ASSIGN_OR_RAISE(auto src_info,
+                          GetContainerPropsAsFileInfo(src, container_client));
+    if (src_info.type() == FileType::NotFound) {
+      return PathNotFound(src);
+    }
+    // Check Move pre-condition 2.
+    if (src.container == dest.container) {
+      return InvalidDirMoveToSubdir(src, dest);
+    }
+    // Instead of checking more pre-conditions, we just abort with a
+    // NotImplemented status.
+    return CrossContainerMoveNotImplemented(src, dest);
+  }
+
+  Status CreateContainerFromPath(const AzureLocation& src, const AzureLocation& dest) {
+    DCHECK(!src.container.empty() && !src.path.empty());
+    DCHECK(!dest.empty() && dest.path.empty());
+    ARROW_ASSIGN_OR_RAISE(auto src_file_info, GetFileInfoOfPathWithinContainer(src));
+    switch (src_file_info.type()) {
+      case FileType::Unknown:
+      case FileType::NotFound:
+        return PathNotFound(src);
+      case FileType::File:
+        return Status::Invalid(
+            "Creating files at '/' is not possible, only directories.");
+      case FileType::Directory:
+        break;
+    }
+    if (src.container == dest.container) {
+      return InvalidDirMoveToSubdir(src, dest);
+    }
+    return CrossContainerMoveNotImplemented(src, dest);
+  }
+
+  Status MovePathWithDataLakeAPI(
+      const DataLake::DataLakeFileSystemClient& src_adlfs_client,
+      const AzureLocation& src, const AzureLocation& dest) {
+    DCHECK(!src.container.empty() && !src.path.empty());
+    DCHECK(!dest.container.empty() && !dest.path.empty());
+    const auto src_path = std::string{internal::RemoveTrailingSlash(src.path)};
+    const auto dest_path = std::string{internal::RemoveTrailingSlash(dest.path)};
+
+    // Ensure that src exists and, if path has a trailing slash, that it's a directory.
+    ARROW_ASSIGN_OR_RAISE(auto src_lease_client,
+                          AcquireBlobLease(src, kLeaseDuration, /*allow_missing=*/false));
+    LeaseGuard src_lease_guard{std::move(src_lease_client), kLeaseDuration};
+    // It might be necessary to check src is a directory 0-3 times in this function,
+    // so we use a lazy evaluation function to avoid redundant calls to GetFileInfo().
+    std::optional<bool> src_is_dir_opt{};
+    auto src_is_dir_lazy = [&]() -> Result<bool> {
+      if (src_is_dir_opt.has_value()) {
+        return *src_is_dir_opt;
+      }
+      ARROW_ASSIGN_OR_RAISE(
+          auto src_info, GetFileInfo(src_adlfs_client, src, src_lease_guard.LeaseId()));
+      src_is_dir_opt = src_info.type() == FileType::Directory;
+      return *src_is_dir_opt;
+    };
+    // src must be a directory if it has a trailing slash.
+    if (internal::HasTrailingSlash(src.path)) {
+      ARROW_ASSIGN_OR_RAISE(auto src_is_dir, src_is_dir_lazy());
+      if (!src_is_dir) {
+        return NotADir(src);
+      }
+    }
+    // The Azure SDK and the backend don't perform many important checks, so we have to
+    // do them ourselves. Additionally, based on many tests on a default-configuration
+    // storage account, if the destination is an empty directory, the rename operation
+    // will most likely fail due to a timeout. Providing both leases -- to source and
+    // destination -- seems to have made things work.
+    ARROW_ASSIGN_OR_RAISE(auto dest_lease_client,
+                          AcquireBlobLease(dest, kLeaseDuration, /*allow_missing=*/true));
+    std::optional<LeaseGuard> dest_lease_guard;
+    if (dest_lease_client) {
+      dest_lease_guard.emplace(std::move(dest_lease_client), kLeaseDuration);
+      // Perform all the checks on dest (and src) before proceeding with the rename.
+      auto dest_adlfs_client = GetFileSystemClient(dest.container);
+      ARROW_ASSIGN_OR_RAISE(auto dest_info, GetFileInfo(dest_adlfs_client, dest,
+                                                        dest_lease_guard->LeaseId()));
+      if (dest_info.type() == FileType::Directory) {
+        ARROW_ASSIGN_OR_RAISE(auto src_is_dir, src_is_dir_lazy());
+        if (!src_is_dir) {
+          // If src is a regular file, complain that dest is a directory
+          // like POSIX rename() does.
+          return internal::IsADir(dest.all);
+        }
+      } else {
+        if (internal::HasTrailingSlash(dest.path)) {
+          return NotADir(dest);
+        }
+      }
+    } else {
+      // If the destination has trailing slash, we would have to check that it's a
+      // directory, but since it doesn't exist we must return PathNotFound...
+      if (internal::HasTrailingSlash(dest.path)) {
+        // ...unless the src is a directory, in which case we can proceed with the rename.
+        ARROW_ASSIGN_OR_RAISE(auto src_is_dir, src_is_dir_lazy());
+        if (!src_is_dir) {
+          return PathNotFound(dest);
+        }
+      }
+    }
+
+    // Now that src and dest are validated, make sure they are on the same filesystem.
+    if (src.container != dest.container) {
+      return CrossContainerMoveNotImplemented(src, dest);
+    }
+
+    try {
+      // NOTE: The Azure SDK provides a RenameDirectory() function, but the
+      // implementation is the same as RenameFile() with the only difference being
+      // the type of the returned object (DataLakeDirectoryClient vs DataLakeFileClient).
+      //
+      // If we call RenameDirectory() and the source is a file, no error would
+      // be returned and the file would be renamed just fine (!).
+      //
+      // Since we don't use the returned object, we can just use RenameFile() for both
+      // files and directories. Ideally, the SDK would simply expose the PathClient
+      // that it uses internally for both files and directories.
+      DataLake::RenameFileOptions options;
+      options.DestinationFileSystem = dest.container;
+      options.SourceAccessConditions.LeaseId = src_lease_guard.LeaseId();
+      if (dest_lease_guard.has_value()) {
+        options.AccessConditions.LeaseId = dest_lease_guard->LeaseId();
+      }
+      src_lease_guard.BreakBeforeDeletion(kTimeNeededForFileOrDirectoryRename);
+      src_adlfs_client.RenameFile(src_path, dest_path, options);
+      src_lease_guard.Forget();
+    } catch (const Storage::StorageException& exception) {
+      // https://learn.microsoft.com/en-gb/rest/api/storageservices/datalakestoragegen2/path/create
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        if (exception.ErrorCode == "PathNotFound") {
+          return PathNotFound(src);
+        }
+        // "FilesystemNotFound" could be triggered by the source or destination filesystem
+        // not existing, but since we already checked the source filesystem exists (and
+        // hold a lease to it), we can assume the destination filesystem is the one the
+        // doesn't exist.
+        if (exception.ErrorCode == "FilesystemNotFound" ||
+            exception.ErrorCode == "RenameDestinationParentPathNotFound") {
+          return DestinationParentPathNotFound(dest);
+        }
+      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict &&
+                 exception.ErrorCode == "PathAlreadyExists") {
+        // "PathAlreadyExists" is only produced when the destination exists and is a
+        // non-empty directory, so we produce the appropriate error.
+        return NotEmpty(dest);
+      }
+      return ExceptionToStatus(exception, "Failed to rename '", src.all, "' to '",
+                               dest.all, "': ", src_adlfs_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
+  Status MovePathUsingBlobsAPI(const AzureLocation& src, const AzureLocation& dest) {
+    DCHECK(!src.container.empty() && !src.path.empty());
+    DCHECK(!dest.container.empty() && !dest.path.empty());
+    if (src.container != dest.container) {
+      ARROW_ASSIGN_OR_RAISE(auto src_file_info, GetFileInfoOfPathWithinContainer(src));
+      if (src_file_info.type() == FileType::NotFound) {
+        return PathNotFound(src);
+      }
+      return CrossContainerMoveNotImplemented(src, dest);
+    }
+    return Status::NotImplemented(
+        "FileSystem::Move() is not implemented for Azure Storage accounts "
+        "without Hierarchical Namespace support (see arrow/issues/40405).");
+  }
+
+  Status MovePath(const AzureLocation& src, const AzureLocation& dest) {
+    DCHECK(!src.container.empty() && !src.path.empty());
+    DCHECK(!dest.container.empty() && !dest.path.empty());
+    auto src_adlfs_client = GetFileSystemClient(src.container);
+    ARROW_ASSIGN_OR_RAISE(auto hns_support,
+                          HierarchicalNamespaceSupport(src_adlfs_client));
+    if (hns_support == HNSSupport::kContainerNotFound) {
+      return PathNotFound(src);
+    }
+    if (hns_support == HNSSupport::kEnabled) {
+      return MovePathWithDataLakeAPI(src_adlfs_client, src, dest);
+    }
+    DCHECK_EQ(hns_support, HNSSupport::kDisabled);
+    return MovePathUsingBlobsAPI(src, dest);
+  }
+
+  Status CopyFile(const AzureLocation& src, const AzureLocation& dest) {
+    RETURN_NOT_OK(ValidateFileLocation(src));
+    RETURN_NOT_OK(ValidateFileLocation(dest));
+    if (src == dest) {
+      return Status::OK();
+    }
+    auto src_url = GetBlobClient(src.container, src.path).GetUrl();
+    auto dest_blob_client = GetBlobClient(dest.container, dest.path);
+    if (!dest.path.empty()) {
+      auto dest_parent = dest.parent();
+      if (!dest_parent.path.empty()) {
+        auto dest_container_client = GetBlobContainerClient(dest_parent.container);
+        ARROW_ASSIGN_OR_RAISE(auto info, GetFileInfo(dest_container_client, dest_parent));
+        if (info.type() == FileType::File) {
+          return NotADir(dest_parent);
+        }
+      }
+    }
+    try {
+      // We use StartCopyFromUri instead of CopyFromUri because it supports blobs larger
+      // than 256 MiB and it doesn't require generating a SAS token to authenticate
+      // reading a source blob in the same storage account.
+      auto copy_operation = dest_blob_client.StartCopyFromUri(src_url);
+      // For large blobs, the copy operation may be slow so we need to poll until it
+      // completes. We use a polling interval of 1 second.
+      copy_operation.PollUntilDone(std::chrono::milliseconds(1000));
+    } catch (const Storage::StorageException& exception) {
+      // StartCopyFromUri failed or a GetProperties call inside PollUntilDone failed.
+      return ExceptionToStatus(
+          exception, "Failed to start blob copy or poll status of ongoing copy. (",
+          src_url, " -> ", dest_blob_client.GetUrl(), ")");
+    } catch (const Azure::Core::RequestFailedException& exception) {
+      // A GetProperties call inside PollUntilDone returned a failed CopyStatus.
+      return ExceptionToStatus(exception, "Failed to copy blob. (", src_url, " -> ",
+                               dest_blob_client.GetUrl(), ")");
+    }
+    return Status::OK();
+  }
+};
+
+std::atomic<LeaseGuard::SteadyClock::time_point> LeaseGuard::latest_known_expiry_time_ =
+    SteadyClock::time_point{SteadyClock::duration::zero()};
+
+AzureFileSystem::AzureFileSystem(std::unique_ptr<Impl>&& impl)
+    : FileSystem(impl->io_context()), impl_(std::move(impl)) {
+  default_async_is_sync_ = false;
+}
+
+void AzureFileSystem::ForceCachedHierarchicalNamespaceSupport(int hns_support) {
+  impl_->ForceCachedHierarchicalNamespaceSupport(hns_support);
+}
+
+Result<std::shared_ptr<AzureFileSystem>> AzureFileSystem::Make(
+    const AzureOptions& options, const io::IOContext& io_context) {
+  ARROW_ASSIGN_OR_RAISE(auto impl, AzureFileSystem::Impl::Make(options, io_context));
+  return std::shared_ptr<AzureFileSystem>(new AzureFileSystem(std::move(impl)));
+}
+
+const AzureOptions& AzureFileSystem::options() const { return impl_->options(); }
+
+bool AzureFileSystem::Equals(const FileSystem& other) const {
+  if (this == &other) {
+    return true;
+  }
+  if (other.type_name() != type_name()) {
+    return false;
+  }
+  const auto& azure_fs = ::arrow::internal::checked_cast<const AzureFileSystem&>(other);
+  return options().Equals(azure_fs.options());
+}
+
+Result<FileInfo> AzureFileSystem::GetFileInfo(const std::string& path) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  if (location.container.empty()) {
+    DCHECK(location.path.empty());
+    // Root directory of the storage account.
+    return FileInfo{"", FileType::Directory};
+  }
+  if (location.path.empty()) {
+    // We have a container, but no path within the container.
+    // The container itself represents a directory.
+    auto container_client = impl_->GetBlobContainerClient(location.container);
+    return GetContainerPropsAsFileInfo(location, container_client);
+  }
+  return impl_->GetFileInfoOfPathWithinContainer(location);
+}
+
+Result<FileInfoVector> AzureFileSystem::GetFileInfo(const FileSelector& select) {
+  Core::Context context;
+  Azure::Nullable<int32_t> page_size_hint;  // unspecified
+  FileInfoVector results;
+  RETURN_NOT_OK(
+      impl_->GetFileInfoWithSelector(context, page_size_hint, select, &results));
+  return {std::move(results)};
+}
+
+Status AzureFileSystem::CreateDir(const std::string& path, bool recursive) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  if (location.container.empty()) {
+    return Status::Invalid("CreateDir requires a non-empty path.");
+  }
+
+  auto container_client = impl_->GetBlobContainerClient(location.container);
+  if (location.path.empty()) {
+    // If the path is just the container, the parent (root) trivially exists,
+    // and the CreateDir operation comes down to just creating the container.
+    return CreateContainerIfNotExists(location.container, container_client);
+  }
+
+  auto adlfs_client = impl_->GetFileSystemClient(location.container);
+  ARROW_ASSIGN_OR_RAISE(auto hns_support,
+                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  if (hns_support == HNSSupport::kContainerNotFound) {
+    if (!recursive) {
+      auto parent = location.parent();
+      return PathNotFound(parent);
+    }
+    RETURN_NOT_OK(CreateContainerIfNotExists(location.container, container_client));
+    // Perform a second check for HNS support after creating the container.
+    ARROW_ASSIGN_OR_RAISE(hns_support, impl_->HierarchicalNamespaceSupport(adlfs_client));
+    if (hns_support == HNSSupport::kContainerNotFound) {
+      // We only get kContainerNotFound if we are unable to read the properties of the
+      // container we just created. This is very unlikely, but theoretically possible in
+      // a concurrent system, so the error is handled to avoid infinite recursion.
+      return Status::IOError("Unable to read properties of a newly created container: ",
+                             location.container, ": " + container_client.GetUrl());
+    }
+  }
+  // CreateDirOnFileSystem and CreateDirOnContainer can handle the container
+  // not existing which is useful and necessary here since the only reason
+  // a container was created above was to check for HNS support when it wasn't
+  // cached yet.
+  if (hns_support == HNSSupport::kEnabled) {
+    return impl_->CreateDirOnFileSystem(adlfs_client, location, recursive);
+  }
+  DCHECK_EQ(hns_support, HNSSupport::kDisabled);
+  return impl_->CreateDirOnContainer(container_client, location, recursive);
+}
+
+Status AzureFileSystem::DeleteDir(const std::string& path) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  if (location.container.empty()) {
+    return Status::Invalid("DeleteDir requires a non-empty path.");
+  }
+  if (location.path.empty()) {
+    auto container_client = impl_->GetBlobContainerClient(location.container);
+    return impl_->DeleteContainer(container_client, location);
+  }
+
+  auto adlfs_client = impl_->GetFileSystemClient(location.container);
+  ARROW_ASSIGN_OR_RAISE(auto hns_support,
+                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  if (hns_support == HNSSupport::kContainerNotFound) {
+    return PathNotFound(location);
+  }
+  if (hns_support == HNSSupport::kEnabled) {
+    return impl_->DeleteDirOnFileSystem(adlfs_client, location, /*recursive=*/true,
+                                        /*require_dir_to_exist=*/true);
+  }
+  DCHECK_EQ(hns_support, HNSSupport::kDisabled);
+  auto container_client = impl_->GetBlobContainerClient(location.container);
+  return impl_->DeleteDirContentsOnContainer(container_client, location,
+                                             /*require_dir_to_exist=*/true,
+                                             /*preserve_dir_marker_blob=*/false,
+                                             "DeleteDir");
+}
+
+Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_dir_ok) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  if (location.container.empty()) {
+    return internal::InvalidDeleteDirContents(location.all);
+  }
+
+  auto adlfs_client = impl_->GetFileSystemClient(location.container);
+  ARROW_ASSIGN_OR_RAISE(auto hns_support,
+                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  if (hns_support == HNSSupport::kContainerNotFound) {
+    return missing_dir_ok ? Status::OK() : PathNotFound(location);
+  }
+
+  if (hns_support == HNSSupport::kEnabled) {
+    return impl_->DeleteDirContentsOnFileSystem(adlfs_client, location, missing_dir_ok);
+  }
+  auto container_client = impl_->GetBlobContainerClient(location.container);
+  return impl_->DeleteDirContentsOnContainer(container_client, location,
+                                             /*require_dir_to_exist=*/!missing_dir_ok,
+                                             /*preserve_dir_marker_blob=*/true,
+                                             "DeleteDirContents");
+}
+
+Status AzureFileSystem::DeleteRootDirContents() {
+  return Status::NotImplemented("Cannot delete all Azure Blob Storage containers");
+}
+
+Status AzureFileSystem::DeleteFile(const std::string& path) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  if (location.container.empty()) {
+    return Status::Invalid("DeleteFile requires a non-empty path.");
+  }
+  auto container_client = impl_->GetBlobContainerClient(location.container);
+  if (location.path.empty()) {
+    // Container paths (locations w/o path) are either not found or represent directories.
+    ARROW_ASSIGN_OR_RAISE(auto container_info,
+                          GetContainerPropsAsFileInfo(location, container_client));
+    return container_info.IsDirectory() ? NotAFile(location) : PathNotFound(location);
+  }
+  auto adlfs_client = impl_->GetFileSystemClient(location.container);
+  ARROW_ASSIGN_OR_RAISE(auto hns_support,
+                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  if (hns_support == HNSSupport::kContainerNotFound) {
+    return PathNotFound(location);
+  }
+  if (hns_support == HNSSupport::kEnabled) {
+    return impl_->DeleteFileOnFileSystem(adlfs_client, location,
+                                         /*require_file_to_exist=*/true);
+  }
+  return impl_->DeleteFileOnContainer(container_client, location,
+                                      /*require_file_to_exist=*/true,
+                                      /*operation=*/"DeleteFile");
+}
+
+Status AzureFileSystem::Move(const std::string& src, const std::string& dest) {
+  ARROW_ASSIGN_OR_RAISE(auto src_location, AzureLocation::FromString(src));
+  ARROW_ASSIGN_OR_RAISE(auto dest_location, AzureLocation::FromString(dest));
+  if (src_location.container.empty()) {
+    return Status::Invalid("Move requires a non-empty source path.");
+  }
+  if (dest_location.container.empty()) {
+    return Status::Invalid("Move requires a non-empty destination path.");
+  }
+  if (src_location.path.empty()) {
+    if (dest_location.path.empty()) {
+      return impl_->RenameContainer(src_location, dest_location);
+    }
+    return impl_->MoveContainerToPath(src_location, dest_location);
+  }
+  if (dest_location.path.empty()) {
+    return impl_->CreateContainerFromPath(src_location, dest_location);
+  }
+  return impl_->MovePath(src_location, dest_location);
+}
+
+Status AzureFileSystem::CopyFile(const std::string& src, const std::string& dest) {
+  ARROW_ASSIGN_OR_RAISE(auto src_location, AzureLocation::FromString(src));
+  ARROW_ASSIGN_OR_RAISE(auto dest_location, AzureLocation::FromString(dest));
+  return impl_->CopyFile(src_location, dest_location);
+}
+
+Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
+    const std::string& path) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  return impl_->OpenInputFile(location, this);
+}
+
+Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
+    const FileInfo& info) {
+  return impl_->OpenInputFile(info, this);
+}
+
+Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
+    const std::string& path) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  return impl_->OpenInputFile(location, this);
+}
+
+Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
+    const FileInfo& info) {
+  return impl_->OpenInputFile(info, this);
+}
+
+Result<std::shared_ptr<io::OutputStream>> AzureFileSystem::OpenOutputStream(
+    const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  return impl_->OpenAppendStream(location, metadata, true, this);
+}
+
+Result<std::shared_ptr<io::OutputStream>> AzureFileSystem::OpenAppendStream(
+    const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
+  ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
+  return impl_->OpenAppendStream(location, metadata, false, this);
+}
+
+Result<std::string> AzureFileSystem::PathFromUri(const std::string& uri_string) const {
+  /// We can not use `internal::PathFromUriHelper` here because for Azure we have to
+  /// support different URI schemes where the authority is handled differently.
+  /// Example (both should yield the same path `container/some/path`):
+  ///   - (1) abfss://storageacc.blob.core.windows.net/container/some/path
+  ///   - (2) abfss://acc:pw@container/some/path
+  /// The authority handling is different with these two URIs. (1) requires no prepending
+  /// of the authority to the path, while (2) requires to preprend the authority to the
+  /// path.
+  std::string path;
+  Uri uri;
+  RETURN_NOT_OK(uri.Parse(uri_string));
+  RETURN_NOT_OK(AzureOptions::FromUri(uri, &path));
+
+  std::vector<std::string> supported_schemes = {"abfs", "abfss"};
+  const auto scheme = uri.scheme();
+  if (std::find(supported_schemes.begin(), supported_schemes.end(), scheme) ==
+      supported_schemes.end()) {
+    std::string expected_schemes =
+        ::arrow::internal::JoinStrings(supported_schemes, ", ");
+    return Status::Invalid("The filesystem expected a URI with one of the schemes (",
+                           expected_schemes, ") but received ", uri_string);
+  }
+
+  return path;
+}
+
+}  // namespace milvus_storage::fs

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -23,9 +23,7 @@
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/lrucache.h"
 
-#ifdef MILVUS_AZURE_FS
-#include "milvus-storage/filesystem/azure/azure_fs.h"
-#endif
+#include "milvus-storage/filesystem/azure/azure_fs_producer.h"
 
 namespace milvus_storage {
 
@@ -65,11 +63,9 @@ arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemCon
     case StorageType::Remote: {
       auto cloud_provider = CloudProviderType_Map[config.cloud_provider];
       switch (cloud_provider) {
-#ifdef MILVUS_AZURE_FS
         case CloudProviderType::AZURE: {
           return AzureFileSystemProducer(config).Make();
         }
-#endif
         case CloudProviderType::AWS:
         case CloudProviderType::GCP:
         case CloudProviderType::ALIYUN:

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -50,7 +50,7 @@
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
-#include "milvus-storage/filesystem/s3/util_internal.h"
+#include "milvus-storage/filesystem/util_internal.h"
 
 using ::arrow::Result;
 using ::arrow::Status;

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -74,7 +74,7 @@
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
-#include "milvus-storage/filesystem/s3/util_internal.h"
+#include "milvus-storage/filesystem/util_internal.h"
 #include "milvus-storage/filesystem/s3/s3_client.h"
 
 using ::arrow::Buffer;
@@ -106,16 +106,11 @@ using ::milvus_storage::fs::internal::ToAwsString;
 namespace S3Model = Aws::S3::Model;
 
 namespace milvus_storage {
+
+using arrow::io::internal::SubmitIO;
+
 // -----------------------------------------------------------------------
 // S3FileSystem implementation
-
-template <typename... SubmitArgs>
-auto SubmitIO(arrow::io::IOContext io_context, SubmitArgs&&... submit_args)
-    -> decltype(std::declval<::arrow::internal::Executor*>()->Submit(submit_args...)) {
-  arrow::internal::TaskHints hints;
-  hints.external_id = io_context.external_id();
-  return io_context.executor()->Submit(hints, io_context.stop_token(), std::forward<SubmitArgs>(submit_args)...);
-};
 
 static constexpr const char kAwsDirectoryContentType[] = "application/x-directory";
 

--- a/cpp/src/filesystem/util_internal.cpp
+++ b/cpp/src/filesystem/util_internal.cpp
@@ -1,5 +1,5 @@
 
-#include "milvus-storage/filesystem/s3/util_internal.h"
+#include "milvus-storage/filesystem/util_internal.h"
 
 #include <algorithm>
 #include <cerrno>

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -395,10 +395,14 @@ TEST_F(TransactionTest, ManifestCacheKeyIncludesRootPath) {
 }
 
 TEST_F(TransactionTest, ConcurrentCommitsWithConditionalWrite) {
-  // Concurrent commit safety requires conditional write (CAS), only available on S3
+  // Concurrent commit safety requires conditional write (CAS), not yet supported on Azure
   auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
   if (storage_type != "remote") {
-    GTEST_SKIP() << "Concurrent commit test requires S3 with conditional write support";
+    GTEST_SKIP() << "Concurrent commit test requires remote storage with conditional write support";
+  }
+  auto cloud_provider = GetEnvVar("CLOUD_PROVIDER");
+  if (cloud_provider.ok() && cloud_provider.ValueOrDie() == "azure") {
+    GTEST_SKIP() << "Conditional write not yet supported on Azure";
   }
   auto bucket_name = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("");
   if (bucket_name.empty()) {

--- a/cpp/test/common/layout_test.cpp
+++ b/cpp/test/common/layout_test.cpp
@@ -119,6 +119,12 @@ TEST_F(FileLayoutTest, CheckLayoutCreation) {
 }
 
 TEST_F(FileLayoutTest, TestChangeBasePath) {
+  auto provider = GetEnvVar("CLOUD_PROVIDER");
+  if (provider.ok() && provider.ValueOrDie() == "azure") {
+    GTEST_SKIP() << "Azure (Azurite) does not support Hierarchical Namespace (HNS) by default, "
+                    "so FileSystem::Move() returns NotImplemented. "
+                    "This test relies on MoveTestBasePath which calls Move() internally.";
+  }
   ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema_));
   auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
   ASSERT_STATUS_OK(writer->write(test_batch_));

--- a/cpp/test/filesystem/azure_file_system_test.cpp
+++ b/cpp/test/filesystem/azure_file_system_test.cpp
@@ -1,0 +1,286 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Azure-specific unit tests ported from Arrow v23 azurefs_test.cc.
+// These test AzureOptions and AzureFileSystem initialization without
+// requiring a running Azure/Azurite instance.
+
+#include <gtest/gtest.h>
+#include <arrow/result.h>
+#include <azure/storage/blobs.hpp>
+#include <azure/storage/files/datalake.hpp>
+
+#include "milvus-storage/filesystem/azure/azurefs.h"
+
+namespace milvus_storage::fs {
+
+// ============================================================================
+// AzureFileSystem initialization tests (no network required)
+// ============================================================================
+
+TEST(AzureFileSystem, InitializingFilesystemWithoutAccountNameFails) {
+  AzureOptions options;
+  ASSERT_FALSE(options.ConfigureAccountKeyCredential("account_key").ok());
+
+  ASSERT_TRUE(options.ConfigureClientSecretCredential("tenant_id", "client_id", "client_secret").ok());
+  ASSERT_FALSE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithDefaultCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureDefaultCredential().ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithDefaultCredentialImplicitly) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  AzureOptions explicitly_default_options;
+  explicitly_default_options.account_name = "dummy-account-name";
+  ASSERT_TRUE(explicitly_default_options.ConfigureDefaultCredential().ok());
+  ASSERT_TRUE(options.Equals(explicitly_default_options));
+}
+
+TEST(AzureFileSystem, InitializeWithAnonymousCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureAnonymousCredential().ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithClientSecretCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureClientSecretCredential("tenant_id", "client_id", "client_secret").ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithManagedIdentityCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureManagedIdentityCredential().ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+
+  ASSERT_TRUE(options.ConfigureManagedIdentityCredential("specific-client-id").ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithCLICredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureCLICredential().ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithWorkloadIdentityCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureWorkloadIdentityCredential().ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, InitializeWithEnvironmentCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ASSERT_TRUE(options.ConfigureEnvironmentCredential().ok());
+  ASSERT_TRUE(AzureFileSystem::Make(options).ok());
+}
+
+TEST(AzureFileSystem, OptionsCompare) {
+  AzureOptions options;
+  EXPECT_TRUE(options.Equals(options));
+}
+
+// ============================================================================
+// AzureOptions::FromUri tests (no network required)
+// ============================================================================
+
+class TestAzureOptions : public ::testing::Test {};
+
+TEST_F(TestAzureOptions, FromUriBlobStorage) {
+  AzureOptions default_options;
+  std::string path;
+  auto result = AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob", &path);
+  ASSERT_TRUE(result.ok());
+  auto options = result.ValueOrDie();
+  EXPECT_EQ(options.account_name, "account");
+  EXPECT_EQ(options.blob_storage_authority, default_options.blob_storage_authority);
+  EXPECT_EQ(options.dfs_storage_authority, default_options.dfs_storage_authority);
+  EXPECT_EQ(options.blob_storage_scheme, default_options.blob_storage_scheme);
+  EXPECT_EQ(options.dfs_storage_scheme, default_options.dfs_storage_scheme);
+  EXPECT_EQ(path, "container/dir/blob");
+  EXPECT_EQ(options.background_writes, true);
+}
+
+TEST_F(TestAzureOptions, FromUriDfsStorage) {
+  AzureOptions default_options;
+  std::string path;
+  auto result = AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/dir/file", &path);
+  ASSERT_TRUE(result.ok());
+  auto options = result.ValueOrDie();
+  EXPECT_EQ(options.account_name, "account");
+  EXPECT_EQ(options.blob_storage_authority, default_options.blob_storage_authority);
+  EXPECT_EQ(options.dfs_storage_authority, default_options.dfs_storage_authority);
+  EXPECT_EQ(path, "file_system/dir/file");
+  EXPECT_EQ(options.background_writes, true);
+}
+
+TEST_F(TestAzureOptions, FromUriAbfs) {
+  std::string path;
+  auto result = AzureOptions::FromUri("abfs://account@127.0.0.1:10000/container/dir/blob", &path);
+  ASSERT_TRUE(result.ok());
+  auto options = result.ValueOrDie();
+  EXPECT_EQ(options.account_name, "account");
+  EXPECT_EQ(options.blob_storage_authority, "127.0.0.1:10000");
+  EXPECT_EQ(options.dfs_storage_authority, "127.0.0.1:10000");
+  EXPECT_EQ(options.blob_storage_scheme, "https");
+  EXPECT_EQ(options.dfs_storage_scheme, "https");
+  EXPECT_EQ(path, "container/dir/blob");
+}
+
+TEST_F(TestAzureOptions, FromUriAbfss) {
+  std::string path;
+  auto result = AzureOptions::FromUri("abfss://account@127.0.0.1:10000/container/dir/blob", &path);
+  ASSERT_TRUE(result.ok());
+  auto options = result.ValueOrDie();
+  EXPECT_EQ(options.account_name, "account");
+  EXPECT_EQ(options.blob_storage_authority, "127.0.0.1:10000");
+  EXPECT_EQ(options.blob_storage_scheme, "https");
+  EXPECT_EQ(path, "container/dir/blob");
+}
+
+TEST_F(TestAzureOptions, FromUriEnableTls) {
+  std::string path;
+  auto result = AzureOptions::FromUri("abfs://account@127.0.0.1:10000/container/dir/blob?enable_tls=false", &path);
+  ASSERT_TRUE(result.ok());
+  auto options = result.ValueOrDie();
+  EXPECT_EQ(options.blob_storage_scheme, "http");
+  EXPECT_EQ(options.dfs_storage_scheme, "http");
+  EXPECT_EQ(path, "container/dir/blob");
+}
+
+TEST_F(TestAzureOptions, FromUriDisableBackgroundWrites) {
+  std::string path;
+  auto result = AzureOptions::FromUri("abfs://account@127.0.0.1:10000/container?background_writes=false", &path);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.ValueOrDie().background_writes, false);
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialDefault) {
+  auto result =
+      AzureOptions::FromUri("abfs://account.blob.core.windows.net/container?credential_kind=default", nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialAnonymous) {
+  auto result =
+      AzureOptions::FromUri("abfs://account.blob.core.windows.net/container?credential_kind=anonymous", nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialClientSecret) {
+  auto result = AzureOptions::FromUri(
+      "abfs://account.blob.core.windows.net/container?"
+      "tenant_id=t&client_id=c&client_secret=s",
+      nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialManagedIdentity) {
+  auto result = AzureOptions::FromUri("abfs://account.blob.core.windows.net/container?client_id=c", nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialCLI) {
+  auto result = AzureOptions::FromUri("abfs://account.blob.core.windows.net/container?credential_kind=cli", nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialWorkloadIdentity) {
+  auto result = AzureOptions::FromUri(
+      "abfs://account.blob.core.windows.net/container?credential_kind=workload_identity", nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialEnvironment) {
+  auto result =
+      AzureOptions::FromUri("abfs://account.blob.core.windows.net/container?credential_kind=environment", nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialSASToken) {
+  const std::string sas_token =
+      "?se=2024-12-12T18:57:47Z&sig=pAs7qEBdI6sjUhqX1nrhNAKsTY%2B1SqLxPK%"
+      "2BbAxLiopw%3D&sp=racwdxylti&spr=https,http&sr=c&sv=2024-08-04";
+  auto result = AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/" + sas_token, nullptr);
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriCredentialInvalid) {
+  auto result = AzureOptions::FromUri(
+      "abfs://file_system@account.dfs.core.windows.net/dir/file?"
+      "credential_kind=invalid",
+      nullptr);
+  ASSERT_FALSE(result.ok());
+}
+
+TEST_F(TestAzureOptions, FromUriBlobStorageAuthority) {
+  auto result = AzureOptions::FromUri(
+      "abfs://account.blob.core.windows.net/container?"
+      "blob_storage_authority=.blob.local",
+      nullptr);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.ValueOrDie().blob_storage_authority, ".blob.local");
+}
+
+TEST_F(TestAzureOptions, FromUriDfsStorageAuthority) {
+  auto result = AzureOptions::FromUri(
+      "abfs://file_system@account.dfs.core.windows.net/dir?"
+      "dfs_storage_authority=.dfs.local",
+      nullptr);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.ValueOrDie().dfs_storage_authority, ".dfs.local");
+}
+
+TEST_F(TestAzureOptions, FromUriInvalidQueryParameter) {
+  auto result = AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/dir?unknown=invalid", nullptr);
+  ASSERT_FALSE(result.ok());
+}
+
+TEST_F(TestAzureOptions, MakeBlobServiceClientInvalidAccountName) {
+  AzureOptions options;
+  ASSERT_FALSE(options.MakeBlobServiceClient().ok());
+}
+
+TEST_F(TestAzureOptions, MakeBlobServiceClientInvalidBlobStorageScheme) {
+  AzureOptions options;
+  options.account_name = "user";
+  options.blob_storage_scheme = "abfs";
+  ASSERT_FALSE(options.MakeBlobServiceClient().ok());
+}
+
+TEST_F(TestAzureOptions, MakeDataLakeServiceClientInvalidAccountName) {
+  AzureOptions options;
+  ASSERT_FALSE(options.MakeDataLakeServiceClient().ok());
+}
+
+TEST_F(TestAzureOptions, MakeDataLakeServiceClientInvalidDfsStorageScheme) {
+  AzureOptions options;
+  options.account_name = "user";
+  options.dfs_storage_scheme = "abfs";
+  ASSERT_FALSE(options.MakeDataLakeServiceClient().ok());
+}
+
+}  // namespace milvus_storage::fs

--- a/cpp/test/filesystem/cloud_file_system_test.cpp
+++ b/cpp/test/filesystem/cloud_file_system_test.cpp
@@ -1,0 +1,756 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Cloud filesystem tests that work for all providers (S3, Azure, GCS, etc.)
+
+#include <arrow/buffer.h>
+#include <arrow/io/memory.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <random>
+#include <thread>
+
+#include "milvus-storage/filesystem/upload_conditional.h"
+#include "milvus-storage/filesystem/upload_sizable.h"
+#include "milvus-storage/filesystem/observable.h"
+#include "milvus-storage/filesystem/fs.h"
+
+#include "test_env.h"
+
+namespace milvus_storage {
+
+// ============================================================================
+// Cloud-env tests (existing)
+// ============================================================================
+
+class CloudFsTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    if (!IsCloudEnv()) {
+      GTEST_SKIP() << "S3 tests skipped in non-cloud environment";
+    }
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+  }
+
+  milvus_storage::api::Properties properties_;
+  ArrowFileSystemPtr fs_;
+};
+
+TEST_F(CloudFsTest, ConditionalWrite) {
+  auto provider = GetEnvVar("CLOUD_PROVIDER");
+  if (provider.ok() && provider.ValueOrDie() == "azure") {
+    GTEST_SKIP() << "Conditional write not yet supported on Azure";
+  }
+  std::string file_to = "/test_conditional_write.txt";
+
+  // Ensure source file does not exist
+  (void)fs_->DeleteFile(file_to);
+
+  std::string content1 = "This is a test file for conditional write.";
+  std::string content2 = "This is a test file for conditional write 2.";
+
+  // Create source file
+  {
+    std::shared_ptr<arrow::Buffer> buffer =
+        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content1.c_str()), content1.size());
+
+    auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs_);
+    ASSERT_NE(conditional_fs, nullptr);
+    ASSERT_AND_ASSIGN(auto output_stream, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
+    ASSERT_STATUS_OK(output_stream->Write(buffer));
+    ASSERT_STATUS_OK(output_stream->Close());
+    // check file exists, it should be a file
+    ASSERT_AND_ASSIGN(auto file_info, fs_->GetFileInfo(file_to));
+    ASSERT_EQ(file_info.type(), arrow::fs::FileType::File);
+  }
+
+  {
+    std::shared_ptr<arrow::Buffer> buffer =
+        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content2.c_str()), content2.size());
+
+    auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs_);
+    ASSERT_NE(conditional_fs, nullptr);
+    ASSERT_AND_ASSIGN(auto output_stream, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
+    ASSERT_STATUS_OK(output_stream->Write(buffer));
+    ASSERT_STATUS_NOT_OK(output_stream->Close());
+  }
+
+  (void)fs_->DeleteFile(file_to);
+
+  // Test conditional write in output_stream close
+  {
+    std::shared_ptr<arrow::Buffer> buffer1 =
+        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content1.c_str()), content1.size());
+    std::shared_ptr<arrow::Buffer> buffer2 =
+        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content2.c_str()), content2.size());
+
+    auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs_);
+    ASSERT_NE(conditional_fs, nullptr);
+    ASSERT_AND_ASSIGN(auto output_stream1, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
+    ASSERT_STATUS_OK(output_stream1->Write(buffer1));
+
+    ASSERT_AND_ASSIGN(auto output_stream2, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
+    ASSERT_STATUS_OK(output_stream2->Write(buffer2));
+
+    ASSERT_STATUS_OK(output_stream1->Close());
+    auto write_status = output_stream2->Close();
+    ASSERT_FALSE(write_status.ok());
+  }
+}
+
+TEST_F(CloudFsTest, TestMetadata) {
+  // predefined metadata
+  {
+    std::string file_to = "/predefined_metadata.txt";
+    (void)fs_->DeleteFile(file_to);
+    std::string content = "This is a test file for metadata.";
+
+    auto kvmeta = arrow::KeyValueMetadata::Make({"Content-Language"}, {"zh-CN"});
+    ASSERT_AND_ASSIGN(auto output_stream, fs_->OpenOutputStream(file_to, kvmeta));
+    std::shared_ptr<arrow::Buffer> buffer =
+        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.c_str()), content.size());
+
+    ASSERT_STATUS_OK(output_stream->Write(buffer));
+    ASSERT_STATUS_OK(output_stream->Close());
+  }
+
+  // custom metadata
+  {
+    std::string file_to = "/custom_metadata.txt";
+    (void)fs_->DeleteFile(file_to);
+    std::string content = "This is a test file for custom metadata.";
+    auto kvmeta = arrow::KeyValueMetadata::Make({"Content-Disposition"}, {"inline"});
+    ASSERT_AND_ASSIGN(auto output_stream, fs_->OpenOutputStream(file_to, kvmeta));
+    std::shared_ptr<arrow::Buffer> buffer =
+        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.c_str()), content.size());
+    ASSERT_STATUS_OK(output_stream->Write(buffer));
+    ASSERT_STATUS_OK(output_stream->Close());
+  }
+}
+
+// ============================================================================
+// background_writes cloud-env tests
+// ============================================================================
+
+TEST_F(CloudFsTest, BackgroundWritesConcurrent) {
+  constexpr int kNumThreads = 10;
+  const std::string base_dir = "/test_background_writes";
+
+  auto run_concurrent_writes = [&](bool background_writes) {
+    // Clear the global fs cache to force re-creation with new config
+    FilesystemCache::getInstance().clean();
+
+    api::Properties properties;
+    ASSERT_STATUS_OK(InitTestProperties(properties));
+    api::SetValue(properties, PROPERTY_FS_BACKGROUND_WRITES, background_writes ? "true" : "false");
+
+    ASSERT_AND_ASSIGN(auto fs, GetFileSystem(properties));
+
+    std::string dir = base_dir + (background_writes ? "/bg_true" : "/bg_false");
+    (void)fs->DeleteDirContents(dir, true);
+    ASSERT_STATUS_OK(fs->CreateDir(dir));
+
+    std::vector<std::thread> threads;
+    std::vector<arrow::Status> statuses(kNumThreads);
+
+    for (int i = 0; i < kNumThreads; ++i) {
+      threads.emplace_back([&, i]() {
+        std::string path = dir + "/file_" + std::to_string(i) + ".txt";
+        std::string content = "thread_" + std::to_string(i) + "_data";
+
+        auto out_result = fs->OpenOutputStream(path);
+        if (!out_result.ok()) {
+          statuses[i] = out_result.status();
+          return;
+        }
+        auto out = out_result.ValueOrDie();
+        auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+        statuses[i] = out->Write(buf);
+        if (statuses[i].ok()) {
+          statuses[i] = out->Close();
+        }
+      });
+    }
+
+    for (auto& t : threads) {
+      t.join();
+    }
+
+    for (int i = 0; i < kNumThreads; ++i) {
+      EXPECT_TRUE(statuses[i].ok()) << "Thread " << i << " failed: " << statuses[i].ToString();
+    }
+
+    // Verify all files exist and content is correct
+    for (int i = 0; i < kNumThreads; ++i) {
+      std::string path = dir + "/file_" + std::to_string(i) + ".txt";
+      std::string expected = "thread_" + std::to_string(i) + "_data";
+
+      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(path));
+      ASSERT_AND_ASSIGN(auto buf, input->Read(expected.size()));
+      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), expected)
+          << "Content mismatch for thread " << i;
+    }
+
+    // Cleanup
+    (void)fs->DeleteDirContents(dir, true);
+  };
+
+  // 1. background_writes = true
+  run_concurrent_writes(true);
+
+  // 2. background_writes = false
+  run_concurrent_writes(false);
+
+  (void)fs_->DeleteDirContents(base_dir, true);
+}
+
+// ============================================================================
+// use_crc32c_checksum cloud-env tests
+// ============================================================================
+
+TEST_F(CloudFsTest, Crc32cChecksumWriteAndRead) {
+  auto provider = GetEnvVar("CLOUD_PROVIDER");
+  if (!provider.ok() || provider.ValueOrDie() != "aws") {
+    GTEST_SKIP() << "CRC32C checksum is S3-specific, only runs with CLOUD_PROVIDER=aws";
+  }
+  const std::string base_dir = "/test_crc32c_checksum";
+
+  auto run_with_checksum = [&](bool use_crc32c) {
+    FilesystemCache::getInstance().clean();
+
+    api::Properties properties;
+    ASSERT_STATUS_OK(InitTestProperties(properties));
+    api::SetValue(properties, PROPERTY_FS_USE_CRC32C_CHECKSUM, use_crc32c ? "true" : "false");
+    // Use the minimum S3 part size (5MB) to trigger multipart upload with less data
+    api::SetValue(properties, PROPERTY_FS_MULTI_PART_UPLOAD_SIZE, "5242880");
+
+    ASSERT_AND_ASSIGN(auto fs, GetFileSystem(properties));
+
+    std::string dir = base_dir + (use_crc32c ? "/crc32c_on" : "/crc32c_off");
+    (void)fs->DeleteDirContents(dir, true);
+
+    // 1. CreateDir - exercises CreateEmptyDir (PutObjectRequest with CRC32C)
+    ASSERT_STATUS_OK(fs->CreateDir(dir));
+    std::string subdir = dir + "/subdir";
+    ASSERT_STATUS_OK(fs->CreateDir(subdir));
+
+    // 2. Single PutObject - small file write (PutObjectRequest via Upload template)
+    std::string path = dir + "/test_file.txt";
+    std::string content = "Hello, CRC32C checksum test!";
+    {
+      ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(path));
+      auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+      ASSERT_STATUS_OK(out->Write(buf));
+      ASSERT_STATUS_OK(out->Close());
+    }
+
+    // Read back and verify
+    {
+      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(path));
+      ASSERT_AND_ASSIGN(auto buf, input->Read(content.size()));
+      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), content);
+    }
+
+    // 3. Multipart upload - write a buffer larger than part size to trigger multipart
+    {
+      std::string mp_path = dir + "/multipart_file.bin";
+      const int64_t kTotalSize = 15LL * 1024 * 1024;  // 15MB, guarantees multiple parts
+      std::string large_content(kTotalSize, 'A');
+      // Fill with a pattern so we can verify integrity
+      for (int64_t i = 0; i < kTotalSize; ++i) {
+        large_content[i] = static_cast<char>('A' + (i % 26));
+      }
+      {
+        ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(mp_path));
+        auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(large_content.data()),
+                                                   large_content.size());
+        ASSERT_STATUS_OK(out->Write(buf));
+        ASSERT_STATUS_OK(out->Close());
+      }
+      // Read back and verify
+      {
+        ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(mp_path));
+        ASSERT_AND_ASSIGN(auto buf, input->Read(kTotalSize));
+        ASSERT_EQ(buf->size(), kTotalSize);
+        EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), large_content);
+      }
+    }
+
+    // 5. CopyObject - exercises CopyObjectRequest with CRC32C
+    std::string copy_path = dir + "/test_file_copy.txt";
+    ASSERT_STATUS_OK(fs->CopyFile(path, copy_path));
+    {
+      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(copy_path));
+      ASSERT_AND_ASSIGN(auto buf, input->Read(content.size()));
+      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), content);
+    }
+
+    // 6. DeleteDirContents - exercises DeleteObjectsRequest with CRC32C (batch delete)
+    // Create several files then batch-delete them
+    for (int i = 0; i < 3; ++i) {
+      std::string p = subdir + "/del_" + std::to_string(i) + ".txt";
+      ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(p));
+      std::string data = "delete_me_" + std::to_string(i);
+      auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+      ASSERT_STATUS_OK(out->Write(buf));
+      ASSERT_STATUS_OK(out->Close());
+    }
+    ASSERT_STATUS_OK(fs->DeleteDirContents(subdir));
+
+    // Cleanup
+    (void)fs->DeleteDirContents(dir, true);
+  };
+
+  // 1. use_crc32c_checksum = true
+  run_with_checksum(true);
+
+  // 2. use_crc32c_checksum = false
+  run_with_checksum(false);
+
+  (void)fs_->DeleteDirContents(base_dir, true);
+}
+
+// ============================================================================
+// Generic cloud filesystem tests (work for S3, Azure, GCS, etc.)
+// Ported from Arrow v23 azurefs_test.cc and extended.
+// ============================================================================
+
+TEST_F(CloudFsTest, WriteAndReadSmallFile) {
+  std::string path = "/test_small_rw.txt";
+  std::string content = "hello cloud storage";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->ToString(), content);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, WriteAndReadLargeFile) {
+  // 12MB exceeds the 10MB Azure block buffer and S3 multipart thresholds
+  std::string path = "/test_large_rw.bin";
+  (void)fs_->DeleteFile(path);
+
+  const int64_t size = 12 * 1024 * 1024;
+  std::string content(size, '\0');
+  std::mt19937 rng(42);
+  for (auto& c : content) {
+    c = static_cast<char>(rng() % 256);
+  }
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputFile(path));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(size + 1));
+  EXPECT_EQ(read_buf->size(), size);
+  EXPECT_EQ(read_buf->ToString(), content);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, WriteMultipleChunks) {
+  std::string path = "/test_multi_chunk.txt";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  std::string part1 = "first part, ";
+  std::string part2 = "second part, ";
+  std::string part3 = "third part.";
+  ASSERT_STATUS_OK(out->Write(part1.data(), part1.size()));
+  ASSERT_STATUS_OK(out->Write(part2.data(), part2.size()));
+  ASSERT_STATUS_OK(out->Write(part3.data(), part3.size()));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->ToString(), part1 + part2 + part3);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, ReadInSmallBuffers) {
+  std::string path = "/test_small_buffers.txt";
+  std::string content = "0123456789abcdef";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
+  std::string result;
+  std::shared_ptr<arrow::Buffer> chunk;
+  do {
+    ASSERT_AND_ASSIGN(chunk, in->Read(4));
+    result.append(chunk->ToString());
+  } while (chunk && chunk->size() != 0);
+  EXPECT_EQ(result, content);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, GetFileInfo) {
+  std::string path = "/test_file_info.txt";
+  (void)fs_->DeleteFile(path);
+
+  // Not found
+  ASSERT_AND_ASSIGN(auto info_before, fs_->GetFileInfo(path));
+  EXPECT_EQ(info_before.type(), arrow::fs::FileType::NotFound);
+
+  // Create
+  std::string content = "file info test data";
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  // Found
+  ASSERT_AND_ASSIGN(auto info_after, fs_->GetFileInfo(path));
+  EXPECT_EQ(info_after.type(), arrow::fs::FileType::File);
+  EXPECT_EQ(info_after.size(), static_cast<int64_t>(content.size()));
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, DeleteFile) {
+  std::string path = "/test_delete_file.txt";
+  std::string content = "to be deleted";
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_STATUS_OK(fs_->DeleteFile(path));
+
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(path));
+  EXPECT_EQ(info.type(), arrow::fs::FileType::NotFound);
+}
+
+TEST_F(CloudFsTest, OpenInputStreamNotFound) {
+  auto result = fs_->OpenInputStream("/nonexistent_file_12345.txt");
+  ASSERT_FALSE(result.ok());
+}
+
+TEST_F(CloudFsTest, OpenInputFileRandomRead) {
+  std::string path = "/test_random_read.txt";
+  std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
+
+  // ReadAt from middle
+  ASSERT_AND_ASSIGN(auto buf1, file->ReadAt(10, 6));
+  EXPECT_EQ(buf1->ToString(), "abcdef");
+
+  // ReadAt from beginning
+  ASSERT_AND_ASSIGN(auto buf2, file->ReadAt(0, 4));
+  EXPECT_EQ(buf2->ToString(), "0123");
+
+  // ReadAt beyond end
+  ASSERT_AND_ASSIGN(auto buf3, file->ReadAt(30, 100));
+  EXPECT_EQ(buf3->ToString(), "uvwxyz");
+
+  // GetSize
+  ASSERT_AND_ASSIGN(auto size, file->GetSize());
+  EXPECT_EQ(size, static_cast<int64_t>(content.size()));
+
+  // Seek + Read
+  ASSERT_STATUS_OK(file->Seek(26));
+  ASSERT_AND_ASSIGN(auto buf4, file->Read(10));
+  EXPECT_EQ(buf4->ToString(), "qrstuvwxyz");
+
+  // Tell
+  ASSERT_AND_ASSIGN(auto pos, file->Tell());
+  EXPECT_EQ(pos, 36);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, OverwriteExistingFile) {
+  std::string path = "/test_overwrite.txt";
+  (void)fs_->DeleteFile(path);
+
+  // Write v1
+  {
+    std::string content = "version 1";
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+    auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+    ASSERT_STATUS_OK(out->Write(buf));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Overwrite with v2
+  {
+    std::string content = "version 2 is longer";
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+    auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+    ASSERT_STATUS_OK(out->Write(buf));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Read should get v2
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->ToString(), "version 2 is longer");
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, CopyFile) {
+  std::string src = "/test_copy_src.txt";
+  std::string dst = "/test_copy_dst.txt";
+  std::string content = "copy me";
+  (void)fs_->DeleteFile(src);
+  (void)fs_->DeleteFile(dst);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(src, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_STATUS_OK(fs_->CopyFile(src, dst));
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(dst));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->ToString(), content);
+
+  (void)fs_->DeleteFile(src);
+  (void)fs_->DeleteFile(dst);
+}
+
+TEST_F(CloudFsTest, CopyFileSourceNotFound) {
+  auto status = fs_->CopyFile("/nonexistent_src_12345.txt", "/nonexistent_dst_12345.txt");
+  ASSERT_FALSE(status.ok());
+}
+
+TEST_F(CloudFsTest, CreateAndDeleteDir) {
+  std::string dir = "/test_dir_ops";
+  (void)fs_->DeleteDir(dir);
+
+  ASSERT_STATUS_OK(fs_->CreateDir(dir, false));
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(dir));
+  EXPECT_EQ(info.type(), arrow::fs::FileType::Directory);
+
+  ASSERT_STATUS_OK(fs_->DeleteDir(dir));
+}
+
+TEST_F(CloudFsTest, CreateDirRecursive) {
+  std::string dir = "/test_recursive_dir/sub1/sub2";
+  (void)fs_->DeleteDir("/test_recursive_dir");
+
+  ASSERT_STATUS_OK(fs_->CreateDir(dir, true));
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(dir));
+  EXPECT_EQ(info.type(), arrow::fs::FileType::Directory);
+
+  (void)fs_->DeleteDir("/test_recursive_dir");
+}
+
+TEST_F(CloudFsTest, DeleteDirContents) {
+  std::string dir = "/test_delete_contents";
+  std::string file1 = dir + "/f1.txt";
+  std::string file2 = dir + "/f2.txt";
+  (void)fs_->DeleteDir(dir);
+
+  ASSERT_STATUS_OK(fs_->CreateDir(dir, false));
+
+  for (const auto& f : {file1, file2}) {
+    std::string c = "data";
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(f, nullptr));
+    auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(c.data()), c.size());
+    ASSERT_STATUS_OK(out->Write(buf));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  ASSERT_STATUS_OK(fs_->DeleteDirContents(dir, false));
+
+  ASSERT_AND_ASSIGN(auto info1, fs_->GetFileInfo(file1));
+  EXPECT_EQ(info1.type(), arrow::fs::FileType::NotFound);
+  ASSERT_AND_ASSIGN(auto info2, fs_->GetFileInfo(file2));
+  EXPECT_EQ(info2.type(), arrow::fs::FileType::NotFound);
+
+  (void)fs_->DeleteDir(dir);
+}
+
+TEST_F(CloudFsTest, GetFileInfoSelector) {
+  std::string dir = "/test_selector";
+  (void)fs_->DeleteDir(dir);
+  ASSERT_STATUS_OK(fs_->CreateDir(dir, false));
+
+  // Create files
+  for (const auto& name : {"a.txt", "b.txt", "c.txt"}) {
+    std::string path = std::string(dir) + "/" + name;
+    std::string content = name;
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+    auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+    ASSERT_STATUS_OK(out->Write(buf));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Create subdirectory with file
+  std::string subdir = dir + "/subdir";
+  ASSERT_STATUS_OK(fs_->CreateDir(subdir, false));
+  {
+    std::string path = subdir + "/d.txt";
+    std::string content = "d";
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+    auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+    ASSERT_STATUS_OK(out->Write(buf));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Non-recursive selector
+  {
+    arrow::fs::FileSelector selector;
+    selector.base_dir = dir;
+    selector.recursive = false;
+    ASSERT_AND_ASSIGN(auto infos, fs_->GetFileInfo(selector));
+    // Should have at least 3 files + 1 subdir
+    EXPECT_GE(infos.size(), 4u);
+  }
+
+  // Recursive selector
+  {
+    arrow::fs::FileSelector selector;
+    selector.base_dir = dir;
+    selector.recursive = true;
+    ASSERT_AND_ASSIGN(auto infos, fs_->GetFileInfo(selector));
+    // Should have 3 files + 1 subdir + 1 file in subdir = at least 5
+    EXPECT_GE(infos.size(), 5u);
+  }
+
+  (void)fs_->DeleteDir(dir);
+}
+
+TEST_F(CloudFsTest, WriteWithHttpHeaders) {
+  std::string path = "/test_http_headers.txt";
+  (void)fs_->DeleteFile(path);
+  std::string content = "http header test";
+
+  auto kvmeta =
+      arrow::KeyValueMetadata::Make({"Content-Type", "Cache-Control"}, {"application/octet-stream", "no-cache"});
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, kvmeta));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(path));
+  EXPECT_EQ(info.type(), arrow::fs::FileType::File);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, OpenOutputStreamWithUploadSize) {
+  auto provider = GetEnvVar("CLOUD_PROVIDER");
+  if (provider.ok() && provider.ValueOrDie() == "azure") {
+    GTEST_SKIP() << "UploadSizable not yet supported on Azure";
+  }
+  std::string path = "/test_upload_size.txt";
+  (void)fs_->DeleteFile(path);
+
+  auto sizable_fs = std::dynamic_pointer_cast<UploadSizable>(fs_);
+  ASSERT_NE(sizable_fs, nullptr);
+
+  std::string content = "upload size test content";
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_AND_ASSIGN(auto out, sizable_fs->OpenOutputStreamWithUploadSize(path, nullptr, 5 * 1024 * 1024));
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->ToString(), content);
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, GetMetrics) {
+  auto observable_fs = std::dynamic_pointer_cast<Observable>(fs_);
+  ASSERT_NE(observable_fs, nullptr);
+  // Should not crash; may return nullptr for providers that don't implement it yet
+  observable_fs->GetMetrics();
+}
+
+TEST_F(CloudFsTest, OpenInputFileClosed) {
+  std::string path = "/test_closed_input.txt";
+  std::string content = "closed test";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
+  ASSERT_STATUS_OK(file->Close());
+  ASSERT_TRUE(file->closed());
+
+  // Operations on closed file should fail
+  auto read_result = file->Read(10);
+  ASSERT_FALSE(read_result.ok());
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, OpenOutputStreamClosed) {
+  std::string path = "/test_closed_output.txt";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  ASSERT_STATUS_OK(out->Close());
+  ASSERT_TRUE(out->closed());
+
+  // Write to closed stream should fail
+  auto write_result = out->Write("data", 4);
+  ASSERT_FALSE(write_result.ok());
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, WriteEmptyFile) {
+  std::string path = "/test_empty_file.txt";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->size(), 0);
+
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(path));
+  EXPECT_EQ(info.type(), arrow::fs::FileType::File);
+  EXPECT_EQ(info.size(), 0);
+
+  (void)fs_->DeleteFile(path);
+}
+
+}  // namespace milvus_storage

--- a/cpp/test/filesystem/s3_client_metrics_test.cpp
+++ b/cpp/test/filesystem/s3_client_metrics_test.cpp
@@ -37,6 +37,10 @@ class S3ClientMetricsTest : public ::testing::Test {
     if (!IsCloudEnv()) {
       GTEST_SKIP() << "S3 tests skipped in non-cloud environment";
     }
+    auto provider = GetEnvVar("CLOUD_PROVIDER");
+    if (provider.ok() && provider.ValueOrDie() == "azure") {
+      GTEST_SKIP() << "Azure filesystem does not yet implement Observable::GetMetrics(), returns nullptr";
+    }
 
     api::Properties properties;
     ASSERT_STATUS_OK(InitTestProperties(properties));
@@ -48,7 +52,7 @@ class S3ClientMetricsTest : public ::testing::Test {
 
   void TearDown() override {
     // Clean up test files
-    if (IsCloudEnv()) {
+    if (IsCloudEnv() && arrowfs_) {
       ASSERT_STATUS_OK(DeleteTestDir(arrowfs_, base_path_));
     }
   }

--- a/cpp/test/filesystem/s3_client_test.cpp
+++ b/cpp/test/filesystem/s3_client_test.cpp
@@ -41,6 +41,10 @@ class S3ClientTest : public ::testing::Test {
     if (!IsCloudEnv()) {
       GTEST_SKIP() << "Skipping S3ClientTest since STORAGE_TYPE is not 'remote'";
     }
+    auto provider = GetEnvVar("CLOUD_PROVIDER");
+    if (provider.ok() && provider.ValueOrDie() == "azure") {
+      GTEST_SKIP() << "S3ClientTest requires AWS S3 SDK, skipped for Azure provider";
+    }
 
     bucket_ = GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("test-bucket");
 

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -38,124 +38,28 @@
 #include "milvus-storage/filesystem/s3/s3_auth_signer.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
-#include "milvus-storage/filesystem/s3/util_internal.h"
+#include "milvus-storage/filesystem/util_internal.h"
 #include "milvus-storage/filesystem/fs.h"
 
 #include "test_env.h"
 
 namespace milvus_storage {
-
 // ============================================================================
-// Cloud-env tests (existing)
+// Non-cloud unit tests — S3 SDK initialized but no real cloud connection needed
 // ============================================================================
 
-class S3FsTest : public ::testing::Test {
+class S3UnitTest : public ::testing::Test {
   protected:
   void SetUp() override {
-    if (!IsCloudEnv()) {
-      GTEST_SKIP() << "S3 tests skipped in non-cloud environment";
+    auto provider = GetEnvVar("CLOUD_PROVIDER");
+    if (provider.ok() && provider.ValueOrDie() == "azure") {
+      GTEST_SKIP() << "S3 unit tests skipped for Azure provider";
     }
-    ASSERT_STATUS_OK(InitTestProperties(properties_));
-    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
   }
-
-  milvus_storage::api::Properties properties_;
-  ArrowFileSystemPtr fs_;
+  static void SetUpTestSuite() { ASSERT_TRUE(EnsureS3Initialized().ok()); }
 };
 
-TEST_F(S3FsTest, ConditionalWrite) {
-  std::string file_to = "/test_conditional_write.txt";
-
-  // Ensure source file does not exist
-  (void)fs_->DeleteFile(file_to);
-
-  std::string content1 = "This is a test file for conditional write.";
-  std::string content2 = "This is a test file for conditional write 2.";
-
-  // Create source file
-  {
-    std::shared_ptr<arrow::Buffer> buffer =
-        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content1.c_str()), content1.size());
-
-    auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs_);
-    ASSERT_NE(conditional_fs, nullptr);
-    ASSERT_AND_ASSIGN(auto output_stream, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
-    ASSERT_STATUS_OK(output_stream->Write(buffer));
-    ASSERT_STATUS_OK(output_stream->Close());
-    // check file exists, it should be a file
-    ASSERT_AND_ASSIGN(auto file_info, fs_->GetFileInfo(file_to));
-    ASSERT_EQ(file_info.type(), arrow::fs::FileType::File);
-  }
-
-  {
-    std::shared_ptr<arrow::Buffer> buffer =
-        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content2.c_str()), content2.size());
-
-    auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs_);
-    ASSERT_NE(conditional_fs, nullptr);
-    ASSERT_AND_ASSIGN(auto output_stream, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
-    ASSERT_STATUS_OK(output_stream->Write(buffer));
-    ASSERT_STATUS_NOT_OK(output_stream->Close());
-  }
-
-  (void)fs_->DeleteFile(file_to);
-
-  // Test conditional write in output_stream close
-  {
-    std::shared_ptr<arrow::Buffer> buffer1 =
-        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content1.c_str()), content1.size());
-    std::shared_ptr<arrow::Buffer> buffer2 =
-        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content2.c_str()), content2.size());
-
-    auto conditional_fs = std::dynamic_pointer_cast<UploadConditional>(fs_);
-    ASSERT_NE(conditional_fs, nullptr);
-    ASSERT_AND_ASSIGN(auto output_stream1, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
-    ASSERT_STATUS_OK(output_stream1->Write(buffer1));
-
-    ASSERT_AND_ASSIGN(auto output_stream2, conditional_fs->OpenConditionalOutputStream(file_to, nullptr));
-    ASSERT_STATUS_OK(output_stream2->Write(buffer2));
-
-    ASSERT_STATUS_OK(output_stream1->Close());
-    auto write_status = output_stream2->Close();
-    ASSERT_FALSE(write_status.ok());
-    auto extend_status = ExtendStatusDetail::UnwrapStatus(write_status);
-    ASSERT_NE(extend_status, nullptr);
-    ASSERT_TRUE(extend_status->code() == ExtendStatusCode::AwsErrorPreConditionFailed ||
-                extend_status->code() == ExtendStatusCode::AwsErrorConflict);
-  }
-}
-
-TEST_F(S3FsTest, TestMetadata) {
-  // predefined metadata
-  {
-    std::string file_to = "/predefined_metadata.txt";
-    (void)fs_->DeleteFile(file_to);
-    std::string content = "This is a test file for metadata.";
-
-    auto kvmeta = arrow::KeyValueMetadata::Make({"Content-Language"}, {"zh-CN"});
-    ASSERT_AND_ASSIGN(auto output_stream, fs_->OpenOutputStream(file_to, kvmeta));
-    std::shared_ptr<arrow::Buffer> buffer =
-        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.c_str()), content.size());
-
-    ASSERT_STATUS_OK(output_stream->Write(buffer));
-    ASSERT_STATUS_OK(output_stream->Close());
-  }
-
-  // custom metadata
-  {
-    std::string file_to = "/custom_metadata.txt";
-    (void)fs_->DeleteFile(file_to);
-    std::string content = "This is a test file for custom metadata.";
-    auto kvmeta = arrow::KeyValueMetadata::Make({"Content-Disposition"}, {"inline"});
-    ASSERT_AND_ASSIGN(auto output_stream, fs_->OpenOutputStream(file_to, kvmeta));
-    std::shared_ptr<arrow::Buffer> buffer =
-        std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.c_str()), content.size());
-    ASSERT_STATUS_OK(output_stream->Write(buffer));
-    ASSERT_STATUS_OK(output_stream->Close());
-  }
-}
-
-TEST_F(S3FsTest, TestExtendErrorInFs) {
+TEST_F(S3UnitTest, TestExtendErrorInFs) {
   Aws::Client::AWSError<Aws::S3::S3Errors> test_err(Aws::S3::S3Errors::NO_SUCH_UPLOAD,
                                                     Aws::Client::RetryableType::NOT_RETRYABLE, "AwsErrorNoSuchUpload",
                                                     "Just for test");
@@ -167,15 +71,6 @@ TEST_F(S3FsTest, TestExtendErrorInFs) {
   ASSERT_EQ(extend_status->code(), ExtendStatusCode::AwsErrorNoSuchUpload);
   ASSERT_TRUE(status.ToString().find(extend_status->ToString()) != std::string::npos);
 }
-
-// ============================================================================
-// Non-cloud unit tests — S3 SDK initialized but no real cloud connection needed
-// ============================================================================
-
-class S3UnitTest : public ::testing::Test {
-  protected:
-  static void SetUpTestSuite() { ASSERT_TRUE(EnsureS3Initialized().ok()); }
-};
 
 TEST_F(S3UnitTest, TestSignRequest) {
   // GET
@@ -994,185 +889,6 @@ TEST_F(S3UnitTest, TestS3ClientHolder) {
     auto moved = lock.Move();
     EXPECT_EQ(moved.get(), ptr_before);
   }
-}
-
-// ============================================================================
-// background_writes cloud-env tests
-// ============================================================================
-
-TEST_F(S3FsTest, BackgroundWritesConcurrent) {
-  constexpr int kNumThreads = 10;
-  const std::string base_dir = "/test_background_writes";
-
-  auto run_concurrent_writes = [&](bool background_writes) {
-    // Clear the global fs cache to force re-creation with new config
-    FilesystemCache::getInstance().clean();
-
-    api::Properties properties;
-    ASSERT_STATUS_OK(InitTestProperties(properties));
-    api::SetValue(properties, PROPERTY_FS_BACKGROUND_WRITES, background_writes ? "true" : "false");
-
-    ASSERT_AND_ASSIGN(auto fs, GetFileSystem(properties));
-
-    std::string dir = base_dir + (background_writes ? "/bg_true" : "/bg_false");
-    (void)fs->DeleteDirContents(dir, true);
-    ASSERT_STATUS_OK(fs->CreateDir(dir));
-
-    std::vector<std::thread> threads;
-    std::vector<arrow::Status> statuses(kNumThreads);
-
-    threads.reserve(kNumThreads);
-    for (int i = 0; i < kNumThreads; ++i) {
-      threads.emplace_back([&, i]() {
-        std::string path = dir + "/file_" + std::to_string(i) + ".txt";
-        std::string content = "thread_" + std::to_string(i) + "_data";
-
-        auto out_result = fs->OpenOutputStream(path);
-        if (!out_result.ok()) {
-          statuses[i] = out_result.status();
-          return;
-        }
-        auto out = out_result.ValueOrDie();
-        auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
-        statuses[i] = out->Write(buf);
-        if (statuses[i].ok()) {
-          statuses[i] = out->Close();
-        }
-      });
-    }
-
-    for (auto& t : threads) {
-      t.join();
-    }
-
-    for (int i = 0; i < kNumThreads; ++i) {
-      EXPECT_TRUE(statuses[i].ok()) << "Thread " << i << " failed: " << statuses[i].ToString();
-    }
-
-    // Verify all files exist and content is correct
-    for (int i = 0; i < kNumThreads; ++i) {
-      std::string path = dir + "/file_" + std::to_string(i) + ".txt";
-      std::string expected = "thread_" + std::to_string(i) + "_data";
-
-      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(path));
-      ASSERT_AND_ASSIGN(auto buf, input->Read(expected.size()));
-      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), expected)
-          << "Content mismatch for thread " << i;
-    }
-
-    // Cleanup
-    (void)fs->DeleteDirContents(dir, true);
-  };
-
-  // 1. background_writes = true
-  run_concurrent_writes(true);
-
-  // 2. background_writes = false
-  run_concurrent_writes(false);
-
-  (void)fs_->DeleteDirContents(base_dir, true);
-}
-
-// ============================================================================
-// use_crc32c_checksum cloud-env tests
-// ============================================================================
-
-TEST_F(S3FsTest, Crc32cChecksumWriteAndRead) {
-  const std::string base_dir = "/test_crc32c_checksum";
-
-  auto run_with_checksum = [&](bool use_crc32c) {
-    FilesystemCache::getInstance().clean();
-
-    api::Properties properties;
-    ASSERT_STATUS_OK(InitTestProperties(properties));
-    api::SetValue(properties, PROPERTY_FS_USE_CRC32C_CHECKSUM, use_crc32c ? "true" : "false");
-    // Use the minimum S3 part size (5MB) to trigger multipart upload with less data
-    api::SetValue(properties, PROPERTY_FS_MULTI_PART_UPLOAD_SIZE, "5242880");
-
-    ASSERT_AND_ASSIGN(auto fs, GetFileSystem(properties));
-
-    std::string dir = base_dir + (use_crc32c ? "/crc32c_on" : "/crc32c_off");
-    (void)fs->DeleteDirContents(dir, true);
-
-    // 1. CreateDir - exercises CreateEmptyDir (PutObjectRequest with CRC32C)
-    ASSERT_STATUS_OK(fs->CreateDir(dir));
-    std::string subdir = dir + "/subdir";
-    ASSERT_STATUS_OK(fs->CreateDir(subdir));
-
-    // 2. Single PutObject - small file write (PutObjectRequest via Upload template)
-    std::string path = dir + "/test_file.txt";
-    std::string content = "Hello, CRC32C checksum test!";
-    {
-      ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(path));
-      auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
-      ASSERT_STATUS_OK(out->Write(buf));
-      ASSERT_STATUS_OK(out->Close());
-    }
-
-    // Read back and verify
-    {
-      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(path));
-      ASSERT_AND_ASSIGN(auto buf, input->Read(content.size()));
-      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), content);
-    }
-
-    // 3. Multipart upload - write a buffer larger than part size to trigger multipart
-    {
-      std::string mp_path = dir + "/multipart_file.bin";
-      const int64_t kTotalSize = 15LL * 1024 * 1024;  // 15MB, guarantees multiple parts
-      std::string large_content(kTotalSize, 'A');
-      // Fill with a pattern so we can verify integrity
-      for (int64_t i = 0; i < kTotalSize; ++i) {
-        large_content[i] = static_cast<char>('A' + (i % 26));
-      }
-      {
-        ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(mp_path));
-        auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(large_content.data()),
-                                                   large_content.size());
-        ASSERT_STATUS_OK(out->Write(buf));
-        ASSERT_STATUS_OK(out->Close());
-      }
-      // Read back and verify
-      {
-        ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(mp_path));
-        ASSERT_AND_ASSIGN(auto buf, input->Read(kTotalSize));
-        ASSERT_EQ(buf->size(), kTotalSize);
-        EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), large_content);
-      }
-    }
-
-    // 5. CopyObject - exercises CopyObjectRequest with CRC32C
-    std::string copy_path = dir + "/test_file_copy.txt";
-    ASSERT_STATUS_OK(fs->CopyFile(path, copy_path));
-    {
-      ASSERT_AND_ASSIGN(auto input, fs->OpenInputStream(copy_path));
-      ASSERT_AND_ASSIGN(auto buf, input->Read(content.size()));
-      EXPECT_EQ(std::string(reinterpret_cast<const char*>(buf->data()), buf->size()), content);
-    }
-
-    // 6. DeleteDirContents - exercises DeleteObjectsRequest with CRC32C (batch delete)
-    // Create several files then batch-delete them
-    for (int i = 0; i < 3; ++i) {
-      std::string p = subdir + "/del_" + std::to_string(i) + ".txt";
-      ASSERT_AND_ASSIGN(auto out, fs->OpenOutputStream(p));
-      std::string data = "delete_me_" + std::to_string(i);
-      auto buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(data.data()), data.size());
-      ASSERT_STATUS_OK(out->Write(buf));
-      ASSERT_STATUS_OK(out->Close());
-    }
-    ASSERT_STATUS_OK(fs->DeleteDirContents(subdir));
-
-    // Cleanup
-    (void)fs->DeleteDirContents(dir, true);
-  };
-
-  // 1. use_crc32c_checksum = true
-  run_with_checksum(true);
-
-  // 2. use_crc32c_checksum = false
-  run_with_checksum(false);
-
-  (void)fs_->DeleteDirContents(base_dir, true);
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/include/test_env.h
+++ b/cpp/test/include/test_env.h
@@ -38,6 +38,7 @@
 #define ENV_VAR_ACCESS_KEY_VALUE "SECRET_KEY"
 #define ENV_VAR_REGION "REGION"
 #define ENV_VAR_USE_IAM "USE_IAM"
+#define ENV_VAR_USE_SSL "USE_SSL"
 
 // only used in local storage
 #define ENV_VAR_ROOT_PATH "ROOT_PATH"

--- a/cpp/test/test_env.cpp
+++ b/cpp/test/test_env.cpp
@@ -53,6 +53,11 @@ arrow::Status InitTestProperties(api::Properties& properties) {
     api::SetValue(properties, PROPERTY_FS_BUCKET_NAME, GetEnvVar(ENV_VAR_BUCKET_NAME).ValueOr("test-bucket").c_str());
     api::SetValue(properties, PROPERTY_FS_REGION, GetEnvVar(ENV_VAR_REGION).ValueOr("").c_str());
 
+    auto use_ssl = GetEnvVar(ENV_VAR_USE_SSL).ValueOr("");
+    if (use_ssl == "true" || use_ssl == "1") {
+      api::SetValue(properties, PROPERTY_FS_USE_SSL, "true");
+    }
+
     auto use_iam = GetEnvVar(ENV_VAR_USE_IAM).ValueOr("");
     if (use_iam == "true" || use_iam == "1") {
       api::SetValue(properties, PROPERTY_FS_USE_IAM, "true");


### PR DESCRIPTION
Ported the Azure filesystem implementation from Arrow 23.0.0 into milvus-storage directly, instead of relying on Arrow v17's built-in version. This brings in write buffering with async background uploads, SAS token authentication, improved CopyFile via StartCopyFromUri, PathFromUri support for abfs:// URIs, and several bug fixes from upstream.

The v23 code lives under the milvus_storage::fs namespace to avoid symbol conflicts with Arrow v17's own Azure FS that still ships in libarrow. A namespace bridge imports all the arrow types so the upstream code stays mostly untouched.

Removed the WITH_AZURE_FS / MILVUS_AZURE_FS conditional compilation entirely so Azure FS is always built. Also enabled arrow:with_azure=True on macOS since we now need the Azure SDK headers everywhere. Also renamed azure_fs.h/cpp to azure_fs_producer.h/cpp for clarity, and promoted util_internal.h from the s3 directory to the shared filesystem level since both S3 and Azure FS need it. Moved the SubmitIO template there as well.