### PR TITLE
fix: add back conditional write support in filesystem FFI

### DIFF
--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -100,7 +100,6 @@ _loon_column_groups_debug_string
 # Manifest interface
 _loon_manifest_destroy
 _loon_manifest_debug_string
-_loon_reset_context
 
 # ThreadPool interface
 _loon_thread_pool_singleton

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -41,7 +41,8 @@ extern "C" {
 #define LOON_UNREACHABLE_ERROR 6
 #define LOON_INVALID_PROPERTIES 7
 #define LOON_FAULT_INJECT_ERROR 8
-#define LOON_ERRORCODE_MAX 9
+#define LOON_NOT_SUPPORT 9
+#define LOON_ERRORCODE_MAX 10
 
 // usage example(caller must free the message string):
 //

--- a/cpp/include/milvus-storage/ffi_filesystem_c.h
+++ b/cpp/include/milvus-storage/ffi_filesystem_c.h
@@ -98,9 +98,11 @@ FFI_EXPORT void loon_close_filesystems();
  * @param path_len The length of the path.
  * @param meta_array The metadata array.
  * @param num_of_meta The number of metadata.
+ * @param conditional If true, use conditional write (fail if file already exists).
+ *                    Returns LOON_NOT_SUPPORT if the filesystem does not support conditional writes.
  * @param out_handle The output writer instance.
  *
- * The metadata will be passed into the `OpenOutputStream`.
+ * The metadata will be passed into the `OpenOutputStream` or `OpenConditionalOutputStream`.
  * @return result of FFI
  */
 FFI_EXPORT LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
@@ -108,6 +110,7 @@ FFI_EXPORT LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
                                                      uint32_t path_len,
                                                      const LoonFileSystemMeta* meta_array,
                                                      uint32_t num_of_meta,
+                                                     bool conditional,
                                                      FileSystemWriterHandle* out_handle);
 
 /**

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -28,6 +28,7 @@
 #include "milvus-storage/ffi_internal/result.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/ffi/filesystem_internal.h"
+#include "milvus-storage/filesystem/upload_conditional.h"
 #include "milvus-storage/properties.h"
 
 using namespace milvus_storage::api;
@@ -87,6 +88,7 @@ LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
                                           uint32_t path_len,
                                           const LoonFileSystemMeta* meta_array,
                                           uint32_t num_of_meta,
+                                          bool conditional,
                                           FileSystemWriterHandle* out_writer_ptr) {
   try {
     // Note: fs.open.fail fault injection is in FileSystemProxy::OpenOutputStream
@@ -100,7 +102,7 @@ LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
     }
 
     // build metadata if passed
-    std::shared_ptr<const arrow::KeyValueMetadata> metadatas = nullptr;
+    std::shared_ptr<arrow::KeyValueMetadata> metadatas = nullptr;
     if (num_of_meta > 0) {
       std::vector<std::string> keys(num_of_meta);
       std::vector<std::string> values(num_of_meta);
@@ -117,7 +119,19 @@ LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
 
     auto fs = reinterpret_cast<FileSystemWrapper*>(handle)->get();
     std::string path(reinterpret_cast<const char*>(path_ptr), path_len);
-    auto output_stream_result = fs->OpenOutputStream(path, metadatas);
+
+    arrow::Result<std::shared_ptr<arrow::io::OutputStream>> output_stream_result;
+    if (conditional) {
+      auto conditional_fs = std::dynamic_pointer_cast<milvus_storage::UploadConditional>(fs);
+      if (!conditional_fs) {
+        RETURN_ERROR(LOON_NOT_SUPPORT, "Filesystem does not support conditional write, [type=", fs->type_name(),
+                     ", path=", path, "]");
+      }
+      output_stream_result = conditional_fs->OpenConditionalOutputStream(path, metadatas);
+    } else {
+      output_stream_result = fs->OpenOutputStream(path, metadatas);
+    }
+
     if (!output_stream_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, output_stream_result.status().ToString());
     }

--- a/cpp/src/ffi/result_c.cpp
+++ b/cpp/src/ffi/result_c.cpp
@@ -28,7 +28,8 @@ std::string error_to_string(int code) {
                                         "Got exception",             //
                                         "Unreachable code",          //
                                         "Invalid properties",        //
-                                        "Fault injection error"};
+                                        "Fault injection error",     //
+                                        "Not supported"};
   static_assert(sizeof(error_strings) / sizeof((error_strings)[0]) == LOON_ERRORCODE_MAX);
 
   if (code < LOON_SUCCESS || code >= LOON_ERRORCODE_MAX) {

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -37,6 +37,7 @@ unsafe extern "C" {
         path_len: u32,
         meta_array: *const LoonFileSystemMeta,
         num_of_meta: u32,
+        conditional: bool,
         out_handle: *mut *mut std::ffi::c_void,
     ) -> LoonFFIResult;
 
@@ -184,6 +185,7 @@ impl Write for ObjectStoreWriterCpp {
                     path.as_bytes().len() as u32,
                     std::ptr::null(), // meta_array
                     0 as u32,         // num_of_meta
+                    false,            // conditional
                     &mut writer_raw);
                 check_loon_ffi_result(&mut result, "Failed to open ObjectStoreWriterCpp")
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -128,7 +128,7 @@ static void test_filesystem_write_and_read(void) {
   // test write
   {
     FileSystemWriterHandle write_handle;
-    rc = loon_filesystem_open_writer(fs_handle, TEST_FILE_NAME, strlen(TEST_FILE_NAME), NULL, 0, &write_handle);
+    rc = loon_filesystem_open_writer(fs_handle, TEST_FILE_NAME, strlen(TEST_FILE_NAME), NULL, 0, false, &write_handle);
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
     ck_assert(write_handle != 0);
 
@@ -462,8 +462,8 @@ static void test_filesystem_write_with_metadata(void) {
   meta_array[1].value = "test-value";
 
   // Open writer with metadata
-  rc =
-      loon_filesystem_open_writer(fs_handle, "file_with_meta", strlen("file_with_meta"), meta_array, 2, &writer_handle);
+  rc = loon_filesystem_open_writer(fs_handle, "file_with_meta", strlen("file_with_meta"), meta_array, 2, false,
+                                   &writer_handle);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   ck_assert(writer_handle != 0);
 
@@ -499,20 +499,20 @@ static void test_filesystem_error_handling(void) {
   loon_ffi_free_result(&rc);
 
   // Test loon_filesystem_open_writer with null arguments
-  rc = loon_filesystem_open_writer(0, "path", 4, NULL, 0, &writer_handle);
+  rc = loon_filesystem_open_writer(0, "path", 4, NULL, 0, false, &writer_handle);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 
-  rc = loon_filesystem_open_writer(fs_handle, NULL, 0, NULL, 0, &writer_handle);
+  rc = loon_filesystem_open_writer(fs_handle, NULL, 0, NULL, 0, false, &writer_handle);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 
-  rc = loon_filesystem_open_writer(fs_handle, "path", 4, NULL, 0, NULL);
+  rc = loon_filesystem_open_writer(fs_handle, "path", 4, NULL, 0, false, NULL);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 
   // Test loon_filesystem_open_writer with invalid metadata (num_of_meta > 0 but meta_array is NULL)
-  rc = loon_filesystem_open_writer(fs_handle, "path", 4, NULL, 1, &writer_handle);
+  rc = loon_filesystem_open_writer(fs_handle, "path", 4, NULL, 1, false, &writer_handle);
   ck_assert(!loon_ffi_is_success(&rc));
   loon_ffi_free_result(&rc);
 
@@ -644,7 +644,7 @@ static void test_filesystem_metadata(void) {
   {
     meta_array[0].key = NULL;
     meta_array[0].value = "test-value";
-    rc = loon_filesystem_open_writer(fs_handle, "test_null_meta", strlen("test_null_meta"), meta_array, 1,
+    rc = loon_filesystem_open_writer(fs_handle, "test_null_meta", strlen("test_null_meta"), meta_array, 1, false,
                                      &writer_handle);
     ck_assert(!loon_ffi_is_success(&rc));
     loon_ffi_free_result(&rc);
@@ -654,7 +654,7 @@ static void test_filesystem_metadata(void) {
   {
     meta_array[0].key = "test-key";
     meta_array[0].value = NULL;
-    rc = loon_filesystem_open_writer(fs_handle, "test_null_meta", strlen("test_null_meta"), meta_array, 1,
+    rc = loon_filesystem_open_writer(fs_handle, "test_null_meta", strlen("test_null_meta"), meta_array, 1, false,
                                      &writer_handle);
     ck_assert(!loon_ffi_is_success(&rc));
     loon_ffi_free_result(&rc);

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -19,7 +19,9 @@ LOON_LOGICAL_ERROR = 4
 LOON_GOT_EXCEPTION = 5
 LOON_UNREACHABLE_ERROR = 6
 LOON_INVALID_PROPERTIES = 7
-LOON_ERRORCODE_MAX = 8
+LOON_FAULT_INJECT_ERROR = 8
+LOON_NOT_SUPPORT = 9
+LOON_ERRORCODE_MAX = 10
 
 # Chunk metadata type flags from ffi_c.h
 LOON_CHUNK_METADATA_ESTIMATED_MEMORY = 0x01
@@ -382,6 +384,7 @@ _ffi.cdef(
                                               uint32_t path_len,
                                               const LoonFileSystemMeta* meta_array,
                                               uint32_t num_of_meta,
+                                              bool conditional,
                                               FileSystemWriterHandle* out_handle);
 
     LoonFFIResult loon_filesystem_writer_write(FileSystemWriterHandle handle,

--- a/python/milvus_storage/filesystem.py
+++ b/python/milvus_storage/filesystem.py
@@ -680,6 +680,7 @@ class Filesystem:
         self,
         path: str,
         metadata: Optional[Dict[str, str]] = None,
+        conditional: bool = False,
     ) -> FilesystemWriter:
         """
         Open a file for writing.
@@ -687,6 +688,7 @@ class Filesystem:
         Args:
             path: File path to write
             metadata: Optional key-value metadata
+            conditional: If True, use conditional write (fail if file already exists)
 
         Returns:
             FilesystemWriter for writing data
@@ -719,7 +721,7 @@ class Filesystem:
 
         handle = self._ffi.new("FileSystemWriterHandle*")
         result = self._lib.loon_filesystem_open_writer(
-            self._handle, path_bytes, len(path_bytes), meta_array, meta_count, handle
+            self._handle, path_bytes, len(path_bytes), meta_array, meta_count, conditional, handle
         )
         check_result(result)
 


### PR DESCRIPTION
MetricsInputStream, MetricsRandomAccessFile, and MetricsOutputStream were introduced in 9c273ac (PR #390 "feat: add observable support to local filesystem") but only overrode a subset of virtual methods from the Arrow IO interfaces. The rest fell through to base class defaults that silently returned nullptr or NotImplemented.

This adds a `conditional` parameter to `loon_filesystem_open_writer` so callers can request a conditional write that fails if the file already exists. Under the hood it routes to `OpenConditionalOutputStream` when the flag is set, and returns the new `LOON_NOT_SUPPORT` error code if the filesystem doesn't implement it. The Rust bridge, Python bindings, and error code table are all updated to match.