### PR TITLE
fix: make clang-format CI actually catch format violations

### DIFF
--- a/.github/workflows/clang-format-ci.yml
+++ b/.github/workflows/clang-format-ci.yml
@@ -19,10 +19,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-     
+
+      - name: install clang-format-18
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -y clang-format-18
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-18
+          clang-format --version | grep -q "version 18" || { echo "clang-format is not 18"; exit 1; }
+
       - name: check-format
         working-directory: ./cpp
-        run: 
-          make check-format
+        run: make check-format
 
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -108,12 +108,14 @@ FORMAT_FIND = $(foreach dir,$(FORMAT_DIRS),\
 	find $(dir) -type f \( ! -name "*.pb.h" \) \( -iname "*.c" -o -iname "*.h" -o -iname "*.cpp" \))
 
 fix-format:
-	@$(foreach dir,$(FORMAT_DIRS),\
-		find $(dir) -type f \( ! -name "*.pb.h" \) \( -iname "*.c" -o -iname "*.h" -o -iname "*.cpp" \) -exec clang-format -i {} +;)
+	@set -e; for dir in $(FORMAT_DIRS); do \
+		find $$dir -type f \( ! -name "*.pb.h" \) \( -iname "*.c" -o -iname "*.h" -o -iname "*.cpp" \) -exec clang-format -i {} +; \
+	done
 
 check-format:
-	@$(foreach dir,$(FORMAT_DIRS),\
-		find $(dir) -type f \( ! -name "*.pb.h" \) \( -iname "*.c" -o -iname "*.h" -o -iname "*.cpp" \) -exec clang-format --dry-run --Werror {} +;)
+	@set -e; for dir in $(FORMAT_DIRS); do \
+		find $$dir -type f \( ! -name "*.pb.h" \) \( -iname "*.c" -o -iname "*.h" -o -iname "*.cpp" \) -exec clang-format --dry-run --Werror {} +; \
+	done
 
 check-tidy:
 	python3 ./scripts/run-clang-tidy.py -p build/${build_type}

--- a/cpp/include/milvus-storage/ffi_internal/v2_column_groups_builder.h
+++ b/cpp/include/milvus-storage/ffi_internal/v2_column_groups_builder.h
@@ -41,9 +41,8 @@ namespace milvus_storage {
 //   - zero column groups
 //   - a group with empty columns or empty files
 //   - a group where rowCounts.size() != files.size()
-LoonColumnGroups* BuildLoonColumnGroups(
-    const std::vector<std::vector<std::string>>& columns_per_group,
-    const std::vector<std::vector<std::string>>& files_per_group,
-    const std::vector<std::vector<int64_t>>& row_counts_per_group);
+LoonColumnGroups* BuildLoonColumnGroups(const std::vector<std::vector<std::string>>& columns_per_group,
+                                        const std::vector<std::vector<std::string>>& files_per_group,
+                                        const std::vector<std::vector<int64_t>>& row_counts_per_group);
 
 }  // namespace milvus_storage

--- a/cpp/src/ffi/v2_column_groups_builder.cpp
+++ b/cpp/src/ffi/v2_column_groups_builder.cpp
@@ -35,10 +35,9 @@ char* dup_cstr(const std::string& s) {
 
 }  // namespace
 
-LoonColumnGroups* BuildLoonColumnGroups(
-    const std::vector<std::vector<std::string>>& columns_per_group,
-    const std::vector<std::vector<std::string>>& files_per_group,
-    const std::vector<std::vector<int64_t>>& row_counts_per_group) {
+LoonColumnGroups* BuildLoonColumnGroups(const std::vector<std::vector<std::string>>& columns_per_group,
+                                        const std::vector<std::vector<std::string>>& files_per_group,
+                                        const std::vector<std::vector<int64_t>>& row_counts_per_group) {
   const size_t num_groups = columns_per_group.size();
   if (num_groups != files_per_group.size() || num_groups != row_counts_per_group.size()) {
     throw std::invalid_argument("per-group array length mismatch: cols=" + std::to_string(num_groups) +
@@ -63,13 +62,13 @@ LoonColumnGroups* BuildLoonColumnGroups(
       }
       if (rcs.size() != files.size()) {
         throw std::invalid_argument("group[" + std::to_string(g) + "]: rowCounts.length (" +
-                                    std::to_string(rcs.size()) + ") != files.length (" +
-                                    std::to_string(files.size()) + ")");
+                                    std::to_string(rcs.size()) + ") != files.length (" + std::to_string(files.size()) +
+                                    ")");
       }
 
       LoonColumnGroup& out = cgroups->column_group_array[g];
       out.num_of_columns = static_cast<uint32_t>(cols.size());
-      out.columns = new const char*[cols.size()]{};
+      out.columns = new const char* [cols.size()] {};
       out.format = dup_cstr(LOON_FORMAT_PARQUET);
       out.num_of_files = static_cast<uint32_t>(files.size());
       out.files = new LoonColumnGroupFile[files.size()]{};

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -215,9 +215,9 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() 
 
   if (IsInCooldown()) {
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Skipping credential reload — in cooldown after previous failure."
-                           << " has_valid_cached=" << hasExisting);
+    AWS_LOGSTREAM_WARN(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Skipping credential reload — in cooldown after previous failure." << " has_valid_cached=" << hasExisting);
     return;
   }
 

--- a/cpp/src/filesystem/s3/s3_global.cpp
+++ b/cpp/src/filesystem/s3/s3_global.cpp
@@ -44,7 +44,9 @@ class GlogAwsLogger : public Aws::Utils::Logging::FormattedLogSystem {
   void Flush() override {}
 
   protected:
-  void ProcessFormattedStatement(Aws::String&& statement) override { LOG_STORAGE_INFO_ << "[Storage-AWS] " << statement; }
+  void ProcessFormattedStatement(Aws::String&& statement) override {
+    LOG_STORAGE_INFO_ << "[Storage-AWS] " << statement;
+  }
 };
 
 S3GlobalOptions S3GlobalOptions::Defaults() {

--- a/cpp/src/jni/v2_column_groups_jni.cpp
+++ b/cpp/src/jni/v2_column_groups_jni.cpp
@@ -44,9 +44,11 @@ void ThrowJava(JNIEnv* env, const char* cls_name, const std::string& msg) {
 
 // Copy a jstring into std::string; returns false if the jstring is null.
 bool ReadJString(JNIEnv* env, jstring js, std::string* out) {
-  if (js == nullptr) return false;
+  if (js == nullptr)
+    return false;
   const char* s = env->GetStringUTFChars(js, nullptr);
-  if (s == nullptr) return false;
+  if (s == nullptr)
+    return false;
   out->assign(s);
   env->ReleaseStringUTFChars(js, s);
   return true;
@@ -72,12 +74,12 @@ extern "C" {
 //
 //  Returns a LoonColumnGroups* as jlong; caller frees via destroy().
 //  Throws IllegalArgumentException / RuntimeException on any error.
-JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageColumnGroupsNative_createFromGroups(
-    JNIEnv* env,
-    jobject /*obj*/,
-    jobjectArray columns_per_group,
-    jobjectArray files_per_group,
-    jobjectArray file_row_counts_per_group) {
+JNIEXPORT jlong JNICALL
+Java_io_milvus_storage_MilvusStorageColumnGroupsNative_createFromGroups(JNIEnv* env,
+                                                                        jobject /*obj*/,
+                                                                        jobjectArray columns_per_group,
+                                                                        jobjectArray files_per_group,
+                                                                        jobjectArray file_row_counts_per_group) {
   try {
     if (!columns_per_group || !files_per_group || !file_row_counts_per_group) {
       ThrowJava(env, "java/lang/IllegalArgumentException",
@@ -149,8 +151,9 @@ JNIEXPORT jlong JNICALL Java_io_milvus_storage_MilvusStorageColumnGroupsNative_c
 // -----------------------------------------------------------------------------
 //  io.milvus.storage.MilvusStorageColumnGroupsNative.destroy(long)
 // -----------------------------------------------------------------------------
-JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageColumnGroupsNative_destroy(
-    JNIEnv* /*env*/, jobject /*obj*/, jlong ptr) {
+JNIEXPORT void JNICALL Java_io_milvus_storage_MilvusStorageColumnGroupsNative_destroy(JNIEnv* /*env*/,
+                                                                                      jobject /*obj*/,
+                                                                                      jlong ptr) {
   loon_column_groups_destroy(reinterpret_cast<LoonColumnGroups*>(ptr));
 }
 

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -106,9 +106,9 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
               cgs.end());
 
     // Phase 3: auto-drop all indexes attached to this column
-    indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
-                                 [&](const Index& idx) { return idx.column_name == col_name; }),
-                  indexes.end());
+    indexes.erase(
+        std::remove_if(indexes.begin(), indexes.end(), [&](const Index& idx) { return idx.column_name == col_name; }),
+        indexes.end());
   }
 
   // Validate: Check if adding column groups has existing column names

--- a/cpp/test/ffi/v2_column_groups_builder_test.cpp
+++ b/cpp/test/ffi/v2_column_groups_builder_test.cpp
@@ -81,9 +81,7 @@ TEST(V2ColumnGroupsBuilder, BuildsExpectedLayout) {
   loon_column_groups_destroy(cgs);
 }
 
-TEST(V2ColumnGroupsBuilder, DestroyTolerantOfNull) {
-  loon_column_groups_destroy(nullptr);
-}
+TEST(V2ColumnGroupsBuilder, DestroyTolerantOfNull) { loon_column_groups_destroy(nullptr); }
 
 TEST(V2ColumnGroupsBuilder, RejectsMismatchedOuterLengths) {
   std::vector<std::vector<std::string>> cols = {{"a"}};


### PR DESCRIPTION
Turns out the clang-format CI check has been silently passing even when files were misformatted. The root cause was in cpp/Makefile: the check-format target used $(foreach ...) which expands all the find commands into a single shell line joined by semicolons, so the shell only ever returned the exit code of the last command. Any violations in ./src, ./include, or ./test got printed to stderr but swallowed as long as ./benchmark was clean. Rewrote both check-format and fix-format to use a proper shell loop with set -e so any failure actually fails the target.

On top of that, the CI workflow never pinned a clang-format version, so the ubuntu-22.04 runner was using the default clang-format 14 while most of us run 18 locally. That mismatch meant running make fix-format locally could still leave diffs that CI disagreed with (or vice versa). Added a step to install clang-format-18 from the official LLVM apt repo and point /usr/bin/clang-format at it via update-alternatives, so CI and local are on the same version.