### PR TITLE
enhance: move GCP out of s3_filesystem_producer into its own producer

### DIFF
--- a/cpp/include/milvus-storage/filesystem/gcp/gcp_filesystem_producer.h
+++ b/cpp/include/milvus-storage/filesystem/gcp/gcp_filesystem_producer.h
@@ -1,0 +1,46 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/result.h>
+
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/s3/s3_options.h"
+
+namespace milvus_storage {
+
+// GCS access through the S3-compatible XML API, using the AWS SDK S3Client.
+// Authentication is layered via a custom HttpClientFactory:
+//   - IAM mode: OAuth2 Bearer token from ComputeEngineCredentials (GCE metadata).
+//     The AWS SDK is fed anonymous credentials so it does not overwrite the
+//     injected Authorization header.
+//   - HMAC mode: GCS HMAC ak/sk with standard AWS SigV4 for non-conditional
+//     requests, and GOOG4-HMAC-SHA256 re-signing for conditional writes
+//     (x-goog-if-generation-match), which GCS does not accept via SigV4.
+class GcpFileSystemProducer : public FileSystemProducer {
+  public:
+  explicit GcpFileSystemProducer(const ArrowFileSystemConfig& config) : config_(config) {}
+
+  arrow::Result<ArrowFileSystemPtr> Make() override;
+
+  private:
+  arrow::Status InitS3Compat();
+
+  arrow::Result<S3Options> CreateS3Options();
+
+  const ArrowFileSystemConfig config_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_filesystem_producer.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_filesystem_producer.h
@@ -19,11 +19,6 @@
 #include <aws/core/http/curl/CurlHttpClient.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <arrow/util/uri.h>
-#include <google/cloud/internal/oauth2_credentials.h>
-#include <google/cloud/internal/oauth2_google_credentials.h>
-#include <google/cloud/storage/oauth2/compute_engine_credentials.h>
-#include <google/cloud/storage/oauth2/google_credentials.h>
-#include <google/cloud/status_or.h>
 #include <cstdlib>
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -40,7 +35,7 @@ class S3FileSystemProducer : public FileSystemProducer {
 
   arrow::Result<S3Options> CreateS3Options();
 
-  void InitS3();
+  arrow::Status InitS3();
 
   private:
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> CreateCredentialsProvider();

--- a/cpp/include/milvus-storage/filesystem/tls_http_client.h
+++ b/cpp/include/milvus-storage/filesystem/tls_http_client.h
@@ -1,0 +1,61 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include <aws/core/Aws.h>
+#include <aws/core/http/curl/CurlHttpClient.h>
+#include <curl/curl.h>
+
+namespace milvus_storage {
+
+// Convert tls_min_version string to CURLOPT_SSLVERSION value.
+// Returns CURL_SSLVERSION_DEFAULT (0) if the version string is empty or unrecognized.
+inline long TlsVersionToCurlOpt(const std::string& tls_min_version) {
+  if (tls_min_version == "1.0") {
+    return CURL_SSLVERSION_TLSv1_0;
+  }
+  if (tls_min_version == "1.1") {
+    return CURL_SSLVERSION_TLSv1_1;
+  }
+  if (tls_min_version == "1.2") {
+    return CURL_SSLVERSION_TLSv1_2;
+  }
+  if (tls_min_version == "1.3") {
+    return CURL_SSLVERSION_TLSv1_3;
+  }
+
+  return CURL_SSLVERSION_DEFAULT;
+}
+
+// CurlHttpClient subclass that enforces a minimum TLS version via CURLOPT_SSLVERSION.
+class TlsCurlHttpClient : public Aws::Http::CurlHttpClient {
+  public:
+  TlsCurlHttpClient(const Aws::Client::ClientConfiguration& config, const std::string& tls_min_version)
+      : CurlHttpClient(config), tls_ssl_version_(TlsVersionToCurlOpt(tls_min_version)) {}
+
+  protected:
+  void OverrideOptionsOnConnectionHandle(CURL* handle) const override {
+    if (tls_ssl_version_ != CURL_SSLVERSION_DEFAULT) {
+      curl_easy_setopt(handle, CURLOPT_SSLVERSION, tls_ssl_version_);
+    }
+  }
+
+  private:
+  long tls_ssl_version_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
+#include "milvus-storage/filesystem/gcp/gcp_filesystem_producer.h"
 #include "milvus-storage/filesystem/local_fs_producer.h"
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/lrucache.h"
@@ -66,8 +67,10 @@ arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemCon
         case CloudProviderType::AZURE: {
           return AzureFileSystemProducer(config).Make();
         }
+        case CloudProviderType::GCP: {
+          return GcpFileSystemProducer(config).Make();
+        }
         case CloudProviderType::AWS:
-        case CloudProviderType::GCP:
         case CloudProviderType::ALIYUN:
         case CloudProviderType::TENCENTCLOUD:
         case CloudProviderType::HUAWEICLOUD: {

--- a/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
+++ b/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
@@ -1,0 +1,322 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/gcp/gcp_filesystem_producer.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <google/cloud/internal/oauth2_credentials.h>
+#include <google/cloud/internal/oauth2_google_credentials.h>
+#include <google/cloud/internal/rest_client.h>
+#include <google/cloud/options.h>
+#include <google/cloud/status_or.h>
+#include <google/cloud/storage/oauth2/compute_engine_credentials.h>
+#include <google/cloud/storage/oauth2/google_credentials.h>
+
+#include <aws/core/Aws.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/curl/CurlHttpClient.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/status.h>
+#include <fmt/format.h>
+
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/log.h"
+#include "milvus-storage/common/macro.h"
+#include "milvus-storage/filesystem/s3/s3_auth_signer.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
+#include "milvus-storage/filesystem/s3/s3_global.h"
+#include "milvus-storage/filesystem/tls_http_client.h"
+
+namespace milvus_storage {
+
+namespace {
+
+constexpr const char* kGoogleClientFactoryAllocationTag = "GoogleHttpClientFactory";
+
+const std::unordered_map<std::string, S3LogLevel> kLogLevelMap = {
+    {"off", S3LogLevel::Off},   {"fatal", S3LogLevel::Fatal}, {"error", S3LogLevel::Error}, {"warn", S3LogLevel::Warn},
+    {"info", S3LogLevel::Info}, {"debug", S3LogLevel::Debug}, {"trace", S3LogLevel::Trace}};
+
+// GoogleHttpClientDelegator: Delegation-pattern HttpClient
+// Modifies request headers on MakeRequest, then delegates to the underlying CurlHttpClient
+class GoogleHttpClientDelegator : public Aws::Http::HttpClient {
+  public:
+  explicit GoogleHttpClientDelegator(const Aws::Client::ClientConfiguration& config,
+                                     bool use_iam,
+                                     const std::string& access_key = "",
+                                     const std::string& secret_key = "",
+                                     const std::string& tls_min_version = "")
+      : use_iam_(use_iam), access_key_(access_key), secret_key_(secret_key) {
+    // Create underlying CurlHttpClient, optionally with TLS version enforcement
+    if (!tls_min_version.empty()) {
+      underlying_client_ =
+          Aws::MakeShared<TlsCurlHttpClient>(kGoogleClientFactoryAllocationTag, config, tls_min_version);
+    } else {
+      underlying_client_ = Aws::MakeShared<Aws::Http::CurlHttpClient>(kGoogleClientFactoryAllocationTag, config);
+    }
+  }
+
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override {
+    bool is_conditional_write = request->HasHeader("x-goog-if-generation-match");
+    bool needs_goog4_signing = !use_iam_ && !access_key_.empty() && !secret_key_.empty() && is_conditional_write;
+    if (needs_goog4_signing) {
+      auto status = ApplyGoog4Signing(request, access_key_, secret_key_);
+      if (!status.ok()) {
+        // Standard AWS XML error format so ErrorMarshaller parses it correctly.
+        auto error_response =
+            Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(kGoogleClientFactoryAllocationTag, request);
+        error_response->SetResponseCode(Aws::Http::HttpResponseCode::FORBIDDEN);
+        error_response->GetResponseBody() << fmt::format(
+            R"(<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>SignatureFailed</Code>
+  <Message>{}</Message>
+</Error>)",
+            status.message());
+        return error_response;
+      }
+    }
+    return underlying_client_->MakeRequest(request, readLimiter, writeLimiter);
+  }
+
+  private:
+  // Strip AWS SigV4 headers, rewrite x-amz-meta-* → x-goog-meta-*, and re-sign
+  // the request with GOOG4-HMAC-SHA256.
+  static arrow::Status ApplyGoog4Signing(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                                         const std::string& access_key,
+                                         const std::string& secret_key) {
+    // Remove possible AWS signature headers
+    request->DeleteHeader("Authorization");
+    request->DeleteHeader("x-amz-date");
+    request->DeleteHeader("x-amz-content-sha256");
+    request->DeleteHeader("x-amz-security-token");
+    request->DeleteHeader("x-amz-api-version");
+
+    // AWS uses x-amz-meta-*, GCS uses x-goog-meta-*
+    std::vector<std::pair<std::string, std::string>> meta_headers_to_convert;
+    std::vector<std::string> old_keys_to_delete;
+    for (const auto& [key, value] : request->GetHeaders()) {
+      std::string lower_key = key;
+      std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
+
+      if (lower_key.find("x-amz-meta-") == 0) {
+        std::string suffix = key.substr(11);  // strip "x-amz-meta-"
+        meta_headers_to_convert.emplace_back("x-goog-meta-" + suffix, value);
+        old_keys_to_delete.push_back(key);
+      }
+    }
+    for (const auto& old_key : old_keys_to_delete) {
+      request->DeleteHeader(old_key.c_str());
+    }
+    for (const auto& [new_key, value] : meta_headers_to_convert) {
+      request->SetHeaderValue(new_key, value);
+    }
+
+    if (!milvus_storage::auth_signer::googv4::SignRequest(request, access_key, secret_key)) {
+      return arrow::Status::ExecutionError("GOOG4-HMAC-SHA256 signing failed");
+    }
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<Aws::Http::HttpClient> underlying_client_;
+  bool use_iam_;
+  std::string access_key_;
+  std::string secret_key_;
+};
+
+class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
+  public:
+  // Constructor: accepts both credentials (for IAM) and ak/sk (for HMAC)
+  GoogleHttpClientFactory(std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials,
+                          bool use_iam,
+                          const std::string& access_key = "",
+                          const std::string& secret_key = "",
+                          const std::string& tls_min_version = "")
+      : credentials_(std::move(credentials)),
+        use_iam_(use_iam),
+        access_key_(access_key),
+        secret_key_(secret_key),
+        tls_min_version_(tls_min_version) {}
+
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+      const Aws::Client::ClientConfiguration& clientConfiguration) const override {
+    // Delegator decides whether to apply GOOG4 signing based on use_iam
+    return Aws::MakeShared<GoogleHttpClientDelegator>(kGoogleClientFactoryAllocationTag, clientConfiguration, use_iam_,
+                                                      access_key_, secret_key_, tls_min_version_);
+  }
+
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
+    return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
+  }
+
+  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri,
+      Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override {
+    auto request =
+        Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(kGoogleClientFactoryAllocationTag, uri, method);
+    request->SetResponseStreamFactory(streamFactory);
+
+    if (!use_iam_) {
+      // HMAC mode: return unsigned request; signing handled by GoogleHttpClientDelegator
+      return request;
+    }
+
+    // IAM mode: inject OAuth2 Bearer header
+    if (!credentials_) {
+      throw std::invalid_argument("GoogleHttpClientFactory: credentials_ is nullptr");
+    }
+
+    auto auth_header = google::cloud::oauth2_internal::AuthorizationHeader(*credentials_);
+    if (!auth_header.ok()) {
+      throw std::invalid_argument("GoogleHttpClientFactory: create http request get authorization failed");
+    }
+    request->SetHeaderValue(auth_header->first.c_str(), auth_header->second.c_str());
+    return request;
+  }
+
+  private:
+  std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials_;
+  bool use_iam_;
+  std::string access_key_;
+  std::string secret_key_;
+  std::string tls_min_version_;
+};
+
+}  // namespace
+
+arrow::Status GcpFileSystemProducer::InitS3Compat() {
+  // FIXME: assumes no cross-cloud-provider usage in practice; if it does happen,
+  // this will produce unknown issues (InitializeS3 installs the HttpClientFactory
+  // process-globally, and whichever producer runs call_once first wins).
+  static std::once_flag s3_init_flag;
+  static arrow::Status init_status = arrow::Status::OK();
+  std::call_once(s3_init_flag, [this]() {
+    S3GlobalOptions global_options;
+    auto it = kLogLevelMap.find(config_.log_level);
+    global_options.log_level = it != kLogLevelMap.end() ? it->second : S3LogLevel::Off;
+
+    // tls_min_version only takes effect when use_ssl is enabled
+    std::string tls_min_ver = (config_.use_ssl && !config_.tls_min_version.empty()) ? config_.tls_min_version : "";
+
+    std::string ak = config_.access_key_id;
+    std::string sk = config_.access_key_value;
+    bool use_iam = config_.use_iam;
+
+    Aws::HttpOptions http_options;
+    http_options.httpClientFactory_create_fn = [ak, sk, use_iam, tls_min_ver]() {
+      auto client_factory = [](google::cloud::Options const& opts) {
+        return google::cloud::rest_internal::MakeDefaultRestClient("", opts);
+      };
+      auto credentials = std::make_shared<google::cloud::oauth2_internal::ComputeEngineCredentials>(
+          google::cloud::Options{}, std::move(client_factory));
+      return Aws::MakeShared<GoogleHttpClientFactory>(kGoogleClientFactoryAllocationTag, credentials, use_iam,
+                                                      use_iam ? "" : ak,  // IAM mode does not need ak
+                                                      use_iam ? "" : sk,  // IAM mode does not need sk
+                                                      tls_min_ver);
+    };
+    global_options.http_options = http_options;
+    global_options.override_default_http_options = true;
+
+    auto status = InitializeS3(global_options);
+    if (!status.ok()) {
+      init_status = arrow::Status::Invalid("GcpFileSystemProducer failed to initialize S3: ", status.ToString());
+      return;
+    }
+
+    // Register cleanup on exit. atexit handlers must not throw, so log on failure.
+    std::atexit([]() {
+      auto status = EnsureS3Finalized();
+      if (!status.ok()) {
+        LOG_STORAGE_ERROR_ << "GcpFileSystemProducer failed to finalize S3: " << status.ToString();
+      }
+    });
+  });
+  return init_status;
+}
+
+arrow::Result<S3Options> GcpFileSystemProducer::CreateS3Options() {
+  S3Options options;
+
+  // Three cases:
+  // 1. no ssl, verifySSL=false
+  // 2. self-signed certificate, verifySSL=false
+  // 3. CA-signed certificate, verifySSL=true
+  options.scheme = config_.use_ssl ? "https" : "http";
+
+  if (config_.use_ssl && !config_.ssl_ca_cert.empty()) {
+    arrow::fs::FileSystemGlobalOptions fs_global_options;
+    fs_global_options.tls_ca_file_path = config_.ssl_ca_cert;
+    ARROW_RETURN_NOT_OK(arrow::fs::Initialize(fs_global_options));
+  }
+
+  options.endpoint_override = config_.address;
+  options.force_virtual_addressing = config_.use_virtual_host;
+
+  if (!config_.region.empty()) {
+    options.region = config_.region;
+  }
+
+  options.request_timeout = config_.request_timeout_ms <= 0 ? DEFAULT_ARROW_FILESYSTEM_S3_REQUEST_TIMEOUT_SEC
+                                                            : config_.request_timeout_ms / 1000;
+  options.max_connections = config_.max_connections;
+  options.multi_part_upload_size = config_.multi_part_upload_size;
+  options.cloud_provider = config_.cloud_provider;
+  options.background_writes = config_.background_writes;
+  options.use_crc32c_checksum = config_.use_crc32c_checksum;
+
+  // GCP does not support AssumeRole
+  if (!config_.role_arn.empty()) {
+    return arrow::Status::Invalid("AssumeRole credentials are only supported for AWS cloud provider, got: ",
+                                  config_.cloud_provider);
+  }
+
+  if (config_.use_iam) {
+    // GCP+IAM: authentication is handled by GoogleHttpClientFactory which injects
+    // OAuth2 Authorization headers in CreateHttpRequest(). Use anonymous credentials
+    // so the AWS SDK's SigV4 signer skips signing and preserves the OAuth2 header.
+    options.ConfigureAnonymousCredentials();
+  } else {
+    options.ConfigureAccessKey(config_.access_key_id, config_.access_key_value);
+  }
+
+  return options;
+}
+
+arrow::Result<ArrowFileSystemPtr> GcpFileSystemProducer::Make() {
+  ARROW_RETURN_NOT_OK(InitS3Compat());
+
+  ARROW_ASSIGN_OR_RAISE(auto s3_options, CreateS3Options());
+  ARROW_ASSIGN_OR_RAISE(auto fs, S3FileSystem::Make(s3_options));
+  return std::make_shared<FileSystemProxy>(config_.bucket_name, fs);
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -17,8 +17,6 @@
 #include "milvus-storage/filesystem/fs.h"
 
 #include <cstdlib>
-#include <google/cloud/internal/rest_client.h>
-#include <google/cloud/options.h>
 #include <mutex>
 #include <sstream>
 #include <utility>
@@ -26,11 +24,9 @@
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
-#include <aws/core/utils/logging/ConsoleLogSystem.h>
+#include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
-#include <aws/core/http/standard/StandardHttpResponse.h>
-#include <aws/core/http/curl/CurlHttpClient.h>
-#include <curl/curl.h>
+#include <aws/core/utils/logging/ConsoleLogSystem.h>
 #include <aws/s3/model/CreateBucketRequest.h>
 #include <aws/s3/model/DeleteBucketRequest.h>
 #include <aws/s3/model/DeleteObjectRequest.h>
@@ -52,56 +48,18 @@
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem.h"
-#include "milvus-storage/filesystem/s3/s3_options.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
-#include "milvus-storage/filesystem/s3/s3_auth_signer.h"
+#include "milvus-storage/filesystem/s3/s3_options.h"
+#include "milvus-storage/filesystem/tls_http_client.h"
 
 namespace milvus_storage {
 
-static std::unordered_map<std::string, S3LogLevel> LogLevel_Map = {
-    {"off", S3LogLevel::Off},   {"fatal", S3LogLevel::Fatal}, {"error", S3LogLevel::Error}, {"warn", S3LogLevel::Warn},
-    {"info", S3LogLevel::Info}, {"debug", S3LogLevel::Debug}, {"trace", S3LogLevel::Trace}};
+namespace {
 
-static const char* GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG = "GoogleHttpClientFactory";
-static const char* TLS_FACTORY_ALLOCATION_TAG = "TlsHttpClientFactory";
+constexpr const char* kTlsFactoryAllocationTag = "TlsHttpClientFactory";
 
-// Convert tls_min_version string to CURLOPT_SSLVERSION value.
-// Returns CURL_SSLVERSION_DEFAULT (0) if the version string is empty or unrecognized.
-static long TlsVersionToCurlOpt(const std::string& tls_min_version) {
-  if (tls_min_version == "1.0") {
-    return CURL_SSLVERSION_TLSv1_0;
-  }
-  if (tls_min_version == "1.1") {
-    return CURL_SSLVERSION_TLSv1_1;
-  }
-  if (tls_min_version == "1.2") {
-    return CURL_SSLVERSION_TLSv1_2;
-  }
-  if (tls_min_version == "1.3") {
-    return CURL_SSLVERSION_TLSv1_3;
-  }
-
-  return CURL_SSLVERSION_DEFAULT;
-}
-
-// CurlHttpClient subclass that enforces a minimum TLS version via CURLOPT_SSLVERSION.
-class TlsCurlHttpClient : public Aws::Http::CurlHttpClient {
-  public:
-  TlsCurlHttpClient(const Aws::Client::ClientConfiguration& config, const std::string& tls_min_version)
-      : CurlHttpClient(config), tls_ssl_version_(TlsVersionToCurlOpt(tls_min_version)) {}
-
-  protected:
-  void OverrideOptionsOnConnectionHandle(CURL* handle) const override {
-    if (tls_ssl_version_ != CURL_SSLVERSION_DEFAULT) {
-      curl_easy_setopt(handle, CURLOPT_SSLVERSION, tls_ssl_version_);
-    }
-  }
-
-  private:
-  long tls_ssl_version_;
-};
-
-// HttpClientFactory that creates TlsCurlHttpClient instances for non-GCP S3 providers.
+// HttpClientFactory that creates TlsCurlHttpClient instances so the AWS SDK
+// honors the configured minimum TLS version for S3-compatible providers.
 class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
   public:
   explicit TlsHttpClientFactory(const std::string& tls_min_version) : tls_min_version_(tls_min_version) {}
@@ -113,9 +71,9 @@ class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
     // (e.g. "SSL connection using TLSv1.3 / ...") are routed through the AWS SDK logger.
     auto traced_config = config;
     traced_config.enableHttpClientTrace = true;
-    return Aws::MakeShared<TlsCurlHttpClient>(TLS_FACTORY_ALLOCATION_TAG, traced_config, tls_min_version_);
+    return Aws::MakeShared<TlsCurlHttpClient>(kTlsFactoryAllocationTag, traced_config, tls_min_version_);
 #else
-    return Aws::MakeShared<TlsCurlHttpClient>(TLS_FACTORY_ALLOCATION_TAG, config, tls_min_version_);
+    return Aws::MakeShared<TlsCurlHttpClient>(kTlsFactoryAllocationTag, config, tls_min_version_);
 #endif
   }
 
@@ -128,7 +86,7 @@ class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
       const Aws::Http::URI& uri,
       Aws::Http::HttpMethod method,
       const Aws::IOStreamFactory& streamFactory) const override {
-    auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(TLS_FACTORY_ALLOCATION_TAG, uri, method);
+    auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(kTlsFactoryAllocationTag, uri, method);
     request->SetResponseStreamFactory(streamFactory);
     return request;
   }
@@ -137,168 +95,15 @@ class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
   std::string tls_min_version_;
 };
 
-// GoogleHttpClientDelegator: Delegation-pattern HttpClient
-// Modifies request headers on MakeRequest, then delegates to the underlying CurlHttpClient
-class GoogleHttpClientDelegator : public Aws::Http::HttpClient {
-  public:
-  explicit GoogleHttpClientDelegator(const Aws::Client::ClientConfiguration& config,
-                                     bool use_iam,
-                                     const std::string& access_key = "",
-                                     const std::string& secret_key = "",
-                                     const std::string& tls_min_version = "")
-      : use_iam_(use_iam), access_key_(access_key), secret_key_(secret_key) {
-    // Create underlying CurlHttpClient, optionally with TLS version enforcement
-    if (!tls_min_version.empty()) {
-      underlying_client_ =
-          Aws::MakeShared<TlsCurlHttpClient>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, config, tls_min_version);
-    } else {
-      underlying_client_ = Aws::MakeShared<Aws::Http::CurlHttpClient>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, config);
-    }
-  }
+}  // namespace
 
-  public:
-  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
-      const std::shared_ptr<Aws::Http::HttpRequest>& request,
-      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
-      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override {
-    // Check header to see if this is a conditional write
-    bool is_conditional_write = request->HasHeader("x-goog-if-generation-match");
-    // Decide if GOOG4 signing is needed (HMAC mode + conditional write)
-    bool needs_goog4_signing = !use_iam_ && !access_key_.empty() && !secret_key_.empty() && is_conditional_write;
-    if (needs_goog4_signing) {
-      // Remove possible AWS signature headers
-      request->DeleteHeader("Authorization");
-      request->DeleteHeader("x-amz-date");
-      request->DeleteHeader("x-amz-content-sha256");
-      request->DeleteHeader("x-amz-security-token");
-      request->DeleteHeader("x-amz-api-version");
+static std::unordered_map<std::string, S3LogLevel> LogLevel_Map = {
+    {"off", S3LogLevel::Off},   {"fatal", S3LogLevel::Fatal}, {"error", S3LogLevel::Error}, {"warn", S3LogLevel::Warn},
+    {"info", S3LogLevel::Info}, {"debug", S3LogLevel::Debug}, {"trace", S3LogLevel::Trace}};
 
-      // Convert AWS metadata headers to GCS metadata headers
-      // AWS uses x-amz-meta-*, GCS uses x-goog-meta-*
-      std::vector<std::pair<std::string, std::string>> meta_headers_to_convert;
-      std::vector<std::string> old_keys_to_delete;
-
-      // Collect all x-amz-meta-* headers to convert
-      for (const auto& [key, value] : request->GetHeaders()) {
-        std::string lower_key = key;
-        std::transform(lower_key.begin(), lower_key.end(), lower_key.begin(), ::tolower);
-
-        if (lower_key.find("x-amz-meta-") == 0) {
-          // Found x-amz-meta- prefix
-          std::string suffix = key.substr(11);  // strip "x-amz-meta-" (11 chars)
-          std::string new_key = "x-goog-meta-" + suffix;
-          meta_headers_to_convert.emplace_back(new_key, value);
-          old_keys_to_delete.push_back(key);
-        }
-      }
-
-      // Remove old x-amz-meta-* headers, add new x-goog-meta-* headers
-      if (!meta_headers_to_convert.empty()) {
-        // Delete old headers
-        for (const auto& old_key : old_keys_to_delete) {
-          request->DeleteHeader(old_key.c_str());
-        }
-
-        // Add new headers
-        for (const auto& [new_key, value] : meta_headers_to_convert) {
-          request->SetHeaderValue(new_key, value);
-        }
-      }
-
-      // Sign with GOOG4-HMAC-SHA256
-      if (!milvus_storage::auth_signer::googv4::SignRequest(request, access_key_, secret_key_)) {
-        // Signature failed, create error response with FORBIDDEN status
-        // Using standard AWS XML error format that will be parsed by ErrorMarshaller
-        auto error_response =
-            Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, request);
-        error_response->SetResponseCode(Aws::Http::HttpResponseCode::FORBIDDEN);
-        std::string error_body = R"(<?xml version="1.0" encoding="UTF-8"?>
-<Error>
-  <Code>SignatureFailed</Code>
-  <Message>Signature failed</Message>
-</Error>)";
-        error_response->GetResponseBody() << error_body;
-        return error_response;
-      }
-    }
-    return underlying_client_->MakeRequest(request, readLimiter, writeLimiter);
-  }
-
-  private:
-  std::shared_ptr<Aws::Http::HttpClient> underlying_client_;
-  bool use_iam_;
-  std::string access_key_;
-  std::string secret_key_;
-};
-
-class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
-  public:
-  // Constructor: accepts both credentials (for IAM) and ak/sk (for HMAC)
-  GoogleHttpClientFactory(std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials,
-                          bool use_iam,
-                          const std::string& access_key = "",
-                          const std::string& secret_key = "",
-                          const std::string& tls_min_version = "")
-      : credentials_(std::move(credentials)),
-        use_iam_(use_iam),
-        access_key_(access_key),
-        secret_key_(secret_key),
-        tls_min_version_(tls_min_version) {}
-
-  void SetCredentials(std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials) {
-    credentials_ = std::move(credentials);
-  }
-
-  [[nodiscard]] std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
-      const Aws::Client::ClientConfiguration& clientConfiguration) const override {
-    // Create GoogleHttpClientDelegator with use_iam and ak/sk.
-    // Delegator will decide whether to use GOOG4 signing based on use_iam
-    return Aws::MakeShared<GoogleHttpClientDelegator>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, clientConfiguration,
-                                                      use_iam_, access_key_, secret_key_, tls_min_version_);
-  }
-
-  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
-      const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
-    return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
-  }
-
-  [[nodiscard]] std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
-      const Aws::Http::URI& uri,
-      Aws::Http::HttpMethod method,
-      const Aws::IOStreamFactory& streamFactory) const override {
-    auto request =
-        Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, uri, method);
-    request->SetResponseStreamFactory(streamFactory);
-
-    if (!use_iam_) {
-      // HMAC mode: directly return unsigned request
-      // Actual signing will be handled in GoogleHttpClientDelegator::MakeRequest
-      return request;
-    }
-
-    // For IAM, add OAuth2 header
-    if (!credentials_) {
-      throw std::invalid_argument("GoogleHttpClientFactory: credentials_ is nullptr");
-    }
-
-    auto auth_header = google::cloud::oauth2_internal::AuthorizationHeader(*credentials_);
-    if (!auth_header.ok()) {
-      throw std::invalid_argument("GoogleHttpClientFactory: create http request get authorization failed");
-    }
-    request->SetHeaderValue(auth_header->first.c_str(), auth_header->second.c_str());
-    return request;
-  }
-
-  private:
-  std::shared_ptr<google::cloud::oauth2_internal::Credentials> credentials_;
-  bool use_iam_;
-  std::string access_key_;
-  std::string secret_key_;
-  std::string tls_min_version_;
-};
-
-void S3FileSystemProducer::InitS3() {
+arrow::Status S3FileSystemProducer::InitS3() {
   static std::once_flag s3_init_flag;
+  static arrow::Status init_status = arrow::Status::OK();
   std::call_once(s3_init_flag, [this]() {
     S3GlobalOptions global_options;
     global_options.log_level = LogLevel_Map[config_.log_level];
@@ -306,49 +111,30 @@ void S3FileSystemProducer::InitS3() {
     // tls_min_version only takes effect when use_ssl is enabled
     std::string tls_min_ver = (config_.use_ssl && !config_.tls_min_version.empty()) ? config_.tls_min_version : "";
 
-    if (config_.cloud_provider == kCloudProviderGCP) {
-      std::string ak = config_.access_key_id;
-      std::string sk = config_.access_key_value;
-      bool use_iam = config_.use_iam;
-
-      Aws::HttpOptions http_options;
-      http_options.httpClientFactory_create_fn = [ak, sk, use_iam, tls_min_ver]() {
-        auto client_factory = [](google::cloud::Options const& opts) {
-          return google::cloud::rest_internal::MakeDefaultRestClient("", opts);
-        };
-        auto credentials = std::make_shared<google::cloud::oauth2_internal::ComputeEngineCredentials>(
-            google::cloud::Options{}, std::move(client_factory));
-        return Aws::MakeShared<GoogleHttpClientFactory>(GOOGLE_CLIENT_FACTORY_ALLOCATION_TAG, credentials,
-                                                        use_iam,            // Explicitly pass use_iam flag
-                                                        use_iam ? "" : ak,  // IAM mode does not need ak
-                                                        use_iam ? "" : sk,  // IAM mode does not need sk
-                                                        tls_min_ver         // TLS minimum version
-        );
-      };
-      global_options.http_options = http_options;
-      global_options.override_default_http_options = true;
-    } else if (!tls_min_ver.empty()) {
-      // Non-GCP S3-compatible providers with TLS version override (only when use_ssl=true)
+    if (!tls_min_ver.empty()) {
       Aws::HttpOptions http_options;
       http_options.httpClientFactory_create_fn = [tls_min_ver]() {
-        return Aws::MakeShared<TlsHttpClientFactory>(TLS_FACTORY_ALLOCATION_TAG, tls_min_ver);
+        return Aws::MakeShared<TlsHttpClientFactory>(kTlsFactoryAllocationTag, tls_min_ver);
       };
       global_options.http_options = http_options;
       global_options.override_default_http_options = true;
     }
+
     auto status = InitializeS3(global_options);
     if (!status.ok()) {
-      throw std::invalid_argument("ArrowFileSystem failed to initialize S3: " + status.ToString());
+      init_status = arrow::Status::Invalid("S3FileSystemProducer failed to initialize S3: ", status.ToString());
+      return;
     }
 
-    // Register cleanup on exit
+    // Register cleanup on exit. atexit handlers must not throw, so log on failure.
     std::atexit([]() {
       auto status = EnsureS3Finalized();
       if (!status.ok()) {
-        throw std::invalid_argument("ArrowFileSystem failed to finalize S3: " + status.ToString());
+        LOG_STORAGE_ERROR_ << "S3FileSystemProducer failed to finalize S3: " << status.ToString();
       }
     });
   });
+  return init_status;
 }
 
 arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
@@ -389,8 +175,7 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
 
   // Credential configuration priority:
   // 1. AssumeRole (role_arn) — AWS only
-  // 2. IAM — GCP uses anonymous credentials (auth handled by GoogleHttpClientFactory via OAuth2),
-  //          other providers use their respective STS credential providers
+  // 2. IAM — use provider-specific STS credential providers
   // 3. Explicit access key / secret key
   if (!config_.role_arn.empty()) {
     if (config_.cloud_provider != kCloudProviderAWS) {
@@ -402,22 +187,15 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
     options.ConfigureAssumeRoleCredentials(config_.role_arn, config_.session_name, config_.external_id,
                                            config_.load_frequency);
   } else if (config_.use_iam) {
-    if (config_.cloud_provider == kCloudProviderGCP) {
-      // GCP+IAM: authentication is handled by GoogleHttpClientFactory which injects
-      // OAuth2 Authorization headers in CreateHttpRequest(). Use anonymous credentials
-      // so the AWS SDK's SigV4 signer skips signing and preserves the OAuth2 header.
-      options.ConfigureAnonymousCredentials();
-    } else {
-      auto provider = CreateCredentialsProvider();
-      if (!provider) {
-        return arrow::Status::Invalid("Unknown credentials provider, cloud provider: ", config_.cloud_provider);
-      }
-      auto credentials = provider->GetAWSCredentials();
-      assert(!credentials.GetAWSAccessKeyId().empty() && "AWS Access Key ID is empty");
-      assert(!credentials.GetAWSSecretKey().empty() && "AWS Secret Key is empty");
-      assert(!credentials.GetSessionToken().empty() && "AWS Session Token is empty");
-      options.credentials_provider = provider;
+    auto provider = CreateCredentialsProvider();
+    if (!provider) {
+      return arrow::Status::Invalid("Unknown credentials provider, cloud provider: ", config_.cloud_provider);
     }
+    auto credentials = provider->GetAWSCredentials();
+    assert(!credentials.GetAWSAccessKeyId().empty() && "AWS Access Key ID is empty");
+    assert(!credentials.GetAWSSecretKey().empty() && "AWS Secret Key is empty");
+    assert(!credentials.GetSessionToken().empty() && "AWS Session Token is empty");
+    options.credentials_provider = provider;
   } else {
     options.ConfigureAccessKey(config_.access_key_id, config_.access_key_value);
   }
@@ -465,7 +243,7 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateT
 }
 
 arrow::Result<ArrowFileSystemPtr> S3FileSystemProducer::Make() {
-  InitS3();
+  ARROW_RETURN_NOT_OK(InitS3());
 
   ARROW_ASSIGN_OR_RAISE(auto s3_options, CreateS3Options());
   ARROW_ASSIGN_OR_RAISE(auto fs, S3FileSystem::Make(s3_options));

--- a/cpp/test/filesystem/s3_client_test.cpp
+++ b/cpp/test/filesystem/s3_client_test.cpp
@@ -53,7 +53,7 @@ class S3ClientTest : public ::testing::Test {
     ASSERT_AND_ASSIGN(auto fs_config, GetFileSystemConfig(properties));
 
     milvus_storage::S3FileSystemProducer producer(fs_config);
-    producer.InitS3();
+    ASSERT_STATUS_OK(producer.InitS3());
     ASSERT_AND_ASSIGN(auto s3_options, producer.CreateS3Options());
 
     // Build an S3Client via ClientBuilder

--- a/cpp/test/s3_tls_version_test.cpp
+++ b/cpp/test/s3_tls_version_test.cpp
@@ -253,7 +253,8 @@ class S3TlsVersionTest : public ::testing::Test {
     logger->Clear();
 
     S3FileSystemProducer producer(fs_config_);
-    producer.InitS3();
+    auto init_status = producer.InitS3();
+    EXPECT_TRUE(init_status.ok()) << init_status.ToString();
     auto s3_options_result = producer.CreateS3Options();
     EXPECT_TRUE(s3_options_result.ok()) << s3_options_result.status().ToString();
     auto s3_options = std::move(s3_options_result).ValueOrDie();
@@ -334,7 +335,8 @@ TEST_F(S3TlsVersionTest, EnforceMinTlsTest) {
   // so we must install our CapturingLogger AFTER InitS3() to override it.
   {
     S3FileSystemProducer producer(fs_config_);
-    producer.InitS3();
+    auto init_status = producer.InitS3();
+    EXPECT_TRUE(init_status.ok()) << init_status.ToString();
   }
 
   auto logger = Aws::MakeShared<CapturingLogger>("TlsTest");
@@ -423,7 +425,8 @@ TEST_F(S3TlsVersionTest, EnforceMinTlsArrowFsTest) {
   fs_config_.tls_min_version = target_tls_version;
   {
     S3FileSystemProducer producer(fs_config_);
-    producer.InitS3();
+    auto init_status = producer.InitS3();
+    EXPECT_TRUE(init_status.ok()) << init_status.ToString();
   }
 
   auto logger = Aws::MakeShared<CapturingLogger>("TlsTest");


### PR DESCRIPTION
s3_filesystem_producer.cpp had accumulated a fair bit of GCP-specific code — GoogleHttpClientFactory, OAuth2 Bearer injection for IAM mode, GOOG4 re-signing for conditional writes — all tangled up with the AWS/Aliyun/Tencent/Huawei paths. This pulls everything GCP out into a new GcpFileSystemProducer under cpp/src/filesystem/gcp/ that inherits straight from FileSystemProducer. No shared base class or virtual hooks with the S3 side, the two producers are fully independent now.

The one thing both sides still share is TlsCurlHttpClient plus its TlsVersionToCurlOpt helper, which I pulled up to cpp/include/milvus-storage/filesystem/tls_http_client.h. It's a generic curl+AWS-SDK TLS knob, not really S3- or GCP-specific. TlsHttpClientFactory stays inside s3_filesystem_producer.cpp since only the S3 side uses it.

Worth flagging, this split relies on only one cloud provider being active per process, because InitializeS3 installs the HttpClientFactory globally via call_once. The old code had the exact same constraint, it just wasn't made explicit anywhere. If we ever need to mix providers in a single process we'll have to revisit this, but the split doesn't make the situation any worse.