### PR TITLE
feat: add property to force non-view schema in vortex schemaless reads

### DIFF
--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -86,6 +86,10 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   std::shared_ptr<arrow::Schema> file_schema_;  // always derived from file in open()
 
   uint64_t logical_chunk_rows_;
+  // Schemaless-only knob (PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW). When
+  // true and `read_schema_` is null, schemaless reads / GetFileSchema
+  // emit plain Utf8/Binary instead of vortex's Utf8View/BinaryView.
+  bool schema_non_view_ = false;
   std::vector<RowGroupInfo> row_group_infos_;
   std::unique_ptr<VortexFile> vxfile_;
 };

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -150,6 +150,11 @@ struct PropertyInfo {
 #define PROPERTY_READER_RECORD_BATCH_MAX_ROWS "reader.record_batch_max_rows"
 #define PROPERTY_READER_RECORD_BATCH_MAX_SIZE "reader.record_batch_max_size"
 #define PROPERTY_READER_LOGICAL_CHUNK_ROWS "reader.logical_chunk_rows"
+// When true AND no output schema is supplied to the Vortex reader, the
+// schemaless code path emits plain Utf8/Binary instead of Vortex's
+// preferred Utf8View/BinaryView. Has no effect when an explicit output
+// schema is set on the reader. Default: false.
+#define PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW "reader.vortex.schema_non_view"
 
 // --- Define Iceberg property keys ---
 #define PROPERTY_ICEBERG_SNAPSHOT_ID "iceberg.snapshot_id"

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -197,7 +197,9 @@ class VortexFile {
   uint64_t RowCount() const;
 
   /// Get the file schema, exported as Arrow C schema.
-  void GetFileSchema(ArrowSchema& out_schema) const;
+  /// When `non_view` is true, Utf8/Binary fields are returned as plain
+  /// Utf8/Binary instead of vortex's preferred Utf8View/BinaryView.
+  void GetFileSchema(ArrowSchema& out_schema, bool non_view = false) const;
 
   /// Create a scan builder for the file.
   /// The scan builder can be used to scan the file.
@@ -263,6 +265,13 @@ class ScanBuilder {
   /// TODO: currently if pass in this option, the schema needs to be the schema after adding projection.
   ScanBuilder& WithOutputSchema(ArrowSchema& output_schema) &;
   ScanBuilder&& WithOutputSchema(ArrowSchema& output_schema) &&;
+
+  /// Schemaless-only knob: when true AND no output schema is set, the
+  /// emitted arrow schema uses plain Utf8/Binary instead of vortex's
+  /// preferred Utf8View/BinaryView. Has no effect once WithOutputSchema
+  /// has been called.
+  ScanBuilder& WithNonViewSchema(bool non_view) &;
+  ScanBuilder&& WithNonViewSchema(bool non_view) &&;
 
   /// Take ownership and consume the scan builder to a stream of record batches.
   ArrowArrayStream IntoStream() &&;

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -214,7 +214,7 @@ pub mod vortex_ffi {
         // reader
         type VortexFile;
         fn row_count(self: &VortexFile) -> u64;
-        unsafe fn get_schema(self: &VortexFile, out_schema: *mut u8) -> Result<()>;
+        unsafe fn get_schema(self: &VortexFile, out_schema: *mut u8, non_view: bool) -> Result<()>;
         fn scan_builder(self: &VortexFile) -> Result<Box<VortexScanBuilder>>;
         unsafe fn scan_builder_with_schema(self: &VortexFile, in_schema: *mut u8) -> Result<Box<VortexScanBuilder>>;
         fn splits(self: &VortexFile) -> Result<Vec<u64>>;
@@ -234,6 +234,7 @@ pub mod vortex_ffi {
             self: &mut VortexScanBuilder,
             output_schema: *mut u8,
         ) -> Result<()>;
+        fn with_non_view_schema(self: &mut VortexScanBuilder, non_view: bool);
         unsafe fn scan_builder_into_stream(
             builder: Box<VortexScanBuilder>,
             out_stream: *mut u8,

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -184,9 +184,9 @@ std::unique_ptr<VortexFile> VortexFile::OpenUnique(uint8_t* fs_rawptr,
 
 uint64_t VortexFile::RowCount() const { return impl_->row_count(); }
 
-void VortexFile::GetFileSchema(ArrowSchema& out_schema) const {
+void VortexFile::GetFileSchema(ArrowSchema& out_schema, bool non_view) const {
   try {
-    impl_->get_schema(reinterpret_cast<uint8_t*>(&out_schema));
+    impl_->get_schema(reinterpret_cast<uint8_t*>(&out_schema), non_view);
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }
@@ -292,6 +292,16 @@ ScanBuilder&& ScanBuilder::WithOutputSchema(ArrowSchema& output_schema) && {
   } catch (const rust::cxxbridge1::Error& e) {
     throw VortexException(e.what());
   }
+  return std::move(*this);
+}
+
+ScanBuilder& ScanBuilder::WithNonViewSchema(bool non_view) & {
+  impl_->with_non_view_schema(non_view);
+  return *this;
+}
+
+ScanBuilder&& ScanBuilder::WithNonViewSchema(bool non_view) && {
+  impl_->with_non_view_schema(non_view);
   return std::move(*this);
 }
 

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -12,7 +12,7 @@ use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_array::ffi_stream::{FFI_ArrowArrayStream};
 use arrow_data::ffi::{FFI_ArrowArray};
 use arrow_data::ArrayData;
-use arrow_schema::{Field, ArrowError, DataType, Schema, SchemaRef};
+use arrow_schema::{Field, FieldRef, ArrowError, DataType, Schema, SchemaBuilder, SchemaRef};
 
 
 use vortex::stats::Precision;
@@ -24,6 +24,9 @@ use vortex::file::{BlockingWriter, OpenOptionsSessionExt};
 use vortex::scan::ScanBuilder;
 use vortex::dtype::{DType as RustDType, DecimalDType, Nullability, PType as RustPType, FieldName};
 use vortex::dtype::arrow::FromArrowType;
+use vortex::dtype::datetime::is_temporal_ext_type;
+use vortex::dtype::datetime::arrow::make_arrow_temporal_dtype;
+use vortex::error::vortex_bail;
 use vortex::expr::Expression;
 use vortex::io::runtime::current::CurrentThreadRuntime;
 use vortex::io::runtime::BlockingRuntime;
@@ -421,6 +424,100 @@ fn convert_struct_array_for_vortex(struct_array: &arrow_array::StructArray) -> a
  * writer
  */
 
+/*
+ * Non-view DType -> Arrow conversion (milvus-storage local override)
+ *
+ * vortex's own `DType::to_arrow_schema()` deliberately maps `DType::Utf8` ->
+ * `DataType::Utf8View` and `DType::Binary` -> `DataType::BinaryView` (its
+ * "preferred" Arrow output). milvus does not consume view types, so when
+ * the caller does NOT supply an explicit output schema, we fall back to a
+ * non-view variant: `DType::Utf8` -> `DataType::Utf8`, `DType::Binary` ->
+ * `DataType::Binary`. Everything else mirrors vortex's own mapping.
+ *
+ * See: https://github.com/vortex-data/vortex/issues/4522 — upstream's
+ * official answer is "pass a schema". This helper is what we pass when no
+ * caller-provided schema exists, so the reader's external behavior is
+ * consistent regardless of whether the user supplied a schema.
+ */
+
+fn to_arrow_dtype(dtype: &RustDType) -> Result<DataType, VortexError> {
+    Ok(match dtype {
+        RustDType::Null => DataType::Null,
+        RustDType::Bool(_) => DataType::Boolean,
+        RustDType::Primitive(ptype, _) => match ptype {
+            RustPType::U8 => DataType::UInt8,
+            RustPType::U16 => DataType::UInt16,
+            RustPType::U32 => DataType::UInt32,
+            RustPType::U64 => DataType::UInt64,
+            RustPType::I8 => DataType::Int8,
+            RustPType::I16 => DataType::Int16,
+            RustPType::I32 => DataType::Int32,
+            RustPType::I64 => DataType::Int64,
+            RustPType::F16 => DataType::Float16,
+            RustPType::F32 => DataType::Float32,
+            RustPType::F64 => DataType::Float64,
+        },
+        RustDType::Decimal(dt, _) => {
+            let precision = dt.precision();
+            let scale = dt.scale();
+            match precision {
+                0..=38 => DataType::Decimal128(precision, scale),
+                39.. => DataType::Decimal256(precision, scale),
+            }
+        }
+        // The two overrides this whole helper exists for:
+        RustDType::Utf8(_) => DataType::Utf8,
+        RustDType::Binary(_) => DataType::Binary,
+        RustDType::List(elem_dtype, _) => DataType::List(FieldRef::new(Field::new_list_field(
+            to_arrow_dtype(elem_dtype)?,
+            elem_dtype.is_nullable(),
+        ))),
+        RustDType::FixedSizeList(elem_dtype, size, _) => DataType::FixedSizeList(
+            FieldRef::new(Field::new_list_field(
+                to_arrow_dtype(elem_dtype)?,
+                elem_dtype.is_nullable(),
+            )),
+            *size as i32,
+        ),
+        RustDType::Struct(struct_dtype, _) => {
+            let mut fields = Vec::with_capacity(struct_dtype.names().len());
+            for (field_name, field_dt) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
+                fields.push(FieldRef::from(Field::new(
+                    field_name.to_string(),
+                    to_arrow_dtype(&field_dt)?,
+                    field_dt.is_nullable(),
+                )));
+            }
+            DataType::Struct(arrow_schema::Fields::from(fields))
+        }
+        RustDType::Extension(ext_dtype) => {
+            if is_temporal_ext_type(ext_dtype.id()) {
+                make_arrow_temporal_dtype(ext_dtype)
+            } else {
+                vortex_bail!("Unsupported extension type \"{}\"", ext_dtype.id())
+            }
+        }
+    })
+}
+
+fn to_arrow_schema(dtype: &RustDType) -> Result<Schema, VortexError> {
+    let RustDType::Struct(struct_dtype, nullable) = dtype else {
+        vortex_bail!("only DType::Struct can be converted to arrow schema");
+    };
+    if *nullable != Nullability::NonNullable {
+        vortex_bail!("top-level struct in Schema must be NonNullable");
+    }
+    let mut builder = SchemaBuilder::with_capacity(struct_dtype.names().len());
+    for (field_name, field_dtype) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
+        builder.push(FieldRef::from(Field::new(
+            field_name.to_string(),
+            to_arrow_dtype(&field_dtype)?,
+            field_dtype.is_nullable(),
+        )));
+    }
+    Ok(builder.finish())
+}
+
 pub const VORTEX_BASIC_STATS: &[Stat] = &[
     Stat::Min,
     Stat::Max,
@@ -544,6 +641,7 @@ impl VortexFile {
             inner: self.inner.scan()?,
             output_schema: None,
             original_schema: None,
+            non_view_schema: false,
         }))
     }
 
@@ -558,12 +656,21 @@ impl VortexFile {
             inner: self.inner.scan()?,
             output_schema: Some(converted_schema),
             original_schema: Some(original_schema),
+            non_view_schema: false,
         }))
     }
 
-    pub(crate) unsafe fn get_schema(&self, out_schema: *mut u8) -> Result<()> {
+    pub(crate) unsafe fn get_schema(&self, out_schema: *mut u8, non_view: bool) -> Result<()> {
         let dtype = self.inner.dtype();
-        let arrow_schema = dtype.to_arrow_schema()?;
+        // When `non_view` is set, return plain Utf8/Binary so GetFileSchema
+        // agrees with what schemaless reads will emit under the same flag
+        // (see scan_builder_into_stream's (None, _) branch). Default uses
+        // vortex's preferred mapping (Utf8View / BinaryView).
+        let arrow_schema = if non_view {
+            to_arrow_schema(dtype)?
+        } else {
+            dtype.to_arrow_schema()?
+        };
         let ffi_schema = FFI_ArrowSchema::try_from(&arrow_schema)?;
         unsafe { std::ptr::write(out_schema as *mut FFI_ArrowSchema, ffi_schema) };
         Ok(())
@@ -641,6 +748,11 @@ pub(crate) struct VortexScanBuilder {
     inner: ScanBuilder<ArrayRef>,
     output_schema: Option<SchemaRef>,          // Converted schema for Vortex (FixedSizeList<u8>)
     original_schema: Option<SchemaRef>,        // Original schema from user (may contain FixedSizeBinary)
+    // Schemaless-only knob: when no `output_schema` is set, a true value
+    // makes scan_builder_into_stream synthesize a non-view (plain
+    // Utf8/Binary) arrow schema instead of Vortex's preferred Utf8View /
+    // BinaryView. Has no effect once output_schema is set.
+    non_view_schema: bool,
 }
 
 impl VortexScanBuilder {
@@ -692,6 +804,10 @@ impl VortexScanBuilder {
         self.original_schema = Some(original_schema);
         Ok(())
     }
+
+    pub(crate) fn with_non_view_schema(&mut self, non_view: bool) {
+        self.non_view_schema = non_view;
+    }
 }
 
 /// A wrapper RecordBatchReader that converts FixedSizeList<u8> back to FixedSizeBinary
@@ -728,12 +844,22 @@ pub(crate) unsafe fn scan_builder_into_stream(
     builder: Box<VortexScanBuilder>,
     out_stream: *mut u8,
 ) -> Result<()> {
+    let non_view_schema = builder.non_view_schema;
     let (vortex_schema, original_schema) = match (builder.output_schema, builder.original_schema) {
         (Some(vs), Some(os)) => (vs, os),
         (Some(vs), None) => (vs.clone(), vs),
         (None, _) => {
+            // Schemaless: pick the arrow schema that drives the per-chunk
+            // arrow type (see vortex-scan-0.56.0/src/arrow.rs). When the
+            // caller asked for non-view via with_non_view_schema(true),
+            // synthesize plain Utf8/Binary; otherwise keep vortex's
+            // preferred Utf8View / BinaryView.
             let dtype = builder.inner.dtype()?;
-            let arrow_schema = Arc::new(dtype.to_arrow_schema()?);
+            let arrow_schema = if non_view_schema {
+                Arc::new(to_arrow_schema(&dtype)?)
+            } else {
+                Arc::new(dtype.to_arrow_schema()?)
+            };
             (arrow_schema.clone(), arrow_schema)
         }
     };

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -116,16 +116,21 @@ arrow::Status VortexFormatReader::open() {
   assert(!vxfile_);
 
   ARROW_ASSIGN_OR_RAISE(logical_chunk_rows_, api::GetValue<uint64_t>(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
+  ARROW_ASSIGN_OR_RAISE(schema_non_view_, api::GetValue<bool>(properties_, PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW));
   if (read_schema_ && read_schema_->num_fields() == 0) {
     read_schema_ = nullptr;
   }
   vxfile_ = VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder_.get()), path_, file_size_, footer_size_);
 
-  // Always derive full file schema from file metadata
+  // Always derive full file schema from file metadata. If the caller set
+  // schema_non_view_ and didn't supply an explicit read_schema_, we ask
+  // the bridge for the non-view variant so file_schema_ matches what
+  // schemaless reads will actually produce.
   {
     ArrowSchema c_schema;
+    bool non_view_for_file_schema = schema_non_view_ && !read_schema_;
     try {
-      vxfile_->GetFileSchema(c_schema);
+      vxfile_->GetFileSchema(c_schema, non_view_for_file_schema);
     } catch (const VortexException& e) {
       return arrow::Status::IOError(fmt::format("Failed to get vortex file schema: {}", e.what()));
     }
@@ -213,6 +218,8 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start, uin
   if (read_schema_) {
     ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(read_schema_));
     scan_builder.WithOutputSchema(c_arrow_schema);
+  } else if (schema_non_view_) {
+    scan_builder.WithNonViewSchema(true);
   }
 
   scan_builder.WithRowRange(row_start, row_end);
@@ -241,6 +248,8 @@ arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std:
   if (read_schema_) {
     ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(read_schema_));
     scan_builder.WithOutputSchema(c_arrow_schema);
+  } else if (schema_non_view_) {
+    scan_builder.WithNonViewSchema(true);
   }
 
   scan_builder.WithIncludeByIndex(reinterpret_cast<const uint64_t*>(row_indices.data()), row_indices.size());

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -518,6 +518,12 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
         "control the rows read per chunk. The actual chunk rows is min(logical_chunk_rows, layout_rows).",
         uint64_t(8192),  // 8192 rows
         ValidatePropertyType() + ValidatePropertyRange<uint64_t>(1, UINT64_MAX)),
+    REGISTER_PROPERTY(PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW,
+                      PropertyType::BOOL,
+                      "When true AND no output schema is supplied, the Vortex reader's schemaless path "
+                      "returns plain Utf8/Binary instead of Vortex's preferred Utf8View/BinaryView.",
+                      false,
+                      ValidatePropertyType()),
 
     // --- transaction properties define ---
     REGISTER_PROPERTY(PROPERTY_TRANSACTION_COMMIT_NUM_RETRIES,

--- a/cpp/test/format/vortex/non_view_schema_test.cpp
+++ b/cpp/test/format/vortex/non_view_schema_test.cpp
@@ -1,0 +1,420 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Coverage for `PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW`.
+//
+// Vortex's default `to_arrow_dtype` maps `DType::Utf8` -> `DataType::Utf8View`
+// and `DType::Binary` -> `DataType::BinaryView` (its preferred Arrow output).
+// milvus consumes plain non-view buffers downstream, so when the caller does
+// not supply an explicit read schema, the bridge's override emits plain Utf8
+// / Binary instead.
+//
+// Two angles for top-level columns:
+//
+// (A) Default behavior — property unset / false. Schemaless reads of Utf8 /
+//     Binary columns come back as Utf8View / BinaryView (vortex's default).
+//
+// (B) Fixed behavior — property set to true. Schemaless reads of Utf8 /
+//     Binary columns come back as plain Utf8 / Binary, matching what milvus
+//     writes. GetFileSchema agrees with what reads produce.
+//
+// Plus nested-type cases (List, FixedSizeList, Struct) that exercise the
+// recursion in the override's `to_arrow_dtype`.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/api.h>
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_nested.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
+#include <boost/filesystem/operations.hpp>
+
+#include "test_env.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/format/vortex/vortex_format_reader.h"
+#include "milvus-storage/format/vortex/vortex_writer.h"
+
+namespace milvus_storage {
+
+using namespace vortex;
+
+class VortexNonViewSchemaTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    file_system_ = std::make_shared<arrow::fs::LocalFileSystem>();
+  }
+
+  void TearDown() override {
+    auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
+    if (storage_type == "local" || storage_type.empty()) {
+      boost::filesystem::remove_all(utf8_file_);
+      boost::filesystem::remove_all(binary_file_);
+      boost::filesystem::remove_all(fsl_f32_file_);
+      boost::filesystem::remove_all(list_utf8_file_);
+      boost::filesystem::remove_all(struct_utf8_file_);
+    }
+  }
+
+  void WriteVortex(const std::string& path, const std::shared_ptr<arrow::RecordBatch>& batch) {
+    auto writer = VortexFileWriter(file_system_, batch->schema(), path, properties_);
+    ASSERT_STATUS_OK(writer.Write(batch));
+    ASSERT_STATUS_OK(writer.Flush());
+    ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+    ASSERT_EQ(batch->num_rows(), cgfile.end_index);
+  }
+
+  std::shared_ptr<arrow::RecordBatch> MakeBatch(int64_t count, const std::shared_ptr<arrow::DataType>& str_type) {
+    arrow::Int32Builder id_b;
+    for (int64_t i = 0; i < count; ++i) {
+      EXPECT_TRUE(id_b.Append(static_cast<int32_t>(i)).ok());
+    }
+    std::shared_ptr<arrow::Array> id_arr;
+    EXPECT_TRUE(id_b.Finish(&id_arr).ok());
+
+    std::shared_ptr<arrow::Array> str_arr;
+    if (str_type->id() == arrow::Type::STRING) {
+      arrow::StringBuilder b;
+      for (int64_t i = 0; i < count; ++i) {
+        EXPECT_TRUE(b.Append("v" + std::to_string(i)).ok());
+      }
+      EXPECT_TRUE(b.Finish(&str_arr).ok());
+    } else {
+      arrow::BinaryBuilder b;
+      for (int64_t i = 0; i < count; ++i) {
+        EXPECT_TRUE(b.Append("v" + std::to_string(i)).ok());
+      }
+      EXPECT_TRUE(b.Finish(&str_arr).ok());
+    }
+
+    auto schema = arrow::schema({
+        arrow::field("id", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+        arrow::field("str_col", str_type, false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
+    });
+    return arrow::RecordBatch::Make(schema, count, {id_arr, str_arr});
+  }
+
+  void WriteFile(const std::string& path, const std::shared_ptr<arrow::DataType>& str_type) {
+    auto rb = MakeBatch(kRows, str_type);
+    auto writer = VortexFileWriter(file_system_, rb->schema(), path, properties_);
+    ASSERT_STATUS_OK(writer.Write(rb));
+    ASSERT_STATUS_OK(writer.Flush());
+    ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+    ASSERT_EQ(kRows, cgfile.end_index);
+  }
+
+  api::Properties properties_;
+  std::shared_ptr<arrow::fs::FileSystem> file_system_;
+  const std::string utf8_file_ = "test-non-view-utf8.vx";
+  const std::string binary_file_ = "test-non-view-binary.vx";
+  const std::string fsl_f32_file_ = "test-non-view-fsl-f32.vx";
+  const std::string list_utf8_file_ = "test-non-view-list-utf8.vx";
+  const std::string struct_utf8_file_ = "test-non-view-struct-utf8.vx";
+  static constexpr int64_t kRows = 64;
+};
+
+// (A) Default: property unset → schemaless Utf8 read comes back as
+// Utf8View (vortex's preferred mapping for DType::Utf8).
+TEST_F(VortexNonViewSchemaTest, SchemalessUtf8DefaultsToUtf8View) {
+  WriteFile(utf8_file_, arrow::utf8());
+
+  std::shared_ptr<arrow::Schema> no_schema;  // schemaless
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, utf8_file_, properties_, std::vector<std::string>{"id", "str_col"});
+  ASSERT_STATUS_OK(reader.open());
+
+  auto str_type = reader.get_schema()->GetFieldByName("str_col")->type();
+  EXPECT_EQ(str_type->id(), arrow::Type::STRING_VIEW)
+      << "Without the non-view property, vortex's schemaless path returns "
+         "its preferred Utf8View.";
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
+  EXPECT_EQ(rb->column(1)->type_id(), arrow::Type::STRING_VIEW);
+}
+
+// (A') Same for Binary.
+TEST_F(VortexNonViewSchemaTest, SchemalessBinaryDefaultsToBinaryView) {
+  WriteFile(binary_file_, arrow::binary());
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, binary_file_, properties_, std::vector<std::string>{"id", "str_col"});
+  ASSERT_STATUS_OK(reader.open());
+  EXPECT_EQ(reader.get_schema()->GetFieldByName("str_col")->type()->id(), arrow::Type::BINARY_VIEW);
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
+  EXPECT_EQ(rb->column(1)->type_id(), arrow::Type::BINARY_VIEW);
+}
+
+// (B) Fix: PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW=true on a schemaless
+// reader. GetFileSchema and schemaless take()/blocking_read() all return
+// plain Utf8 (3-buffer StringArray). Round-trip data values verified.
+TEST_F(VortexNonViewSchemaTest, NonViewPropertyForcesUtf8) {
+  WriteFile(utf8_file_, arrow::utf8());
+
+  api::Properties props = properties_;
+  props[PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW] = true;
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, utf8_file_, props, std::vector<std::string>{"id", "str_col"});
+  ASSERT_STATUS_OK(reader.open());
+
+  // GetFileSchema also reflects the non-view choice.
+  auto str_type = reader.get_schema()->GetFieldByName("str_col")->type();
+  EXPECT_EQ(str_type->id(), arrow::Type::STRING) << "non_view=true should make GetFileSchema report STRING, not "
+                                                    "STRING_VIEW.";
+
+  // take() — backed by ImportChunkedArray on the C-stream.
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
+  ASSERT_EQ(rb->column(1)->type_id(), arrow::Type::STRING);
+  auto strs = std::dynamic_pointer_cast<arrow::StringArray>(rb->column(1));
+  ASSERT_NE(strs, nullptr);
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(strs->GetString(i), "v" + std::to_string(i));
+  }
+
+  // blocking_read() goes through the same code path; spot-check it too.
+  ASSERT_AND_ASSIGN(auto chunked, reader.blocking_read(0, kRows));
+  ASSERT_GT(chunked->num_chunks(), 0);
+  ASSERT_AND_ASSIGN(auto rb2, arrow::RecordBatch::FromStructArray(chunked->chunk(0)));
+  EXPECT_EQ(rb2->column(1)->type_id(), arrow::Type::STRING);
+}
+
+// (B') Same for Binary.
+TEST_F(VortexNonViewSchemaTest, NonViewPropertyForcesBinary) {
+  WriteFile(binary_file_, arrow::binary());
+
+  api::Properties props = properties_;
+  props[PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW] = true;
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, binary_file_, props, std::vector<std::string>{"id", "str_col"});
+  ASSERT_STATUS_OK(reader.open());
+  EXPECT_EQ(reader.get_schema()->GetFieldByName("str_col")->type()->id(), arrow::Type::BINARY);
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
+  EXPECT_EQ(rb->column(1)->type_id(), arrow::Type::BINARY);
+}
+
+// (B'') With non_view=true but the caller still supplies an explicit
+// read_schema, the explicit schema wins (the property only acts on the
+// schemaless code path). Pins down the precedence.
+TEST_F(VortexNonViewSchemaTest, ExplicitSchemaOverridesNonViewProperty) {
+  WriteFile(utf8_file_, arrow::utf8());
+
+  api::Properties props = properties_;
+  props[PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW] = true;
+
+  // Explicit read schema = utf8_view. The property is set, but it should
+  // NOT override an explicit caller schema — vortex must honor utf8_view.
+  auto explicit_schema = arrow::schema({
+      arrow::field("id", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("str_col", arrow::utf8_view(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
+  });
+
+  auto reader =
+      VortexFormatReader(file_system_, explicit_schema, utf8_file_, props, std::vector<std::string>{"id", "str_col"});
+  ASSERT_STATUS_OK(reader.open());
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
+  EXPECT_EQ(rb->column(1)->type_id(), arrow::Type::STRING_VIEW)
+      << "explicit read_schema (utf8_view) should override the non_view "
+         "property.";
+}
+
+// (C) Nested-type coverage. The fix's `to_arrow_dtype` recurses through
+// List / FixedSizeList / Struct; without these tests the recursion is
+// unverified and a future change to either branch would silently regress.
+// All three nested cases use schemaless reads (the path milvus actually
+// hits at load time).
+
+// FixedSizeList<f32> is the dense-vector shape (FloatVector). vortex maps
+// it to plain FixedSizeList by default — never a view type — so this is a
+// regression guard rather than a bug case. If someone changes the override
+// to also touch FSL, this test catches it.
+TEST_F(VortexNonViewSchemaTest, FixedSizeListFloatRoundTripsAsPlain) {
+  constexpr int kDim = 8;
+  arrow::Int32Builder id_b;
+  arrow::FloatBuilder values_b;
+  for (int64_t i = 0; i < kRows; ++i) {
+    EXPECT_TRUE(id_b.Append(static_cast<int32_t>(i)).ok());
+    for (int j = 0; j < kDim; ++j) {
+      EXPECT_TRUE(values_b.Append(static_cast<float>(i * kDim + j)).ok());
+    }
+  }
+  std::shared_ptr<arrow::Array> id_arr, values_arr;
+  EXPECT_TRUE(id_b.Finish(&id_arr).ok());
+  EXPECT_TRUE(values_b.Finish(&values_arr).ok());
+  ASSERT_AND_ASSIGN(auto fsl_arr, arrow::FixedSizeListArray::FromArrays(values_arr, kDim));
+
+  auto schema = arrow::schema({
+      arrow::field("id", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("vec", arrow::fixed_size_list(arrow::float32(), kDim), false,
+                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
+  });
+  auto rb = arrow::RecordBatch::Make(schema, kRows, {id_arr, fsl_arr});
+  WriteVortex(fsl_f32_file_, rb);
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, fsl_f32_file_, properties_, std::vector<std::string>{"id", "vec"});
+  ASSERT_STATUS_OK(reader.open());
+
+  auto vec_type = reader.get_schema()->GetFieldByName("vec")->type();
+  ASSERT_EQ(vec_type->id(), arrow::Type::FIXED_SIZE_LIST);
+  EXPECT_EQ(vec_type->field(0)->type()->id(), arrow::Type::FLOAT);
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto rb_out, table->CombineChunksToBatch());
+  ASSERT_EQ(rb_out->column(1)->type_id(), arrow::Type::FIXED_SIZE_LIST);
+  auto fsl_out = std::dynamic_pointer_cast<arrow::FixedSizeListArray>(rb_out->column(1));
+  ASSERT_NE(fsl_out, nullptr);
+  auto values_out = std::dynamic_pointer_cast<arrow::FloatArray>(fsl_out->values());
+  ASSERT_NE(values_out, nullptr);
+  // Row 0 = floats [0, 1, ..., kDim-1].
+  for (int j = 0; j < kDim; ++j) {
+    EXPECT_FLOAT_EQ(values_out->Value(j), static_cast<float>(j));
+  }
+}
+
+// Helper to build a List<Utf8> column: each row holds two strings.
+static std::shared_ptr<arrow::RecordBatch> MakeListUtf8Batch(int64_t count) {
+  arrow::Int32Builder id_b;
+  arrow::ListBuilder list_b(arrow::default_memory_pool(), std::make_shared<arrow::StringBuilder>());
+  auto* str_b = static_cast<arrow::StringBuilder*>(list_b.value_builder());
+  for (int64_t i = 0; i < count; ++i) {
+    EXPECT_TRUE(id_b.Append(static_cast<int32_t>(i)).ok());
+    EXPECT_TRUE(list_b.Append().ok());
+    EXPECT_TRUE(str_b->Append("a" + std::to_string(i)).ok());
+    EXPECT_TRUE(str_b->Append("b" + std::to_string(i)).ok());
+  }
+  std::shared_ptr<arrow::Array> id_arr, list_arr;
+  EXPECT_TRUE(id_b.Finish(&id_arr).ok());
+  EXPECT_TRUE(list_b.Finish(&list_arr).ok());
+
+  auto schema = arrow::schema({
+      arrow::field("id", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("tags", arrow::list(arrow::utf8()), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
+  });
+  return arrow::RecordBatch::Make(schema, count, {id_arr, list_arr});
+}
+
+// Default: vortex's `to_arrow_dtype` recurses into List, so the inner Utf8
+// becomes Utf8View — the bug shape extends to nested types.
+TEST_F(VortexNonViewSchemaTest, SchemalessListUtf8DefaultsToListOfUtf8View) {
+  WriteVortex(list_utf8_file_, MakeListUtf8Batch(kRows));
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, list_utf8_file_, properties_, std::vector<std::string>{"id", "tags"});
+  ASSERT_STATUS_OK(reader.open());
+
+  auto tags_type = reader.get_schema()->GetFieldByName("tags")->type();
+  ASSERT_EQ(tags_type->id(), arrow::Type::LIST);
+  EXPECT_EQ(tags_type->field(0)->type()->id(), arrow::Type::STRING_VIEW)
+      << "Without the non-view property, vortex's recursive default mapping "
+         "propagates Utf8View into List children too.";
+}
+
+// Fix: with the property on, the override's `to_arrow_dtype` recurses
+// through List and forces the inner Utf8 to plain Utf8.
+TEST_F(VortexNonViewSchemaTest, NonViewPropertyForcesListUtf8Children) {
+  WriteVortex(list_utf8_file_, MakeListUtf8Batch(kRows));
+
+  api::Properties props = properties_;
+  props[PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW] = true;
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, list_utf8_file_, props, std::vector<std::string>{"id", "tags"});
+  ASSERT_STATUS_OK(reader.open());
+
+  auto tags_type = reader.get_schema()->GetFieldByName("tags")->type();
+  ASSERT_EQ(tags_type->id(), arrow::Type::LIST);
+  EXPECT_EQ(tags_type->field(0)->type()->id(), arrow::Type::STRING)
+      << "With non-view property, the override's recursion must reach the "
+         "List element and replace Utf8View with plain Utf8.";
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1}));
+  ASSERT_AND_ASSIGN(auto rb_out, table->CombineChunksToBatch());
+  auto list_out = std::dynamic_pointer_cast<arrow::ListArray>(rb_out->column(1));
+  ASSERT_NE(list_out, nullptr);
+  auto values_out = std::dynamic_pointer_cast<arrow::StringArray>(list_out->values());
+  ASSERT_NE(values_out, nullptr) << "List values should be StringArray, not StringViewArray";
+  // Row 0 = ["a0","b0"], row 1 = ["a1","b1"].
+  EXPECT_EQ(values_out->GetString(0), "a0");
+  EXPECT_EQ(values_out->GetString(1), "b0");
+  EXPECT_EQ(values_out->GetString(2), "a1");
+  EXPECT_EQ(values_out->GetString(3), "b1");
+}
+
+// Same recursion concern but for Struct fields — vortex's default also
+// recurses through Struct, so a Utf8 field inside Struct flips to Utf8View
+// without the override.
+TEST_F(VortexNonViewSchemaTest, NonViewPropertyForcesStructUtf8Children) {
+  arrow::Int32Builder id_b;
+  arrow::StringBuilder name_b;
+  for (int64_t i = 0; i < kRows; ++i) {
+    EXPECT_TRUE(id_b.Append(static_cast<int32_t>(i)).ok());
+    EXPECT_TRUE(name_b.Append("n" + std::to_string(i)).ok());
+  }
+  std::shared_ptr<arrow::Array> id_arr, name_arr;
+  EXPECT_TRUE(id_b.Finish(&id_arr).ok());
+  EXPECT_TRUE(name_b.Finish(&name_arr).ok());
+
+  auto name_field = arrow::field("name", arrow::utf8(), false);
+  ASSERT_AND_ASSIGN(auto struct_arr, arrow::StructArray::Make({name_arr}, {name_field}));
+
+  auto schema = arrow::schema({
+      arrow::field("id", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("info", arrow::struct_({name_field}), false,
+                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
+  });
+  auto rb = arrow::RecordBatch::Make(schema, kRows, {id_arr, struct_arr});
+  WriteVortex(struct_utf8_file_, rb);
+
+  api::Properties props = properties_;
+  props[PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW] = true;
+
+  std::shared_ptr<arrow::Schema> no_schema;
+  auto reader =
+      VortexFormatReader(file_system_, no_schema, struct_utf8_file_, props, std::vector<std::string>{"id", "info"});
+  ASSERT_STATUS_OK(reader.open());
+
+  auto info_type = reader.get_schema()->GetFieldByName("info")->type();
+  ASSERT_EQ(info_type->id(), arrow::Type::STRUCT);
+  EXPECT_EQ(info_type->field(0)->type()->id(), arrow::Type::STRING)
+      << "With non-view property, the override's recursion must reach Struct "
+         "fields and replace Utf8View with plain Utf8.";
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
Vortex maps DType::Utf8 / DType::Binary to Utf8View / BinaryView when nothing tells it otherwise, which is its preferred Arrow output but not what milvus consumes downstream.  Upstream's stance (vortex-data/vortex#4522) is that this is by design and callers should pass a schema. So instead of waiting on them, this adds a milvus-storage-side knob: PROPERTY_READER_VORTEX_SCHEMA_NON_VIEW, default false. When it's true AND the caller doesn't supply a read schema, the bridge synthesizes a plain Utf8 / Binary arrow schema (mirroring vortex's own to_arrow_dtype but swapping the two view branches) and feeds that to into_record_batch_reader. Vortex honors it and emits 3-buffer Utf8 / plain Binary. GetFileSchema gets the same treatment so it agrees with what reads actually produce.

If a caller passes their own read schema, the property is ignored — explicit schema always wins. Default-off means existing callers see zero behavior change.