### PR TITLE
fix: restore GH-45304 empty-body S3 upload workaround dropped by #199

### DIFF
--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -977,28 +977,34 @@ class CustomOutputStream final : public arrow::io::OutputStream {
                        std::shared_ptr<Buffer> owned_buffer = nullptr) {
     req.SetBucket(ToAwsString(path_.bucket));
     req.SetKey(ToAwsString(path_.key));
-    req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
     req.SetContentLength(nbytes);
     if (use_crc32c_checksum_) {
       req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
     }
 
     if (!background_writes_) {
-      req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
+      // GH-45304: avoid setting a body stream if length is 0.
+      // This workaround can be removed once we require AWS SDK 1.11.489 or later.
+      if (nbytes != 0) {
+        req.SetBody(std::make_shared<StringViewStream>(data, nbytes));
+      }
 
       ARROW_ASSIGN_OR_RAISE(auto outcome, TriggerUploadRequest(req, holder_));
 
       ARROW_RETURN_NOT_OK(sync_result_callback(req, upload_state_, part_number_, outcome));
     } else {
-      // If the data isn't owned, make an immutable copy for the lifetime of the closure
-      if (owned_buffer == nullptr) {
-        ARROW_ASSIGN_OR_RAISE(owned_buffer, AllocateBuffer(nbytes, io_context_.pool()));
-        memcpy(owned_buffer->mutable_data(), data, nbytes);
-      } else {
-        DCHECK_EQ(data, owned_buffer->data());
-        DCHECK_EQ(nbytes, owned_buffer->size());
+      // (GH-45304: avoid setting a body stream if length is 0, see above)
+      if (nbytes != 0) {
+        // If the data isn't owned, make an immutable copy for the lifetime of the closure
+        if (owned_buffer == nullptr) {
+          ARROW_ASSIGN_OR_RAISE(owned_buffer, AllocateBuffer(nbytes, io_context_.pool()));
+          memcpy(owned_buffer->mutable_data(), data, nbytes);
+        } else {
+          DCHECK_EQ(data, owned_buffer->data());
+          DCHECK_EQ(nbytes, owned_buffer->size());
+        }
+        req.SetBody(std::make_shared<StringViewStream>(owned_buffer->data(), owned_buffer->size()));
       }
-      req.SetBody(std::make_shared<StringViewStream>(owned_buffer->data(), owned_buffer->size()));
 
       {
         std::unique_lock<std::mutex> lock(upload_state_->mutex);


### PR DESCRIPTION
The ObjectOutputStream path used to carry Arrow's GH-45304 workaround, which guards against a chunked-encoding bug in AWS SDK C++ < 1.11.489 that manifests as MinIO (and some other S3-compatible gateways) rejecting uploads whose body stream is 0 bytes. The fix is simply to skip req.SetBody(...) when nbytes == 0.

That workaround was cherry-picked in #196 against multi_part_upload_s3_fs.cpp on 2025-05-20. Six days later #199 ("Use PutObject request for S3 in OutputStream when only uploading small data", porting Arrow's GH-40557 / GH-44334) was merged from a branch that predated #196, so the merge silently overwrote the GH-45304 block back to the pre-workaround shape.

Symptoms without this workaround: closing an OutputStream that wrote exactly 0 bytes triggers an UploadPart / PutObject of empty content, which against affected SDK/server combos fails with a malformed chunked-encoding error. We hit this in practice on older Minio deployments.