### PR TITLE
Revert "feat: add aliyun assume role support for Iceberg external tables (#502)

### DIFF
--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -21,6 +21,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -259,7 +270,7 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer 56.2.0",
  "arrow-data 56.2.0",
  "arrow-schema 56.2.0",
@@ -276,7 +287,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
@@ -507,7 +518,7 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array 56.2.0",
  "arrow-buffer 56.2.0",
  "arrow-data 56.2.0",
@@ -521,7 +532,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-data 57.3.0",
@@ -1286,16 +1297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bnum"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
-dependencies = [
- "serde",
- "serde-big-array",
-]
-
-[[package]]
 name = "bon"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1318,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
  "syn 2.0.110",
 ]
 
@@ -1346,6 +1371,28 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1989,7 +2036,7 @@ version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ipc 56.2.0",
  "base64",
@@ -2235,7 +2282,7 @@ version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07331fc13603a9da97b74fd8a273f4238222943dffdbbed1c4c6f862a30105bf"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2256,7 +2303,7 @@ version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5951e572a8610b89968a09b5420515a121fbc305c0258651f318dc07c97ab17"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2366,7 +2413,7 @@ version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8668103361a272cbbe3a61f72eca60c9b7c706e87cc3565bcf21e2b277b84f6"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2404,7 +2451,7 @@ version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6652fe7b5bf87e85ed175f571745305565da2c0b599d98e697bcbedc7baa47c3"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2438,7 +2485,7 @@ version = "50.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2f7f778a1a838dec124efb96eae6144237d546945587557c9e6936b3414558c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ord 56.2.0",
  "arrow-schema 56.2.0",
@@ -2749,17 +2796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,18 +2904,6 @@ dependencies = [
  "num-traits",
  "paste",
  "seq-macro",
-]
-
-[[package]]
-name = "fastnum"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4089ab2dfd45d8ddc92febb5ca80644389d5ebb954f40231274a3f18341762e2"
-dependencies = [
- "bnum",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3348,6 +3372,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3355,7 +3382,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "allocator-api2",
 ]
 
@@ -3651,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b795ef2e2197596efad630c5e8cc4b4ebdfc488c02dadc709bef0416e1ffd49"
+checksum = "e65918e701cf610ab0cea57f7f31db5bf4f973230c2c160244067bce01f7c5fa"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3675,19 +3702,22 @@ dependencies = [
  "chrono",
  "derive_builder",
  "expect-test",
- "fastnum",
  "flate2",
  "fnv",
  "futures",
  "itertools 0.13.0",
  "moka",
  "murmur3",
+ "num-bigint",
  "once_cell",
+ "opendal",
  "ordered-float 4.6.0",
  "parquet 57.3.0",
  "rand 0.8.5",
+ "reqsign",
  "reqwest",
  "roaring 0.11.3",
+ "rust_decimal",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -3697,29 +3727,9 @@ dependencies = [
  "strum 0.27.2",
  "tokio",
  "typed-builder",
- "typetag",
  "url",
  "uuid",
  "zstd",
-]
-
-[[package]]
-name = "iceberg-storage-opendal"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8745ded8db2a4c2febc84ce2d5e9aaf5e2a1c0c9f6a82a1ea8134691e30a0b"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "cfg-if",
- "iceberg",
- "opendal",
- "reqsign",
- "reqwest",
- "serde",
- "typetag",
- "url",
 ]
 
 [[package]]
@@ -5356,7 +5366,7 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array 56.2.0",
  "arrow-buffer 56.2.0",
  "arrow-cast 56.2.0",
@@ -5393,7 +5403,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-cast 57.3.0",
@@ -5803,6 +5813,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quad-rand"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,7 +6037,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "brotli",
  "paste",
  "rand 0.9.2",
@@ -6142,6 +6172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqsign"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6234,6 +6273,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "roaring"
 version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6312,7 +6380,6 @@ dependencies = [
  "futures",
  "hmac",
  "iceberg",
- "iceberg-storage-opendal",
  "lance",
  "lance-encoding",
  "lance-index",
@@ -6331,7 +6398,6 @@ dependencies = [
  "take_mut",
  "tempfile",
  "tokio",
- "typetag",
  "url",
  "uuid",
  "vortex",
@@ -6356,6 +6422,22 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6550,6 +6632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6592,15 +6680,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7635,40 +7714,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "typetag"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
 
 [[package]]
 name = "unicase"

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -46,19 +46,8 @@ opendal = { version = "0.55", features = ["services-oss"] }
 object_store_opendal = "0.55"
 
 # Iceberg Ecosystem
-# iceberg 0.9 moved the opendal-backed storage implementations (s3/gcs/azdls/oss)
-# out of the core crate into a separate `iceberg-storage-opendal` crate. We enable
-# s3/gcs/azdls there, but deliberately NOT oss — OSS is handled by our own
-# `AliyunOssStorageFactory` in aliyun_oss_provider.rs so we can forward per-tenant
-# role_arn (OIDC) + the ECS-IMDS RAM flow, neither of which upstream's `OssConfig`
-# supports (it only accepts endpoint/AK/SK).
 bytes = "1"
-iceberg = "0.9"
-iceberg-storage-opendal = { version = "0.9", features = ["opendal-s3", "opendal-gcs", "opendal-azdls"] }
-# Required for #[typetag::serde] on our custom Storage/StorageFactory impls that
-# plug into iceberg's FileIO pipeline. Pinned to match iceberg-storage-opendal's
-# own typetag dep so we don't end up with two typetag copies.
-typetag = "0.2"
+iceberg = { version = "0.8", features = ["storage-azdls", "storage-gcs"] }
 parquet = { version = "56.2.0", features = ["arrow"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
@@ -1,68 +1,56 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright Zilliz
 
-//! Aliyun OSS with per-tenant `role_arn` support.
+//! Aliyun OSS store provider with per-tenant `role_arn` support.
 //!
-//! This file plugs the same per-tenant OSS credential flow into two separate
-//! consumers:
-//!   * [`AliyunOssStoreProvider`] — lance-io's [`ObjectStoreProvider`], used
-//!     by the Lance reader/writer path.
-//!   * [`AliyunOssStorageFactory`] / [`AliyunOssStorage`] — iceberg 0.9's
-//!     [`StorageFactory`] / [`Storage`], used by the iceberg
-//!     `plan_files` / metadata reader path.
+//! In the default OIDC mode this is a thin shim over opendal's `Oss` service:
+//! opendal + reqsign handle `AssumeRoleWithOIDC` natively. The shim mirrors
+//! lance-io's stock `OssStoreProvider` but also forwards `oss_role_arn` and
+//! `oss_role_session_name` from `storage_options` into opendal's config,
+//! which stock does not.
 //!
-//! Both consumers share:
-//!   * A common env-sweep + bucket/root helper (`init_oss_env_config`) plus
-//!     two caller-shaped public entry points that each read their own
-//!     storage-options naming convention:
-//!       - [`build_oss_config_from_lance_opts`] — lance-style underscored
-//!         keys (`oss_endpoint`, `oss_role_arn`, …)
-//!       - [`build_oss_config_from_iceberg_opts`] — iceberg-style dotted
-//!         keys (`oss.endpoint`, `oss.role-arn`, …)
-//!     Both emit the two extra keys (`role_arn`, `role_session_name`) that
-//!     stock lance-io `OssStoreProvider` and stock
-//!     `iceberg-storage-opendal::OssConfig` both drop — that missing pair
-//!     is the entire reason this module exists.
-//!   * [`apply_ram_mode_if_requested`] — resolves `role_arn` to concrete STS
-//!     creds when `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is set (ECS IMDS →
-//!     `sts:AssumeRole` flow). No-op in the default OIDC mode.
-//!   * The inner [`ram`] module — IMDSv2, `sts:AssumeRole`, and POP v1
-//!     signing, all kept out of the default OIDC path.
+//! In RAM mode (opt-in, see below) the module additionally resolves
+//! `role_arn` to concrete short-lived credentials itself — IMDS +
+//! `sts:AssumeRole` + POP v1 signing live in this file rather than in
+//! opendal.
 //!
-//! # Two AssumeRole flows
+//! Machine identity (`ALIBABA_CLOUD_OIDC_TOKEN_FILE` /
+//! `ALIBABA_CLOUD_OIDC_PROVIDER_ARN`) continues to live in process env — the
+//! env sweep preserved here routes them into opendal config.
 //!
-//! In the default OIDC mode everything downstream of [`build_oss_config`] is
-//! a thin forwarder to opendal: opendal + reqsign handle
-//! `AssumeRoleWithOIDC` natively. The OIDC path does not touch anything in
-//! `ram::*`.
+//! # Why a custom provider and not the stock one
 //!
-//! In RAM mode (`ALIYUN_ROLE_ARN_AUTH_MODE=ram`) we resolve `role_arn` to
-//! short-lived STS credentials *in this module* (IMDS then
-//! `sts:AssumeRole`), inject them into opendal's static-credential slots,
-//! and strip `role_arn` so reqsign's AssumeRoleWithOIDC path never fires.
+//! Stock `OssStoreProvider` only reads four `storage_options` keys
+//! (`oss_endpoint`, `oss_access_key_id`, `oss_secret_access_key`, `oss_region`).
+//! It cannot forward per-tenant `role_arn` / `role_session_name` — those can
+//! only reach opendal via process env. Process env is per-tenant-hostile
+//! (single-tenant only), so we add the missing two keys here.
+//!
+//! # RAM-mode alternative (ECS IMDS → sts:AssumeRole)
+//!
+//! On an Aliyun ECS instance with an attached RAM role (and no OIDC token),
+//! set `ALIYUN_ROLE_ARN_AUTH_MODE=ram`. This path resolves
+//! `role_arn` to short-lived STS credentials *in this module* (via IMDS then
+//! `sts:AssumeRole`), then injects them into opendal's static-credential
+//! slots (`access_key_id` / `access_key_secret` / `security_token`) and
+//! strips `role_arn` so reqsign's AssumeRoleWithOIDC path never fires.
 //! There is no auto-fallback — an unset or missing-OIDC-token environment
 //! would otherwise silently route through the wrong path, which is exactly
 //! the kind of thing an explicit env var is for.
+//!
+//! All RAM-mode helpers live in the inner [`ram`] module. The OIDC path
+//! does not touch anything in `ram::*` — it flows through `build_oss_config`
+//! and straight into opendal/reqsign.
 //!
 //! # Static AK/SK must not be forwarded on the OIDC role_arn path
 //!
 //! reqsign loads credentials in this order
 //! (`reqsign::aliyun::credential.rs` — `load_via_static` before
 //! `load_via_assume_role_with_oidc`): if static creds are set alongside
-//! `role_arn`, the OIDC path is silently skipped. `lance_common.cpp` and
-//! `iceberg_common.cpp` must not emit AK/SK when `role_arn` is set. In RAM
-//! mode this is turned on its head — we *do* want reqsign to use the static
-//! creds we just derived, and we strip `role_arn` ourselves to keep that
-//! route unambiguous.
-//!
-//! # Iceberg property naming
-//!
-//! iceberg uses dotted+hyphenated keys (`oss.endpoint`,
-//! `oss.access-key-id`) whereas lance-io uses underscored keys
-//! (`oss_endpoint`, `oss_access_key_id`). Each consumer has its own
-//! `build_oss_config_from_*_opts` entry point; neither translates into
-//! the other's shape. The shared machinery sits below the storage-option
-//! read, not above it.
+//! `role_arn`, the OIDC path is silently skipped. `lance_common.cpp` must
+//! not emit AK/SK when `role_arn` is set. In RAM mode this is turned on its
+//! head — we *do* want reqsign to use the static creds we just derived,
+//! and we strip `role_arn` ourselves to keep that route unambiguous.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -70,7 +58,6 @@ use std::sync::Arc;
 use object_store::ObjectStore as OSObjectStore;
 use object_store_opendal::OpendalStore;
 use opendal::{Operator, services::Oss};
-use serde::{Deserialize, Serialize};
 use snafu::location;
 use url::Url;
 
@@ -81,12 +68,6 @@ use lance_io::object_store::{
     ObjectStoreRegistry, StorageOptions,
 };
 
-use iceberg::io::{
-    FileMetadata, FileRead, FileWrite, InputFile, OutputFile, Storage as IcebergStorage,
-    StorageConfig, StorageFactory,
-};
-use iceberg::{Error as IcebergError, ErrorKind as IcebergErrorKind, Result as IcebergResult};
-
 /// lance-io's `DEFAULT_CLOUD_BLOCK_SIZE` is crate-private; mirror the 64 KiB
 /// value used by stock `OssStoreProvider`.
 const OSS_DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
@@ -94,19 +75,105 @@ const OSS_DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
 /// Mirrors stock `OssStoreProvider::download_retry_count()` fallback.
 const OSS_DEFAULT_DOWNLOAD_RETRIES: usize = 3;
 
-// ============================================================================
-// Shared: opendal OSS config assembly + RAM-mode credential swap
-// ============================================================================
+#[derive(Default, Debug)]
+pub struct AliyunOssStoreProvider;
 
-/// Build the env-and-URL part of the opendal OSS config map. Caller-specific
-/// key overlays (`oss.endpoint` for iceberg, `oss_endpoint` for lance) are
-/// applied on top of this by the caller-specific `build_oss_config_from_*`
-/// functions below.
+#[async_trait::async_trait]
+impl ObjectStoreProvider for AliyunOssStoreProvider {
+    async fn new_store(
+        &self,
+        base_path: Url,
+        params: &ObjectStoreParams,
+    ) -> LanceResult<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(OSS_DEFAULT_BLOCK_SIZE);
+        let storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+
+        let bucket = base_path
+            .host_str()
+            .ok_or_else(|| {
+                LanceError::invalid_input("OSS URL must contain bucket name", location!())
+            })?
+            .to_string();
+
+        let mut config_map = build_oss_config(bucket, &base_path, &storage_options)?;
+
+        // RAM-mode swap: when `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is set in env
+        // and `role_arn` is present in the config, turn the indirection into
+        // concrete creds here. No-op in every other case — OIDC callers,
+        // plain AK/SK callers, and any caller without the env var flipped
+        // fall straight through to `Operator::from_iter` below.
+        //
+        // FIXME(aliyun-ram-refresh): the STS creds resolved here are injected
+        // as static `access_key_id` / `access_key_secret` / `security_token`
+        // into opendal's config and never refreshed. Aliyun `sts:AssumeRole`
+        // tokens expire after ~1h, so any operator kept alive past that
+        // window (long scans, compactions) will start getting 403s until the
+        // next `new_store` call. Not fixed here because production deploys
+        // use the OIDC path (`ALIBABA_CLOUD_OIDC_TOKEN_FILE` +
+        // `AssumeRoleWithOIDC`), where reqsign handles refresh internally —
+        // RAM mode exists for ECS-with-RAM-role dev/bench environments only.
+        // If RAM mode ever becomes a supported production path, wrap the
+        // operator so it re-fetches via `fetch_assume_role_creds` before
+        // expiration.
+        if std::env::var(ram::AUTH_MODE_ENV).as_deref() == Ok(ram::AUTH_MODE_RAM) {
+            if let Some(role_arn) = config_map.get("role_arn").cloned() {
+                let session_name = config_map
+                    .get("role_session_name")
+                    .cloned()
+                    .unwrap_or_else(ram::default_session_name);
+                let creds = ram::fetch_assume_role_creds(&role_arn, &session_name)
+                    .await
+                    .map_err(|e| {
+                        LanceError::invalid_input(
+                            format!("Aliyun RAM-mode credential resolution failed: {e}"),
+                            location!(),
+                        )
+                    })?;
+                ram::apply_credentials(&mut config_map, creds);
+            }
+        }
+
+        let operator = Operator::from_iter::<Oss>(config_map)
+            .map_err(|e| {
+                LanceError::invalid_input(
+                    format!("Failed to create OSS operator: {:?}", e),
+                    location!(),
+                )
+            })?
+            .finish();
+
+        let inner = Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>;
+
+        let mut url = base_path;
+        if !url.path().ends_with('/') {
+            url.set_path(&format!("{}/", url.path()));
+        }
+
+        Ok(ObjectStore::new(
+            inner,
+            url,
+            Some(block_size),
+            params.object_store_wrapper.clone(),
+            params.use_constant_size_upload_parts,
+            // OSS object listings are lexically ordered (matches stock provider).
+            params.list_is_lexically_ordered.unwrap_or(true),
+            DEFAULT_CLOUD_IO_PARALLELISM,
+            OSS_DEFAULT_DOWNLOAD_RETRIES,
+            params.storage_options.as_ref(),
+        ))
+    }
+}
+
+/// Build the opendal OSS config map from env + `storage_options`.
 ///
-/// The error type is a plain `String` so that each caller can wrap it into
-/// its own error type without this module pulling both error hierarchies
-/// into its signature.
-fn init_oss_env_config(bucket: String, base_path: &Url) -> HashMap<String, String> {
+/// Extracted as a pure function so tests can assert the forwarding logic
+/// without building a live `Operator`.
+fn build_oss_config(
+    bucket: String,
+    base_path: &Url,
+    storage_options: &StorageOptions,
+) -> LanceResult<HashMap<String, String>> {
     // Env sweep: env vars starting with `OSS_`, `AWS_`, or `ALIBABA_CLOUD_`
     // are lowercased, and those three substrings are removed from the key
     // via `.replace()` (all occurrences, not just the prefix — for any real
@@ -144,201 +211,38 @@ fn init_oss_env_config(bucket: String, base_path: &Url) -> HashMap<String, Strin
         config_map.insert("root".to_string(), "/".to_string());
     }
 
-    config_map
-}
-
-/// Returns `Err` when no endpoint ended up in the config map. Both callers
-/// use the identical error string so the failure mode is uniform.
-fn require_endpoint(config_map: &HashMap<String, String>) -> Result<(), String> {
-    if !config_map.contains_key("endpoint") {
-        return Err(
-            "OSS endpoint is required. Provide an OSS endpoint in storage options or set OSS_ENDPOINT environment variable".to_string(),
-        );
-    }
-    Ok(())
-}
-
-/// Lance-style (underscored) storage_options → opendal OSS config. Keys
-/// consumed: `oss_endpoint`, `oss_access_key_id`, `oss_secret_access_key`,
-/// `oss_region`, `oss_role_arn`, `oss_role_session_name`.
-pub(crate) fn build_oss_config_from_lance_opts(
-    bucket: String,
-    base_path: &Url,
-    storage_options: &HashMap<String, String>,
-) -> Result<HashMap<String, String>, String> {
-    let mut config_map = init_oss_env_config(bucket, base_path);
-
     // storage_options overrides (later wins over env). Stock four keys:
-    if let Some(endpoint) = storage_options.get("oss_endpoint") {
+    if let Some(endpoint) = storage_options.0.get("oss_endpoint") {
         config_map.insert("endpoint".to_string(), endpoint.clone());
     }
-    if let Some(access_key_id) = storage_options.get("oss_access_key_id") {
+    if let Some(access_key_id) = storage_options.0.get("oss_access_key_id") {
         config_map.insert("access_key_id".to_string(), access_key_id.clone());
     }
-    if let Some(secret_access_key) = storage_options.get("oss_secret_access_key") {
+    if let Some(secret_access_key) = storage_options.0.get("oss_secret_access_key") {
         config_map.insert("access_key_secret".to_string(), secret_access_key.clone());
     }
-    if let Some(region) = storage_options.get("oss_region") {
+    if let Some(region) = storage_options.0.get("oss_region") {
         config_map.insert("region".to_string(), region.clone());
     }
 
-    // The two keys stock lance-io `OssStoreProvider` does NOT forward. This
-    // is the reason this provider exists — per-tenant role_arn /
-    // session_name can only reach opendal via `storage_options`.
-    if let Some(role_arn) = storage_options.get("oss_role_arn") {
+    // The two keys stock does NOT forward. This is the reason this provider
+    // exists — per-tenant role_arn / session_name can only reach opendal via
+    // `storage_options`.
+    if let Some(role_arn) = storage_options.0.get("oss_role_arn") {
         config_map.insert("role_arn".to_string(), role_arn.clone());
     }
-    if let Some(role_session_name) = storage_options.get("oss_role_session_name") {
+    if let Some(role_session_name) = storage_options.0.get("oss_role_session_name") {
         config_map.insert("role_session_name".to_string(), role_session_name.clone());
     }
 
-    require_endpoint(&config_map)?;
+    if !config_map.contains_key("endpoint") {
+        return Err(LanceError::invalid_input(
+            "OSS endpoint is required. Provide 'oss_endpoint' in storage options or set OSS_ENDPOINT environment variable",
+            location!(),
+        ));
+    }
+
     Ok(config_map)
-}
-
-/// Iceberg-style (dotted+hyphenated) storage_options → opendal OSS config.
-/// Keys consumed: `oss.endpoint`, `oss.access-key-id`, `oss.access-key-secret`,
-/// `oss.region`, `oss.role-arn`, `oss.role-session-name`.
-///
-/// The three endpoint/AK/SK keys match iceberg core's `OSS_*` constants
-/// (`OSS_ENDPOINT`, `OSS_ACCESS_KEY_ID`, `OSS_ACCESS_KEY_SECRET`). The other
-/// three are custom to this project — stock iceberg-storage-opendal's
-/// `OssConfig` drops them, which is why we never route through it.
-pub(crate) fn build_oss_config_from_iceberg_opts(
-    bucket: String,
-    base_path: &Url,
-    storage_options: &HashMap<String, String>,
-) -> Result<HashMap<String, String>, String> {
-    let mut config_map = init_oss_env_config(bucket, base_path);
-
-    if let Some(endpoint) = storage_options.get("oss.endpoint") {
-        config_map.insert("endpoint".to_string(), endpoint.clone());
-    }
-    if let Some(access_key_id) = storage_options.get("oss.access-key-id") {
-        config_map.insert("access_key_id".to_string(), access_key_id.clone());
-    }
-    if let Some(access_key_secret) = storage_options.get("oss.access-key-secret") {
-        config_map.insert("access_key_secret".to_string(), access_key_secret.clone());
-    }
-    if let Some(region) = storage_options.get("oss.region") {
-        config_map.insert("region".to_string(), region.clone());
-    }
-
-    // Custom keys unrecognised by stock iceberg-storage-opendal's
-    // `OssConfig`; they carry the per-tenant AssumeRole indirection.
-    if let Some(role_arn) = storage_options.get("oss.role-arn") {
-        config_map.insert("role_arn".to_string(), role_arn.clone());
-    }
-    if let Some(role_session_name) = storage_options.get("oss.role-session-name") {
-        config_map.insert("role_session_name".to_string(), role_session_name.clone());
-    }
-
-    require_endpoint(&config_map)?;
-    Ok(config_map)
-}
-
-/// RAM-mode credential swap: when `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is set in
-/// env and `role_arn` is present in `config_map`, resolve it to concrete STS
-/// creds via the ECS IMDS → `sts:AssumeRole` flow and mutate `config_map`
-/// so opendal sees static creds instead. No-op in every other case — OIDC
-/// callers, plain AK/SK callers, and any caller without the env var flipped
-/// fall straight through.
-///
-/// FIXME(aliyun-ram-refresh): the STS creds resolved here are injected as
-/// static `access_key_id` / `access_key_secret` / `security_token` into
-/// opendal's config and never refreshed. Aliyun `sts:AssumeRole` tokens
-/// expire after ~1h, so any operator kept alive past that window (long
-/// scans, compactions) will start getting 403s until the next credential
-/// resolution. Not fixed here because production deploys use the OIDC path
-/// (`ALIBABA_CLOUD_OIDC_TOKEN_FILE` + `AssumeRoleWithOIDC`), where reqsign
-/// handles refresh internally — RAM mode exists for ECS-with-RAM-role
-/// dev/bench environments only. If RAM mode ever becomes a supported
-/// production path, wrap the operator so it re-fetches via
-/// `fetch_assume_role_creds` before expiration.
-pub(crate) async fn apply_ram_mode_if_requested(
-    config_map: &mut HashMap<String, String>,
-) -> Result<(), String> {
-    if std::env::var(ram::AUTH_MODE_ENV).as_deref() != Ok(ram::AUTH_MODE_RAM) {
-        return Ok(());
-    }
-    let Some(role_arn) = config_map.get("role_arn").cloned() else {
-        return Ok(());
-    };
-    let session_name = config_map
-        .get("role_session_name")
-        .cloned()
-        .unwrap_or_else(ram::default_session_name);
-    let creds = ram::fetch_assume_role_creds(&role_arn, &session_name).await?;
-    ram::apply_credentials(config_map, creds);
-    Ok(())
-}
-
-// ============================================================================
-// Lance: ObjectStoreProvider
-// ============================================================================
-
-#[derive(Default, Debug)]
-pub struct AliyunOssStoreProvider;
-
-#[async_trait::async_trait]
-impl ObjectStoreProvider for AliyunOssStoreProvider {
-    async fn new_store(
-        &self,
-        base_path: Url,
-        params: &ObjectStoreParams,
-    ) -> LanceResult<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(OSS_DEFAULT_BLOCK_SIZE);
-        let storage_options =
-            StorageOptions(params.storage_options.clone().unwrap_or_default());
-
-        let bucket = base_path
-            .host_str()
-            .ok_or_else(|| {
-                LanceError::invalid_input("OSS URL must contain bucket name", location!())
-            })?
-            .to_string();
-
-        let mut config_map = build_oss_config_from_lance_opts(bucket, &base_path, &storage_options.0)
-            .map_err(|e| LanceError::invalid_input(e, location!()))?;
-
-        apply_ram_mode_if_requested(&mut config_map)
-            .await
-            .map_err(|e| {
-                LanceError::invalid_input(
-                    format!("Aliyun RAM-mode credential resolution failed: {e}"),
-                    location!(),
-                )
-            })?;
-
-        let operator = Operator::from_iter::<Oss>(config_map)
-            .map_err(|e| {
-                LanceError::invalid_input(
-                    format!("Failed to create OSS operator: {:?}", e),
-                    location!(),
-                )
-            })?
-            .finish();
-
-        let inner = Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>;
-
-        let mut url = base_path;
-        if !url.path().ends_with('/') {
-            url.set_path(&format!("{}/", url.path()));
-        }
-
-        Ok(ObjectStore::new(
-            inner,
-            url,
-            Some(block_size),
-            params.object_store_wrapper.clone(),
-            params.use_constant_size_upload_parts,
-            // OSS object listings are lexically ordered (matches stock provider).
-            params.list_is_lexically_ordered.unwrap_or(true),
-            DEFAULT_CLOUD_IO_PARALLELISM,
-            OSS_DEFAULT_DOWNLOAD_RETRIES,
-            params.storage_options.as_ref(),
-        ))
-    }
 }
 
 /// Build a `Session` whose `ObjectStoreRegistry` overrides the `oss` scheme
@@ -357,211 +261,9 @@ pub fn build_aliyun_oss_session() -> Arc<Session> {
     Arc::new(Session::new(0, 0, Arc::new(registry)))
 }
 
-// ============================================================================
-// Iceberg: StorageFactory / Storage
-// ============================================================================
-
-fn from_opendal_error(e: opendal::Error) -> IcebergError {
-    IcebergError::new(IcebergErrorKind::Unexpected, "Failure in doing io operation").with_source(e)
-}
-
-/// `StorageFactory` produces an [`AliyunOssStorage`] wrapping the iceberg
-/// `StorageConfig` props. Cross-process serialization (via `typetag`) is
-/// trivial because the factory is a unit struct.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct AliyunOssStorageFactory;
-
-#[typetag::serde(name = "AliyunOssStorageFactory")]
-impl StorageFactory for AliyunOssStorageFactory {
-    fn build(&self, config: &StorageConfig) -> IcebergResult<Arc<dyn IcebergStorage>> {
-        Ok(Arc::new(AliyunOssStorage {
-            props: Arc::new(config.props().clone()),
-        }))
-    }
-}
-
-/// Iceberg `Storage` impl for `oss://` URLs. Mirrors
-/// `iceberg_storage_opendal::OpenDalStorage::Oss` in shape — lazy per-call
-/// operator construction via [`Self::create_operator`], delegation of every
-/// async I/O method to the resulting opendal Operator — but builds the
-/// opendal config via [`build_oss_config`] + [`apply_ram_mode_if_requested`]
-/// so per-tenant `oss.role-arn` and the ECS-IMDS RAM flow are honoured
-/// (stock iceberg-storage-opendal's `OssConfig` cannot carry either).
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AliyunOssStorage {
-    props: Arc<HashMap<String, String>>,
-}
-
-impl AliyunOssStorage {
-    /// Derive bucket from the absolute `oss://bucket/key` path, then build
-    /// and return an opendal `Operator` for that bucket along with the
-    /// relative path (the `key` part) to use with it. Mirrors
-    /// `OpenDalStorage::create_operator` + `oss_config_build`.
-    async fn create_operator(&self, path: &str) -> IcebergResult<(Operator, String)> {
-        let url = Url::parse(path).map_err(|e| {
-            IcebergError::new(
-                IcebergErrorKind::DataInvalid,
-                format!("Invalid oss url: {path}: {e}"),
-            )
-        })?;
-        let bucket = url
-            .host_str()
-            .ok_or_else(|| {
-                IcebergError::new(
-                    IcebergErrorKind::DataInvalid,
-                    format!("Invalid oss url: {path}, missing bucket"),
-                )
-            })?
-            .to_string();
-
-        let mut config_map = build_oss_config_from_iceberg_opts(bucket, &url, &self.props)
-            .map_err(|e| IcebergError::new(IcebergErrorKind::DataInvalid, e))?;
-
-        apply_ram_mode_if_requested(&mut config_map)
-            .await
-            .map_err(|e| {
-                IcebergError::new(
-                    IcebergErrorKind::Unexpected,
-                    format!("Aliyun RAM-mode credential resolution failed: {e}"),
-                )
-            })?;
-
-        let op = Operator::from_iter::<Oss>(config_map)
-            .map_err(|e| {
-                IcebergError::new(
-                    IcebergErrorKind::Unexpected,
-                    format!("Failed to create OSS operator: {e}"),
-                )
-            })?
-            .finish();
-
-        let prefix = format!("oss://{}/", op.info().name());
-        let relative = path
-            .strip_prefix(&prefix)
-            .ok_or_else(|| {
-                IcebergError::new(
-                    IcebergErrorKind::DataInvalid,
-                    format!("Invalid oss url: {path}, should start with {prefix}"),
-                )
-            })?
-            .to_string();
-
-        Ok((op, relative))
-    }
-}
-
-#[typetag::serde(name = "AliyunOssStorage")]
-#[async_trait::async_trait]
-impl IcebergStorage for AliyunOssStorage {
-    async fn exists(&self, path: &str) -> IcebergResult<bool> {
-        let (op, rel) = self.create_operator(path).await?;
-        op.exists(&rel).await.map_err(from_opendal_error)
-    }
-
-    async fn metadata(&self, path: &str) -> IcebergResult<FileMetadata> {
-        let (op, rel) = self.create_operator(path).await?;
-        let meta = op.stat(&rel).await.map_err(from_opendal_error)?;
-        Ok(FileMetadata {
-            size: meta.content_length(),
-        })
-    }
-
-    async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
-        let (op, rel) = self.create_operator(path).await?;
-        Ok(op
-            .read(&rel)
-            .await
-            .map_err(from_opendal_error)?
-            .to_bytes())
-    }
-
-    async fn reader(&self, path: &str) -> IcebergResult<Box<dyn FileRead>> {
-        let (op, rel) = self.create_operator(path).await?;
-        Ok(Box::new(OpenDalReader(
-            op.reader(&rel).await.map_err(from_opendal_error)?,
-        )))
-    }
-
-    async fn write(&self, path: &str, bs: bytes::Bytes) -> IcebergResult<()> {
-        let (op, rel) = self.create_operator(path).await?;
-        op.write(&rel, bs).await.map_err(from_opendal_error)?;
-        Ok(())
-    }
-
-    async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
-        let (op, rel) = self.create_operator(path).await?;
-        Ok(Box::new(OpenDalWriter(
-            op.writer(&rel).await.map_err(from_opendal_error)?,
-        )))
-    }
-
-    async fn delete(&self, path: &str) -> IcebergResult<()> {
-        let (op, rel) = self.create_operator(path).await?;
-        op.delete(&rel).await.map_err(from_opendal_error)
-    }
-
-    async fn delete_prefix(&self, path: &str) -> IcebergResult<()> {
-        let (op, rel) = self.create_operator(path).await?;
-        let prefixed = if rel.ends_with('/') {
-            rel.clone()
-        } else {
-            format!("{rel}/")
-        };
-        op.remove_all(&prefixed).await.map_err(from_opendal_error)
-    }
-
-    fn new_input(&self, path: &str) -> IcebergResult<InputFile> {
-        Ok(InputFile::new(Arc::new(self.clone()), path.to_string()))
-    }
-
-    fn new_output(&self, path: &str) -> IcebergResult<OutputFile> {
-        Ok(OutputFile::new(Arc::new(self.clone()), path.to_string()))
-    }
-}
-
-/// `FileRead` wrapper around an opendal `Reader`. Copied in shape from
-/// `iceberg_storage_opendal::OpenDalReader` since that type is `pub(crate)`
-/// over there. The trait method does the same `opendal::Reader::read` →
-/// `Bytes` conversion that `OpenDalStorage` does.
-struct OpenDalReader(opendal::Reader);
-
-#[async_trait::async_trait]
-impl FileRead for OpenDalReader {
-    async fn read(&self, range: std::ops::Range<u64>) -> IcebergResult<bytes::Bytes> {
-        Ok(opendal::Reader::read(&self.0, range)
-            .await
-            .map_err(from_opendal_error)?
-            .to_bytes())
-    }
-}
-
-/// `FileWrite` wrapper around an opendal `Writer`. Same rationale as
-/// [`OpenDalReader`] — upstream's wrapper is `pub(crate)`.
-struct OpenDalWriter(opendal::Writer);
-
-#[async_trait::async_trait]
-impl FileWrite for OpenDalWriter {
-    async fn write(&mut self, bs: bytes::Bytes) -> IcebergResult<()> {
-        Ok(opendal::Writer::write(&mut self.0, bs)
-            .await
-            .map_err(from_opendal_error)?)
-    }
-
-    async fn close(&mut self) -> IcebergResult<()> {
-        let _ = opendal::Writer::close(&mut self.0)
-            .await
-            .map_err(from_opendal_error)?;
-        Ok(())
-    }
-}
-
-// ============================================================================
-// RAM-mode helpers (ECS IMDS → sts:AssumeRole + POP v1 signing)
-// ============================================================================
-
 /// ECS IMDS → `sts:AssumeRole` path. Nothing outside this module should call
 /// into `ram::*`; the OIDC path bypasses it entirely.
-pub(crate) mod ram {
+mod ram {
     use std::collections::HashMap;
     use std::time::Duration;
 
@@ -573,8 +275,8 @@ pub(crate) mod ram {
 
     /// Explicit opt-in env var for the ECS-IMDS → AssumeRole flow. `"ram"` selects
     /// it; anything else (including unset) keeps the default OIDC behaviour.
-    pub(crate) const AUTH_MODE_ENV: &str = "ALIYUN_ROLE_ARN_AUTH_MODE";
-    pub(crate) const AUTH_MODE_RAM: &str = "ram";
+    pub(super) const AUTH_MODE_ENV: &str = "ALIYUN_ROLE_ARN_AUTH_MODE";
+    pub(super) const AUTH_MODE_RAM: &str = "ram";
 
     /// ECS metadata service — Aliyun's fixed link-local HTTP endpoint.
     const IMDS_BASE: &str = "http://100.100.100.200";
@@ -587,10 +289,10 @@ pub(crate) mod ram {
 
     /// Short-lived credentials returned from `sts:AssumeRole`.
     #[derive(Debug, Clone)]
-    pub(crate) struct AssumeRoleCreds {
-        pub(crate) access_key_id: String,
-        pub(crate) access_key_secret: String,
-        pub(crate) security_token: String,
+    pub(super) struct AssumeRoleCreds {
+        pub(super) access_key_id: String,
+        pub(super) access_key_secret: String,
+        pub(super) security_token: String,
     }
 
     /// Mutate `config_map` for the RAM-mode hand-off: insert the concrete STS
@@ -600,7 +302,7 @@ pub(crate) mod ram {
     /// `role_arn` make reqsign silently pick the static path — here that's what
     /// we want, *and* keeping `role_arn` around would be a correctness landmine
     /// if reqsign's preference ever inverted).
-    pub(crate) fn apply_credentials(
+    pub(super) fn apply_credentials(
         config_map: &mut HashMap<String, String>,
         creds: AssumeRoleCreds,
     ) {
@@ -611,11 +313,11 @@ pub(crate) mod ram {
         config_map.insert("security_token".to_string(), creds.security_token);
     }
 
-    pub(crate) fn default_session_name() -> String {
+    pub(super) fn default_session_name() -> String {
         format!("milvus-storage-ram-{}", uuid::Uuid::now_v7())
     }
 
-    pub(crate) async fn fetch_assume_role_creds(
+    pub(super) async fn fetch_assume_role_creds(
         role_arn: &str,
         role_session_name: &str,
     ) -> Result<AssumeRoleCreds, String> {
@@ -864,16 +566,16 @@ pub(crate) mod ram {
 
         #[test]
         fn pop_sign_known_vector() {
-            // Aliyun POP v1 DescribeRegions example, signed with POST (our
-            // sts:AssumeRole is POSTed). Aliyun's doc publishes the GET variant
-            // `OLeaidS1JvxuMvnyHOwuJ+uX5qY=`; the POST expected below was
-            // independently recomputed from the POP v1 spec.
+            // Aliyun's canonical POP v1 example from their SDK reference doc.
+            // Given SecretAccessKey="testsecret" + "&" as the signing key, and
+            // the canonical query below, the signature must reproduce exactly.
+            // If this fails we're miscomputing either StringToSign or the HMAC.
             let canonical =
                 "AccessKeyId=testid&Action=DescribeRegions&Format=XML&SignatureMethod=HMAC-SHA1\
                  &SignatureNonce=3ee8c1b8-83d3-44af-a94f-4e0ad82fd6cf&SignatureVersion=1.0\
                  &Timestamp=2016-02-23T12%3A46%3A24Z&Version=2014-05-26";
             let sig = pop_sign("testsecret", canonical);
-            assert_eq!(sig, "MxbnVAM4w6sft9xjVpe/GCKueuk=");
+            assert_eq!(sig, "OLeaidS1JvxuMvnyHOwuJ+uX5qY=");
         }
     }
 }
@@ -882,22 +584,19 @@ pub(crate) mod ram {
 mod tests {
     use super::*;
 
-    fn opts(kvs: &[(&str, &str)]) -> HashMap<String, String> {
-        kvs.iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect()
+    fn opts(kvs: &[(&str, &str)]) -> StorageOptions {
+        StorageOptions(kvs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect())
     }
 
     #[test]
-    fn lance_opts_forward_role_arn_and_session_name() {
+    fn forwards_role_arn_and_session_name() {
         let url = Url::parse("oss://my-bucket/prefix").unwrap();
         let storage_options = opts(&[
             ("oss_endpoint", "oss-cn-hangzhou.aliyuncs.com"),
             ("oss_role_arn", "acs:ram::111:role/tenant-A"),
             ("oss_role_session_name", "tenant-A-session"),
         ]);
-        let cfg = build_oss_config_from_lance_opts("my-bucket".to_string(), &url, &storage_options)
-            .unwrap();
+        let cfg = build_oss_config("my-bucket".to_string(), &url, &storage_options).unwrap();
         assert_eq!(cfg.get("role_arn").map(String::as_str), Some("acs:ram::111:role/tenant-A"));
         assert_eq!(cfg.get("role_session_name").map(String::as_str), Some("tenant-A-session"));
         assert_eq!(cfg.get("endpoint").map(String::as_str), Some("oss-cn-hangzhou.aliyuncs.com"));
@@ -909,81 +608,38 @@ mod tests {
     }
 
     #[test]
-    fn iceberg_opts_forward_role_arn_and_session_name() {
-        // Iceberg-shaped (dotted+hyphenated) keys must produce the identical
-        // opendal config as the lance path — same output contract, different
-        // input naming convention. If these two shapes ever diverge on the
-        // role_arn path, iceberg + Aliyun ARN silently breaks.
-        let url = Url::parse("oss://my-bucket/prefix").unwrap();
+    fn storage_options_override_env() {
+        // Verify that values from storage_options land in the opendal config
+        // map. We intentionally do not call `set_var` to set a conflicting
+        // env var here — Rust tests run in parallel by default and `set_var`
+        // is process-global, which would race with any other test that reads
+        // env. A stricter "storage_options beats env" check would need to
+        // serialise env access.
+        let url = Url::parse("oss://my-bucket/").unwrap();
         let storage_options = opts(&[
-            ("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com"),
-            ("oss.role-arn", "acs:ram::111:role/tenant-A"),
-            ("oss.role-session-name", "tenant-A-session"),
-            // Unknown keys (e.g. other-scheme leakage, or stock iceberg
-            // keys we don't consume) must be dropped — opendal's Oss
-            // service would reject them.
-            ("gcs.service-account", "wrong-scheme"),
+            ("oss_endpoint", "from-storage-options.aliyuncs.com"),
+            ("oss_role_arn", "acs:ram::222:role/from-storage-options"),
         ]);
-        let cfg =
-            build_oss_config_from_iceberg_opts("my-bucket".to_string(), &url, &storage_options)
-                .unwrap();
-        assert_eq!(cfg.get("role_arn").map(String::as_str), Some("acs:ram::111:role/tenant-A"));
-        assert_eq!(cfg.get("role_session_name").map(String::as_str), Some("tenant-A-session"));
-        assert_eq!(cfg.get("endpoint").map(String::as_str), Some("oss-cn-hangzhou.aliyuncs.com"));
-        assert_eq!(cfg.get("bucket").map(String::as_str), Some("my-bucket"));
-        assert!(!cfg.contains_key("access_key_id"));
-        assert!(!cfg.contains_key("access_key_secret"));
-        // Make sure the unrecognised key did not leak through under some
-        // other name.
-        assert!(!cfg.values().any(|v| v == "wrong-scheme"));
+        let cfg = build_oss_config("my-bucket".to_string(), &url, &storage_options).unwrap();
+        assert_eq!(cfg.get("endpoint").map(String::as_str), Some("from-storage-options.aliyuncs.com"));
+        assert_eq!(
+            cfg.get("role_arn").map(String::as_str),
+            Some("acs:ram::222:role/from-storage-options")
+        );
     }
 
     #[test]
-    fn iceberg_opts_forward_static_aksk() {
-        // The non-ARN iceberg path (static AK/SK) is the one iceberg_common.cpp
-        // takes when `config.role_arn` is empty. Assert it still lands the
-        // three stock iceberg-core keys (OSS_ENDPOINT / OSS_ACCESS_KEY_ID /
-        // OSS_ACCESS_KEY_SECRET) into opendal's slots.
+    fn missing_endpoint_is_rejected() {
+        // No endpoint in storage_options and no OSS_ENDPOINT in env — expect an
+        // invalid_input error, matching stock provider behavior.
         let url = Url::parse("oss://my-bucket/").unwrap();
-        let storage_options = opts(&[
-            ("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com"),
-            ("oss.access-key-id", "AKID"),
-            ("oss.access-key-secret", "AKSK"),
-        ]);
-        let cfg =
-            build_oss_config_from_iceberg_opts("my-bucket".to_string(), &url, &storage_options)
-                .unwrap();
-        assert_eq!(cfg.get("access_key_id").map(String::as_str), Some("AKID"));
-        assert_eq!(cfg.get("access_key_secret").map(String::as_str), Some("AKSK"));
-        assert!(!cfg.contains_key("role_arn"));
-    }
-
-    #[test]
-    fn missing_endpoint_is_rejected_on_both_sides() {
-        // No endpoint in storage_options and no OSS_ENDPOINT in env — expect
-        // the same error string regardless of which caller-side entry point
-        // we go through.
-        let url = Url::parse("oss://my-bucket/").unwrap();
-        // If the test host happens to have OSS_ENDPOINT set, skip — the
-        // assertions below would be meaningless.
+        let storage_options = opts(&[("oss_role_arn", "acs:ram::111:role/tenant-A")]);
+        // If the test host happens to have OSS_ENDPOINT set, skip — the assertion
+        // below would be meaningless.
         if std::env::var("OSS_ENDPOINT").is_ok() {
             return;
         }
-
-        let lance_err = build_oss_config_from_lance_opts(
-            "my-bucket".to_string(),
-            &url,
-            &opts(&[("oss_role_arn", "acs:ram::111:role/tenant-A")]),
-        )
-        .unwrap_err();
-        assert!(lance_err.contains("OSS endpoint is required"));
-
-        let iceberg_err = build_oss_config_from_iceberg_opts(
-            "my-bucket".to_string(),
-            &url,
-            &opts(&[("oss.role-arn", "acs:ram::111:role/tenant-A")]),
-        )
-        .unwrap_err();
-        assert!(iceberg_err.contains("OSS endpoint is required"));
+        let err = build_oss_config("my-bucket".to_string(), &url, &storage_options).unwrap_err();
+        assert!(format!("{}", err).contains("OSS endpoint is required"));
     }
 }

--- a/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
@@ -17,15 +17,12 @@ use crate::TOKIO_RT;
 use arrow_array::Array;
 use futures::TryStreamExt;
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use iceberg::io::{FileIOBuilder, LocalFsStorageFactory, MemoryStorageFactory, StorageFactory};
+use iceberg::io::FileIOBuilder;
 use iceberg::scan::FileScanTask;
 use iceberg::table::StaticTable;
 use iceberg::TableIdent;
-use iceberg_storage_opendal::OpenDalStorageFactory;
 
-use crate::aliyun_oss_provider::AliyunOssStorageFactory;
 use crate::gcp_impersonation::{fetch_impersonated_bearer, DEFAULT_TOKEN_LIFETIME_SECS};
 use crate::iceberg_ffi::IcebergFileInfo;
 
@@ -44,62 +41,6 @@ struct DeleteFileRef {
 
 pub(crate) fn vec_to_hashmap(keys: Vec<String>, values: Vec<String>) -> HashMap<String, String> {
     keys.into_iter().zip(values.into_iter()).collect()
-}
-
-/// Intercepts `oss://` so per-tenant `oss.role-arn` can reach opendal —
-/// upstream `OpenDalStorageFactory::Oss` only carries endpoint/AK/SK.
-/// Every other scheme is a pure pass-through to upstream.
-fn storage_factory_for_scheme(scheme: &str) -> anyhow::Result<Arc<dyn StorageFactory>> {
-    if scheme == "oss" {
-        return Ok(Arc::new(AliyunOssStorageFactory::default()));
-    }
-    upstream_opendal_factory(scheme)
-}
-
-/// Scheme → `iceberg-storage-opendal` variant. Hand-written because 0.9
-/// ships no `from_scheme` helper; collapse when upstream adds one.
-fn upstream_opendal_factory(scheme: &str) -> anyhow::Result<Arc<dyn StorageFactory>> {
-    match scheme {
-        "s3" | "s3a" => Ok(Arc::new(OpenDalStorageFactory::S3 {
-            configured_scheme: scheme.to_string(),
-            customized_credential_load: None,
-        })),
-        "gs" => Ok(Arc::new(OpenDalStorageFactory::Gcs)),
-        "abfs" | "abfss" | "wasb" | "wasbs" => {
-            // `OpenDalStorageFactory::Azdls { configured_scheme }` is pub,
-            // but its `AzureStorageScheme` field type isn't `pub use`'d in
-            // lib.rs — round-trip via the pub `Deserialize` impl instead.
-            let variant = match scheme {
-                "abfs" => "Abfs",
-                "abfss" => "Abfss",
-                "wasb" => "Wasb",
-                "wasbs" => "Wasbs",
-                _ => unreachable!(),
-            };
-            let json = format!(r#"{{"Azdls":{{"configured_scheme":"{variant}"}}}}"#);
-            let factory: OpenDalStorageFactory = serde_json::from_str(&json)
-                .map_err(|e| anyhow::anyhow!("construct Azdls factory: {e}"))?;
-            Ok(Arc::new(factory))
-        }
-        "file" => Ok(Arc::new(LocalFsStorageFactory)),
-        "memory" => Ok(Arc::new(MemoryStorageFactory)),
-        other => anyhow::bail!("Unsupported scheme for iceberg FileIO: {other}"),
-    }
-}
-
-pub(crate) fn build_file_io(
-    scheme: &str,
-    props: &HashMap<String, String>,
-) -> anyhow::Result<iceberg::io::FileIO> {
-    let factory = storage_factory_for_scheme(scheme)?;
-    let mut builder = FileIOBuilder::new(factory);
-    for (k, v) in props {
-        builder = builder.with_prop(k, v);
-    }
-    // `FileIOBuilder::build` became infallible in iceberg 0.9 (was
-    // `Result<FileIO>` in 0.8); storage construction is deferred to first
-    // use inside `FileIO::get_storage`.
-    Ok(builder.build())
 }
 
 /// Detect the FileIO scheme from a URI.
@@ -283,7 +224,11 @@ pub fn iceberg_plan_files(
         // For Azure ABFSS, expands scheme://container/path to container@endpoint format.
         let (resolved_location, scheme) = normalize_uri(metadata_location, &props);
 
-        let file_io = build_file_io(&scheme, &props)?;
+        let mut file_io_builder = FileIOBuilder::new(&scheme);
+        for (k, v) in &props {
+            file_io_builder = file_io_builder.with_prop(k, v);
+        }
+        let file_io = file_io_builder.build()?;
 
         // Load table metadata directly from location (no catalog needed)
         let table_ident = TableIdent::from_strs(["default", "table"])?;

--- a/cpp/src/format/bridge/rust/src/iceberg_testutil.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_testutil.rs
@@ -26,14 +26,14 @@ use bytes::Bytes;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 
-use iceberg::io::FileIO;
+use iceberg::io::{FileIO, FileIOBuilder};
 use iceberg::spec::{
     DataContentType, DataFileBuilder, DataFileFormat, FormatVersion, ManifestListWriter,
     ManifestWriterBuilder, NestedField, Operation, PartitionSpec, PrimitiveType, Schema, Snapshot,
     SortOrder, Summary, TableMetadataBuilder, Type, UnboundPartitionSpec,
 };
 
-use crate::iceberg_bridgeimpl::{build_file_io, denormalize_uri, normalize_uri, vec_to_hashmap};
+use crate::iceberg_bridgeimpl::{denormalize_uri, normalize_uri, vec_to_hashmap};
 use crate::iceberg_test_ffi::IcebergTestTableInfo;
 use crate::TOKIO_RT;
 
@@ -90,9 +90,12 @@ pub fn iceberg_create_test_table(
 
         let is_local = scheme == "file";
 
-        // Build FileIO with storage options via the shared scheme-dispatch
-        // helper; iceberg 0.9 no longer accepts a bare scheme string.
-        let file_io = build_file_io(&scheme, &props)?;
+        // Build FileIO with storage options
+        let mut file_io_builder = FileIOBuilder::new(&scheme);
+        for (k, v) in &props {
+            file_io_builder = file_io_builder.with_prop(k, v);
+        }
+        let file_io = file_io_builder.build()?;
 
         // Create directories for local filesystem only (S3 has no directories)
         if is_local {

--- a/cpp/src/format/iceberg/iceberg_common.cpp
+++ b/cpp/src/format/iceberg/iceberg_common.cpp
@@ -119,32 +119,10 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
     }
     // Otherwise uses default credentials (VM metadata)
   } else if (provider == kCloudProviderAliyun) {
-    if (!config.role_arn.empty()) {
-      // Per-tenant AssumeRoleWithOIDC. Machine identity (oidc_token_file,
-      // oidc_provider_arn) stays in process env — opendal picks it up via the
-      // env sweep inside `AliyunOssStorage::create_operator`. Do NOT emit
-      // `oss.access-key-id` / `oss.access-key-secret` on this branch:
-      // reqsign's `load_via_static` runs before `load_via_assume_role_with_oidc`,
-      // so static creds would silently bypass the OIDC path. Mirrors the
-      // Aliyun role_arn branch in `lance_common.cpp`.
-      //
-      // `oss.role-arn` / `oss.role-session-name` are bridge-private keys
-      // consumed only by `AliyunOssStorage` on the Rust side — stock
-      // iceberg-storage-opendal's `OssConfig` would drop them, which is the
-      // whole reason we route `oss://` through our own `StorageFactory`
-      // instead of `OpenDalStorageFactory::Oss`.
-      set_endpoint("oss.endpoint", config.address);
-      set("oss.region", config.region);
-      set("oss.role-arn", config.role_arn);
-      set("oss.role-session-name", config.session_name);
-    } else {
-      // Explicit AKSK. iceberg 0.9 `OSS_*` constants in the `iceberg` crate
-      // map to these three dotted keys.
-      set("oss.access-key-id", config.access_key_id);
-      set("oss.access-key-secret", config.access_key_value);
-      set("oss.region", config.region);
-      set_endpoint("oss.endpoint", config.address);
-    }
+    // NO test in IAM
+    set("oss.access-key-id", config.access_key_id);
+    set("oss.access-key-secret", config.access_key_value);
+    set_endpoint("oss.endpoint", config.address);
   } else if (provider == kCloudProviderTencent || provider == kCloudProviderHuawei) {
     throw std::runtime_error("Unsupported cloud provider: " + provider);
   } else {

--- a/cpp/test/format/external_table_arn_test.cpp
+++ b/cpp/test/format/external_table_arn_test.cpp
@@ -683,13 +683,10 @@ INSTANTIATE_TEST_SUITE_P(GcpImpersonationFormats,
 //     (aliyun_oss_provider.rs + lance_common.cpp's role_arn branch).
 //
 // Test data is written with explicit AKSK (cloud_provider=aliyun + AK/SK),
-// then read back using only the role_arn. This mirrors the AWS ARN test.
-//
-// Iceberg now works through the bridge-local `AliyunOssStorageFactory`
-// registered in `iceberg_bridgeimpl.rs::storage_factory_for_scheme` — stock
-// iceberg-storage-opendal's `OssConfig` still drops `role_arn` /
-// `security_token` / `oidc-*`, which is why we route `oss://` to our own
-// `Storage` impl instead of `OpenDalStorageFactory::Oss`.
+// then read back using only the role_arn. This mirrors the AWS ARN test,
+// minus Iceberg — iceberg-rust 0.8's `oss_config_parse` drops every non-AK/SK
+// key (including role_arn / security_token / oidc-*), so Iceberg + Aliyun ARN
+// cannot work through stock iceberg-rust (see design §8 followup).
 //
 // Required environment variables (all must be set; test is skipped otherwise):
 //
@@ -821,36 +818,6 @@ class ExternalTableAliyunArnTest : public ::testing::Test {
     // explore_dir: oss://address/bucket/path (cloud provider URI scheme is oss)
     auto explore_dir = "oss://" + address_ + "/" + arn_bucket_ + "/" + path;
     return ArnWriteResult{std::move(cgfile), schema, num_rows, explore_dir, 0};
-  }
-
-  // Writes an Iceberg v1 table to the customer bucket using the AK/SK-backed
-  // write_props_ (so the write goes through reqsign's static-creds path, not
-  // the AssumeRole path). Returns the metadata.json URI in Milvus-URI shape
-  // for loon_exttable_explore, plus the snapshot id needed as a prop.
-  //
-  // Shape-matches the AWS ExternalTableArnTest iceberg helper, minus the
-  // cloud-provider hard-code — CreateTestTable takes whatever storage options
-  // we hand it, and the Rust bridge picks the factory off the `oss://` scheme
-  // baked into the metadata_location.
-  arrow::Result<ArnWriteResult> CreateIcebergTable(uint64_t num_rows) {
-    auto path = test_base_ + "/iceberg";
-    auto table_uri = "oss://" + arn_bucket_ + "/" + path;
-
-    ArrowFileSystemConfig write_config;
-    ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
-    auto storage_options = iceberg::ToStorageOptions(write_config);
-
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
-    if (file_infos.empty()) {
-      return arrow::Status::Invalid("PlanFiles returned no files");
-    }
-
-    auto milvus_path = iceberg::ToMilvusUri(file_infos[0].data_file_path, address_);
-    api::ColumnGroupFile cg_file{milvus_path, 0, static_cast<int64_t>(file_infos[0].record_count), {}};
-    std::cout << "[Aliyun ARN Test] Iceberg cgfile: " << cg_file.ToString() << std::endl;
-    auto explore_dir = iceberg::ToMilvusUri(table_info.metadata_location, address_);
-    return ArnWriteResult{std::move(cg_file), nullptr, num_rows, explore_dir, table_info.snapshot_id};
   }
 
   // Writes `num_files` parquet files of `rows_per_file` rows each into a fresh
@@ -1005,122 +972,6 @@ TEST_F(ExternalTableAliyunArnTest, ReadLanceWithArnRole) {
   }
   ASSERT_EQ(total_rows, static_cast<int64_t>(num_rows));
   std::cout << "[Aliyun ARN Test] FormatReader read " << total_rows << " rows via Aliyun ARN OK" << std::endl;
-
-  loon_manifest_destroy(out_manifest);
-  free(out_manifest_path);
-  loon_properties_free(&loon_props);
-}
-
-// Iceberg variant: writes an iceberg v1 table with AK/SK to the customer
-// bucket, then exercises loon_exttable_explore + FormatReader via role_arn.
-// End-to-end path:
-//   write  — reqsign load_via_static through `AliyunOssStorage::create_operator`
-//   plan   — iceberg::PlanFiles with role_arn (pre-write verification that
-//            AssumeRoleWithOIDC resolves against the table's metadata.json)
-//   read   — FormatReader drives `AliyunOssStorage` for each data file.
-//
-// Parallels ReadLanceWithArnRole step-for-step; the only format-specific bit
-// is passing PROPERTY_ICEBERG_SNAPSHOT_ID so loon_exttable_explore pins the
-// scan to the snapshot we just wrote.
-TEST_F(ExternalTableAliyunArnTest, ReadIcebergWithArnRole) {
-  const uint64_t num_rows = 100;
-
-  // Step 1: Write iceberg table using AKSK credentials.
-  ASSERT_AND_ASSIGN(auto result, CreateIcebergTable(num_rows));
-
-  std::cout << "[Aliyun ARN Test] Iceberg metadata: " << result.explore_dir << std::endl;
-  std::cout << "[Aliyun ARN Test] Role ARN: " << role_arn_ << std::endl;
-
-  // Step 2: Build properties — our-side AKSK for manifest storage, customer-side
-  // role_arn for reading. Iceberg also needs PROPERTY_ICEBERG_SNAPSHOT_ID so the
-  // Rust bridge pins the scan to our freshly-written snapshot.
-  auto manifest_base = test_base_ + "/manifest";
-
-  std::vector<std::pair<std::string, std::string>> props = {
-      {PROPERTY_FS_STORAGE_TYPE, "remote"},
-      {PROPERTY_FS_CLOUD_PROVIDER, our_cloud_provider_},
-      {PROPERTY_FS_ADDRESS, our_address_},
-      {PROPERTY_FS_BUCKET_NAME, our_bucket_},
-      {PROPERTY_FS_REGION, our_region_},
-      {PROPERTY_FS_ACCESS_KEY_ID, our_ak_},
-      {PROPERTY_FS_ACCESS_KEY_VALUE, our_sk_},
-      {PROPERTY_FS_USE_SSL, "true"},
-      {"extfs.arn.storage_type", "remote"},
-      {"extfs.arn.cloud_provider", kCloudProviderAliyun},
-      {"extfs.arn.address", address_},
-      {"extfs.arn.bucket_name", arn_bucket_},
-      {"extfs.arn.region", region_},
-      {"extfs.arn.use_ssl", "true"},
-      {"extfs.arn.role_arn", role_arn_},
-      {PROPERTY_ICEBERG_SNAPSHOT_ID, std::to_string(result.iceberg_snapshot_id)},
-  };
-
-  std::vector<const char*> c_keys, c_values;
-  c_keys.reserve(props.size());
-  c_values.reserve(props.size());
-  for (const auto& [k, v] : props) {
-    c_keys.push_back(k.c_str());
-    c_values.push_back(v.c_str());
-  }
-
-  LoonProperties loon_props = {};
-  auto rc = loon_properties_create(c_keys.data(), c_values.data(), c_keys.size(), &loon_props);
-  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
-
-  // Step 3: explore (iceberg metadata read) via role_arn.
-  const char* columns_arr[] = {"id", "name", "value"};
-  uint64_t out_num_files = 0;
-  char* out_manifest_path = nullptr;
-
-  rc = loon_exttable_explore(columns_arr, 3, LOON_FORMAT_ICEBERG_TABLE, manifest_base.c_str(),
-                             result.explore_dir.c_str(), &loon_props, &out_num_files, &out_manifest_path);
-  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
-  ASSERT_GT(out_num_files, 0u);
-  ASSERT_NE(out_manifest_path, nullptr);
-
-  std::cout << "[Aliyun ARN Test] loon_exttable_explore(iceberg): found " << out_num_files
-            << " files, manifest=" << out_manifest_path << std::endl;
-
-  // Step 4: Read manifest.
-  LoonManifest* out_manifest = nullptr;
-  rc = loon_exttable_read_manifest(out_manifest_path, &loon_props, &out_manifest);
-  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
-  ASSERT_NE(out_manifest, nullptr);
-  ASSERT_EQ(out_manifest->column_groups.num_of_column_groups, 1u);
-
-  auto* cg = &out_manifest->column_groups.column_group_array[0];
-  ASSERT_EQ(cg->num_of_files, out_num_files);
-
-  // Step 5: Read data via FormatReader (each data file re-enters
-  // AliyunOssStorage::read through the role_arn path). iceberg_test_table
-  // writes a schema the read_props_ have to pick up at FormatReader::create
-  // time — we ask the bridge to provide it via loon_exttable_get_schema so
-  // the test doesn't hard-code the schema shape.
-  std::vector<std::string> columns = {"id", "name", "value"};
-  int64_t total_rows = 0;
-  for (uint64_t f = 0; f < cg->num_of_files; ++f) {
-    auto& loon_file = cg->files[f];
-    api::ColumnGroupFile cgfile;
-    cgfile.path = loon_file.path;
-    cgfile.start_index = loon_file.start_index;
-    cgfile.end_index = loon_file.end_index;
-    if (loon_file.property_keys != nullptr) {
-      for (uint32_t p = 0; p < loon_file.num_properties; ++p) {
-        cgfile.properties[loon_file.property_keys[p]] = loon_file.property_values[p];
-      }
-    }
-
-    ASSERT_AND_ASSIGN(auto reader, FormatReader::create(result.schema, LOON_FORMAT_ICEBERG_TABLE, cgfile, read_props_,
-                                                        columns, nullptr));
-    ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
-    for (size_t i = 0; i < rg_infos.size(); ++i) {
-      ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(i));
-      total_rows += batch->num_rows();
-    }
-  }
-  ASSERT_EQ(total_rows, static_cast<int64_t>(num_rows));
-  std::cout << "[Aliyun ARN Test] FormatReader read " << total_rows << " rows from iceberg via Aliyun ARN OK"
-            << std::endl;
 
   loon_manifest_destroy(out_manifest);
   free(out_manifest_path);

--- a/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
@@ -67,37 +67,6 @@ TEST_F(IcebergStorageOptionsTest, AliyunKeys) {
   EXPECT_EQ(opts["oss.access-key-id"], "LTAI5tExample");
   EXPECT_EQ(opts["oss.access-key-secret"], "OSSSecretExample");
   EXPECT_EQ(opts["oss.endpoint"], "https://oss-cn-hangzhou.aliyuncs.com");
-  // Static-AKSK branch must NOT emit role_arn keys — otherwise the Rust side
-  // would incorrectly route through AliyunOssStorage's AssumeRole path.
-  EXPECT_EQ(opts.count("oss.role-arn"), 0);
-  EXPECT_EQ(opts.count("oss.role-session-name"), 0);
-}
-
-TEST_F(IcebergStorageOptionsTest, AliyunArnRole) {
-  // Per-tenant AssumeRoleWithOIDC. Must emit endpoint/region + role_arn +
-  // session_name, and must NOT emit AK/SK (reqsign's static-creds loader
-  // would otherwise take precedence over the OIDC path; see the module-level
-  // comment in aliyun_oss_provider.rs).
-  ArrowFileSystemConfig config;
-  config.storage_type = "remote";
-  config.cloud_provider = kCloudProviderAliyun;
-  config.role_arn = "acs:ram::111111111111:role/tenant-A";
-  config.session_name = "tenant-A-session";
-  config.region = "cn-hangzhou";
-  config.address = "oss-cn-hangzhou.aliyuncs.com";
-  // Even if the caller populates AK/SK alongside role_arn, the iceberg
-  // branch must drop them — a caller mistake here should not bypass OIDC.
-  config.access_key_id = "LTAI-should-be-ignored";
-  config.access_key_value = "aksk-should-be-ignored";
-
-  auto opts = ToStorageOptions(config);
-
-  EXPECT_EQ(opts["oss.endpoint"], "https://oss-cn-hangzhou.aliyuncs.com");
-  EXPECT_EQ(opts["oss.region"], "cn-hangzhou");
-  EXPECT_EQ(opts["oss.role-arn"], "acs:ram::111111111111:role/tenant-A");
-  EXPECT_EQ(opts["oss.role-session-name"], "tenant-A-session");
-  EXPECT_EQ(opts.count("oss.access-key-id"), 0);
-  EXPECT_EQ(opts.count("oss.access-key-secret"), 0);
 }
 
 TEST_F(IcebergStorageOptionsTest, LocalEmpty) {


### PR DESCRIPTION
This reverts commit 4c2761c96a23082414e1ba71cb79ef550a8e649a.

iceberg-rust 0.9 requires rustc 1.92 as MSRV, but milvus is pinned to rustc 1.89. Revert the upgrade until milvus bumps its toolchain.