### PR TITLE
enhance: switch from ARROW_LOG to glog which align with milvus

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ include(GNUInstallDirs)
 find_package(Boost REQUIRED)
 find_package(fmt REQUIRED)
 find_package(folly REQUIRED)
+find_package(glog REQUIRED)
 find_package(Arrow REQUIRED)
 # Support both Conan (lowercase) and system (mixed-case) variable names
 if(NOT Arrow_INCLUDE_DIRS AND arrow_INCLUDE_DIRS)
@@ -60,7 +61,7 @@ list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/jni/.*\\.cpp$")
 
 add_library(milvus-storage SHARED ${ALL_SRC_FILES})
 
-list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management google-cloud-cpp::storage ${AVRO_TARGET} Folly::folly fmt::fmt azure-sdk-for-cpp::azure-sdk-for-cpp)
+list(APPEND LINK_LIBS arrow::arrow Boost::boost protobuf::protobuf AWS::aws-sdk-cpp-identity-management google-cloud-cpp::storage ${AVRO_TARGET} Folly::folly fmt::fmt azure-sdk-for-cpp::azure-sdk-for-cpp glog::glog)
 list(APPEND INCLUDE_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Fault injection support using libfiu

--- a/cpp/include/milvus-storage/common/log.h
+++ b/cpp/include/milvus-storage/common/log.h
@@ -1,0 +1,48 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <typeinfo>
+#include <sys/types.h>
+#include <unistd.h>
+#include "glog/logging.h"
+#include <fmt/format.h>
+
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
+#endif
+
+// GLOG has no debug and trace level, using VLOG to implement it.
+#define GLOG_DEBUG 5
+#define GLOG_TRACE 6
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+#define STORAGE_MODULE_NAME "STORAGE"
+#define STORAGE_MODULE_CLASS_FUNCTION \
+  fmt::format("[{}][{}::{}][{}] ", STORAGE_MODULE_NAME, typeid(*this).name(), __FUNCTION__, GetThreadName())
+#define STORAGE_MODULE_FUNCTION fmt::format("[{}][{}][{}] ", STORAGE_MODULE_NAME, __FUNCTION__, GetThreadName())
+
+#define LOG_STORAGE_TRACE_ VLOG(GLOG_TRACE) << STORAGE_MODULE_FUNCTION
+#define LOG_STORAGE_DEBUG_ VLOG(GLOG_DEBUG) << STORAGE_MODULE_FUNCTION
+#define LOG_STORAGE_INFO_ LOG(INFO) << STORAGE_MODULE_FUNCTION
+#define LOG_STORAGE_WARNING_ LOG(WARNING) << STORAGE_MODULE_FUNCTION
+#define LOG_STORAGE_ERROR_ LOG(ERROR) << STORAGE_MODULE_FUNCTION
+#define LOG_STORAGE_FATAL_ LOG(FATAL) << STORAGE_MODULE_FUNCTION
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::string GetThreadName();

--- a/cpp/include/milvus-storage/filesystem/s3/s3_global.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_global.h
@@ -18,7 +18,7 @@
 #include <aws/core/http/HttpTypes.h>
 
 #include <arrow/status.h>
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 
 namespace milvus_storage {
 

--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -32,7 +32,7 @@
 
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/status.h>
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 #include <arrow/util/print.h>
 #include <arrow/util/string.h>
 
@@ -191,7 +191,7 @@ arrow::Status ErrorToStatus(const std::string& prefix,
   }
   std::string message = "AWS Error " + ss.str() + " during " + operation + " operation: " + error.GetMessage() +
                         wrong_region_msg.value_or("");
-  ARROW_LOG(WARNING) << message;
+  LOG_STORAGE_WARNING_ << message;
 
   switch (error_type) {
     case Aws::S3::S3Errors::NO_SUCH_UPLOAD:

--- a/cpp/src/common/log.cpp
+++ b/cpp/src/common/log.cpp
@@ -1,0 +1,32 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/common/log.h"
+
+#include <cstdint>
+#include <pthread.h>
+
+std::string GetThreadName() {
+  char buf[16] = {};
+  if (pthread_getname_np(pthread_self(), buf, sizeof(buf)) == 0 && buf[0] != '\0') {
+    return buf;
+  }
+#ifdef __APPLE__
+  uint64_t tid;
+  pthread_threadid_np(nullptr, &tid);
+#else
+  auto tid = gettid();
+#endif
+  return fmt::format("thread-{}", tid);
+}

--- a/cpp/src/ffi/segment_reader_c.cpp
+++ b/cpp/src/ffi/segment_reader_c.cpp
@@ -99,8 +99,7 @@ LoonFFIResult loon_segment_reader_open(const char* segment_path,
     }
 
     // open transaction to read manifest
-    auto txn_result = api::transaction::Transaction::Open(fs, segment_path, version,
-                                                          api::transaction::FailResolver, 1);
+    auto txn_result = api::transaction::Transaction::Open(fs, segment_path, version, api::transaction::FailResolver, 1);
     if (!txn_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, txn_result.status().ToString());
     }

--- a/cpp/src/filesystem/azure/azure_fs_producer.cpp
+++ b/cpp/src/filesystem/azure/azure_fs_producer.cpp
@@ -16,7 +16,7 @@
 #include <cassert>
 
 #include "milvus-storage/filesystem/azure/azurefs.h"
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -26,8 +26,8 @@ namespace milvus_storage {
 
 arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
   if (!config_.tls_min_version.empty()) {
-    ARROW_LOG(WARNING) << "tls_min_version is not yet supported for Azure filesystem. "
-                       << "Requested version: " << config_.tls_min_version << ". Ignoring.";
+    LOG_STORAGE_WARNING_ << "tls_min_version is not yet supported for Azure filesystem. "
+                         << "Requested version: " << config_.tls_min_version << ". Ignoring.";
   }
 
   milvus_storage::fs::AzureOptions options;

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -47,6 +47,7 @@
 #include <arrow/util/formatting.h>
 #include <arrow/util/future.h>
 #include <arrow/util/key_value_metadata.h>
+#include "milvus-storage/common/log.h"
 #include <arrow/util/logging.h>
 #include <arrow/util/string.h>
 
@@ -1653,7 +1654,7 @@ class LeaseGuard {
     // will eventually expire on the backend without any intervention from us (just much
     // later than if we released it).
     [[maybe_unused]] auto status = Release();
-    ARROW_LOG(DEBUG) << status;
+    LOG_STORAGE_DEBUG_ << status.ToString();
   }
 
   bool PendingRelease() const {
@@ -1693,7 +1694,7 @@ class LeaseGuard {
     };
 #ifndef NDEBUG
     if (break_period.HasValue() && !StillValidFor(*break_period)) {
-      ARROW_LOG(WARNING)
+      LOG_STORAGE_WARNING_
           << "Azure Storage: requested break_period ("
           << break_period.ValueOr(std::chrono::seconds{0}).count()
           << "s) is too long or lease duration is too short for all the operations "
@@ -1776,7 +1777,7 @@ class LeaseGuard {
 #ifndef NDEBUG
     int64_t remaining_time_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(remaining_time).count();
-    ARROW_LOG(WARNING) << "LeaseGuard::WaitUntilLatestKnownExpiryTime for "
+    LOG_STORAGE_WARNING_ << "LeaseGuard::WaitUntilLatestKnownExpiryTime for "
                        << remaining_time_ms << "ms...";
 #endif
     DCHECK(remaining_time <= kMaxLeaseDuration);

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "milvus-storage/common/log.h"
 #include <arrow/util/logging.h>
 #include <arrow/result.h>
 #include <arrow/util/thread_pool.h>
@@ -281,9 +282,9 @@ S3Model::CompleteMultipartUploadOutcome S3Client::CompleteMultipartUploadWithErr
 
     const bool should_retry = retry_strategy->ShouldRetry(*aws_error, retries);
 
-    ARROW_LOG(WARNING) << "CompletedMultipartUpload got error embedded in a 200 OK response: "
-                       << aws_error->GetExceptionName() << " (\"" << aws_error->GetMessage()
-                       << "\"), retry = " << should_retry;
+    LOG_STORAGE_WARNING_ << "CompletedMultipartUpload got error embedded in a 200 OK response: "
+                         << aws_error->GetExceptionName() << " (\"" << aws_error->GetMessage()
+                         << "\"), retry = " << should_retry;
 
     if (!should_retry) {
       break;
@@ -478,10 +479,10 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> ClientBuilder::BuildClient(
   // Root cause: Race condition between S3Options construction and ConfigureAccessKey call
   // TODO: Investigate and fix the root cause of the race condition
   if (!credentials_provider_) {
-    ARROW_LOG(ERROR) << "[HOTFIX] credentials_provider is nullptr! "
-                     << "This indicates a race condition or missing initialization. "
-                     << "Using AnonymousCredentialsProvider as fallback. "
-                     << "Please report this error with stack trace.";
+    LOG_STORAGE_ERROR_ << "[HOTFIX] credentials_provider is nullptr! "
+                       << "This indicates a race condition or missing initialization. "
+                       << "Using AnonymousCredentialsProvider as fallback. "
+                       << "Please report this error with stack trace.";
     return arrow::Status::Invalid("credentials_provider is nullptr");
   }
 

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include <arrow/util/async_generator.h>
+#include "milvus-storage/common/log.h"
 #include <arrow/util/logging.h>
 #include <arrow/buffer.h>
 #include <arrow/result.h>

--- a/cpp/src/filesystem/s3/s3_global.cpp
+++ b/cpp/src/filesystem/s3/s3_global.cpp
@@ -21,6 +21,7 @@
 
 #include <arrow/status.h>
 #include <arrow/result.h>
+#include "milvus-storage/common/log.h"
 #include <arrow/util/logging.h>
 #include <arrow/util/string.h>
 #include <arrow/util/uri.h>
@@ -28,11 +29,23 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
+#include <aws/core/utils/logging/FormattedLogSystem.h>
 
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/s3/s3_client.h"
 namespace milvus_storage {
+
+class GlogAwsLogger : public Aws::Utils::Logging::FormattedLogSystem {
+  public:
+  explicit GlogAwsLogger(Aws::Utils::Logging::LogLevel log_level)
+      : Aws::Utils::Logging::FormattedLogSystem(log_level) {}
+  ~GlogAwsLogger() override = default;
+  void Flush() override {}
+
+  protected:
+  void ProcessFormattedStatement(Aws::String&& statement) override { LOG_STORAGE_INFO_ << "[Storage-AWS] " << statement; }
+};
 
 S3GlobalOptions S3GlobalOptions::Defaults() {
   auto log_level = S3LogLevel::Fatal;
@@ -102,8 +115,8 @@ struct AwsInstance {
     if (is_initialized_.exchange(false)) {
       // Was initialized
       if (from_destructor) {
-        ARROW_LOG(WARNING) << " arrow::fs::FinalizeS3 was not called even though S3 was initialized.  "
-                              "This could lead to a segmentation fault at exit";
+        LOG_STORAGE_WARNING_ << " arrow::fs::FinalizeS3 was not called even though S3 was initialized.  "
+                                "This could lead to a segmentation fault at exit";
         auto* leaked_shared_ptr = new std::shared_ptr<S3ClientFinalizer>(client_finalizer);
         ARROW_UNUSED(leaked_shared_ptr);
         return;
@@ -139,9 +152,9 @@ struct AwsInstance {
 #undef LOG_LEVEL_CASE
 
     aws_options_.loggingOptions.logLevel = aws_log_level;
-    // By default the AWS SDK logs to files, log to console instead
-    aws_options_.loggingOptions.logger_create_fn = [this] {
-      return std::make_shared<Aws::Utils::Logging::ConsoleLogSystem>(aws_options_.loggingOptions.logLevel);
+    // Redirect AWS SDK logs to glog instead of console
+    aws_options_.loggingOptions.logger_create_fn = [aws_log_level] {
+      return std::make_shared<GlogAwsLogger>(aws_log_level);
     };
     if (options.override_default_http_options) {
       aws_options_.httpOptions = options.http_options;

--- a/cpp/src/filesystem/s3/s3_options.cpp
+++ b/cpp/src/filesystem/s3/s3_options.cpp
@@ -21,6 +21,7 @@
 #include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 
+#include "milvus-storage/common/log.h"
 #include <arrow/util/logging.h>
 #include <arrow/util/uri.h>
 #include <arrow/filesystem/path_util.h>

--- a/cpp/src/format/parquet/file_reader.cpp
+++ b/cpp/src/format/parquet/file_reader.cpp
@@ -25,7 +25,7 @@
 #include <arrow/type.h>
 #include <arrow/type_fwd.h>
 #include <arrow/util/key_value_metadata.h>
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 
 #include <parquet/arrow/schema.h>
 #include <parquet/type_fwd.h>
@@ -194,7 +194,7 @@ arrow::Status FileRowGroupReader::SliceRowGroupFromTable(std::shared_ptr<arrow::
 
 arrow::Status FileRowGroupReader::ReadNextRowGroup(std::shared_ptr<arrow::Table>* out) {
   if (current_rg_ > rg_end_ || rg_start_ == -1) {
-    ARROW_LOG(WARNING) << "Please set row group offset and count before reading next.";
+    LOG_STORAGE_WARNING_ << "Please set row group offset and count before reading next.";
     current_rg_ = -1;
     rg_start_ = -1;
     rg_end_ = -1;
@@ -230,7 +230,7 @@ arrow::Status FileRowGroupReader::ReadNextRowGroup(std::shared_ptr<arrow::Table>
     // No more row groups to read
     if (buffer_table_ != nullptr) {
       std::string error_msg = "No more row groups to read, but buffer table is not empty";
-      ARROW_LOG(ERROR) << error_msg;
+      LOG_STORAGE_ERROR_ << error_msg;
       return arrow::Status::IOError(error_msg);
     }
     rg_start_ = -1;

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -24,7 +24,7 @@
 #include <arrow/result.h>
 #include <arrow/status.h>
 #include <arrow/table.h>
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 #include <fmt/format.h>
 
 #include <parquet/properties.h>
@@ -49,7 +49,7 @@ PackedRecordBatchReader::PackedRecordBatchReader(const std::shared_ptr<arrow::fs
       read_count_(0) {
   auto status = init(fs, paths, schema, reader_props);
   if (!status.ok()) {
-    ARROW_LOG(ERROR) << "Error initializing PackedRecordBatchReader: " << status.ToString();
+    LOG_STORAGE_ERROR_ << "Error initializing PackedRecordBatchReader: " << status.ToString();
     throw std::runtime_error(status.ToString());
   }
 }
@@ -279,9 +279,9 @@ arrow::Status PackedRecordBatchReader::ReadNext(std::shared_ptr<arrow::RecordBat
 }
 
 arrow::Status PackedRecordBatchReader::Close() {
-  ARROW_LOG(DEBUG) << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
+  LOG_STORAGE_DEBUG_ << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
   for (size_t i = 0; i < column_group_states_.size(); ++i) {
-    ARROW_LOG(DEBUG) << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
+    LOG_STORAGE_DEBUG_ << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
   }
 
   // Clean up remaining data in all tables

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 
 #include <arrow/type.h>
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 #include <arrow/status.h>
 #include <fmt/format.h>
 
@@ -127,8 +127,8 @@ arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::Record
   // Flush column groups until there's enough room for the new column groups
   // to ensure that memory usage stays strictly below the limit
   while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
-    ARROW_LOG(DEBUG) << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
-                     << ", flushing column group: " << max_heap_.top().first;
+    LOG_STORAGE_DEBUG_ << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
+                       << ", flushing column group: " << max_heap_.top().first;
     auto max_group = max_heap_.top();
     max_heap_.pop();
 
@@ -198,7 +198,7 @@ arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
     max_heap_.pop();
     auto& grp_writer = group_writers_[max_group.first];
 
-    ARROW_LOG(DEBUG) << "Flushing remaining column group: " << max_group.first;
+    LOG_STORAGE_DEBUG_ << "Flushing remaining column group: " << max_group.first;
     current_memory_usage_ -= max_group.second;
     ARROW_RETURN_NOT_OK(grp_writer->Flush());
   }

--- a/cpp/src/segment/segment_reader.cpp
+++ b/cpp/src/segment/segment_reader.cpp
@@ -379,8 +379,9 @@ arrow::Result<std::unique_ptr<SegmentReader>> SegmentReader::Create(
   ARROW_ASSIGN_OR_RAISE(auto schema_info, BuildSchemasForExtraction(schema, extracted_columns, config.lob_columns));
   auto& [extracted_schema, storage_schema, lob_column_indices] = schema_info;
 
-  auto reader = std::make_unique<SegmentReaderImpl>(std::move(fs), schema, extracted_schema, storage_schema,
-                                                    std::move(extracted_columns), config, std::move(lob_column_indices));
+  auto reader =
+      std::make_unique<SegmentReaderImpl>(std::move(fs), schema, extracted_schema, storage_schema,
+                                          std::move(extracted_columns), config, std::move(lob_column_indices));
 
   ARROW_RETURN_NOT_OK(reader->Init(column_groups));
 
@@ -421,8 +422,9 @@ arrow::Result<std::unique_ptr<SegmentReader>> SegmentReader::Open(std::shared_pt
   ARROW_ASSIGN_OR_RAISE(auto schema_info, BuildSchemasForExtraction(schema, extracted_columns, config.lob_columns));
   auto& [extracted_schema, storage_schema, lob_column_indices] = schema_info;
 
-  auto reader = std::make_unique<SegmentReaderImpl>(std::move(fs), schema, extracted_schema, storage_schema,
-                                                    std::move(extracted_columns), config, std::move(lob_column_indices));
+  auto reader =
+      std::make_unique<SegmentReaderImpl>(std::move(fs), schema, extracted_schema, storage_schema,
+                                          std::move(extracted_columns), config, std::move(lob_column_indices));
 
   ARROW_RETURN_NOT_OK(reader->Init(column_groups));
 

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -21,7 +21,7 @@
 
 #include <arrow/status.h>
 #include <arrow/result.h>
-#include <arrow/util/logging.h>
+#include "milvus-storage/common/log.h"
 
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/layout.h"
@@ -319,8 +319,8 @@ arrow::Result<int64_t> Transaction::Commit() {
       latest_manifest = read_manifest_;
     } else {
       // Latest version differs, load the latest manifest
-      ARROW_LOG(DEBUG) << fmt::format("Manifest version drift detected: [read_version={}][latest_version={}]",
-                                      read_version_, latest_version);
+      LOG_STORAGE_DEBUG_ << fmt::format("Manifest version drift detected: [read_version={}][latest_version={}]",
+                                        read_version_, latest_version);
       ARROW_ASSIGN_OR_RAISE(latest_manifest, read_manifest(latest_version));
     }
 
@@ -350,7 +350,7 @@ arrow::Result<int64_t> Transaction::Commit() {
 
     // If commit succeeded, return the committed version
     if (status.ok()) {
-      ARROW_LOG(DEBUG) << fmt::format(
+      LOG_STORAGE_DEBUG_ << fmt::format(
           "Manifest committed successfully: [committed_version={}][read_version={}][retries={}]", committed_version,
           read_version_, retry_count);
       return committed_version;
@@ -358,7 +358,7 @@ arrow::Result<int64_t> Transaction::Commit() {
 
     // If commit failed due to conflict (file already exists), retry if within limit
     if (status.code() == arrow::StatusCode::AlreadyExists) {
-      ARROW_LOG(DEBUG) << fmt::format(
+      LOG_STORAGE_DEBUG_ << fmt::format(
           "Commit conflict: manifest version {} already exists, "
           "[read_version={}][latest_version={}][retry={}/{}]",
           committed_version, read_version_, latest_version, retry_count, retry_limit_);

--- a/cpp/test/segment/segment_reader_text_test.cpp
+++ b/cpp/test/segment/segment_reader_text_test.cpp
@@ -154,8 +154,8 @@ class SegmentReaderTextTest : public ::testing::Test {
 
   // helper: open transaction and get manifest
   std::shared_ptr<api::Manifest> OpenManifest(const std::string& segment_path, int64_t version) {
-    auto txn_result = api::transaction::Transaction::Open(fs_, segment_path, version,
-                                                          api::transaction::FailResolver, 1);
+    auto txn_result =
+        api::transaction::Transaction::Open(fs_, segment_path, version, api::transaction::FailResolver, 1);
     EXPECT_TRUE(txn_result.ok()) << txn_result.status().message();
     auto txn = std::move(txn_result).ValueOrDie();
     auto manifest_result = txn->GetManifest();
@@ -637,8 +637,8 @@ TEST_F(SegmentReaderTextTest, CreateFromColumnGroups) {
   int64_t version = WriteTestData(num_rows);
 
   // open transaction to get column groups
-  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
-                                                        api::transaction::FailResolver, 1);
+  auto txn_result =
+      api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version, api::transaction::FailResolver, 1);
   ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
   auto txn = std::move(txn_result).ValueOrDie();
 
@@ -670,8 +670,8 @@ TEST_F(SegmentReaderTextTest, CreateWithColumnSelection) {
   int64_t num_rows = 20;
   int64_t version = WriteTestData(num_rows);
 
-  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
-                                                        api::transaction::FailResolver, 1);
+  auto txn_result =
+      api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version, api::transaction::FailResolver, 1);
   ASSERT_TRUE(txn_result.ok());
   auto txn = std::move(txn_result).ValueOrDie();
   auto manifest_result = txn->GetManifest();
@@ -705,8 +705,8 @@ TEST_F(SegmentReaderTextTest, CreateWithColumnSelection) {
 TEST_F(SegmentReaderTextTest, CreateWithNullFs) {
   int64_t version = WriteTestData(10);
 
-  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
-                                                        api::transaction::FailResolver, 1);
+  auto txn_result =
+      api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version, api::transaction::FailResolver, 1);
   ASSERT_TRUE(txn_result.ok());
   auto txn = std::move(txn_result).ValueOrDie();
   auto manifest_result = txn->GetManifest();
@@ -721,8 +721,8 @@ TEST_F(SegmentReaderTextTest, CreateWithNullFs) {
 TEST_F(SegmentReaderTextTest, CreateWithNullSchema) {
   int64_t version = WriteTestData(10);
 
-  auto txn_result = api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version,
-                                                        api::transaction::FailResolver, 1);
+  auto txn_result =
+      api::transaction::Transaction::Open(fs_, writer_config_.segment_path, version, api::transaction::FailResolver, 1);
   ASSERT_TRUE(txn_result.ok());
   auto txn = std::move(txn_result).ValueOrDie();
   auto manifest_result = txn->GetManifest();

--- a/cpp/test/segment/segment_writer_test.cpp
+++ b/cpp/test/segment/segment_writer_test.cpp
@@ -295,8 +295,8 @@ TEST_F(SegmentWriterTest, WriteAndReadFromManifest) {
     ASSERT_STATUS_OK(InitTestProperties(reader_config.properties));
 
     // open transaction to get manifest
-    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path, -1,
-                                                          api::transaction::FailResolver, 1);
+    auto txn_result =
+        api::transaction::Transaction::Open(fs_, config_.segment_path, -1, api::transaction::FailResolver, 1);
     ASSERT_TRUE(txn_result.ok()) << txn_result.status().message();
     auto txn = std::move(txn_result).ValueOrDie();
     auto manifest_result = txn->GetManifest();
@@ -407,8 +407,8 @@ TEST_F(SegmentWriterTest, IncrementalWrites) {
     reader_config.lob_columns = config_.lob_columns;
     ASSERT_STATUS_OK(InitTestProperties(reader_config.properties));
 
-    auto txn_result = api::transaction::Transaction::Open(fs_, config_.segment_path, version2,
-                                                          api::transaction::FailResolver, 1);
+    auto txn_result =
+        api::transaction::Transaction::Open(fs_, config_.segment_path, version2, api::transaction::FailResolver, 1);
     ASSERT_TRUE(txn_result.ok());
     auto txn = std::move(txn_result).ValueOrDie();
     auto manifest_result = txn->GetManifest();


### PR DESCRIPTION
Previously we removed glog to avoid large TLS issues, but now we need it back to align with milvus-common's logging approach. This brings back glog/0.7.1 as a dependency and recreates the storage log.h/log.cpp that were removed in #269. The log macros (LOG_STORAGE_DEBUG_, LOG_STORAGE_WARNING_, etc.) follow the same pattern as milvus core's Log.h, using VLOG(5) for debug and VLOG(6) for trace so log verbosity is controllable at runtime via --v flag.

For AWS SDK logging, replaced the ConsoleLogSystem with a custom GlogAwsLogger that inherits FormattedLogSystem and forwards formatted statements through LOG_STORAGE_INFO_, consistent with how milvus core bridges AWS logs via its AwsLogger in MinioChunkManager.

The reason we align with milvus is that milvus core already handles glog initialization and configuration (log level, output destination, etc.), so storage just needs to use glog directly and the log output will be managed by the host process. With ARROW_LOG, storage's logs were going through a separate logging path that milvus had no control over.