### PR TITLE
feat: add Vortex V2 format reader and writer with row-group layout support

### DIFF
--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -145,6 +145,8 @@ struct PropertyInfo {
 #define PROPERTY_WRITER_ENC_ALGORITHM "writer.enc.algorithm"
 
 #define PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS "writer.vortex.enable_statistics"
+#define PROPERTY_WRITER_VORTEX_FORMAT_VERSION "writer.vortex.format_version"
+#define PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE "writer.vortex_v2.row_group_max_size"
 
 // --- Define Reader property keys ---
 #define PROPERTY_READER_RECORD_BATCH_MAX_ROWS "reader.record_batch_max_rows"

--- a/cpp/src/format/bridge/rust/CMakeLists.txt
+++ b/cpp/src/format/bridge/rust/CMakeLists.txt
@@ -25,6 +25,10 @@ corrosion_import_crate(
     CRATES rust-bridge
 )
 
+corrosion_set_env_vars(rust_bridge
+    "RUSTFLAGS=-C force-frame-pointers=yes"
+)
+
 # corrosion_add_cxxbridge can only import a single static library; 
 # otherwise, `rlib` will conflict.
 corrosion_add_cxxbridge(rust-bridge

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -6301,6 +6301,7 @@ dependencies = [
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
  "async-compat",
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-credential-types",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3.31"
 paste = "1.0.15"
 take_mut = "0.2.2"
 async-compat = "0.2.5"
+async-stream = "0.3"
 tokio = { version = "1.23", features = ["full"] }
 snafu = "0.8"
 

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -46,13 +46,19 @@ class LanceException : public std::runtime_error {
 class BlockingFragmentReader;
 class BlockingScanner;
 
+/// Lance IO statistics (read-and-reset semantics)
+struct LanceIOStats {
+  uint64_t read_iops = 0;
+  uint64_t read_bytes = 0;
+};
+
 /// Storage options type for S3/cloud access (key-value pairs).
 using StorageOptions = std::unordered_map<std::string, std::string>;
 
 /// Lance data storage format (file version)
 enum class LanceDataStorageFormat : uint8_t {
   Legacy = 0,  // Lance 0.1 format, data in data/
-  Stable = 1,  // Lance 2.0 format, data in _data/
+  Stable = 1,  // Lance 2.1 format, data in _data/
 };
 
 class BlockingDataset {
@@ -95,6 +101,9 @@ class BlockingDataset {
 
   // Dataset-level take: random access by global row indices
   ArrowArrayStream Take(const std::vector<int64_t>& indices, ArrowSchema& schema);
+
+  /// Read and reset IO statistics for this dataset's object store.
+  LanceIOStats IOStatsIncremental();
 
   const ffi::BlockingDataset& Impl() const { return *impl_; }
 

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -160,7 +160,8 @@ class VortexFile;
 
 class VortexWriter {
   public:
-  static VortexWriter Open(uint8_t* fs_rawptr, const std::string& path, const bool enable_stats);
+  static VortexWriter Open(
+      uint8_t* fs_rawptr, const std::string& path, bool enable_stats, uint32_t format_version, uint64_t row_group_size);
 
   void Write(ArrowSchema& in_schema, ArrowArray& in_array);
   ffi::VortexWriteSummary Close();
@@ -274,5 +275,14 @@ class ScanBuilder {
 
   rust::Box<ffi::VortexScanBuilder> impl_;
 };
+
+/// IO trace: enable tracing and reset state
+inline void ResetIOTrace() { ffi::reset_io_trace_ffi(); }
+
+/// IO trace: print collected trace to stderr
+inline void PrintIOTrace() { ffi::print_io_trace_ffi(); }
+
+/// IO trace: disable and clear
+inline void DisableIOTrace() { ffi::disable_io_trace_ffi(); }
 
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -1,18 +1,143 @@
 
 use std::ffi::{c_void};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::io::Write;
 use std::marker::PhantomData;
+use std::time::Instant;
 
 use async_compat::Compat;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
 
-use vortex::buffer::ByteBufferMut;
+use vortex::buffer::{ByteBuffer, ByteBufferMut};
 use vortex::error::{VortexError, VortexResult, vortex_err};
 use vortex::io::runtime::Handle;
 use vortex::io::file::{CoalesceWindow, IntoReadSource, ReadSource, ReadSourceRef, IoRequest};
+
+//=============================================================================
+// IO Trace Collector
+//=============================================================================
+
+#[derive(Clone)]
+struct IoTraceEntry {
+    seq: u32,
+    start_us: u64,   // microseconds since trace reset
+    end_us: u64,
+    offset: u64,
+    size: u64,
+}
+
+struct IoTraceState {
+    enabled: bool,
+    epoch: Instant,
+    entries: Vec<IoTraceEntry>,
+    seq_counter: u32,
+}
+
+static IO_TRACE: std::sync::LazyLock<Mutex<IoTraceState>> =
+    std::sync::LazyLock::new(|| Mutex::new(IoTraceState {
+        enabled: false,
+        epoch: Instant::now(),
+        entries: Vec::new(),
+        seq_counter: 0,
+    }));
+
+pub(crate) fn reset_io_trace() {
+    let mut state = IO_TRACE.lock().unwrap();
+    state.enabled = true;
+    state.epoch = Instant::now();
+    state.entries.clear();
+    state.seq_counter = 0;
+}
+
+pub(crate) fn disable_io_trace() {
+    let mut state = IO_TRACE.lock().unwrap();
+    state.enabled = false;
+    state.entries.clear();
+}
+
+fn record_io_start() -> (bool, Instant) {
+    let state = IO_TRACE.lock().unwrap();
+    (state.enabled, Instant::now())
+}
+
+fn record_io_end(enabled: bool, start_instant: Instant, offset: u64, size: u64) {
+    if !enabled { return; }
+    let mut state = IO_TRACE.lock().unwrap();
+    let epoch = state.epoch;
+    let seq = state.seq_counter;
+    state.seq_counter += 1;
+    state.entries.push(IoTraceEntry {
+        seq,
+        start_us: start_instant.duration_since(epoch).as_micros() as u64,
+        end_us: Instant::now().duration_since(epoch).as_micros() as u64,
+        offset,
+        size,
+    });
+}
+
+pub(crate) fn print_io_trace() {
+    let state = IO_TRACE.lock().unwrap();
+    if state.entries.is_empty() {
+        eprintln!("[IO Trace] No entries recorded");
+        return;
+    }
+
+    let mut entries = state.entries.clone();
+    entries.sort_by_key(|e| e.start_us);
+
+    // Group into rounds: a new round starts when a request's start_us is after
+    // the previous request's end_us (i.e., sequential dependency)
+    let mut rounds: Vec<Vec<&IoTraceEntry>> = Vec::new();
+    let mut current_round: Vec<&IoTraceEntry> = Vec::new();
+    let mut round_end_us: u64 = 0;
+
+    for entry in &entries {
+        if current_round.is_empty() || entry.start_us < round_end_us + 2000 {
+            // Same round (started within 2ms of round begin)
+            current_round.push(entry);
+            if entry.end_us > round_end_us {
+                round_end_us = entry.end_us;
+            }
+        } else {
+            rounds.push(current_round);
+            current_round = vec![entry];
+            round_end_us = entry.end_us;
+        }
+    }
+    if !current_round.is_empty() {
+        rounds.push(current_round);
+    }
+
+    eprintln!("[IO Trace] {} total requests, {} rounds", entries.len(), rounds.len());
+    let total_bytes: u64 = entries.iter().map(|e| e.size).sum();
+    let wall_us = entries.iter().map(|e| e.end_us).max().unwrap_or(0)
+                - entries.iter().map(|e| e.start_us).min().unwrap_or(0);
+    eprintln!("[IO Trace] total_bytes={:.2}MB  wall={:.1}ms",
+             total_bytes as f64 / (1024.0 * 1024.0), wall_us as f64 / 1000.0);
+
+    for (ri, round) in rounds.iter().enumerate() {
+        let r_start = round.iter().map(|e| e.start_us).min().unwrap_or(0);
+        let r_end = round.iter().map(|e| e.end_us).max().unwrap_or(0);
+        let r_wall = r_end - r_start;
+        let longest = round.iter().map(|e| e.end_us - e.start_us).max().unwrap_or(0);
+        let r_bytes: u64 = round.iter().map(|e| e.size).sum();
+        eprintln!("    R{} — {} req, wall={:.1}ms, longest={:.1}ms, bytes={:.2}MB",
+                 ri + 1, round.len(), r_wall as f64 / 1000.0,
+                 longest as f64 / 1000.0, r_bytes as f64 / (1024.0 * 1024.0));
+        for entry in round.iter() {
+            eprintln!("      seq={:<3} start={:>8.1}ms end={:>8.1}ms dur={:>6.1}ms size={:>8} range={}..{}",
+                     entry.seq,
+                     entry.start_us as f64 / 1000.0,
+                     entry.end_us as f64 / 1000.0,
+                     (entry.end_us - entry.start_us) as f64 / 1000.0,
+                     entry.size,
+                     entry.offset,
+                     entry.offset + entry.size);
+        }
+    }
+}
 
 #[repr(C)]
 pub struct LoonFFIResult {
@@ -213,9 +338,9 @@ impl Write for ObjectStoreWriterCpp {
 
 const COALESCING_WINDOW: CoalesceWindow = CoalesceWindow {
     distance: 1024 * 1024,       // 1 MB
-    max_size: 1 * 1024 * 1024,   // 1 MB
+    max_size: 1 * 1024 * 1024,  // 1 MB
 };
-const CONCURRENCY: usize = 192;
+const CONCURRENCY: usize = 256;
 
 /// Arc-wrapped reader handle that ensures the underlying C++ RandomAccessFile
 /// is only closed/destroyed after all concurrent spawn_blocking tasks are done.
@@ -278,6 +403,7 @@ impl ObjectStoreReadSourceCpp {
     }
 }
 
+// Drop is handled by Arc<ReaderHandle> which closes and destroys the reader.
 
 impl IntoReadSource for ObjectStoreReadSourceCpp {
     fn into_read_source(self, handle: Handle) -> VortexResult<ReadSourceRef> {
@@ -350,16 +476,18 @@ impl ReadSource for ObjectStoreIoSourceCpp {
 
                 let alignment = req.alignment();
 
-                // Offload sync FFI to blocking pool, reuse the pre-opened reader handle
-                let blocking = self.handle.spawn_blocking(move || -> VortexResult<Vec<u8>> {
-                    let mut owned: Vec<u8> = Vec::with_capacity(len as usize);
+                // Offload sync FFI to blocking pool, read directly into aligned buffer
+                let blocking = self.handle.spawn_blocking(move || -> VortexResult<ByteBuffer> {
+                    let (trace_enabled, trace_start) = record_io_start();
+                    let mut buffer = ByteBufferMut::with_capacity_aligned(len as usize, alignment);
 
                     unsafe {
+                        let dst = buffer.spare_capacity_mut().as_mut_ptr() as *mut u8;
                         let mut result = loon_filesystem_reader_readat(
                             reader.as_ptr(),
                             start,
                             len,
-                            owned.as_mut_ptr(),
+                            dst,
                         );
 
                         check_loon_ffi_result(
@@ -367,17 +495,16 @@ impl ReadSource for ObjectStoreIoSourceCpp {
                             "Failed to readat from ObjectStoreIoSourceCpp",
                         )?;
 
-                        owned.set_len(len as usize);
+                        buffer.set_len(len as usize);
                     }
 
-                    Ok(owned)
+                    record_io_end(trace_enabled, trace_start, start, len);
+                    Ok(buffer.freeze())
                 });
 
                 let fut = async move {
-                    let bytes: Vec<u8> = Compat::new(blocking).await?;
-                    let mut buffer = ByteBufferMut::with_capacity_aligned(len as usize, alignment);
-                    buffer.extend_from_slice(&bytes);
-                    Ok(buffer.freeze())
+                    let buffer: ByteBuffer = Compat::new(blocking).await?;
+                    Ok(buffer)
                 };
 
                 async move { req.resolve(Compat::new(fut).await) }

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -192,6 +192,15 @@ std::unique_ptr<BlockingScanner> BlockingDataset::Scan(ArrowSchema& schema, uint
   }
 }
 
+LanceIOStats BlockingDataset::IOStatsIncremental() {
+  try {
+    auto stats = impl_->io_stats_incremental();
+    return {stats.read_iops, stats.read_bytes};
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw LanceException(e.what());
+  }
+}
+
 ArrowArrayStream BlockingDataset::Take(const std::vector<int64_t>& indices, ArrowSchema& schema) {
   try {
     ArrowArrayStream stream;

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -312,6 +312,14 @@ impl BlockingDataset {
 }
 
 impl BlockingDataset {
+    pub fn io_stats_incremental(&self) -> crate::lance_ffi::LanceIOStats {
+        let stats = self.inner.object_store().io_stats_incremental();
+        crate::lance_ffi::LanceIOStats {
+            read_iops: stats.read_iops,
+            read_bytes: stats.read_bytes,
+        }
+    }
+
     pub unsafe fn write_stream(&mut self, stream_ptr: *mut u8) -> Result<()> {
         let stream_ptr = stream_ptr as *mut FFI_ArrowArrayStream;
         let stream = unsafe { std::ptr::replace(stream_ptr, FFI_ArrowArrayStream::empty()) };
@@ -563,7 +571,7 @@ pub unsafe fn write_dataset(
 
     let lance_file_version = match data_storage_format {
         LanceDataStorageFormat::Legacy => LanceFileVersion::Legacy,
-        LanceDataStorageFormat::Stable => LanceFileVersion::V2_0,  // Stable resolves to V2_0
+        LanceDataStorageFormat::Stable => LanceFileVersion::V2_1,  // Stable resolves to V2_1
         _ => LanceFileVersion::Legacy,
     };
 
@@ -1036,3 +1044,5 @@ pub unsafe fn dataset_take(
     unsafe { std::ptr::write(out_stream_ptr, ffi_stream) };
     Ok(())
 }
+
+

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -26,19 +26,26 @@ use iceberg_bridgeimpl::*;
 use iceberg_testutil::*;
 
 use std::sync::LazyLock;
+
 use vortex::VortexSessionDefault;
-use vortex::io::runtime::current::CurrentThreadRuntime;
+use vortex::io::runtime::tokio::TokioRuntime;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::session::RuntimeSessionExt;
 use vortex::session::VortexSession;
 
-/// By default, the C++ API uses a current-thread runtime, providing control of the threading
-/// model to the C++ side.
-///
-// TODO(ngates): in the future, we could expose an API for C++ to spawn threads that can drive
-//  this runtime.
-static VORTEX_RT: LazyLock<CurrentThreadRuntime> =
-    LazyLock::new(CurrentThreadRuntime::new);
+/// Use a multi-thread Tokio runtime so that Vortex IO operations can run concurrently.
+/// max_blocking_threads is set to 64 to match Lance's thread pool size,
+/// preventing excessive thread creation under concurrent reader load.
+static VORTEX_TOKIO_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .max_blocking_threads(256)
+        .enable_all()
+        .build()
+        .expect("Failed to create Vortex tokio runtime")
+});
+
+static VORTEX_RT: LazyLock<TokioRuntime> =
+    LazyLock::new(|| TokioRuntime::new(VORTEX_TOKIO_RT.handle().clone()));
 
 static VORTEX_SESSION: LazyLock<VortexSession> =
     LazyLock::new(|| VortexSession::default().with_handle(VORTEX_RT.handle()));
@@ -60,9 +67,16 @@ pub mod lance_ffi {
         Stable = 1,
     }
 
+    /// IO statistics returned by io_stats_incremental (read-and-reset)
+    struct LanceIOStats {
+        read_iops: u64,
+        read_bytes: u64,
+    }
+
     extern "Rust" {
 
         type BlockingDataset;
+        pub fn io_stats_incremental(self: &BlockingDataset) -> LanceIOStats;
         pub fn open_dataset(
             uri: &str,
             storage_options_keys: Vec<String>,
@@ -146,6 +160,7 @@ pub mod lance_ffi {
             schema_ptr: *mut u8,
             out_stream: *mut u8,
         ) -> Result<()>;
+
     }
 }  // mod lance_ffi
 
@@ -206,8 +221,7 @@ pub mod vortex_ffi {
 
         // writer
         type VortexWriter;
-        unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool) -> Result<Box<VortexWriter>>;
-        // unsafe fn write(self: &mut VortexWriter, in_stream: *mut u8) -> Result<()>;
+        unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool, format_version: u32, row_group_size: u64) -> Result<Box<VortexWriter>>;
         unsafe fn write(self: &mut VortexWriter, in_schema: *mut u8, in_array: *mut u8) -> Result<()>;
         unsafe fn close(self: &mut VortexWriter) -> Result<VortexWriteSummary>;
 
@@ -238,6 +252,11 @@ pub mod vortex_ffi {
             builder: Box<VortexScanBuilder>,
             out_stream: *mut u8,
         ) -> Result<()>;
+
+        // IO trace
+        fn reset_io_trace_ffi();
+        fn print_io_trace_ffi();
+        fn disable_io_trace_ffi();
     }
 
     #[repr(u8)]

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -138,9 +138,11 @@ Scalar cast(Scalar scalar, DType dtype) {
 
 }  // namespace scalar
 
-VortexWriter VortexWriter::Open(uint8_t* fs_rawptr, const std::string& path, const bool enable_stats) {
+VortexWriter VortexWriter::Open(
+    uint8_t* fs_rawptr, const std::string& path, bool enable_stats, uint32_t format_version, uint64_t row_group_size) {
   try {
-    return VortexWriter(ffi::open_writer(fs_rawptr, rust::Str(path.data(), path.length()), enable_stats));
+    return VortexWriter(ffi::open_writer(fs_rawptr, rust::Str(path.data(), path.length()), enable_stats, format_version,
+                                         row_group_size));
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -26,9 +26,30 @@ use vortex::scan::ScanBuilder;
 use vortex::dtype::{DType as RustDType, DecimalDType, Nullability, PType as RustPType, FieldName};
 use vortex::dtype::arrow::FromArrowType;
 use vortex::expr::Expression;
-use vortex::io::runtime::current::CurrentThreadRuntime;
+use vortex::io::runtime::tokio::TokioRuntime;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::error::VortexError;
+
+use std::collections::VecDeque;
+use async_trait::async_trait;
+use async_stream::try_stream;
+use futures::{StreamExt as FuturesStreamExt, pin_mut};
+
+use vortex::file::VortexWriteOptions;
+use vortex::file::WriteStrategyBuilder;
+use vortex::IntoArray;
+use vortex::arrays::ChunkedArray;
+use vortex::layout::LayoutStrategy;
+use vortex::layout::LayoutRef as VortexLayoutRef;
+use vortex::layout::segments::SegmentSinkRef;
+use vortex::layout::sequence::{SendableSequentialStream, SequencePointer, SequentialStreamAdapter, SequentialStreamExt};
+use vortex::layout::layouts::flat::writer::FlatLayoutStrategy;
+use vortex::layout::layouts::compressed::CompressingStrategy;
+use vortex::layout::layouts::chunked::writer::ChunkedLayoutStrategy;
+use vortex::layout::layouts::collect::CollectStrategy;
+use vortex::layout::layouts::struct_::writer::StructStrategy;
+use vortex::io::runtime::Handle;
+use vortex::ArrayContext;
 
 use crate::filesystem_c::*;
 use crate::VORTEX_RT;
@@ -435,20 +456,233 @@ pub const VORTEX_NON_STATS: &[Stat] = &[
     Stat::UncompressedSizeInBytes
 ];
 
+const VORTEX_FORMAT_V1: u32 = 1;
+const VORTEX_FORMAT_V2: u32 = 2;
+
+/// Options for byte-size-based row group splitting.
+#[derive(Clone)]
+struct RowGroupSplitOptions {
+    block_size_minimum: u64,
+    canonicalize: bool,
+}
+
+/// Splits a stream of arrays into row groups based on uncompressed byte size.
+///
+/// Unlike `RepartitionStrategy` which slices incoming chunks into fixed-row-count
+/// pieces via `block_len_multiple`, this strategy keeps incoming chunks intact and
+/// flushes all accumulated data as a single row group when the byte threshold is met.
+struct RowGroupSplitStrategy {
+    child: Arc<dyn LayoutStrategy>,
+    options: RowGroupSplitOptions,
+}
+
+impl RowGroupSplitStrategy {
+    fn new<S: LayoutStrategy>(child: S, options: RowGroupSplitOptions) -> Self {
+        Self {
+            child: Arc::new(child),
+            options,
+        }
+    }
+}
+
+/// Simple accumulator that buffers chunks until a byte-size threshold is reached,
+/// then drains them as size-limited row groups.
+///
+/// Each entry stores (chunk, estimated_bytes) because `nbytes()` on a sliced array
+/// may return the underlying buffer's total size, not the slice's portion.
+struct RowGroupBuffer {
+    data: VecDeque<(vortex::ArrayRef, u64)>,
+    nbytes: u64,
+    block_size_minimum: u64,
+}
+
+impl RowGroupBuffer {
+    fn new(block_size_minimum: u64) -> Self {
+        Self {
+            data: VecDeque::new(),
+            nbytes: 0,
+            block_size_minimum,
+        }
+    }
+
+    fn push(&mut self, chunk: vortex::ArrayRef) {
+        let nbytes = chunk.nbytes() as u64;
+        self.nbytes += nbytes;
+        self.data.push_back((chunk, nbytes));
+    }
+
+    fn have_enough(&self) -> bool {
+        self.nbytes >= self.block_size_minimum
+    }
+
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Drain one row group (~block_size_minimum bytes) from the front of the buffer.
+    /// If a chunk would overshoot the limit, slice it and put the remainder back.
+    fn drain_one_group(&mut self, dtype: &vortex::dtype::DType) -> Option<vortex::ArrayRef> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        let mut group = Vec::new();
+        let mut group_bytes: u64 = 0;
+
+        while let Some((chunk, est_bytes)) = self.data.pop_front() {
+            let chunk_len = chunk.len();
+            self.nbytes -= est_bytes;
+
+            if group_bytes + est_bytes <= self.block_size_minimum {
+                group_bytes += est_bytes;
+                group.push(chunk);
+                if group_bytes >= self.block_size_minimum {
+                    break;
+                }
+            } else {
+                // This chunk would overshoot — slice to fit
+                let space_left = self.block_size_minimum - group_bytes;
+                let rows_to_take = if est_bytes > 0 {
+                    ((space_left * chunk_len as u64 + est_bytes - 1) / est_bytes) as usize
+                } else {
+                    chunk_len
+                }.max(1).min(chunk_len);
+
+                let left = chunk.slice(0..rows_to_take);
+                group.push(left);
+
+                if rows_to_take < chunk_len {
+                    let right = chunk.slice(rows_to_take..chunk_len);
+                    let right_est = est_bytes * (chunk_len - rows_to_take) as u64 / chunk_len as u64;
+                    self.nbytes += right_est;
+                    self.data.push_front((right, right_est));
+                }
+                break;
+            }
+        }
+
+        let chunked = ChunkedArray::try_new(group, dtype.clone()).ok()?;
+        Some(chunked.to_canonical().into_array())
+    }
+}
+
+#[async_trait]
+impl LayoutStrategy for RowGroupSplitStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        stream: SendableSequentialStream,
+        eof: SequencePointer,
+        handle: Handle,
+    ) -> vortex::error::VortexResult<VortexLayoutRef> {
+        let dtype = stream.dtype().clone();
+        let stream = if self.options.canonicalize {
+            SequentialStreamAdapter::new(
+                dtype.clone(),
+                stream.map(|chunk| {
+                    let (sequence_id, chunk) = chunk?;
+                    vortex::error::VortexResult::Ok((sequence_id, chunk.to_canonical().into_array()))
+                }),
+            )
+            .sendable()
+        } else {
+            stream
+        };
+
+        let dtype_clone = dtype.clone();
+        let block_size_minimum = self.options.block_size_minimum;
+        let repartitioned_stream = try_stream! {
+            let stream = stream.peekable();
+            pin_mut!(stream);
+            let mut buffer = RowGroupBuffer::new(block_size_minimum);
+
+            // Each input chunk comes from a C++ Write() call via BlockingWriter::push().
+            // The stream closes when C++ calls Close() (BlockingWriter::finish()).
+            while let Some(chunk) = stream.as_mut().next().await {
+                let (sequence_id, chunk) = chunk?;
+                // Create a child sequence pointer for this input chunk.
+                // Each advance() produces a unique, ordered ID (A.0, A.1, ...)
+                // so downstream ChunkedLayoutStrategy can write row groups concurrently
+                // while preserving deterministic ordering in the final file.
+                let mut sp = sequence_id.descend();
+
+                if chunk.len() > 0 {
+                    buffer.push(chunk);
+                }
+
+                // Check if this is the last chunk (writer is closing).
+                let is_eof = stream.as_mut().peek().await.is_none();
+
+                // Drain row groups from the buffer:
+                // - Normally: only drain when accumulated bytes >= block_size_minimum
+                // - At EOF: drain all remaining data as size-limited row groups
+                while buffer.have_enough() || (is_eof && !buffer.is_empty()) {
+                    if let Some(array) = buffer.drain_one_group(&dtype_clone) {
+                        yield (sp.advance(), array)
+                    } else {
+                        break;
+                    }
+                }
+            }
+        };
+
+        self.child
+            .write_stream(
+                ctx,
+                segment_sink,
+                SequentialStreamAdapter::new(dtype, repartitioned_stream).sendable(),
+                eof,
+                handle,
+            )
+            .await
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.child.buffered_bytes()
+    }
+}
+
+fn build_row_group_strategy(row_group_max_size: u64) -> Arc<dyn LayoutStrategy> {
+    let flat = FlatLayoutStrategy { inline_array_node: true, ..Default::default() };
+    let compress_flat = CompressingStrategy::new_btrblocks(flat, false);
+    let chunked_inner = ChunkedLayoutStrategy::new(compress_flat.clone());
+    let validity = CollectStrategy::new(compress_flat);
+    let struct_inner = StructStrategy::new(chunked_inner, validity);
+    let chunked_outer = ChunkedLayoutStrategy::new(struct_inner);
+    // RowGroupSplit is the top-level strategy: it receives the full push stream,
+    // accumulates across batch boundaries, and yields row-group-sized arrays.
+    // Each yield becomes one chunk in the outer ChunkedLayout.
+    Arc::new(RowGroupSplitStrategy::new(
+        chunked_outer,
+        RowGroupSplitOptions {
+            block_size_minimum: row_group_max_size,
+            canonicalize: false,
+        },
+    ))
+}
+
 pub(crate) struct VortexWriter {
     pub fswrapper_ptr: *mut u8,
     pub path: String,
-    pub inner_writer: Option<BlockingWriter<'static, 'static, CurrentThreadRuntime>>,
+    pub inner_writer: Option<BlockingWriter<'static, 'static, TokioRuntime>>,
     pub enable_stats: bool,
+    pub format_version: u32,
+    pub row_group_max_size: u64,
 }
 
-pub(crate) unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool) 
+pub(crate) unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool, format_version: u32, row_group_max_size: u64)
     -> Result<Box<VortexWriter>, Box<dyn std::error::Error>> {
-    Ok(Box::new(VortexWriter { 
-        fswrapper_ptr: fswrapper_ptr,
+    if format_version == VORTEX_FORMAT_V2 && row_group_max_size == 0 {
+        return Err("format_version=V2 requires row_group_max_size > 0".into());
+    }
+    Ok(Box::new(VortexWriter {
+        fswrapper_ptr,
         path: path.to_string(),
-        inner_writer : None,
-        enable_stats : enable_stats,
+        inner_writer: None,
+        enable_stats,
+        format_version,
+        row_group_max_size,
     }))
 }
 
@@ -483,9 +717,17 @@ pub(crate) unsafe fn write(&mut self, in_schema: *mut u8, in_array: *mut u8) -> 
         } else {
             VORTEX_NON_STATS.to_vec()
         };
+        let strategy = if self.format_version == VORTEX_FORMAT_V2 {
+            build_row_group_strategy(self.row_group_max_size)
+        } else {
+            WriteStrategyBuilder::new()
+                .with_inline_array_node(true)
+                .build()
+        };
 
-        let blocking_writer = vortex::file::VortexWriteOptions::new(VORTEX_SESSION.clone())
+        let blocking_writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
             .with_file_statistics(stats_options)
+            .with_strategy(strategy)
             .blocking(&*VORTEX_RT)
             .writer(objw, vortex_schema);
 
@@ -506,16 +748,6 @@ pub(crate) unsafe fn close(&mut self) -> Result<crate::vortex_ffi::VortexWriteSu
         let file_size = summary.size();
 
         // Re-serialize the footer to compute the exact footer region size on disk.
-        // This size is used as `with_initial_read_size()` when opening the file,
-        // so the reader can fetch the entire footer in a single IO.
-        //
-        // serialize() produces all buffers that make up the footer region:
-        //   [dtype fb] [layout fb] [statistics fb] [footer fb] [postscript] [EOF 8B]
-        //
-        // Why re-serialization is accurate:
-        // - with_offset() only affects the absolute offsets stored inside the postscript,
-        //   not the buffer sizes (see FooterSerializer::write_flatbuffer), so offset=0 is safe.
-        // - exclude_dtype defaults to false, matching our writer which never excludes dtype.
         let footer_size: u64 = summary.footer().clone()
             .into_serializer()
             .serialize()
@@ -542,7 +774,7 @@ impl VortexFile {
 
     pub(crate) fn scan_builder(&self) -> Result<Box<VortexScanBuilder>> {
         Ok(Box::new(VortexScanBuilder {
-            inner: self.inner.scan()?,
+            inner: self.inner.scan()?.with_split_row_indices(false),
             output_schema: None,
             original_schema: None,
             row_range: None,
@@ -557,7 +789,7 @@ impl VortexFile {
         let converted_schema = Arc::new(convert_schema_for_vortex(&original_schema));
 
         Ok(Box::new(VortexScanBuilder {
-            inner: self.inner.scan()?,
+            inner: self.inner.scan()?.with_split_row_indices(false),
             output_schema: Some(converted_schema),
             original_schema: Some(original_schema),
             row_range: None,
@@ -628,7 +860,9 @@ pub(crate) unsafe fn open_file(
     }
     if footer_size > 0 {
         // Use cached footer size as initial read size to read entire footer in one IO.
-        open_options = open_options.with_initial_read_size(footer_size as usize);
+        // Add EOF_SIZE for the EOF marker (version + postscript length + magic) that follows the footer.
+        open_options = open_options
+            .with_initial_read_size(footer_size as usize + vortex::file::EOF_SIZE);
     }
     let file = VORTEX_RT.block_on(async move {
         open_options
@@ -675,7 +909,17 @@ impl VortexScanBuilder {
     pub(crate) fn with_include_by_index(&mut self, include_by_index: &[u64]) {
         let selection =
             vortex::scan::Selection::IncludeByIndex(Buffer::copy_from(include_by_index));
-        take_mut::take(&mut self.inner, |inner| inner.with_selection(selection));
+        take_mut::take(&mut self.inner, |inner| {
+            inner
+                .with_selection(selection)
+                // For point queries, increase concurrency so that all natural splits
+                // fit within the buffered() window. This ensures all IO requests are
+                // visible to the IO driver at once, reducing from ~5 IO rounds to 2.
+                // Default is 4 per-thread; with 16 cores this gives buffered(64) which
+                // is too small for files with many chunks (e.g. 370 embedding chunks).
+                // Setting 128 gives buffered(128*16=2048), covering any realistic file.
+                .with_concurrency(128)
+        });
     }
 
     pub(crate) fn with_limit(&mut self, limit: usize) {
@@ -806,3 +1050,16 @@ pub(crate) unsafe fn scan_builder_into_stream(
     unsafe { std::ptr::write(out_stream, stream) };
     Ok(())
 }
+
+pub fn reset_io_trace_ffi() {
+    crate::filesystem_c::reset_io_trace();
+}
+
+pub fn print_io_trace_ffi() {
+    crate::filesystem_c::print_io_trace();
+}
+
+pub fn disable_io_trace_ffi() {
+    crate::filesystem_c::disable_io_trace();
+}
+

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -70,7 +70,7 @@ static std::vector<RowGroupInfo> create_row_group_infos(uint64_t memory_usage_in
     result[i] = RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = last_offset + row_ranges[i],
-        .memory_size = memory_usage_in_file * (row_ranges[i] / rows_in_file),
+        .memory_size = memory_usage_in_file * row_ranges[i] / rows_in_file,
     };
     last_offset += row_ranges[i];
   }

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -34,10 +34,12 @@ VortexFileWriter::VortexFileWriter(const std::shared_ptr<arrow::fs::FileSystem>&
     : closed_(false),
       file_path_(file_path),
       fs_holder_(std::make_unique<FileSystemWrapper>(fs)),
-      vx_writer_(
-          std::move(VortexWriter::Open(reinterpret_cast<uint8_t*>(fs_holder_.get()),
-                                       file_path_,
-                                       GetValueNoError<bool>(properties, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS)))),
+      vx_writer_(std::move(VortexWriter::Open(
+          reinterpret_cast<uint8_t*>(fs_holder_.get()),
+          file_path_,
+          GetValueNoError<bool>(properties, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS),
+          static_cast<uint32_t>(GetValueNoError<uint64_t>(properties, PROPERTY_WRITER_VORTEX_FORMAT_VERSION)),
+          GetValueNoError<uint64_t>(properties, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE)))),
       schema_(std::move(schema)),
       properties_(properties) {}
 

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -495,6 +495,16 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "Whether to enable statistics collection in Vortex writer.",
                       false,
                       ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_WRITER_VORTEX_FORMAT_VERSION,
+                      PropertyType::UINT64,
+                      "Vortex format version: 1 for default layout, 2 for row-group layout.",
+                      uint64_t(2),
+                      ValidatePropertyType() + ValidatePropertyRange<uint64_t>(1, 2)),
+    REGISTER_PROPERTY(PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE,
+                      PropertyType::UINT64,
+                      "Max uncompressed size in bytes per row group for Vortex V2 layout.",
+                      uint64_t(DEFAULT_MAX_ROW_GROUP_SIZE),
+                      ValidatePropertyType() + ValidatePropertyRange<uint64_t>(128 * 1024, UINT64_MAX)),
 
     // --- reader properties define ---
     REGISTER_PROPERTY(PROPERTY_READER_RECORD_BATCH_MAX_ROWS,

--- a/cpp/test/format/vortex/basic_test.cpp
+++ b/cpp/test/format/vortex/basic_test.cpp
@@ -39,6 +39,7 @@
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/format/vortex/vortex_writer.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 
@@ -49,8 +50,9 @@ namespace milvus_storage {
 
 using namespace vortex;
 
-class VortexBasicTest : public ::testing::Test {
-  void SetUp() override {
+class VortexTestBase : public ::testing::Test {
+  protected:
+  void CommonSetUp(uint32_t format_version) {
     schema_ = arrow::Table::FromRecordBatches({makeRecordBatch(0, 0, 0)}).ValueOrDie()->schema();
     record_bacths_ = makeRecordBatchs();
     columngroup_ = std::make_shared<api::ColumnGroup>();
@@ -60,6 +62,9 @@ class VortexBasicTest : public ::testing::Test {
     columngroup_->columns = {"int32", "int64", "binary"};
 
     ASSERT_STATUS_OK(InitTestProperties(properties_));
+
+    format_version_ = format_version;
+    api::SetValue(properties_, PROPERTY_WRITER_VORTEX_FORMAT_VERSION, std::to_string(format_version_).c_str());
 
     file_system_ = std::make_shared<arrow::fs::LocalFileSystem>();
   }
@@ -205,6 +210,7 @@ class VortexBasicTest : public ::testing::Test {
   std::vector<std::shared_ptr<arrow::RecordBatch>> record_bacths_;
   const char* test_file_name_ = "test-file.vx";
   api::Properties properties_;
+  uint32_t format_version_ = 1;
 
   private:
   uint32_t count_each_loop_ = 100;
@@ -212,7 +218,19 @@ class VortexBasicTest : public ::testing::Test {
   uint32_t record_batch_len_ = 10;
 };
 
-TEST_F(VortexBasicTest, TestBasicWrite) {
+// Parameterized fixture: runs each test for both V1 and V2 format
+class VortexBasicTest : public VortexTestBase, public ::testing::WithParamInterface<uint32_t> {
+  void SetUp() override { CommonSetUp(GetParam()); }
+};
+
+INSTANTIATE_TEST_SUITE_P(V1V2,
+                         VortexBasicTest,
+                         ::testing::Values(1, 2),
+                         [](const ::testing::TestParamInfo<uint32_t>& info) {
+                           return "V" + std::to_string(info.param);
+                         });
+
+TEST_P(VortexBasicTest, TestBasicWrite) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
@@ -224,7 +242,7 @@ TEST_F(VortexBasicTest, TestBasicWrite) {
   ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 }
 
-TEST_F(VortexBasicTest, TestBasicRead) {
+TEST_P(VortexBasicTest, TestBasicRead) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
@@ -255,7 +273,7 @@ TEST_F(VortexBasicTest, TestBasicRead) {
   }
 }
 
-TEST_F(VortexBasicTest, TestEmptyWriteRead) {
+TEST_P(VortexBasicTest, TestEmptyWriteRead) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   auto empty_rb = makeRecordBatch(0, 0, 0);
@@ -274,7 +292,7 @@ TEST_F(VortexBasicTest, TestEmptyWriteRead) {
   ASSERT_EQ(0, chunked_array->num_chunks());
 }
 
-TEST_F(VortexBasicTest, TestReaderProjection) {
+TEST_P(VortexBasicTest, TestReaderProjection) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
@@ -357,7 +375,7 @@ TEST_F(VortexBasicTest, TestReaderProjection) {
   }
 }
 
-TEST_F(VortexBasicTest, TestBasicTake) {
+TEST_P(VortexBasicTest, TestBasicTake) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
@@ -401,7 +419,7 @@ TEST_F(VortexBasicTest, TestBasicTake) {
   // so we removed the out-of-range index tests.
 }
 
-TEST_F(VortexBasicTest, FooterSizeMatchesActualFile) {
+TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
   for (const auto& rb : record_bacths_) {
@@ -449,7 +467,7 @@ TEST_F(VortexBasicTest, FooterSizeMatchesActualFile) {
   EXPECT_LT(vx_footer_size, vx_file_size - 4) << "footer_size should be less than file_size minus header magic";
 }
 
-TEST_F(VortexBasicTest, FooterSizeNotMatch) {
+TEST_P(VortexBasicTest, FooterSizeNotMatch) {
   // Write a vortex file
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
   for (const auto& rb : record_bacths_) {
@@ -483,13 +501,378 @@ TEST_F(VortexBasicTest, FooterSizeNotMatch) {
     }
   };
 
-  // Case 1: footer_size too small (1 byte).
-  // Vortex clamps initial_read_size to at least ~65KB and uses NeedMoreData loop for remaining segments.
   verify_read(1);
 
   // Case 2: footer_size too large (= file_size, reads entire file as initial read).
   // Vortex clamps to min(initial_read_size, file_size). Extra bytes get cached as segments.
   verify_read(vx_file_size2);
+}
+
+// V2-specific fixture: always uses format_version=2
+class VortexV2Test : public VortexTestBase {
+  void SetUp() override { CommonSetUp(2); }
+};
+
+TEST_F(VortexV2Test, TestV2RowGroupWrite) {
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(128 * 1024).c_str());
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+  for (const auto& rb : record_bacths_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
+
+  auto total_rows = recordBatchsRows();
+
+  // --- blocking_read: full scan ---
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
+                                              std::vector<std::string>{"int32", "int64", "binary"});
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, total_rows));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+
+  ASSERT_EQ(total_rows, rb->num_rows());
+  ASSERT_EQ(3, rb->num_columns());
+
+  auto i32array = std::dynamic_pointer_cast<arrow::Int32Array>(rb->column(0));
+  auto i64array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(1));
+  for (int i = 0; i < i32array->length(); ++i) {
+    ASSERT_EQ(i32array->Value(i), (int32_t)i);
+    ASSERT_EQ(i64array->Value(i), (int64_t)i);
+  }
+
+  // --- get_chunk: per row-group read ---
+  ASSERT_AND_ASSIGN(auto rg_infos, vx_reader.get_row_group_infos());
+  ASSERT_GT(rg_infos.size(), 1u);
+  uint64_t offset = 0;
+  for (size_t i = 0; i < rg_infos.size(); ++i) {
+    ASSERT_AND_ASSIGN(auto chunk_rb, vx_reader.get_chunk(static_cast<int>(i)));
+    ASSERT_EQ(chunk_rb->num_rows(), rg_infos[i].end_offset - rg_infos[i].start_offset)
+        << "rg[" << i << "] row count mismatch";
+    auto chunk_i32 = std::dynamic_pointer_cast<arrow::Int32Array>(chunk_rb->column(0));
+    ASSERT_EQ(chunk_i32->Value(0), static_cast<int32_t>(offset)) << "rg[" << i << "] first value mismatch";
+    offset += chunk_rb->num_rows();
+  }
+  ASSERT_EQ(offset, total_rows);
+
+  // --- take: random access ---
+  auto proj_schema = arrow::schema(
+      {arrow::field("int32", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto take_reader = vortex::VortexFormatReader(file_system_, proj_schema, test_file_name_, properties_,
+                                                std::vector<std::string>{"int32"});
+  ASSERT_STATUS_OK(take_reader.open());
+
+  std::vector<int64_t> take_indices = {0, 42, total_rows / 2, total_rows - 1};
+  ASSERT_AND_ASSIGN(auto table, take_reader.take(take_indices));
+  ASSERT_AND_ASSIGN(auto take_rb, table->CombineChunksToBatch());
+  ASSERT_EQ(take_rb->num_rows(), static_cast<int64_t>(take_indices.size()));
+  auto take_i32 = std::dynamic_pointer_cast<arrow::Int32Array>(take_rb->column(0));
+  for (size_t i = 0; i < take_indices.size(); ++i) {
+    ASSERT_EQ(take_i32->Value(i), static_cast<int32_t>(take_indices[i]));
+  }
+
+  // --- read_with_range: partial range read ---
+  uint64_t range_start = rg_infos[0].end_offset;
+  uint64_t range_end = rg_infos[1].end_offset;
+  ASSERT_AND_ASSIGN(auto range_reader, vx_reader.read_with_range(range_start, range_end));
+  std::shared_ptr<arrow::RecordBatch> range_batch;
+  int64_t range_rows = 0;
+  while (true) {
+    ASSERT_STATUS_OK(range_reader->ReadNext(&range_batch));
+    if (!range_batch)
+      break;
+    if (range_rows == 0) {
+      auto range_i32 = std::dynamic_pointer_cast<arrow::Int32Array>(range_batch->column(0));
+      ASSERT_EQ(range_i32->Value(0), static_cast<int32_t>(range_start));
+    }
+    range_rows += range_batch->num_rows();
+  }
+  ASSERT_EQ(range_rows, static_cast<int64_t>(range_end - range_start));
+}
+
+// Test that inline_array_node enables sub-segment range reads.
+// Writes FSB(512) data, takes 1 row, and asserts IO read bytes are small.
+// Only runs in cloud (S3) environment where FilesystemMetrics are available.
+TEST_P(VortexBasicTest, TestInlineArrayNodeSubSegmentRead) {
+  if (!IsCloudEnv()) {
+    GTEST_SKIP() << "Sub-segment IO test requires cloud environment with FilesystemMetrics";
+  }
+
+  // Get cloud filesystem with metrics
+  ASSERT_AND_ASSIGN(auto cloud_fs, GetFileSystem(properties_));
+  auto observable = std::dynamic_pointer_cast<Observable>(cloud_fs);
+  ASSERT_NE(observable, nullptr);
+  auto metrics = observable->GetMetrics();
+  ASSERT_NE(metrics, nullptr);
+
+  // Build schema with a single FSB(512) column
+  auto fsb_schema = arrow::schema({arrow::field("embedding", arrow::fixed_size_binary(512), false,
+                                                arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+
+  // Write 10000 rows of FSB(512) data (~5MB)
+  const int64_t num_rows = 10000;
+  const int fsb_width = 512;
+  std::string test_path = GetTestBasePath("vortex-inline-test") + "/test-fsb.vx";
+
+  {
+    auto vx_writer = vortex::VortexFileWriter(cloud_fs, fsb_schema, test_path, properties_);
+
+    arrow::FixedSizeBinaryBuilder fsb_builder(arrow::fixed_size_binary(fsb_width));
+    std::string row_data(fsb_width, '\0');
+    std::mt19937_64 rng(42);
+    for (int64_t i = 0; i < num_rows; ++i) {
+      // Fill with random data to prevent compression from shrinking the file
+      auto* p = reinterpret_cast<uint64_t*>(row_data.data());
+      for (size_t j = 0; j < fsb_width / sizeof(uint64_t); ++j) {
+        p[j] = rng();
+      }
+      ASSERT_TRUE(fsb_builder.Append(row_data).ok());
+    }
+    std::shared_ptr<arrow::Array> fsb_array;
+    ASSERT_TRUE(fsb_builder.Finish(&fsb_array).ok());
+
+    auto rb = arrow::RecordBatch::Make(fsb_schema, num_rows, {fsb_array});
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+    ASSERT_TRUE(vx_writer.Flush().ok());
+    ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+    ASSERT_EQ(num_rows, cgfile.end_index);
+  }
+
+  // Open reader and take 1 row
+  auto vx_reader =
+      vortex::VortexFormatReader(cloud_fs, fsb_schema, test_path, properties_, std::vector<std::string>{"embedding"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  // Reset metrics before take
+  metrics->Reset();
+
+  std::vector<int64_t> indices = {42};
+  ASSERT_AND_ASSIGN(auto table, vx_reader.take(indices));
+  ASSERT_EQ(1, table->num_rows());
+
+  // Check IO: reading 1 row of 512 bytes should read far less than the full file
+  // Full file is ~5MB; sub-segment read should be well under 1MB
+  auto read_bytes = metrics->GetReadBytes();
+  ASSERT_EQ(read_bytes, fsb_width) << "Sub-segment read of 1 row should be exactly " << fsb_width << " bytes, got "
+                                   << read_bytes;
+}
+
+// Test V2 row group splits with variable-size string data.
+// Writes two batches of 8192 rows with different string sizes (128B and 512B),
+// then verifies that row group splits reflect the byte-size-based partitioning.
+TEST_F(VortexV2Test, TestV2RowGroupSplitsBySize) {
+  const int64_t rows_per_batch = 8192;
+  const size_t small_str_len = 128;
+  const size_t large_str_len = 512;
+  const uint64_t row_group_max_size = 1024 * 1024;  // 1MB
+
+  auto str_schema = arrow::schema(
+      {arrow::field("str", arrow::utf8(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(row_group_max_size).c_str());
+
+  std::string test_path = "test-v2-rg-splits.vx";
+
+  // Helper to build a batch of fixed-length random strings
+  auto make_string_batch = [&](size_t str_len, int64_t num_rows) {
+    arrow::StringBuilder builder;
+    std::string s(str_len, 'x');
+    for (int64_t i = 0; i < num_rows; ++i) {
+      EXPECT_TRUE(builder.Append(s).ok());
+    }
+    std::shared_ptr<arrow::Array> arr;
+    EXPECT_TRUE(builder.Finish(&arr).ok());
+    return arrow::RecordBatch::Make(str_schema, num_rows, {arr});
+  };
+
+  // Write: batch1 = 8192 rows * 128B, batch2 = 8192 rows * 512B
+  {
+    auto vx_writer = vortex::VortexFileWriter(file_system_, str_schema, test_path, properties_);
+    ASSERT_TRUE(vx_writer.Write(make_string_batch(small_str_len, rows_per_batch)).ok());
+    ASSERT_TRUE(vx_writer.Write(make_string_batch(large_str_len, rows_per_batch)).ok());
+    ASSERT_TRUE(vx_writer.Flush().ok());
+    ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+    ASSERT_EQ(rows_per_batch * 2, cgfile.end_index);
+  }
+
+  // Read back and check row group infos
+  auto vx_reader =
+      vortex::VortexFormatReader(file_system_, str_schema, test_path, properties_, std::vector<std::string>{"str"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  ASSERT_AND_ASSIGN(auto rg_infos, vx_reader.get_row_group_infos());
+
+  // batch1: 8192 rows * 128B utf8 (132 B/row with offsets) ≈ 1.03 MB
+  // batch2: 8192 rows * 512B utf8 (516 B/row with offsets) ≈ 4.03 MB
+  // row_group_max_size = 1MB → expect 6 row groups:
+  //   rg[0]: batch1 first ~1MB
+  //   rg[1]: batch1 tail + batch2 start (cross-batch merge)
+  //   rg[2..4]: batch2 middle chunks (~1MB each)
+  //   rg[5]: batch2 tail (EOF remainder)
+  ASSERT_EQ(rg_infos.size(), 6u);
+
+  // Verify exact row ranges
+  struct Expected {
+    uint64_t start;
+    uint64_t end;
+  };
+  std::vector<Expected> expected = {{0, 7944},      {7944, 10161},  {10161, 12194},
+                                    {12194, 14227}, {14227, 16260}, {16260, 16384}};
+  for (size_t i = 0; i < expected.size(); ++i) {
+    ASSERT_EQ(rg_infos[i].start_offset, expected[i].start) << "rg[" << i << "] start_offset mismatch";
+    ASSERT_EQ(rg_infos[i].end_offset, expected[i].end) << "rg[" << i << "] end_offset mismatch";
+  }
+
+  // Verify memory_size is non-zero for all row groups
+  for (size_t i = 0; i < rg_infos.size(); ++i) {
+    ASSERT_GT(rg_infos[i].memory_size, 0u) << "rg[" << i << "] memory_size should be > 0";
+  }
+
+  // Verify total rows
+  uint64_t total_rows = 0;
+  for (const auto& rg : rg_infos) {
+    total_rows += (rg.end_offset - rg.start_offset);
+  }
+  ASSERT_EQ(total_rows, static_cast<uint64_t>(rows_per_batch * 2));
+
+  // --- blocking_read: full scan and verify string lengths ---
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, rows_per_batch * 2));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(rb->num_rows(), rows_per_batch * 2);
+  auto str_array = std::dynamic_pointer_cast<arrow::StringArray>(rb->column(0));
+  // batch1 rows should have small_str_len, batch2 rows should have large_str_len
+  ASSERT_EQ(str_array->GetView(0).size(), small_str_len);
+  ASSERT_EQ(str_array->GetView(rows_per_batch).size(), large_str_len);
+  ASSERT_EQ(str_array->GetView(rows_per_batch * 2 - 1).size(), large_str_len);
+
+  // --- get_chunk: per row-group read ---
+  for (size_t i = 0; i < rg_infos.size(); ++i) {
+    ASSERT_AND_ASSIGN(auto chunk_rb, vx_reader.get_chunk(static_cast<int>(i)));
+    ASSERT_EQ(chunk_rb->num_rows(), rg_infos[i].end_offset - rg_infos[i].start_offset)
+        << "rg[" << i << "] row count mismatch";
+  }
+
+  // --- take: spot-check boundary rows ---
+  std::vector<int64_t> take_indices = {0, rows_per_batch - 1, rows_per_batch, rows_per_batch * 2 - 1};
+  ASSERT_AND_ASSIGN(auto table, vx_reader.take(take_indices));
+  ASSERT_AND_ASSIGN(auto take_rb, table->CombineChunksToBatch());
+  ASSERT_EQ(take_rb->num_rows(), 4);
+  auto take_str = std::dynamic_pointer_cast<arrow::StringArray>(take_rb->column(0));
+  ASSERT_EQ(take_str->GetView(0).size(), small_str_len);  // first row of batch1
+  ASSERT_EQ(take_str->GetView(1).size(), small_str_len);  // last row of batch1
+  ASSERT_EQ(take_str->GetView(2).size(), large_str_len);  // first row of batch2
+  ASSERT_EQ(take_str->GetView(3).size(), large_str_len);  // last row of batch2
+}
+
+TEST_F(VortexV2Test, TestV2RowGroupMultiColumnSplitsBySize) {
+  const int64_t rows_per_batch = 8192;
+  const size_t str_len_a = 256;
+  const size_t str_len_b = 512;
+  const size_t str_len_c = 1024;
+  const uint64_t row_group_max_size = 10 * 1024 * 1024;  // 10MB
+
+  auto multi_schema = arrow::schema({
+      arrow::field("col_a", arrow::utf8(), false),
+      arrow::field("col_b", arrow::utf8(), false),
+      arrow::field("col_c", arrow::utf8(), false),
+  });
+
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(row_group_max_size).c_str());
+
+  std::string test_path = "test-v2-rg-multi-col.vx";
+
+  // Helper to build a multi-column batch with fixed-length strings per column
+  auto make_batch = [&](int64_t num_rows) {
+    auto build_col = [&](size_t str_len, int64_t n) {
+      arrow::StringBuilder builder;
+      std::string s(str_len, 'x');
+      for (int64_t i = 0; i < n; ++i) {
+        EXPECT_TRUE(builder.Append(s).ok());
+      }
+      std::shared_ptr<arrow::Array> arr;
+      EXPECT_TRUE(builder.Finish(&arr).ok());
+      return arr;
+    };
+    return arrow::RecordBatch::Make(
+        multi_schema, num_rows,
+        {build_col(str_len_a, num_rows), build_col(str_len_b, num_rows), build_col(str_len_c, num_rows)});
+  };
+
+  // Write 4 batches of 8192 rows each
+  // Per-row uncompressed: 256+4 + 512+4 + 1024+4 ≈ 1804 B/row (with offsets)
+  // Per batch: 8192 * 1804 ≈ 14.1 MB → each batch > 10MB limit → gets split
+  // Total: 4 * 8192 = 32768 rows ≈ 56.4 MB
+  {
+    auto vx_writer = vortex::VortexFileWriter(file_system_, multi_schema, test_path, properties_);
+    for (int i = 0; i < 4; ++i) {
+      ASSERT_TRUE(vx_writer.Write(make_batch(rows_per_batch)).ok());
+    }
+    ASSERT_TRUE(vx_writer.Flush().ok());
+    ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+    ASSERT_EQ(rows_per_batch * 4, cgfile.end_index);
+  }
+
+  // Read back and check row group infos
+  auto vx_reader = vortex::VortexFormatReader(file_system_, multi_schema, test_path, properties_,
+                                              std::vector<std::string>{"col_a", "col_b", "col_c"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  ASSERT_AND_ASSIGN(auto rg_infos, vx_reader.get_row_group_infos());
+
+  // Each batch ≈ 14.1 MB, limit 10MB → each batch should be split into ~2 row groups
+  // 4 batches → expect ~6-8 row groups (with cross-batch merging and EOF tail)
+  ASSERT_GT(rg_infos.size(), 4u) << "Should have more row groups than input batches";
+
+  // Verify contiguous ranges and total rows
+  ASSERT_EQ(rg_infos[0].start_offset, 0u);
+  uint64_t total_rows = 0;
+  for (size_t i = 0; i < rg_infos.size(); ++i) {
+    uint64_t rg_rows = rg_infos[i].end_offset - rg_infos[i].start_offset;
+    ASSERT_GT(rg_rows, 0u) << "rg[" << i << "] should have rows";
+    ASSERT_GT(rg_infos[i].memory_size, 0u) << "rg[" << i << "] memory_size should be > 0";
+    total_rows += rg_rows;
+    if (i > 0) {
+      ASSERT_EQ(rg_infos[i].start_offset, rg_infos[i - 1].end_offset) << "rg[" << i << "] should be contiguous";
+    }
+  }
+  ASSERT_EQ(total_rows, static_cast<uint64_t>(rows_per_batch * 4));
+
+  // --- blocking_read: full scan and verify data ---
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, rows_per_batch * 4));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(rb->num_rows(), rows_per_batch * 4);
+  ASSERT_EQ(rb->num_columns(), 3);
+  // Verify string lengths for each column
+  auto col_a = std::dynamic_pointer_cast<arrow::StringArray>(rb->column(0));
+  auto col_b = std::dynamic_pointer_cast<arrow::StringArray>(rb->column(1));
+  auto col_c = std::dynamic_pointer_cast<arrow::StringArray>(rb->column(2));
+  ASSERT_EQ(col_a->GetView(0).size(), str_len_a);
+  ASSERT_EQ(col_b->GetView(0).size(), str_len_b);
+  ASSERT_EQ(col_c->GetView(0).size(), str_len_c);
+
+  // --- get_chunk: per row-group read ---
+  for (size_t i = 0; i < rg_infos.size(); ++i) {
+    ASSERT_AND_ASSIGN(auto chunk_rb, vx_reader.get_chunk(static_cast<int>(i)));
+    ASSERT_EQ(chunk_rb->num_rows(), rg_infos[i].end_offset - rg_infos[i].start_offset)
+        << "rg[" << i << "] row count mismatch";
+    ASSERT_EQ(chunk_rb->num_columns(), 3);
+  }
+
+  // --- take: random access across batch boundaries ---
+  std::vector<int64_t> take_indices = {0, rows_per_batch - 1, rows_per_batch, rows_per_batch * 3,
+                                       rows_per_batch * 4 - 1};
+  ASSERT_AND_ASSIGN(auto table, vx_reader.take(take_indices));
+  ASSERT_AND_ASSIGN(auto take_rb, table->CombineChunksToBatch());
+  ASSERT_EQ(take_rb->num_rows(), static_cast<int64_t>(take_indices.size()));
+  // All rows should have the same string lengths (uniform data)
+  auto take_col_a = std::dynamic_pointer_cast<arrow::StringArray>(take_rb->column(0));
+  auto take_col_c = std::dynamic_pointer_cast<arrow::StringArray>(take_rb->column(2));
+  for (int i = 0; i < take_rb->num_rows(); ++i) {
+    ASSERT_EQ(take_col_a->GetView(i).size(), str_len_a) << "take row " << i << " col_a size mismatch";
+    ASSERT_EQ(take_col_c->GetView(i).size(), str_len_c) << "take row " << i << " col_c size mismatch";
+  }
 }
 
 }  // namespace milvus_storage


### PR DESCRIPTION
This adds a V2 format option that writes data in a row-group layout (Chunked at root). All columns within a row group are written together so reading one row group is a single contiguous IO. Row groups are split by uncompressed byte size via a custom RowGroupSplitStrategy, which replaces the upstream RepartitionStrategy that could only split by fixed row counts.

Other changes included: switched the Vortex runtime from single-thread CurrentThreadRuntime to multi-thread TokioRuntime for concurrent IO, added with_split_row_indices(false) to the scan builder so reads within a single split always return one chunk, bumped take() concurrency to 128 to avoid buffered() stalls on files with many chunks, fixed the initial_read_size to include EOF_SIZE so the footer can be read in one IO, and added IO trace helpers for debugging.

New properties: writer.vortex.format_version (1 or 2, default 2) and writer.vortex_v2.row_group_max_size (default 1MB).