### PR TITLE
fix: OSS/COS/OBS compatibility with AWS SDK 1.11.692 checksum changes

### DIFF
--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -553,10 +553,12 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> ClientBuilder::BuildClient(
 
   const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
 
-  // GCP's S3-compatible API does not accept the extra x-amz-checksum-* headers
-  // that AWS SDK >= 1.11.x sends by default (WHEN_SUPPORTED). Restrict to
+  // Non-AWS S3-compatible APIs (GCP, Aliyun OSS, Tencent COS, Huawei OBS) do
+  // not accept the extra x-amz-checksum-* headers / aws-chunked streaming that
+  // AWS SDK >= 1.11.x sends by default (WHEN_SUPPORTED). Restrict to
   // WHEN_REQUIRED so the SDK only adds checksums when the API mandates them.
-  if (options_.cloud_provider == kCloudProviderGCP) {
+  if (options_.cloud_provider == kCloudProviderGCP || options_.cloud_provider == kCloudProviderAliyun ||
+      options_.cloud_provider == kCloudProviderTencent || options_.cloud_provider == kCloudProviderHuawei) {
     client_config_.checksumConfig.requestChecksumCalculation = Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
     client_config_.checksumConfig.responseChecksumValidation = Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
   }

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -47,6 +47,7 @@
 #include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/http/HttpResponse.h>
+#include <aws/core/utils/HashingUtils.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
 #include <aws/core/utils/stream/PreallocatedStreamBuf.h>
 #include <aws/core/utils/xml/XmlSerializer.h>
@@ -1771,9 +1772,19 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       if (options().use_crc32c_checksum) {
         req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
       } else if (options().cloud_provider == kCloudProviderGCP) {
-        // GCP's S3-compatible API requires Content-MD5 or x-amz-checksum-crc32
-        // for DeleteObjects, but AWS SDK >= 1.11.x no longer adds it by default.
+        // GCP's S3-compatible API accepts x-amz-checksum-crc32; AWS SDK >=
+        // 1.11.x no longer adds one by default, so set it explicitly.
         req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32);
+      } else if (options().cloud_provider == kCloudProviderAliyun ||
+                 options().cloud_provider == kCloudProviderTencent ||
+                 options().cloud_provider == kCloudProviderHuawei) {
+        // Aliyun OSS / Tencent COS / Huawei OBS only honor Content-MD5 on
+        // DeleteObjects and silently ignore x-amz-checksum-*. AWS SDK >= 1.11.x
+        // no longer auto-computes Content-MD5, so compute it from the
+        // serialized payload and inject it as a custom header.
+        req.SetAdditionalCustomHeaderValue(
+            "Content-MD5",
+            Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(req.SerializePayload())));
       }
       ARROW_ASSIGN_OR_RAISE(
           auto fut, SubmitIO(io_context_, [holder = holder_, req = std::move(req), delete_cb]() -> arrow::Status {


### PR DESCRIPTION
Follow-up to #480. Turns out the same aws-sdk-cpp 1.11.692 checksum mess that broke GCP also broke Aliyun OSS, Tencent COS and Huawei OBS, the error strings just looked different enough that it wasn't obvious until we actually ran against each of them (Aliyun complained about aws-chunked, Huawei threw XAmzContentSHA256Mismatch, Tencent griped about Content-MD5).

For PutObject the fix is identical to what we did for GCP: flip requestChecksumCalculation to WHEN_REQUIRED so the SDK stops tacking on x-amz-checksum-* headers and aws-chunked streaming that none of these providers understand. That single switch clears up the PutObject failures across all three.

DeleteObjects is where things get weird. GCP accepts x-amz-checksum-crc32 so #480 just sets the ChecksumAlgorithm and moves on. Aliyun, Tencent and Huawei silently ignore the whole x-amz-checksum-* family and only honor Content-MD5, which the new SDK no longer computes automatically, and MD5 isn't even an option in the ChecksumAlgorithm enum anymore. So we compute the MD5 ourselves off req.SerializePayload() and inject it as a custom header. That's safe because AmazonSerializableWebServiceRequest::GetBody wraps SerializePayload directly into the body stream, so the bytes we hash are exactly what the SDK sends on the wire.