### PR TITLE
fix: GCP S3 compatibility with AWS SDK 1.11.692 checksum changes

### DIFF
--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "milvus-storage/common/log.h"
+#include "milvus-storage/filesystem/fs.h"
 #include <arrow/util/logging.h>
 #include <arrow/result.h>
 #include <arrow/util/thread_pool.h>
@@ -551,6 +552,14 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> ClientBuilder::BuildClient(
   client_config_.maxConnections = std::max(client_config_.maxConnections, options_.max_connections);
 
   const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
+
+  // GCP's S3-compatible API does not accept the extra x-amz-checksum-* headers
+  // that AWS SDK >= 1.11.x sends by default (WHEN_SUPPORTED). Restrict to
+  // WHEN_REQUIRED so the SDK only adds checksums when the API mandates them.
+  if (options_.cloud_provider == kCloudProviderGCP) {
+    client_config_.checksumConfig.requestChecksumCalculation = Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
+    client_config_.checksumConfig.responseChecksumValidation = Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
+  }
 
 #ifdef ARROW_S3_HAS_S3CLIENT_CONFIGURATION
   client_config_.useVirtualAddressing = use_virtual_addressing;

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -1764,6 +1764,10 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       req.SetDelete(std::move(del));
       if (options().use_crc32c_checksum) {
         req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
+      } else if (options().cloud_provider == kCloudProviderGCP) {
+        // GCP's S3-compatible API requires Content-MD5 or x-amz-checksum-crc32
+        // for DeleteObjects, but AWS SDK >= 1.11.x no longer adds it by default.
+        req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32);
       }
       ARROW_ASSIGN_OR_RAISE(
           auto fut, SubmitIO(io_context_, [holder = holder_, req = std::move(req), delete_cb]() -> arrow::Status {


### PR DESCRIPTION
After PR https://github.com/milvus-io/milvus-storage/pull/464, AWS SDK 1.11.692 changed its default checksum behavior, it now sends x-amz-checksum-* headers on all requests that support them (WHEN_SUPPORTED). GCP's S3-compatible API doesn't recognize these extra headers and rejects requests with "ExcessHeaderValues" for PutObject and "Missing required header Content-MD5 OR x-amz-checksum-crc32" for DeleteObjects.

Two things going on here. First, for GCP we set the SDK's requestChecksumCalculation to WHEN_REQUIRED so it stops tacking on checksum headers to every request like PutObject. Second, DeleteObjects is a special case, GCP actually requires a checksum for it, but the SDK doesn't consider it mandatory, so we explicitly set CRC32 on the request for GCP.