### PR TITLE
fix: unbreak macOS build after Conan 2.x migration

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -21,6 +21,9 @@ libcxx_setting = -s compiler.cppstd=17
 uname_s := $(shell uname -s)
 ifeq ($(uname_s),Darwin)
 	libcxx_setting = -s compiler.libcxx=libc++ -s compiler.cppstd=17
+	# Ensure enough Mach-O header padding so Conan's fix_apple_shared_install_name
+	# (install_name_tool) can rewrite rpaths in dependency binaries like openssl.
+	export LDFLAGS := $(LDFLAGS) -headerpad_max_install_names
 endif
 
 # Common conan flags

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -113,8 +113,12 @@ class StorageConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if self.settings.arch not in ("x86_64", "x86"):
-            del self.options["folly"].use_sse4_2
-        self.options["arrow"].with_jemalloc = self.options.with_jemalloc
+            self.options["folly"].rm_safe("use_sse4_2")
+        if self.settings.os == "Macos":
+            # Macos M1 cannot use jemalloc
+            self.options["arrow"].with_jemalloc = False
+        else:
+            self.options["arrow"].with_jemalloc = self.options.with_jemalloc
         self.options["arrow"].with_azure = True
         if self.options.with_jni and self.settings.os != "Macos":
             self.options["arrow"].shared = True
@@ -160,10 +164,7 @@ class StorageConan(ConanFile):
             self.requires("benchmark/1.8.3")
         if self.options.with_ut:
             self.requires("gtest/1.15.0")
-        if self.settings.os == "Macos":
-            # Macos M1 cannot use jemalloc
-            self.options["arrow"].with_jemalloc = False
-        else:
+        if self.settings.os != "Macos":
             self.requires("libunwind/1.8.1#748a981ace010b80163a08867b732e71")
 
     def validate(self):


### PR DESCRIPTION
A few things were broken on macOS after the Conan 2.x migration.

First, conanfile.py was setting self.options["arrow"].with_jemalloc inside requirements(), which Conan 2.x flatly rejects with "Dependencies options were defined incorrectly". Moved it into configure() where dep option overrides actually belong. While I was there, the old del self.options["folly"].use_sse4_2 also blows up with KeyError if the folly recipe no longer exposes that option, so swapped it for rm_safe which just silently no-ops in that case.

Second, the openssl package() step was dying on arm64 macOS when Conan tried to rewrite rpaths via install_name_tool, with the classic "larger updated load commands do not fit" error. The openssl binary just wasn't linked with enough Mach-O header padding. Exporting LDFLAGS=-headerpad_max_install_names in the Makefile on Darwin gets inherited by the openssl subprocess build so its binary actually has room for install_name_tool to add rpaths later.