### PR TITLE
fix: use correct endpoint URL format for Azure sovereign clouds

### DIFF
--- a/cpp/scripts/azurite_env.sh
+++ b/cpp/scripts/azurite_env.sh
@@ -1,5 +1,6 @@
 # https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string 
 # azurite defualt AK/SK
+export USE_AZURITE="true"
 export ACCESS_KEY="devstoreaccount1"
 export SECRET_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 export ADDRESS="127.0.0.1:10000"

--- a/cpp/src/filesystem/azure/azure_fs_producer.cpp
+++ b/cpp/src/filesystem/azure/azure_fs_producer.cpp
@@ -35,8 +35,15 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
   options.account_name = config_.access_key_id;
 
   if (!config_.address.empty()) {
-    options.blob_storage_authority = config_.address;
-    options.dfs_storage_authority = config_.address;
+    const char* azurite_env = std::getenv("USE_AZURITE");
+    // use the azurite
+    if (azurite_env && (std::string(azurite_env) == "true")) {
+      options.blob_storage_authority = config_.address;
+      options.dfs_storage_authority = config_.address;
+    } else {  // use the azure cloud
+      options.blob_storage_authority = ".blob." + config_.address;
+      options.dfs_storage_authority = ".dfs." + config_.address;
+    }
   }
   if (!config_.use_ssl) {
     options.blob_storage_scheme = "http";


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus-storage/issues/475

This is actually a long-standing issue with Storage V2. Before we ported Arrow v23's Azure FS implementation (commit 619f242), the old Azure FS code didn't support `blob_storage_authority` or `dfs_storage_authority` at all, so it always pointed to the default `.blob.core.windows.net` and `.dfs.core.windows.net`. That means sovereign clouds like US Government or China never worked through the C++ segcore path.

When we ported Arrow v23, we wired config_.address into these fields, but passed it directly without the leading dot prefix. This produced path-style URLs like "https://core.usgovcloudapi.net/{account}/" instead of virtual-host-style "https://{account}.blob.core.usgovcloudapi.net/", which is still broken for sovereign clouds.

Now we check a USE_AZURITE env var to decide the behavior. For Azurite we keep the address as-is so path-style URLs still work, and for real Azure clouds we prepend ".blob." / ".dfs." to the address so Arrow generates the correct virtual-host-style URLs.