### PR TITLE
fix: force aws-c-* deps to shared to avoid duplicate aws-c-common copes in JNI builds

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -51,7 +51,15 @@ class StorageConan(ConanFile):
         "aws-sdk-cpp:config": True,
         "aws-sdk-cpp:text-to-speech": False,
         "aws-sdk-cpp:transfer": False,
-        "aws-sdk-cpp:s3-crt": True,
+        # Force aws-c-* / s2n to be shared so all aws-cpp-sdk subdir .so files
+        # dynamically link a SINGLE libaws-c-common.so. Otherwise (with the
+        # default static aws-c-common), every aws-cpp-sdk-* .so embeds its own
+        # private copy of aws_default_allocator with hidden visibility, and
+        # Aws::InitAPI (which lives in aws-cpp-sdk-core) only initializes
+        # core's copy. S3Client ctor in libaws-cpp-sdk-s3.so then aborts inside
+        # aws_mem_acquire because s3's private allocator is still NULL. See
+        # docs/aws-sdk-cpp-multi-copy-bug.md for the full root-cause analysis.
+        "aws-c-*:shared": True,
         "arrow:with_s3": True,
         "arrow:filesystem_layer": True,
         "arrow:dataset_modules": True,


### PR DESCRIPTION
aws-sdk-cpp 1.11.692 requires aws-c-common at runtime regardless of the s3-crt option. Conan defaults to building aws-c-* as static libraries with hidden visibility, so each libaws-cpp-sdk-*.so ends up embedding its own private copy of aws_default_allocator. Aws::InitAPI (linked into libaws-cpp-sdk-core.so) only initializes core's copy, leaving the copy inside libaws-cpp-sdk-s3.so uninitialized. The first S3Client construction then aborts inside aws_mem_acquire:

Fatal error condition occurred in
.../aws-c-common/0.12.5/.../allocator.c:202: allocator != NULL

Stack trace (abridged):

libaws-cpp-sdk-s3.so   DefaultEndpointProvider<S3ClientConfiguration>::C1
libaws-cpp-sdk-s3.so   Aws::S3::S3Client::C2
libmilvus-storage.so   ClientBuilder::BuildClient
libmilvus-storage.so   S3FileSystem::Make
libmilvus-storage.so   S3FileSystemProducer::Make    (InitS3() already ran)
libmilvus-storage.so   FilesystemCache::get
libmilvus-storage.so   loon_transaction_begin

Verified with `nm libaws-cpp-sdk-s3.so | grep aws_default_allocator`:
- before: `t aws_default_allocator` (private static copy per .so)
- after:  `U aws_default_allocator` (resolved dynamically from libaws-c-common.so.1)

The monolithic milvus binary does not hit this because all aws-cpp-sdk sub-modules are linked into a single ELF, so there is only one aws_default_allocator. Any downstream that splits aws-cpp-sdk into separate .so files (e.g. the JNI fat jar consumed by spark-connector) trips on it.

Fix: force the entire aws-c-* family to be built as shared libraries via a wildcard option, so all aws-cpp-sdk-*.so dynamically link a single libaws-c-common.so.1. Requires Conan >= 1.41 for wildcard keys in default_options. The existing package_fat_jar.sh already copies SONAME-versioned `*.so.*` files (since #477), so the new libaws-c-*.so.1 artifacts are picked up automatically with no script change.