### PR TITLE
enhance: align aws-sdk-cpp version with milvus

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -24,7 +24,7 @@ ifeq ($(uname_s),Darwin)
 endif
 
 # Common conan flags
-CONAN_BASE = conan install .. --build=missing ${libcxx_setting} -s build_type=${build_type} --update
+CONAN_BASE = conan install .. --build=arrow --build=missing ${libcxx_setting} -s build_type=${build_type} --update
 
 build:
 	# Example building debug mode: BUILD_TYPE=Debug WITH_UT=False make

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -53,6 +53,7 @@ class StorageConan(ConanFile):
         "aws-sdk-cpp:config": True,
         "aws-sdk-cpp:text-to-speech": False,
         "aws-sdk-cpp:transfer": False,
+        "aws-sdk-cpp:s3-crt": True,
         "arrow:with_s3": True,
         "arrow:filesystem_layer": True,
         "arrow:dataset_modules": True,
@@ -137,6 +138,7 @@ class StorageConan(ConanFile):
         self.requires("folly/2024.08.12.00@milvus/dev#e09fc71826ce6b4568441910665f0889")
         self.requires("libavrocpp/1.12.1.1@milvus/dev#a77043b1b435c3abef7b45710d05b300")
         self.requires("google-cloud-cpp/2.28.0@milvus/dev#25e69d743269d6c9ae5bf676af2174dc")
+        self.requires("aws-sdk-cpp/1.11.692@milvus/dev#1e17deac19383217d291a01c23147b33")
         # Force override transitive deps to align with milvus-common
         self.requires("protobuf/5.27.0@milvus/dev#6fff8583e2fe32babef04a9097f1d581", force=True, override=True)
         self.requires("grpc/1.67.1@milvus/dev#5aa62c51bced448b83d7db9e5b3a13c7", force=True, override=True)


### PR DESCRIPTION
Pin aws-sdk-cpp to 1.11.692@milvus/dev and enable the s3-crt option to stay consistent with the milvus dependency set.