### PR TITLE
Fix Aliyun OIDC role chaining for external tables

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h
@@ -1,0 +1,79 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/utils/memory/AWSMemory.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+
+#include "AliyunCredentialsProvider.h"
+#include "AliyunRAMSTSClient.h"
+
+namespace milvus_storage {
+
+// Two-step OIDC chain for cross-account OSS access:
+//
+//   1. AssumeRoleWithOIDC against the *machine-identity* role from env
+//      (ALIBABA_CLOUD_ROLE_ARN + ALIBABA_CLOUD_OIDC_PROVIDER_ARN +
+//      ALIBABA_CLOUD_OIDC_TOKEN_FILE) — same account, the only shape Aliyun
+//      STS accepts for AssumeRoleWithOIDC.
+//   2. sts:AssumeRole into the customer-supplied target role using the STS
+//      creds from step 1 as caller. This is the only step that crosses
+//      accounts; the customer's role trust policy must list the step-1 role
+//      as Principal.
+//
+// The single-step alternative — feeding the customer's role straight into
+// AssumeRoleWithOIDC alongside the env's OIDCProviderArn — is what the
+// previous code did and Aliyun rejects it with AssumeRolePolicy / ImplicitDeny
+// because RoleArn and OIDCProviderArn must share an account.
+//
+// Mirrors the structure of AliyunRAMCredentialsProvider (IMDS step 1, same
+// step 2). Selected for OIDC deployments at the dispatch layer; RAM mode
+// (ALIYUN_ROLE_ARN_AUTH_MODE=ram) keeps using AliyunRAMCredentialsProvider.
+class AWS_CORE_API AliyunOIDCAssumeRoleChainProvider : public ::Aws::Auth::AWSCredentialsProvider {
+  public:
+  // `target_external_id` is forwarded to step 2 (sts:AssumeRole). Aliyun's
+  // AssumeRoleWithOIDC API itself has no ExternalId concept, so step 1 never
+  // sees it. Empty means no ExternalId is sent (the parameter remains
+  // optional from the target role's trust policy perspective).
+  AliyunOIDCAssumeRoleChainProvider(const ::Aws::String& target_role_arn,
+                                    const ::Aws::String& target_session_name,
+                                    const ::Aws::String& target_external_id = "");
+
+  ::Aws::Auth::AWSCredentials GetAWSCredentials() override;
+
+  protected:
+  void Reload() override;
+
+  private:
+  void RefreshIfExpired();
+  bool ExpiresSoon() const;
+
+  // Step 1: env-driven OIDC. Default-constructed provider reads
+  // ALIBABA_CLOUD_ROLE_ARN / ALIBABA_CLOUD_OIDC_TOKEN_FILE / etc. and refreshes
+  // itself; we just call GetAWSCredentials() on it each time we reload.
+  ::Aws::UniquePtr<AliyunSTSAssumeRoleWebIdentityCredentialsProvider> m_innerOidc;
+
+  // Step 2: cross-account AssumeRole. Same client used by RAM mode.
+  ::Aws::UniquePtr<AliyunRAMSTSClient> m_stsClient;
+
+  ::Aws::Auth::AWSCredentials m_credentials;
+  ::Aws::String m_targetRoleArn;
+  ::Aws::String m_targetSessionName;
+  ::Aws::String m_targetExternalId;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h
@@ -35,7 +35,9 @@ namespace milvus_storage {
 // deployments are unaffected.
 class AWS_CORE_API AliyunRAMCredentialsProvider : public ::Aws::Auth::AWSCredentialsProvider {
   public:
-  AliyunRAMCredentialsProvider(const ::Aws::String& role_arn, const ::Aws::String& role_session_name);
+  AliyunRAMCredentialsProvider(const ::Aws::String& role_arn,
+                               const ::Aws::String& role_session_name,
+                               const ::Aws::String& external_id = "");
 
   ::Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
@@ -50,6 +52,7 @@ class AWS_CORE_API AliyunRAMCredentialsProvider : public ::Aws::Auth::AWSCredent
   ::Aws::Auth::AWSCredentials m_credentials;
   ::Aws::String m_roleArn;
   ::Aws::String m_roleSessionName;
+  ::Aws::String m_externalId;
 };
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h
@@ -44,6 +44,11 @@ class AWS_CORE_API AliyunRAMSTSClient : public ::Aws::Internal::AWSHttpResourceC
     ::Aws::String callerSecurityToken;
     ::Aws::String roleArn;
     ::Aws::String roleSessionName;
+    // Optional cross-account confused-deputy guard. Empty means no
+    // ExternalId is sent — Aliyun's AssumeRole rejects requests where the
+    // target role's trust policy *requires* an ExternalId and none is
+    // supplied. Same semantics as AWS sts:AssumeRole.
+    ::Aws::String externalId;
   };
 
   struct AssumeRoleResult {

--- a/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
@@ -1,0 +1,117 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
+
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/core/utils/UUID.h>
+#include <aws/core/utils/logging/LogMacros.h>
+
+namespace milvus_storage {
+
+static const char kLogTag[] = "AliyunOIDCAssumeRoleChainProvider";
+// Refresh when less than this many ms remain. Matches the OIDC and RAM
+// providers so all three rotate on the same schedule.
+static const int kRefreshGraceMs = 180 * 1000;
+
+AliyunOIDCAssumeRoleChainProvider::AliyunOIDCAssumeRoleChainProvider(const Aws::String& target_role_arn,
+                                                                     const Aws::String& target_session_name,
+                                                                     const Aws::String& target_external_id)
+    : m_targetRoleArn(target_role_arn),
+      m_targetSessionName(target_session_name),
+      m_targetExternalId(target_external_id) {
+  if (m_targetSessionName.empty()) {
+    m_targetSessionName = Aws::Utils::UUID::RandomUUID();
+  }
+
+  // Default ctor: reads ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_TOKEN_FILE,
+  // and ALIBABA_CLOUD_ROLE_SESSION_NAME from env. Provider ARN is read inside
+  // AliyunSTSCredentialsClient (also from env). The dispatch layer in
+  // s3_filesystem_producer.cpp pre-flights ALIBABA_CLOUD_OIDC_TOKEN_FILE and
+  // ALIBABA_CLOUD_OIDC_PROVIDER_ARN before constructing this provider, so we
+  // do not re-validate here.
+  m_innerOidc = Aws::MakeUnique<AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(kLogTag);
+
+  Aws::Client::ClientConfiguration cfg;
+  cfg.scheme = Aws::Http::Scheme::HTTPS;
+  m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
+
+  AWS_LOGSTREAM_INFO(kLogTag, "Created OIDC chain provider for target_role_arn=" << m_targetRoleArn
+                                                                                 << " session=" << m_targetSessionName);
+}
+
+Aws::Auth::AWSCredentials AliyunOIDCAssumeRoleChainProvider::GetAWSCredentials() {
+  RefreshIfExpired();
+  Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+  return m_credentials;
+}
+
+bool AliyunOIDCAssumeRoleChainProvider::ExpiresSoon() const {
+  return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < kRefreshGraceMs);
+}
+
+void AliyunOIDCAssumeRoleChainProvider::RefreshIfExpired() {
+  Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+  if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
+    return;
+  }
+
+  guard.UpgradeToWriterLock();
+  if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) {
+    return;
+  }
+
+  Reload();
+}
+
+void AliyunOIDCAssumeRoleChainProvider::Reload() {
+  AWS_LOGSTREAM_INFO(kLogTag, "Credentials missing or expiring; refreshing via OIDC -> AssumeRole.");
+
+  // Step 1: inner provider self-refreshes on call.
+  Aws::Auth::AWSCredentials inner = m_innerOidc->GetAWSCredentials();
+  if (inner.IsEmpty()) {
+    AWS_LOGSTREAM_ERROR(
+        kLogTag, "Inner OIDC step returned empty credentials; cannot chain to target_role_arn=" << m_targetRoleArn);
+    return;
+  }
+
+  // Step 2: cross-account AssumeRole using inner creds as caller. SecurityToken
+  // is mandatory because the caller is itself an STS-temporary identity.
+  // ExternalId belongs here, not on step 1: AssumeRoleWithOIDC has no
+  // ExternalId concept, and the cross-account confused-deputy guard applies
+  // to the customer-side hop.
+  AliyunRAMSTSClient::AssumeRoleRequest req;
+  req.callerAccessKeyId = inner.GetAWSAccessKeyId();
+  req.callerAccessKeySecret = inner.GetAWSSecretKey();
+  req.callerSecurityToken = inner.GetSessionToken();
+  req.roleArn = m_targetRoleArn;
+  req.roleSessionName = m_targetSessionName;
+  req.externalId = m_targetExternalId;
+
+  auto res = m_stsClient->GetAssumeRoleCredentials(req);
+  if (res.creds.IsEmpty()) {
+    AWS_LOGSTREAM_ERROR(kLogTag,
+                        "Cross-account AssumeRole returned empty credentials; target_role_arn="
+                            << m_targetRoleArn
+                            << " — check the target role's trust policy lists the OIDC step-1 role as Principal");
+    return;
+  }
+  m_credentials = res.creds;
+  AWS_LOGSTREAM_INFO(kLogTag, "OIDC chain succeeded; target_role_arn="
+                                  << m_targetRoleArn << " expires="
+                                  << m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
@@ -153,8 +153,9 @@ bool FetchImdsCreds(ImdsCreds& out) {
 }  // namespace
 
 AliyunRAMCredentialsProvider::AliyunRAMCredentialsProvider(const Aws::String& role_arn,
-                                                           const Aws::String& role_session_name)
-    : m_roleArn(role_arn), m_roleSessionName(role_session_name) {
+                                                           const Aws::String& role_session_name,
+                                                           const Aws::String& external_id)
+    : m_roleArn(role_arn), m_roleSessionName(role_session_name), m_externalId(external_id) {
   if (m_roleSessionName.empty()) {
     m_roleSessionName = Aws::Utils::UUID::RandomUUID();
   }
@@ -163,7 +164,9 @@ AliyunRAMCredentialsProvider::AliyunRAMCredentialsProvider(const Aws::String& ro
   cfg.scheme = Aws::Http::Scheme::HTTPS;
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 
-  AWS_LOGSTREAM_INFO(kLogTag, "Created RAM provider for role_arn=" << m_roleArn << " session=" << m_roleSessionName);
+  AWS_LOGSTREAM_INFO(kLogTag,
+                     "Created RAM provider for role_arn=" << m_roleArn << " session=" << m_roleSessionName
+                                                          << (m_externalId.empty() ? "" : " (with external_id)"));
 }
 
 Aws::Auth::AWSCredentials AliyunRAMCredentialsProvider::GetAWSCredentials() {
@@ -205,6 +208,7 @@ void AliyunRAMCredentialsProvider::Reload() {
   req.callerSecurityToken = imds.security_token.c_str();
   req.roleArn = m_roleArn;
   req.roleSessionName = m_roleSessionName;
+  req.externalId = m_externalId;
 
   auto res = m_stsClient->GetAssumeRoleCredentials(req);
   if (res.creds.IsEmpty()) {

--- a/cpp/src/filesystem/s3/provider/AliyunRAMSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMSTSClient.cpp
@@ -97,6 +97,14 @@ AliyunRAMSTSClient::AssumeRoleResult AliyunRAMSTSClient::GetAssumeRoleCredential
   if (!request.callerSecurityToken.empty()) {
     params["SecurityToken"] = request.callerSecurityToken;
   }
+  // ExternalId is optional and only included when the caller sets it.
+  // The target role's trust policy decides whether ExternalId is required;
+  // sending an empty value would still flip the request to the
+  // "ExternalId-supplied" branch on Aliyun's side, which fails the policy
+  // check, so the explicit non-empty guard matters.
+  if (!request.externalId.empty()) {
+    params["ExternalId"] = request.externalId;
+  }
   params["SignatureMethod"] = "HMAC-SHA1";
   // 64-bit random nonce. UUID alone is enough but cheap insurance against
   // correlated clocks on the same host.

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -46,6 +46,7 @@
 #include "milvus-storage/filesystem/s3/provider/AliyunSTSClient.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
+#include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
@@ -197,34 +198,39 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
       //     whose attached RAM role is trusted by the customer's target role.
       const auto auth_mode = Aws::Environment::GetEnv("ALIYUN_ROLE_ARN_AUTH_MODE");
       if (auth_mode == "ram") {
-        if (!config_.external_id.empty()) {
-          LOG_STORAGE_WARNING_ << "Aliyun RAM AssumeRole has no external_id concept; ignoring";
-        }
         if (config_.load_frequency > 0) {
           LOG_STORAGE_WARNING_ << "Aliyun RAM AssumeRole refresh grace is fixed; load_frequency ignored";
         }
         options.credentials_provider = Aws::MakeShared<AliyunRAMCredentialsProvider>(
-            "AliyunRAMCredentialsProvider", config_.role_arn, config_.session_name);
+            "AliyunRAMCredentialsProvider", config_.role_arn, config_.session_name, config_.external_id);
         options.credentials_kind = S3CredentialsKind::Role;
       } else {
-        // OIDC path: machine identity (OIDC token file and provider ARN)
-        // must live in process env — fail fast if missing so the misconfig
-        // surfaces here rather than as a generic OSS 401 later.
+        // OIDC chain path: the machine identity (token file, provider ARN,
+        // and the same-account role to assume in step 1) must all live in
+        // process env. Fail fast if any is missing so the misconfig surfaces
+        // here rather than as a silent anonymous OSS request later.
         if (Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_TOKEN_FILE").empty() ||
-            Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN").empty()) {
+            Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN").empty() ||
+            Aws::Environment::GetEnv("ALIBABA_CLOUD_ROLE_ARN").empty()) {
           return arrow::Status::Invalid(
-              "Aliyun role_arn requires ALIBABA_CLOUD_OIDC_TOKEN_FILE and "
-              "ALIBABA_CLOUD_OIDC_PROVIDER_ARN in process environment "
-              "(or set ALIYUN_ROLE_ARN_AUTH_MODE=ram for ECS IMDS-based AssumeRole)");
-        }
-        if (!config_.external_id.empty()) {
-          LOG_STORAGE_WARNING_ << "Aliyun AssumeRoleWithOIDC has no external_id concept; ignoring";
+              "Aliyun role_arn requires ALIBABA_CLOUD_OIDC_TOKEN_FILE, "
+              "ALIBABA_CLOUD_OIDC_PROVIDER_ARN and ALIBABA_CLOUD_ROLE_ARN "
+              "in process environment (or set ALIYUN_ROLE_ARN_AUTH_MODE=ram "
+              "for ECS IMDS-based AssumeRole)");
         }
         if (config_.load_frequency > 0) {
-          LOG_STORAGE_WARNING_ << "Aliyun AssumeRoleWithOIDC refresh grace is fixed; load_frequency ignored";
+          LOG_STORAGE_WARNING_ << "Aliyun OIDC chain AssumeRole refresh grace is fixed; load_frequency ignored";
         }
-        options.credentials_provider = Aws::MakeShared<AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(
-            "AliyunSTSAssumeRoleWebIdentityCredentialsProvider", config_.role_arn, config_.session_name);
+        // Two-step chain: env-driven AssumeRoleWithOIDC for the machine
+        // identity role (account A) -> sts:AssumeRole into the customer's
+        // target role (account B). The previous single-step variant fed
+        // config_.role_arn straight into AssumeRoleWithOIDC, which Aliyun
+        // rejects whenever RoleArn and OIDCProviderArn live in different
+        // accounts (the cross-tenant case this provider exists for).
+        // external_id is forwarded to step 2 only — Aliyun's
+        // AssumeRoleWithOIDC has no ExternalId concept.
+        options.credentials_provider = Aws::MakeShared<AliyunOIDCAssumeRoleChainProvider>(
+            "AliyunOIDCAssumeRoleChainProvider", config_.role_arn, config_.session_name, config_.external_id);
         options.credentials_kind = S3CredentialsKind::WebIdentity;
       }
     } else {

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -41,7 +41,8 @@ lance-table = "1.0.0"
 # OSS backend for the AliyunOssStoreProvider in src/aliyun_oss_provider.rs.
 # Pinned to the same version lance-io 1.0.0 resolves transitively, so we don't
 # end up with two copies of opendal in the build graph. `services-oss` is the
-# only service this module uses; reqsign handles AssumeRoleWithOIDC internally.
+# only service this module uses; this project handles the two-step Aliyun
+# role_arn credential flow before handing static STS creds to opendal.
 opendal = { version = "0.55", features = ["services-oss"] }
 object_store_opendal = "0.55"
 

--- a/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
@@ -1,46 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright Zilliz
 
-//! Aliyun OSS store provider with per-tenant `role_arn` support.
+//! Aliyun OSS with per-tenant `role_arn` support for the Lance path.
 //!
-//! In the default OIDC mode this is a thin shim over opendal's `Oss` service:
-//! opendal + reqsign handle `AssumeRoleWithOIDC` natively. The shim mirrors
-//! lance-io's stock `OssStoreProvider` but also forwards `oss_role_arn` and
-//! `oss_role_session_name` from `storage_options` into opendal's config,
-//! which stock does not.
+//! This file provides:
+//!   * [`AliyunOssStoreProvider`] — lance-io's [`ObjectStoreProvider`], used
+//!     by the Lance reader/writer path.
+//!   * A common env-sweep + bucket/root helper plus Lance-shaped
+//!     `storage_options` parsing (`oss_endpoint`, `oss_role_arn`, ...).
+//!   * [`apply_ram_mode_if_requested`] — resolves `role_arn` to concrete STS
+//!     creds when `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is set (ECS IMDS →
+//!     `sts:AssumeRole` flow). No-op in the default OIDC mode.
+//!   * The inner [`ram`] module — IMDSv2 for RAM mode plus the POP v1
+//!     `sts:AssumeRole` helper reused by both RAM and OIDC step 2.
 //!
-//! In RAM mode (opt-in, see below) the module additionally resolves
-//! `role_arn` to concrete short-lived credentials itself — IMDS +
-//! `sts:AssumeRole` + POP v1 signing live in this file rather than in
-//! opendal.
+//! # Two AssumeRole flows
 //!
-//! Machine identity (`ALIBABA_CLOUD_OIDC_TOKEN_FILE` /
-//! `ALIBABA_CLOUD_OIDC_PROVIDER_ARN`) continues to live in process env — the
-//! env sweep preserved here routes them into opendal config.
+//! In the default OIDC mode we resolve `role_arn` with a two-step chain in
+//! this module: `AssumeRoleWithOIDC` mints machine-identity STS credentials,
+//! then `sts:AssumeRole` mints customer-side STS credentials. The final
+//! credentials are injected into opendal's static-credential slots and
+//! `role_arn` is stripped so reqsign's single-step AssumeRoleWithOIDC path
+//! cannot fire.
 //!
-//! # Why a custom provider and not the stock one
-//!
-//! Stock `OssStoreProvider` only reads four `storage_options` keys
-//! (`oss_endpoint`, `oss_access_key_id`, `oss_secret_access_key`, `oss_region`).
-//! It cannot forward per-tenant `role_arn` / `role_session_name` — those can
-//! only reach opendal via process env. Process env is per-tenant-hostile
-//! (single-tenant only), so we add the missing two keys here.
-//!
-//! # RAM-mode alternative (ECS IMDS → sts:AssumeRole)
-//!
-//! On an Aliyun ECS instance with an attached RAM role (and no OIDC token),
-//! set `ALIYUN_ROLE_ARN_AUTH_MODE=ram`. This path resolves
-//! `role_arn` to short-lived STS credentials *in this module* (via IMDS then
-//! `sts:AssumeRole`), then injects them into opendal's static-credential
-//! slots (`access_key_id` / `access_key_secret` / `security_token`) and
-//! strips `role_arn` so reqsign's AssumeRoleWithOIDC path never fires.
-//! There is no auto-fallback — an unset or missing-OIDC-token environment
-//! would otherwise silently route through the wrong path, which is exactly
-//! the kind of thing an explicit env var is for.
-//!
-//! All RAM-mode helpers live in the inner [`ram`] module. The OIDC path
-//! does not touch anything in `ram::*` — it flows through `build_oss_config`
-//! and straight into opendal/reqsign.
+//! In RAM mode (`ALIYUN_ROLE_ARN_AUTH_MODE=ram`) we resolve `role_arn` to
+//! short-lived STS credentials *in this module* (IMDS then
+//! `sts:AssumeRole`) and perform the same static-credential hand-off. There
+//! is no auto-fallback — an unset or missing-OIDC-token environment would
+//! otherwise silently route through the wrong path, which is exactly the kind
+//! of thing an explicit env var is for.
 //!
 //! # Static AK/SK must not be forwarded on the OIDC role_arn path
 //!
@@ -49,16 +37,24 @@
 //! `load_via_assume_role_with_oidc`): if static creds are set alongside
 //! `role_arn`, the OIDC path is silently skipped. `lance_common.cpp` must
 //! not emit AK/SK when `role_arn` is set. In RAM mode this is turned on its
-//! head — we *do* want reqsign to use the static creds we just derived,
-//! and we strip `role_arn` ourselves to keep that route unambiguous.
+//! head — we *do* want reqsign to use the static creds we just derived, and
+//! we strip `role_arn` ourselves to keep that route unambiguous.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use object_store::ObjectStore as OSObjectStore;
+use futures::{stream, StreamExt, TryStreamExt};
+use object_store::{
+    path::Path, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore as OSObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    Result as ObjectStoreResult,
+};
 use object_store_opendal::OpendalStore;
 use opendal::{Operator, services::Oss};
 use snafu::location;
+use tokio::sync::RwLock;
 use url::Url;
 
 use lance::session::Session;
@@ -67,7 +63,6 @@ use lance_io::object_store::{
     DEFAULT_CLOUD_IO_PARALLELISM, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
     ObjectStoreRegistry, StorageOptions,
 };
-
 /// lance-io's `DEFAULT_CLOUD_BLOCK_SIZE` is crate-private; mirror the 64 KiB
 /// value used by stock `OssStoreProvider`.
 const OSS_DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
@@ -75,105 +70,17 @@ const OSS_DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
 /// Mirrors stock `OssStoreProvider::download_retry_count()` fallback.
 const OSS_DEFAULT_DOWNLOAD_RETRIES: usize = 3;
 
-#[derive(Default, Debug)]
-pub struct AliyunOssStoreProvider;
+const ALIYUN_OSS_STORE_NAME: &str = "aliyun_oss";
+const OSS_CREDENTIAL_REFRESH_SECS_KEY: &str = "oss_credential_refresh_secs";
+const DEFAULT_OSS_CREDENTIAL_REFRESH_SECS: u64 = 50 * 60;
+const REFRESH_LOCK_RETRY_MS: u64 = 10;
 
-#[async_trait::async_trait]
-impl ObjectStoreProvider for AliyunOssStoreProvider {
-    async fn new_store(
-        &self,
-        base_path: Url,
-        params: &ObjectStoreParams,
-    ) -> LanceResult<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(OSS_DEFAULT_BLOCK_SIZE);
-        let storage_options =
-            StorageOptions(params.storage_options.clone().unwrap_or_default());
+// ============================================================================
+// Shared: opendal OSS config assembly + RAM-mode credential swap
+// ============================================================================
 
-        let bucket = base_path
-            .host_str()
-            .ok_or_else(|| {
-                LanceError::invalid_input("OSS URL must contain bucket name", location!())
-            })?
-            .to_string();
-
-        let mut config_map = build_oss_config(bucket, &base_path, &storage_options)?;
-
-        // RAM-mode swap: when `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is set in env
-        // and `role_arn` is present in the config, turn the indirection into
-        // concrete creds here. No-op in every other case — OIDC callers,
-        // plain AK/SK callers, and any caller without the env var flipped
-        // fall straight through to `Operator::from_iter` below.
-        //
-        // FIXME(aliyun-ram-refresh): the STS creds resolved here are injected
-        // as static `access_key_id` / `access_key_secret` / `security_token`
-        // into opendal's config and never refreshed. Aliyun `sts:AssumeRole`
-        // tokens expire after ~1h, so any operator kept alive past that
-        // window (long scans, compactions) will start getting 403s until the
-        // next `new_store` call. Not fixed here because production deploys
-        // use the OIDC path (`ALIBABA_CLOUD_OIDC_TOKEN_FILE` +
-        // `AssumeRoleWithOIDC`), where reqsign handles refresh internally —
-        // RAM mode exists for ECS-with-RAM-role dev/bench environments only.
-        // If RAM mode ever becomes a supported production path, wrap the
-        // operator so it re-fetches via `fetch_assume_role_creds` before
-        // expiration.
-        if std::env::var(ram::AUTH_MODE_ENV).as_deref() == Ok(ram::AUTH_MODE_RAM) {
-            if let Some(role_arn) = config_map.get("role_arn").cloned() {
-                let session_name = config_map
-                    .get("role_session_name")
-                    .cloned()
-                    .unwrap_or_else(ram::default_session_name);
-                let creds = ram::fetch_assume_role_creds(&role_arn, &session_name)
-                    .await
-                    .map_err(|e| {
-                        LanceError::invalid_input(
-                            format!("Aliyun RAM-mode credential resolution failed: {e}"),
-                            location!(),
-                        )
-                    })?;
-                ram::apply_credentials(&mut config_map, creds);
-            }
-        }
-
-        let operator = Operator::from_iter::<Oss>(config_map)
-            .map_err(|e| {
-                LanceError::invalid_input(
-                    format!("Failed to create OSS operator: {:?}", e),
-                    location!(),
-                )
-            })?
-            .finish();
-
-        let inner = Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>;
-
-        let mut url = base_path;
-        if !url.path().ends_with('/') {
-            url.set_path(&format!("{}/", url.path()));
-        }
-
-        Ok(ObjectStore::new(
-            inner,
-            url,
-            Some(block_size),
-            params.object_store_wrapper.clone(),
-            params.use_constant_size_upload_parts,
-            // OSS object listings are lexically ordered (matches stock provider).
-            params.list_is_lexically_ordered.unwrap_or(true),
-            DEFAULT_CLOUD_IO_PARALLELISM,
-            OSS_DEFAULT_DOWNLOAD_RETRIES,
-            params.storage_options.as_ref(),
-        ))
-    }
-}
-
-/// Build the opendal OSS config map from env + `storage_options`.
-///
-/// Extracted as a pure function so tests can assert the forwarding logic
-/// without building a live `Operator`.
-fn build_oss_config(
-    bucket: String,
-    base_path: &Url,
-    storage_options: &StorageOptions,
-) -> LanceResult<HashMap<String, String>> {
+/// Build the env-and-URL part of the opendal OSS config map.
+fn init_oss_env_config(bucket: String, base_path: &Url) -> HashMap<String, String> {
     // Env sweep: env vars starting with `OSS_`, `AWS_`, or `ALIBABA_CLOUD_`
     // are lowercased, and those three substrings are removed from the key
     // via `.replace()` (all occurrences, not just the prefix — for any real
@@ -211,38 +118,597 @@ fn build_oss_config(
         config_map.insert("root".to_string(), "/".to_string());
     }
 
+    config_map
+}
+
+/// Returns `Err` when no endpoint ended up in the config map.
+fn require_endpoint(config_map: &HashMap<String, String>) -> Result<(), String> {
+    if !config_map.contains_key("endpoint") {
+        return Err(
+            "OSS endpoint is required. Provide an OSS endpoint in storage options or set OSS_ENDPOINT environment variable".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Lance-style (underscored) storage_options → opendal OSS config. Keys
+/// consumed: `oss_endpoint`, `oss_access_key_id`, `oss_secret_access_key`,
+/// `oss_region`, `oss_role_arn`, `oss_role_session_name`, `oss_external_id`.
+pub(crate) fn build_oss_config_from_lance_opts(
+    bucket: String,
+    base_path: &Url,
+    storage_options: &HashMap<String, String>,
+) -> Result<HashMap<String, String>, String> {
+    let mut config_map = init_oss_env_config(bucket, base_path);
+
     // storage_options overrides (later wins over env). Stock four keys:
-    if let Some(endpoint) = storage_options.0.get("oss_endpoint") {
+    if let Some(endpoint) = storage_options.get("oss_endpoint") {
         config_map.insert("endpoint".to_string(), endpoint.clone());
     }
-    if let Some(access_key_id) = storage_options.0.get("oss_access_key_id") {
+    if let Some(access_key_id) = storage_options.get("oss_access_key_id") {
         config_map.insert("access_key_id".to_string(), access_key_id.clone());
     }
-    if let Some(secret_access_key) = storage_options.0.get("oss_secret_access_key") {
+    if let Some(secret_access_key) = storage_options.get("oss_secret_access_key") {
         config_map.insert("access_key_secret".to_string(), secret_access_key.clone());
     }
-    if let Some(region) = storage_options.0.get("oss_region") {
+    if let Some(region) = storage_options.get("oss_region") {
         config_map.insert("region".to_string(), region.clone());
     }
 
-    // The two keys stock does NOT forward. This is the reason this provider
-    // exists — per-tenant role_arn / session_name can only reach opendal via
-    // `storage_options`.
-    if let Some(role_arn) = storage_options.0.get("oss_role_arn") {
+    // The three keys stock lance-io `OssStoreProvider` does NOT forward.
+    // This is the reason this provider exists — per-tenant role_arn /
+    // session_name / external_id can only reach opendal via `storage_options`.
+    // `external_id` is consumed by the OIDC chain / RAM mode helpers below
+    // (step-2 sts:AssumeRole), not by opendal/reqsign directly.
+    if let Some(role_arn) = storage_options.get("oss_role_arn") {
         config_map.insert("role_arn".to_string(), role_arn.clone());
     }
-    if let Some(role_session_name) = storage_options.0.get("oss_role_session_name") {
+    if let Some(role_session_name) = storage_options.get("oss_role_session_name") {
         config_map.insert("role_session_name".to_string(), role_session_name.clone());
     }
-
-    if !config_map.contains_key("endpoint") {
-        return Err(LanceError::invalid_input(
-            "OSS endpoint is required. Provide 'oss_endpoint' in storage options or set OSS_ENDPOINT environment variable",
-            location!(),
-        ));
+    if let Some(external_id) = storage_options.get("oss_external_id") {
+        config_map.insert("external_id".to_string(), external_id.clone());
     }
 
+    require_endpoint(&config_map)?;
     Ok(config_map)
+}
+/// OIDC-mode credential chain: when no `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is
+/// set and `role_arn` is present in `config_map`, do the two-step chain
+///
+///   1. `AssumeRoleWithOIDC` for the *machine identity* role from env
+///      (`ALIBABA_CLOUD_ROLE_ARN` + `ALIBABA_CLOUD_OIDC_PROVIDER_ARN` +
+///      `ALIBABA_CLOUD_OIDC_TOKEN_FILE`) — same account, the only shape
+///      Aliyun STS accepts for AssumeRoleWithOIDC.
+///   2. `sts:AssumeRole` into the caller-supplied target role using the
+///      step-1 STS creds. This is the only step that crosses accounts;
+///      the customer's role trust policy must list the step-1 role as
+///      Principal.
+///
+/// Single-step (handing the customer role straight to AssumeRoleWithOIDC,
+/// which is what stock reqsign would do if we left `role_arn` in the
+/// config map) fails whenever `RoleArn` and `OIDCProviderArn` live in
+/// different accounts — Aliyun rejects with `AssumeRolePolicy ImplicitDeny`.
+/// This function exists exclusively to fix that cross-tenant case; the
+/// shape mirrors the C++ `AliyunOIDCAssumeRoleChainProvider`.
+///
+/// On success the chain hand-off matches `ram::apply_credentials`: static
+/// creds + `security_token` injected into `config_map`, `role_arn` stripped
+/// so reqsign's own AssumeRoleWithOIDC path cannot re-fire.
+pub(crate) async fn apply_oidc_chain_if_requested(
+    config_map: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    apply_oidc_chain_if_requested_with_expiration(config_map)
+        .await
+        .map(|_| ())
+}
+
+async fn apply_oidc_chain_if_requested_with_expiration(
+    config_map: &mut HashMap<String, String>,
+) -> Result<Option<u64>, String> {
+    // RAM mode owns this config_map; do not double-resolve.
+    if std::env::var(ram::AUTH_MODE_ENV).as_deref() == Ok(ram::AUTH_MODE_RAM) {
+        return Ok(None);
+    }
+    let Some(target_role_arn) = config_map.get("role_arn").cloned() else {
+        return Ok(None);
+    };
+
+    // Three machine-identity env vars are required for the inner step.
+    // Failing here keeps the misconfig at the operator-construction site
+    // rather than letting it surface as a silent anonymous OSS request
+    // a few stack frames down.
+    let inner_role_arn = std::env::var("ALIBABA_CLOUD_ROLE_ARN").map_err(|_| {
+        "Aliyun role_arn requires ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_TOKEN_FILE \
+         and ALIBABA_CLOUD_OIDC_PROVIDER_ARN in process environment \
+         (or set ALIYUN_ROLE_ARN_AUTH_MODE=ram for ECS IMDS-based AssumeRole)"
+            .to_string()
+    })?;
+    let token_file = std::env::var("ALIBABA_CLOUD_OIDC_TOKEN_FILE").map_err(|_| {
+        "Aliyun role_arn requires ALIBABA_CLOUD_OIDC_TOKEN_FILE in process environment".to_string()
+    })?;
+    let provider_arn = std::env::var("ALIBABA_CLOUD_OIDC_PROVIDER_ARN").map_err(|_| {
+        "Aliyun role_arn requires ALIBABA_CLOUD_OIDC_PROVIDER_ARN in process environment"
+            .to_string()
+    })?;
+    let token = std::fs::read_to_string(&token_file)
+        .map_err(|e| format!("read OIDC token file {token_file}: {e}"))?;
+
+    let session_name = config_map
+        .get("role_session_name")
+        .cloned()
+        .unwrap_or_else(ram::default_session_name);
+    // ExternalId belongs to step 2 only — Aliyun's AssumeRoleWithOIDC API
+    // has no ExternalId concept. Empty == not sent.
+    let external_id = config_map.get("external_id").cloned().unwrap_or_default();
+
+    let client = ram::build_http_client()?;
+    let inner =
+        call_assume_role_with_oidc(&client, &inner_role_arn, &provider_arn, token.trim()).await?;
+    let outer =
+        ram::call_assume_role(&client, &inner, &target_role_arn, &session_name, &external_id)
+            .await?;
+    let expires_at_ms = outer.expires_at_ms;
+
+    ram::apply_credentials(config_map, outer);
+    Ok(expires_at_ms)
+}
+
+/// Step 1 of the OIDC chain: `AssumeRoleWithOIDC` against same-account
+/// `role_arn` + `provider_arn` using a freshly-read OIDC `token`. Parses
+/// the JSON response (Format=JSON) into the same `AssumeRoleCreds` shape
+/// the RAM-mode helpers use, so step 2 can reuse `ram::call_assume_role`
+/// unchanged.
+async fn call_assume_role_with_oidc(
+    client: &reqwest::Client,
+    role_arn: &str,
+    provider_arn: &str,
+    token: &str,
+) -> Result<ram::AssumeRoleCreds, String> {
+    use chrono::Utc;
+    let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let nonce = uuid::Uuid::now_v7().to_string();
+    // AssumeRoleWithOIDC is unsigned: the OIDC token in the form body is
+    // the auth material. POP v1 signing (which the RAM-mode step 2 needs)
+    // would be wrong here.
+    let form = [
+        ("Action", "AssumeRoleWithOIDC"),
+        ("Version", "2015-04-01"),
+        ("Format", "JSON"),
+        ("Timestamp", &timestamp),
+        ("SignatureNonce", &nonce),
+        ("RoleArn", role_arn),
+        ("OIDCProviderArn", provider_arn),
+        ("OIDCToken", token),
+        ("RoleSessionName", "milvus-storage-oidc-chain"),
+    ];
+    let resp = client
+        .post("https://sts.aliyuncs.com/")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| format!("AssumeRoleWithOIDC POST: {e}"))?;
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("AssumeRoleWithOIDC body read: {e}"))?;
+    if !status.is_success() {
+        return Err(format!("AssumeRoleWithOIDC HTTP {status}: {text}"));
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "PascalCase")]
+    struct CredsJson {
+        access_key_id: String,
+        access_key_secret: String,
+        security_token: String,
+    }
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "PascalCase")]
+    struct OidcResponseJson {
+        credentials: CredsJson,
+    }
+    let parsed: OidcResponseJson = serde_json::from_str(&text)
+        .map_err(|e| format!("AssumeRoleWithOIDC JSON parse failed ({e}); body was: {text}"))?;
+    Ok(ram::AssumeRoleCreds {
+        access_key_id: parsed.credentials.access_key_id,
+        access_key_secret: parsed.credentials.access_key_secret,
+        security_token: parsed.credentials.security_token,
+        expires_at_ms: None,
+    })
+}
+
+/// RAM-mode credential swap: when `ALIYUN_ROLE_ARN_AUTH_MODE=ram` is set in
+/// env and `role_arn` is present in `config_map`, resolve it to concrete STS
+/// creds via the ECS IMDS → `sts:AssumeRole` flow and mutate `config_map`
+/// so opendal sees static creds instead. No-op in every other case — OIDC
+/// callers, plain AK/SK callers, and any caller without the env var flipped
+/// fall straight through. Lance `role_arn` stores wrap this one-shot swap in
+/// [`RefreshableAliyunOssStore`] so long-lived scans rebuild the opendal store
+/// on the configured refresh interval. Iceberg intentionally calls this from
+/// `create_operator()` for each I/O operation instead of keeping a cache.
+pub(crate) async fn apply_ram_mode_if_requested(
+    config_map: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    apply_ram_mode_if_requested_with_expiration(config_map)
+        .await
+        .map(|_| ())
+}
+
+async fn apply_ram_mode_if_requested_with_expiration(
+    config_map: &mut HashMap<String, String>,
+) -> Result<Option<u64>, String> {
+    if std::env::var(ram::AUTH_MODE_ENV).as_deref() != Ok(ram::AUTH_MODE_RAM) {
+        return Ok(None);
+    }
+    let Some(role_arn) = config_map.get("role_arn").cloned() else {
+        return Ok(None);
+    };
+    let session_name = config_map
+        .get("role_session_name")
+        .cloned()
+        .unwrap_or_else(ram::default_session_name);
+    let external_id = config_map.get("external_id").cloned().unwrap_or_default();
+    let creds = ram::fetch_assume_role_creds(&role_arn, &session_name, &external_id).await?;
+    let expires_at_ms = creds.expires_at_ms;
+    ram::apply_credentials(config_map, creds);
+    Ok(expires_at_ms)
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_millis() as u64
+}
+
+fn parse_aliyun_expiration_to_ms(s: &str) -> Result<u64, String> {
+    let dt = chrono::DateTime::parse_from_rfc3339(s).map_err(|e| e.to_string())?;
+    u64::try_from(dt.timestamp_millis()).map_err(|_| format!("pre-epoch Expiration: {s}"))
+}
+
+fn parse_oss_credential_refresh_interval(
+    storage_options: &HashMap<String, String>,
+) -> Result<Duration, String> {
+    let Some(raw) = storage_options.get(OSS_CREDENTIAL_REFRESH_SECS_KEY) else {
+        return Ok(Duration::from_secs(DEFAULT_OSS_CREDENTIAL_REFRESH_SECS));
+    };
+    let secs = raw.parse::<u64>().map_err(|e| {
+        format!("{OSS_CREDENTIAL_REFRESH_SECS_KEY} must be a positive integer seconds value: {e}")
+    })?;
+    if secs == 0 {
+        return Err(format!(
+            "{OSS_CREDENTIAL_REFRESH_SECS_KEY} must be greater than 0"
+        ));
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn should_refresh(last_refresh_at_ms: u64, now_ms: u64, refresh_interval: Duration) -> bool {
+    now_ms >= last_refresh_at_ms.saturating_add(duration_millis(refresh_interval))
+}
+
+fn validate_refresh_interval_before_expiration(
+    refresh_interval: Duration,
+    issued_at_ms: u64,
+    expires_at_ms: u64,
+) -> Result<(), String> {
+    if expires_at_ms <= issued_at_ms {
+        return Err("Aliyun STS credentials are already expired".to_string());
+    }
+    let lifetime_ms = expires_at_ms - issued_at_ms;
+    let refresh_ms = duration_millis(refresh_interval);
+    if refresh_ms >= lifetime_ms {
+        return Err(format!(
+            "Aliyun OSS credential refresh interval {}s must be less than server credential lifetime {}s",
+            refresh_interval.as_secs(),
+            lifetime_ms / 1000
+        ));
+    }
+    Ok(())
+}
+
+fn aliyun_object_store_error(message: impl Into<String>) -> object_store::Error {
+    let message: String = message.into();
+    object_store::Error::Generic {
+        store: ALIYUN_OSS_STORE_NAME,
+        source: message.into(),
+    }
+}
+
+#[derive(Clone)]
+struct CachedAliyunOssStore {
+    store: Arc<dyn OSObjectStore>,
+    refreshed_at_ms: u64,
+}
+
+#[derive(Clone)]
+struct RefreshableAliyunOssStore {
+    base_config: HashMap<String, String>,
+    refresh_interval: Duration,
+    cache: Arc<RwLock<Option<CachedAliyunOssStore>>>,
+}
+
+impl RefreshableAliyunOssStore {
+    fn new(base_config: HashMap<String, String>, refresh_interval: Duration) -> Self {
+        Self {
+            base_config,
+            refresh_interval,
+            cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    fn cached_store_is_fresh(&self, cached: &Option<CachedAliyunOssStore>) -> bool {
+        match cached {
+            Some(c) => !should_refresh(c.refreshed_at_ms, now_ms(), self.refresh_interval),
+            None => false,
+        }
+    }
+
+    async fn current_store(&self) -> ObjectStoreResult<Arc<dyn OSObjectStore>> {
+        loop {
+            if let Some(store) = self.try_current_store().await? {
+                return Ok(store);
+            }
+            tokio::time::sleep(Duration::from_millis(REFRESH_LOCK_RETRY_MS)).await;
+        }
+    }
+
+    async fn try_current_store(&self) -> ObjectStoreResult<Option<Arc<dyn OSObjectStore>>> {
+        {
+            let cached = self.cache.read().await;
+            if self.cached_store_is_fresh(&cached) {
+                if let Some(c) = &*cached {
+                    return Ok(Some(c.store.clone()));
+                }
+            }
+        }
+
+        let Ok(mut cached) = self.cache.try_write() else {
+            return Ok(None);
+        };
+
+        if self.cached_store_is_fresh(&cached) {
+            if let Some(c) = &*cached {
+                return Ok(Some(c.store.clone()));
+            }
+        }
+
+        let refreshed = self.refresh_store().await?;
+        let store = refreshed.store.clone();
+        *cached = Some(refreshed);
+        Ok(Some(store))
+    }
+
+    async fn refresh_store(&self) -> ObjectStoreResult<CachedAliyunOssStore> {
+        let mut config_map = self.base_config.clone();
+
+        let ram_expires_at_ms = apply_ram_mode_if_requested_with_expiration(&mut config_map)
+            .await
+            .map_err(|e| {
+                aliyun_object_store_error(format!(
+                    "Aliyun RAM-mode credential refresh failed: {e}"
+                ))
+            })?;
+        let oidc_expires_at_ms = apply_oidc_chain_if_requested_with_expiration(&mut config_map)
+            .await
+            .map_err(|e| {
+                aliyun_object_store_error(format!(
+                    "Aliyun OIDC chain credential refresh failed: {e}"
+                ))
+            })?;
+        let expires_at_ms = ram_expires_at_ms.or(oidc_expires_at_ms).ok_or_else(|| {
+            aliyun_object_store_error("Aliyun role_arn credential refresh did not return an Expiration")
+        })?;
+        let refreshed_at_ms = now_ms();
+
+        validate_refresh_interval_before_expiration(
+            self.refresh_interval,
+            refreshed_at_ms,
+            expires_at_ms,
+        )
+        .map_err(aliyun_object_store_error)?;
+
+        let operator = Operator::from_iter::<Oss>(config_map)
+            .map_err(|e| {
+                aliyun_object_store_error(format!("Failed to create OSS operator: {e:?}"))
+            })?
+            .finish();
+        Ok(CachedAliyunOssStore {
+            store: Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>,
+            refreshed_at_ms,
+        })
+    }
+}
+
+impl fmt::Debug for RefreshableAliyunOssStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RefreshableAliyunOssStore")
+            .field("refresh_interval", &self.refresh_interval)
+            .field("has_role_arn", &self.base_config.contains_key("role_arn"))
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for RefreshableAliyunOssStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RefreshableAliyunOssStore(refresh_interval={}s)",
+            self.refresh_interval.as_secs()
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl OSObjectStore for RefreshableAliyunOssStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        self.current_store()
+            .await?
+            .put_opts(location, payload, opts)
+            .await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.current_store().await?.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.current_store()
+            .await?
+            .put_multipart_opts(location, opts)
+            .await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> ObjectStoreResult<GetResult> {
+        self.current_store().await?.get_opts(location, options).await
+    }
+
+    async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
+        self.current_store().await?.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> futures::stream::BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        let this = self.clone();
+        let prefix = prefix.cloned();
+        stream::once(async move {
+            let store = this.current_store().await?;
+            Ok::<_, object_store::Error>(store.list(prefix.as_ref()))
+        })
+        .try_flatten()
+        .boxed()
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> futures::stream::BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        let this = self.clone();
+        let prefix = prefix.cloned();
+        let offset = offset.clone();
+        stream::once(async move {
+            let store = this.current_store().await?;
+            Ok::<_, object_store::Error>(store.list_with_offset(prefix.as_ref(), &offset))
+        })
+        .try_flatten()
+        .boxed()
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
+        self.current_store()
+            .await?
+            .list_with_delimiter(prefix)
+            .await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        self.current_store().await?.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
+        self.current_store()
+            .await?
+            .copy_if_not_exists(from, to)
+            .await
+    }
+}
+
+// ============================================================================
+// Lance: ObjectStoreProvider
+// ============================================================================
+
+#[derive(Default, Debug)]
+pub struct AliyunOssStoreProvider;
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for AliyunOssStoreProvider {
+    async fn new_store(
+        &self,
+        base_path: Url,
+        params: &ObjectStoreParams,
+    ) -> LanceResult<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(OSS_DEFAULT_BLOCK_SIZE);
+        let storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+
+        let bucket = base_path
+            .host_str()
+            .ok_or_else(|| {
+                LanceError::invalid_input("OSS URL must contain bucket name", location!())
+            })?
+            .to_string();
+
+        let config_map = build_oss_config_from_lance_opts(bucket, &base_path, &storage_options.0)
+            .map_err(|e| LanceError::invalid_input(e, location!()))?;
+
+        let inner = if config_map.contains_key("role_arn") {
+            let refresh_interval = parse_oss_credential_refresh_interval(&storage_options.0)
+                .map_err(|e| LanceError::invalid_input(e, location!()))?;
+            let refreshable = Arc::new(RefreshableAliyunOssStore::new(
+                config_map,
+                refresh_interval,
+            ));
+            refreshable.current_store().await.map_err(|e| LanceError::IO {
+                source: Box::new(e),
+                location: location!(),
+            })?;
+            refreshable as Arc<dyn OSObjectStore>
+        } else {
+            let operator = Operator::from_iter::<Oss>(config_map)
+                .map_err(|e| {
+                    LanceError::invalid_input(
+                        format!("Failed to create OSS operator: {:?}", e),
+                        location!(),
+                    )
+                })?
+                .finish();
+            Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>
+        };
+
+        let mut url = base_path;
+        if !url.path().ends_with('/') {
+            url.set_path(&format!("{}/", url.path()));
+        }
+
+        Ok(ObjectStore::new(
+            inner,
+            url,
+            Some(block_size),
+            params.object_store_wrapper.clone(),
+            params.use_constant_size_upload_parts,
+            // OSS object listings are lexically ordered (matches stock provider).
+            params.list_is_lexically_ordered.unwrap_or(true),
+            DEFAULT_CLOUD_IO_PARALLELISM,
+            OSS_DEFAULT_DOWNLOAD_RETRIES,
+            params.storage_options.as_ref(),
+        ))
+    }
 }
 
 /// Build a `Session` whose `ObjectStoreRegistry` overrides the `oss` scheme
@@ -261,9 +727,13 @@ pub fn build_aliyun_oss_session() -> Arc<Session> {
     Arc::new(Session::new(0, 0, Arc::new(registry)))
 }
 
-/// ECS IMDS → `sts:AssumeRole` path. Nothing outside this module should call
-/// into `ram::*`; the OIDC path bypasses it entirely.
-mod ram {
+// ============================================================================
+// RAM-mode helpers (ECS IMDS → sts:AssumeRole + POP v1 signing)
+// ============================================================================
+
+/// ECS IMDS helpers plus the POP v1 `sts:AssumeRole` call shared by RAM mode
+/// and OIDC step 2.
+pub(crate) mod ram {
     use std::collections::HashMap;
     use std::time::Duration;
 
@@ -275,8 +745,8 @@ mod ram {
 
     /// Explicit opt-in env var for the ECS-IMDS → AssumeRole flow. `"ram"` selects
     /// it; anything else (including unset) keeps the default OIDC behaviour.
-    pub(super) const AUTH_MODE_ENV: &str = "ALIYUN_ROLE_ARN_AUTH_MODE";
-    pub(super) const AUTH_MODE_RAM: &str = "ram";
+    pub(crate) const AUTH_MODE_ENV: &str = "ALIYUN_ROLE_ARN_AUTH_MODE";
+    pub(crate) const AUTH_MODE_RAM: &str = "ram";
 
     /// ECS metadata service — Aliyun's fixed link-local HTTP endpoint.
     const IMDS_BASE: &str = "http://100.100.100.200";
@@ -287,50 +757,58 @@ mod ram {
 
     const STS_ENDPOINT: &str = "https://sts.aliyuncs.com/";
 
-    /// Short-lived credentials returned from `sts:AssumeRole`.
+    /// Short-lived credentials returned from STS.
     #[derive(Debug, Clone)]
-    pub(super) struct AssumeRoleCreds {
-        pub(super) access_key_id: String,
-        pub(super) access_key_secret: String,
-        pub(super) security_token: String,
+    pub(crate) struct AssumeRoleCreds {
+        pub(crate) access_key_id: String,
+        pub(crate) access_key_secret: String,
+        pub(crate) security_token: String,
+        /// Epoch milliseconds when STS says these credentials expire. IMDS
+        /// source creds do not need this; final `sts:AssumeRole` creds do.
+        pub(crate) expires_at_ms: Option<u64>,
     }
 
     /// Mutate `config_map` for the RAM-mode hand-off: insert the concrete STS
     /// creds that opendal's static-credential path expects, and remove the
-    /// `role_arn` / `role_session_name` keys so reqsign cannot re-enter its own
-    /// AssumeRoleWithOIDC flow (see module-level comment: static creds alongside
-    /// `role_arn` make reqsign silently pick the static path — here that's what
-    /// we want, *and* keeping `role_arn` around would be a correctness landmine
-    /// if reqsign's preference ever inverted).
-    pub(super) fn apply_credentials(
+    /// `role_arn` / `role_session_name` / `external_id` keys so reqsign cannot
+    /// re-enter its own AssumeRoleWithOIDC flow (see module-level comment:
+    /// static creds alongside `role_arn` make reqsign silently pick the static
+    /// path — here that's what we want, *and* keeping `role_arn` around would
+    /// be a correctness landmine if reqsign's preference ever inverted).
+    /// `external_id` is stripped for hygiene: opendal does not consume it,
+    /// but leaving it in the config map would let stale state leak across
+    /// operator constructions if a future caller reused the same map.
+    pub(crate) fn apply_credentials(
         config_map: &mut HashMap<String, String>,
         creds: AssumeRoleCreds,
     ) {
         config_map.remove("role_arn");
         config_map.remove("role_session_name");
+        config_map.remove("external_id");
         config_map.insert("access_key_id".to_string(), creds.access_key_id);
         config_map.insert("access_key_secret".to_string(), creds.access_key_secret);
         config_map.insert("security_token".to_string(), creds.security_token);
     }
 
-    pub(super) fn default_session_name() -> String {
+    pub(crate) fn default_session_name() -> String {
         format!("milvus-storage-ram-{}", uuid::Uuid::now_v7())
     }
 
-    pub(super) async fn fetch_assume_role_creds(
+    pub(crate) async fn fetch_assume_role_creds(
         role_arn: &str,
         role_session_name: &str,
+        external_id: &str,
     ) -> Result<AssumeRoleCreds, String> {
         let client = build_http_client()?;
         let caller = fetch_imds_credentials(&client).await?;
-        call_assume_role(&client, &caller, role_arn, role_session_name).await
+        call_assume_role(&client, &caller, role_arn, role_session_name, external_id).await
     }
 
     /// Build a reqwest client with short timeouts tuned for IMDS + STS. IMDS
     /// answers in milliseconds on a healthy ECS; STS is a single round-trip on
     /// the public internet. A stalled request here would block the caller's
     /// whole `new_store`, so the tight caps are intentional.
-    fn build_http_client() -> Result<reqwest::Client, String> {
+    pub(super) fn build_http_client() -> Result<reqwest::Client, String> {
         reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(5))
             .timeout(Duration::from_secs(15))
@@ -413,6 +891,7 @@ mod ram {
             access_key_id: parsed.access_key_id,
             access_key_secret: parsed.access_key_secret,
             security_token: parsed.security_token,
+            expires_at_ms: None,
         })
     }
 
@@ -444,16 +923,26 @@ mod ram {
         base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
     }
 
-    async fn call_assume_role(
+    pub(super) async fn call_assume_role(
         client: &reqwest::Client,
         caller: &AssumeRoleCreds,
         role_arn: &str,
         role_session_name: &str,
+        external_id: &str,
     ) -> Result<AssumeRoleCreds, String> {
         // BTreeMap for deterministic ASCII ordering of keys (POP v1 requirement).
         let mut params = std::collections::BTreeMap::new();
         params.insert("AccessKeyId", caller.access_key_id.as_str());
         params.insert("Action", "AssumeRole");
+        // ExternalId is optional. We only insert it when non-empty so the
+        // canonical query (and therefore the signature) stays identical to
+        // the no-ExternalId case when the caller hasn't asked for one —
+        // sending an empty `ExternalId=` would be a different request and
+        // would fail the target role's trust-policy check if that policy
+        // requires the parameter to be absent.
+        if !external_id.is_empty() {
+            params.insert("ExternalId", external_id);
+        }
         params.insert("Format", "JSON");
         params.insert("RoleArn", role_arn);
         params.insert("RoleSessionName", role_session_name);
@@ -504,6 +993,7 @@ mod ram {
             access_key_id: String,
             access_key_secret: String,
             security_token: String,
+            expiration: String,
         }
         #[derive(Deserialize)]
         #[serde(rename_all = "PascalCase")]
@@ -513,10 +1003,13 @@ mod ram {
         let parsed: AssumeRoleResponseJson = serde_json::from_str(&text).map_err(|e| {
             format!("sts:AssumeRole JSON parse failed ({e}); body was: {text}")
         })?;
+        let expires_at_ms = super::parse_aliyun_expiration_to_ms(&parsed.credentials.expiration)
+            .map_err(|e| format!("sts:AssumeRole Expiration parse failed: {e}"))?;
         Ok(AssumeRoleCreds {
             access_key_id: parsed.credentials.access_key_id,
             access_key_secret: parsed.credentials.access_key_secret,
             security_token: parsed.credentials.security_token,
+            expires_at_ms: Some(expires_at_ms),
         })
     }
 
@@ -527,25 +1020,29 @@ mod ram {
         #[test]
         fn apply_credentials_strips_role_arn_and_injects_static_creds() {
             // Simulates the state right before the opendal operator is built in
-            // RAM mode: `role_arn` + `role_session_name` must disappear, concrete
-            // AKID / SK / token must be present. If any of these assertions break
-            // we risk reqsign re-entering AssumeRoleWithOIDC with a role_arn it
-            // can't authenticate against.
+            // RAM mode: `role_arn` + `role_session_name` + `external_id` must
+            // disappear, concrete AKID / SK / token must be present. If any of
+            // these assertions break we risk reqsign re-entering
+            // AssumeRoleWithOIDC with a role_arn it can't authenticate against,
+            // or a stale external_id leaking into a future operator.
             let mut cfg: HashMap<String, String> = HashMap::new();
             cfg.insert("bucket".to_string(), "b".to_string());
             cfg.insert("endpoint".to_string(), "e".to_string());
             cfg.insert("role_arn".to_string(), "acs:ram::1:role/x".to_string());
             cfg.insert("role_session_name".to_string(), "sess".to_string());
+            cfg.insert("external_id".to_string(), "tenant-A-ext".to_string());
             apply_credentials(
                 &mut cfg,
                 AssumeRoleCreds {
                     access_key_id: "AKID".to_string(),
                     access_key_secret: "AKSK".to_string(),
                     security_token: "TOKEN".to_string(),
+                    expires_at_ms: Some(1),
                 },
             );
             assert!(!cfg.contains_key("role_arn"));
             assert!(!cfg.contains_key("role_session_name"));
+            assert!(!cfg.contains_key("external_id"));
             assert_eq!(cfg.get("access_key_id").map(String::as_str), Some("AKID"));
             assert_eq!(cfg.get("access_key_secret").map(String::as_str), Some("AKSK"));
             assert_eq!(cfg.get("security_token").map(String::as_str), Some("TOKEN"));
@@ -566,16 +1063,16 @@ mod ram {
 
         #[test]
         fn pop_sign_known_vector() {
-            // Aliyun's canonical POP v1 example from their SDK reference doc.
-            // Given SecretAccessKey="testsecret" + "&" as the signing key, and
-            // the canonical query below, the signature must reproduce exactly.
-            // If this fails we're miscomputing either StringToSign or the HMAC.
+            // Aliyun POP v1 DescribeRegions example, signed with POST (our
+            // sts:AssumeRole is POSTed). Aliyun's doc publishes the GET variant
+            // `OLeaidS1JvxuMvnyHOwuJ+uX5qY=`; the POST expected below was
+            // independently recomputed from the POP v1 spec.
             let canonical =
                 "AccessKeyId=testid&Action=DescribeRegions&Format=XML&SignatureMethod=HMAC-SHA1\
                  &SignatureNonce=3ee8c1b8-83d3-44af-a94f-4e0ad82fd6cf&SignatureVersion=1.0\
                  &Timestamp=2016-02-23T12%3A46%3A24Z&Version=2014-05-26";
             let sig = pop_sign("testsecret", canonical);
-            assert_eq!(sig, "OLeaidS1JvxuMvnyHOwuJ+uX5qY=");
+            assert_eq!(sig, "MxbnVAM4w6sft9xjVpe/GCKueuk=");
         }
     }
 }
@@ -584,21 +1081,26 @@ mod ram {
 mod tests {
     use super::*;
 
-    fn opts(kvs: &[(&str, &str)]) -> StorageOptions {
-        StorageOptions(kvs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect())
+    fn opts(kvs: &[(&str, &str)]) -> HashMap<String, String> {
+        kvs.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
     #[test]
-    fn forwards_role_arn_and_session_name() {
+    fn lance_opts_forward_role_arn_session_name_and_external_id() {
         let url = Url::parse("oss://my-bucket/prefix").unwrap();
         let storage_options = opts(&[
             ("oss_endpoint", "oss-cn-hangzhou.aliyuncs.com"),
             ("oss_role_arn", "acs:ram::111:role/tenant-A"),
             ("oss_role_session_name", "tenant-A-session"),
+            ("oss_external_id", "tenant-A-ext"),
         ]);
-        let cfg = build_oss_config("my-bucket".to_string(), &url, &storage_options).unwrap();
+        let cfg = build_oss_config_from_lance_opts("my-bucket".to_string(), &url, &storage_options)
+            .unwrap();
         assert_eq!(cfg.get("role_arn").map(String::as_str), Some("acs:ram::111:role/tenant-A"));
         assert_eq!(cfg.get("role_session_name").map(String::as_str), Some("tenant-A-session"));
+        assert_eq!(cfg.get("external_id").map(String::as_str), Some("tenant-A-ext"));
         assert_eq!(cfg.get("endpoint").map(String::as_str), Some("oss-cn-hangzhou.aliyuncs.com"));
         assert_eq!(cfg.get("bucket").map(String::as_str), Some("my-bucket"));
         // AK/SK not set by caller — must not appear in config (would trigger
@@ -608,38 +1110,22 @@ mod tests {
     }
 
     #[test]
-    fn storage_options_override_env() {
-        // Verify that values from storage_options land in the opendal config
-        // map. We intentionally do not call `set_var` to set a conflicting
-        // env var here — Rust tests run in parallel by default and `set_var`
-        // is process-global, which would race with any other test that reads
-        // env. A stricter "storage_options beats env" check would need to
-        // serialise env access.
-        let url = Url::parse("oss://my-bucket/").unwrap();
-        let storage_options = opts(&[
-            ("oss_endpoint", "from-storage-options.aliyuncs.com"),
-            ("oss_role_arn", "acs:ram::222:role/from-storage-options"),
-        ]);
-        let cfg = build_oss_config("my-bucket".to_string(), &url, &storage_options).unwrap();
-        assert_eq!(cfg.get("endpoint").map(String::as_str), Some("from-storage-options.aliyuncs.com"));
-        assert_eq!(
-            cfg.get("role_arn").map(String::as_str),
-            Some("acs:ram::222:role/from-storage-options")
-        );
-    }
-
-    #[test]
     fn missing_endpoint_is_rejected() {
-        // No endpoint in storage_options and no OSS_ENDPOINT in env — expect an
-        // invalid_input error, matching stock provider behavior.
+        // No endpoint in storage_options and no OSS_ENDPOINT in env — expect
+        // the Lance-path error string.
         let url = Url::parse("oss://my-bucket/").unwrap();
-        let storage_options = opts(&[("oss_role_arn", "acs:ram::111:role/tenant-A")]);
-        // If the test host happens to have OSS_ENDPOINT set, skip — the assertion
-        // below would be meaningless.
+        // If the test host happens to have OSS_ENDPOINT set, skip — the
+        // assertions below would be meaningless.
         if std::env::var("OSS_ENDPOINT").is_ok() {
             return;
         }
-        let err = build_oss_config("my-bucket".to_string(), &url, &storage_options).unwrap_err();
-        assert!(format!("{}", err).contains("OSS endpoint is required"));
+
+        let lance_err = build_oss_config_from_lance_opts(
+            "my-bucket".to_string(),
+            &url,
+            &opts(&[("oss_role_arn", "acs:ram::111:role/tenant-A")]),
+        )
+        .unwrap_err();
+        assert!(lance_err.contains("OSS endpoint is required"));
     }
 }

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -106,16 +106,19 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
     // Otherwise uses default credentials (VM metadata)
   } else if (provider == kCloudProviderAliyun) {
     if (!config.role_arn.empty()) {
-      // Per-tenant AssumeRoleWithOIDC. Machine identity (oidc_token_file,
-      // oidc_provider_arn) stays in process env — opendal picks it up via the
-      // env sweep in AliyunOssStoreProvider. Do NOT emit access_key_id /
-      // access_key_secret on this branch: reqsign's `load_via_static` runs
-      // before `load_via_assume_role_with_oidc`, so static creds would
-      // silently bypass the OIDC path.
+      // Per-tenant Aliyun role_arn. Machine identity
+      // (ALIBABA_CLOUD_OIDC_TOKEN_FILE / OIDC_PROVIDER_ARN / ROLE_ARN) stays
+      // in process env for the Rust AliyunOssStoreProvider to resolve the
+      // two-step OIDC chain. Do NOT emit access_key_id / access_key_secret on
+      // this branch: static creds would bypass the role_arn path.
       set_endpoint("oss_endpoint", config.address);
       set("oss_region", config.region);
       set("oss_role_arn", config.role_arn);
       set("oss_role_session_name", config.session_name);
+      set("oss_external_id", config.external_id);
+      if (config.load_frequency > 0) {
+        options["oss_credential_refresh_secs"] = std::to_string(config.load_frequency);
+      }
     } else {
       set("oss_access_key_id", config.access_key_id);
       set("oss_secret_access_key", config.access_key_value);

--- a/cpp/test/filesystem/s3_provider_test.cpp
+++ b/cpp/test/filesystem/s3_provider_test.cpp
@@ -36,6 +36,7 @@
 #include <aws/core/utils/stream/ResponseStream.h>
 
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
+#include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
@@ -1513,6 +1514,249 @@ TEST_F(S3ProviderTest, TestAliyunRAMProviderEmptySessionNameDefaults) {
   const auto value_end = body.find('&', value_start);
   const auto value = body.substr(value_start, value_end - value_start);
   EXPECT_FALSE(value.empty()) << "ctor must synthesize a non-empty session name when caller passes empty";
+}
+
+// ============================================================================
+// Aliyun OIDC AssumeRole Chain Provider Tests
+// ============================================================================
+
+namespace {
+
+constexpr const char* kInnerOidcSuccessXml = R"(<?xml version='1.0' encoding='UTF-8'?>
+<AssumeRoleWithOIDCResponse>
+  <RequestId>TEST-INNER-RID</RequestId>
+  <Credentials>
+    <AccessKeyId>INNER_AK</AccessKeyId>
+    <AccessKeySecret>INNER_SK</AccessKeySecret>
+    <SecurityToken>INNER_TOKEN</SecurityToken>
+    <Expiration>2099-12-31T23:59:59Z</Expiration>
+  </Credentials>
+</AssumeRoleWithOIDCResponse>)";
+
+constexpr const char* kOuterAssumeRoleSuccessXml = R"(<?xml version='1.0' encoding='UTF-8'?>
+<AssumeRoleResponse>
+  <RequestId>TEST-OUTER-RID</RequestId>
+  <Credentials>
+    <AccessKeyId>OUTER_AK</AccessKeyId>
+    <AccessKeySecret>OUTER_SK</AccessKeySecret>
+    <SecurityToken>OUTER_TOKEN</SecurityToken>
+    <Expiration>2099-12-31T23:59:59Z</Expiration>
+  </Credentials>
+</AssumeRoleResponse>)";
+
+}  // namespace
+
+TEST_F(S3ProviderTest, TestAliyunOIDCChainProviderEndToEnd) {
+  // Two responses queued under the same URL substring; consumed FIFO. The
+  // chain provider issues AssumeRoleWithOIDC first (inner step) and then
+  // sts:AssumeRole (outer step), so this ordering matches.
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kInnerOidcSuccessXml);
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kOuterAssumeRoleSuccessXml);
+
+  TempFile token_file("oidc-jwt-payload");
+  ScopedEnvVar set_inner_role("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::1111:role/zilliz-machine-role");
+  ScopedEnvVar set_token("ALIBABA_CLOUD_OIDC_TOKEN_FILE", token_file.path());
+  ScopedEnvVar set_provider("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::1111:oidc-provider/zilliz-rrsa");
+  ScopedEnvUnset unset_session("ALIBABA_CLOUD_ROLE_SESSION_NAME");
+
+  AliyunOIDCAssumeRoleChainProvider provider("acs:ram::2222:role/customer-target", "tenant-A-session");
+  auto creds = provider.GetAWSCredentials();
+  EXPECT_EQ(creds.GetAWSAccessKeyId(), "OUTER_AK");
+  EXPECT_EQ(creds.GetAWSSecretKey(), "OUTER_SK");
+  EXPECT_EQ(creds.GetSessionToken(), "OUTER_TOKEN");
+
+  const auto recorded = mock_client_->GetRecordedRequests();
+  std::vector<std::shared_ptr<Aws::Http::HttpRequest>> sts_reqs;
+  for (const auto& r : recorded) {
+    if (r->GetURIString().find("sts.aliyuncs.com") != Aws::String::npos) {
+      sts_reqs.push_back(r);
+    }
+  }
+  ASSERT_EQ(sts_reqs.size(), 2u) << "chain must issue exactly two STS calls";
+
+  // Inner request: AssumeRoleWithOIDC against the env-driven machine-identity
+  // role, with the env's OIDC provider ARN. Customer's target role must NOT
+  // appear here — that was the bug this provider exists to fix.
+  const auto inner_body = ReadRequestBody(sts_reqs[0]);
+  EXPECT_NE(inner_body.find("Action=AssumeRoleWithOIDC"), std::string::npos) << inner_body;
+  EXPECT_NE(inner_body.find("zilliz-machine-role"), std::string::npos) << inner_body;
+  EXPECT_NE(inner_body.find("zilliz-rrsa"), std::string::npos) << inner_body;
+  EXPECT_EQ(inner_body.find("customer-target"), std::string::npos)
+      << "inner OIDC step must not carry the customer target role: " << inner_body;
+
+  // Outer request: AssumeRole signed by the inner step's STS creds, targeting
+  // the customer role with the caller-supplied session name.
+  const auto outer_body = ReadRequestBody(sts_reqs[1]);
+  EXPECT_NE(outer_body.find("Action=AssumeRole"), std::string::npos) << outer_body;
+  EXPECT_NE(outer_body.find("customer-target"), std::string::npos) << outer_body;
+  EXPECT_NE(outer_body.find("AccessKeyId=INNER_AK"), std::string::npos) << outer_body;
+  EXPECT_NE(outer_body.find("SecurityToken=INNER_TOKEN"), std::string::npos) << outer_body;
+  EXPECT_NE(outer_body.find("RoleSessionName=tenant-A-session"), std::string::npos) << outer_body;
+}
+
+TEST_F(S3ProviderTest, TestAliyunOIDCChainProviderInnerStepFailsReturnsEmpty) {
+  // STS replies to the inner AssumeRoleWithOIDC with an empty body — the
+  // outer call must never fire and the provider must surface empty creds
+  // rather than silently falling back to anonymous.
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, "");
+
+  TempFile token_file("oidc-jwt-payload");
+  ScopedEnvVar set_inner_role("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::1111:role/zilliz-machine-role");
+  ScopedEnvVar set_token("ALIBABA_CLOUD_OIDC_TOKEN_FILE", token_file.path());
+  ScopedEnvVar set_provider("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::1111:oidc-provider/zilliz-rrsa");
+  ScopedEnvUnset unset_session("ALIBABA_CLOUD_ROLE_SESSION_NAME");
+
+  AliyunOIDCAssumeRoleChainProvider provider("acs:ram::2222:role/customer-target", "sess");
+  auto creds = provider.GetAWSCredentials();
+  EXPECT_TRUE(creds.IsEmpty());
+
+  // Exactly one STS hit (the inner one); outer must be skipped.
+  size_t sts_calls = 0;
+  for (const auto& r : mock_client_->GetRecordedRequests()) {
+    if (r->GetURIString().find("sts.aliyuncs.com") != Aws::String::npos)
+      ++sts_calls;
+  }
+  EXPECT_EQ(sts_calls, 1u);
+}
+
+TEST_F(S3ProviderTest, TestAliyunOIDCChainProviderOuterStepEmptyReturnsEmpty) {
+  // Inner step succeeds, outer AssumeRole returns an empty body (e.g. cross-
+  // account trust policy not yet configured). Provider must surface empty
+  // creds, not the inner step's creds — those would let the caller through
+  // to the customer's bucket using zilliz's own identity.
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kInnerOidcSuccessXml);
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, "");
+
+  TempFile token_file("oidc-jwt-payload");
+  ScopedEnvVar set_inner_role("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::1111:role/zilliz-machine-role");
+  ScopedEnvVar set_token("ALIBABA_CLOUD_OIDC_TOKEN_FILE", token_file.path());
+  ScopedEnvVar set_provider("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::1111:oidc-provider/zilliz-rrsa");
+  ScopedEnvUnset unset_session("ALIBABA_CLOUD_ROLE_SESSION_NAME");
+
+  AliyunOIDCAssumeRoleChainProvider provider("acs:ram::2222:role/customer-target", "sess");
+  auto creds = provider.GetAWSCredentials();
+  EXPECT_TRUE(creds.IsEmpty());
+}
+
+TEST_F(S3ProviderTest, TestAliyunRAMProviderForwardsExternalId) {
+  // ExternalId belongs in the step-2 sts:AssumeRole body when the caller
+  // supplies one. Aliyun's AssumeRole semantics match AWS: empty == not sent
+  // (so the parameter behaves like "absent" from the trust policy's POV),
+  // non-empty == sent verbatim.
+  EnqueueImdsHappyPath(*mock_client_);
+
+  AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess",
+                                        /*external_id=*/"tenant-A-ext-id");
+  auto creds = provider.GetAWSCredentials();
+  EXPECT_EQ(creds.GetAWSAccessKeyId(), "STS_AK");
+
+  std::shared_ptr<Aws::Http::HttpRequest> sts_req;
+  for (const auto& r : mock_client_->GetRecordedRequests()) {
+    if (r->GetURIString().find("sts.aliyuncs.com") != Aws::String::npos) {
+      sts_req = r;
+      break;
+    }
+  }
+  ASSERT_NE(sts_req, nullptr);
+  const auto body = ReadRequestBody(sts_req);
+  EXPECT_NE(body.find("ExternalId=tenant-A-ext-id"), std::string::npos) << body;
+}
+
+TEST_F(S3ProviderTest, TestAliyunRAMProviderOmitsExternalIdWhenEmpty) {
+  // Sending an empty ExternalId would still tip the request into the
+  // "ExternalId-supplied" branch on Aliyun's side and fail the trust-policy
+  // check whenever the policy doesn't list ExternalId. The provider must
+  // omit the parameter entirely when the caller leaves it empty.
+  EnqueueImdsHappyPath(*mock_client_);
+
+  AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess");
+  auto creds = provider.GetAWSCredentials();
+  ASSERT_EQ(creds.GetAWSAccessKeyId(), "STS_AK");
+
+  std::shared_ptr<Aws::Http::HttpRequest> sts_req;
+  for (const auto& r : mock_client_->GetRecordedRequests()) {
+    if (r->GetURIString().find("sts.aliyuncs.com") != Aws::String::npos) {
+      sts_req = r;
+      break;
+    }
+  }
+  ASSERT_NE(sts_req, nullptr);
+  const auto body = ReadRequestBody(sts_req);
+  EXPECT_EQ(body.find("ExternalId="), std::string::npos)
+      << "RAM provider must not emit ExternalId at all when caller passes empty: " << body;
+}
+
+TEST_F(S3ProviderTest, TestAliyunOIDCChainProviderForwardsExternalIdToStep2Only) {
+  // ExternalId is a step-2 (sts:AssumeRole) concern. Aliyun's
+  // AssumeRoleWithOIDC API has no ExternalId parameter, so step 1 must NOT
+  // carry it; step 2 must. Verifying both halves catches the easy bug of
+  // accidentally putting ExternalId in the inner provider's body.
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kInnerOidcSuccessXml);
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kOuterAssumeRoleSuccessXml);
+
+  TempFile token_file("oidc-jwt-payload");
+  ScopedEnvVar set_inner_role("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::1111:role/zilliz-machine-role");
+  ScopedEnvVar set_token("ALIBABA_CLOUD_OIDC_TOKEN_FILE", token_file.path());
+  ScopedEnvVar set_provider("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::1111:oidc-provider/zilliz-rrsa");
+  ScopedEnvUnset unset_session("ALIBABA_CLOUD_ROLE_SESSION_NAME");
+
+  AliyunOIDCAssumeRoleChainProvider provider("acs:ram::2222:role/customer-target", "sess",
+                                             /*target_external_id=*/"tenant-A-ext-id");
+  auto creds = provider.GetAWSCredentials();
+  EXPECT_EQ(creds.GetAWSAccessKeyId(), "OUTER_AK");
+
+  const auto recorded = mock_client_->GetRecordedRequests();
+  std::vector<std::shared_ptr<Aws::Http::HttpRequest>> sts_reqs;
+  for (const auto& r : recorded) {
+    if (r->GetURIString().find("sts.aliyuncs.com") != Aws::String::npos) {
+      sts_reqs.push_back(r);
+    }
+  }
+  ASSERT_EQ(sts_reqs.size(), 2u);
+
+  const auto inner_body = ReadRequestBody(sts_reqs[0]);
+  EXPECT_NE(inner_body.find("Action=AssumeRoleWithOIDC"), std::string::npos) << inner_body;
+  EXPECT_EQ(inner_body.find("ExternalId"), std::string::npos)
+      << "AssumeRoleWithOIDC has no ExternalId concept; step 1 must not carry it: " << inner_body;
+
+  const auto outer_body = ReadRequestBody(sts_reqs[1]);
+  EXPECT_NE(outer_body.find("Action=AssumeRole"), std::string::npos) << outer_body;
+  EXPECT_NE(outer_body.find("ExternalId=tenant-A-ext-id"), std::string::npos) << outer_body;
+}
+
+TEST_F(S3ProviderTest, TestAliyunOIDCChainProviderEmptySessionNameDefaults) {
+  // Empty target session name should be replaced by a UUID — the outer
+  // AssumeRole body must never carry an empty RoleSessionName.
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kInnerOidcSuccessXml);
+  mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kOuterAssumeRoleSuccessXml);
+
+  TempFile token_file("oidc-jwt-payload");
+  ScopedEnvVar set_inner_role("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::1111:role/zilliz-machine-role");
+  ScopedEnvVar set_token("ALIBABA_CLOUD_OIDC_TOKEN_FILE", token_file.path());
+  ScopedEnvVar set_provider("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::1111:oidc-provider/zilliz-rrsa");
+
+  AliyunOIDCAssumeRoleChainProvider provider("acs:ram::2222:role/customer-target", /*target_session_name=*/"");
+  auto creds = provider.GetAWSCredentials();
+  EXPECT_EQ(creds.GetAWSAccessKeyId(), "OUTER_AK");
+
+  std::shared_ptr<Aws::Http::HttpRequest> outer_req;
+  for (const auto& r : mock_client_->GetRecordedRequests()) {
+    if (r->GetURIString().find("sts.aliyuncs.com") != Aws::String::npos) {
+      const auto body = ReadRequestBody(r);
+      if (body.find("Action=AssumeRole&") != std::string::npos ||
+          body.find("&Action=AssumeRole&") != std::string::npos) {
+        outer_req = r;
+      }
+    }
+  }
+  ASSERT_NE(outer_req, nullptr);
+  const auto body = ReadRequestBody(outer_req);
+  const auto pos = body.find("RoleSessionName=");
+  ASSERT_NE(pos, std::string::npos) << body;
+  const auto value_start = pos + std::string("RoleSessionName=").size();
+  const auto value_end = body.find('&', value_start);
+  const auto value = body.substr(value_start, value_end - value_start);
+  EXPECT_FALSE(value.empty());
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/format/external_table_arn_test.cpp
+++ b/cpp/test/format/external_table_arn_test.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
 #include <thread>
 
@@ -1083,6 +1084,350 @@ TEST_F(ExternalTableAliyunArnTest, ReadTwoParquetFilesWithArnRole) {
   ASSERT_EQ(total_rows_read, static_cast<int64_t>(total_rows));
   std::cout << "[Aliyun ARN Test] FormatReader read " << total_rows_read << " rows from " << num_files
             << " parquet files via Aliyun ARN OK" << std::endl;
+
+  loon_manifest_destroy(out_manifest);
+  free(out_manifest_path);
+  loon_properties_free(&loon_props);
+}
+
+// ===========================================================================
+// Aliyun OIDC chain integration test (`AliyunOIDCAssumeRoleChainProvider` on
+// the C++ side, `apply_oidc_chain_if_requested` on the Rust side).
+//
+// RAM mode is intentionally NOT covered here; that path stays under
+// `ExternalTableAliyunArnTest` above which exercises both modes via env.
+//
+// Required process env (the three RRSA-style ALIBABA_CLOUD_* triple, same
+// shape K8s would inject inside an ACK pod):
+//   ALIBABA_CLOUD_ROLE_ARN          machine identity role (zilliz-side)
+//   ALIBABA_CLOUD_OIDC_PROVIDER_ARN machine identity OIDC provider
+//   ALIBABA_CLOUD_OIDC_TOKEN_FILE   absolute path to a JWT pulled from a
+//                                   live pod. Tokens expire ~1h after issue.
+//
+// `aliyun-config/oidc-config.env` in the repo root is a `source`-able
+// template — fill in the token absolute path, then `source` it before
+// running the test. The fixture itself doesn't read any files, just env.
+//
+// Optional `ALIYUN_ARN_TEST_ENV_EXTERNAL_ID` — set only if the customer's
+// role trust policy carries a matching `sts:ExternalId` condition. Empty
+// means no `ExternalId` parameter is sent on the step-2 AssumeRole.
+// ===========================================================================
+#define ALIYUN_ARN_ENV_EXTERNAL_ID "ALIYUN_ARN_TEST_ENV_EXTERNAL_ID"
+
+class ExternalTableAliyunOIDCArnTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    // 1. Machine identity must be in process env. The dispatch in
+    //    s3_filesystem_producer.cpp fails fast if missing, but skipping
+    //    here gives a clearer diagnostic when the user just forgot to
+    //    `source aliyun-config/oidc-config.env`.
+    if (std::getenv("ALIBABA_CLOUD_ROLE_ARN") == nullptr || std::getenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN") == nullptr ||
+        std::getenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE") == nullptr) {
+      GTEST_SKIP() << "Aliyun OIDC chain test requires ALIBABA_CLOUD_ROLE_ARN, "
+                      "ALIBABA_CLOUD_OIDC_PROVIDER_ARN and ALIBABA_CLOUD_OIDC_TOKEN_FILE "
+                      "in process env. Try `source aliyun-config/oidc-config.env`.";
+    }
+
+    // 2. Per-tenant test config — same env vars as ExternalTableAliyunArnTest
+    //    so the same CI secrets can drive both fixtures.
+    our_address_ = GetEnvVar(OUR_ENV_ADDRESS).ValueOr("");
+    our_bucket_ = GetEnvVar(OUR_ENV_BUCKET).ValueOr("");
+    our_region_ = GetEnvVar(OUR_ENV_REGION).ValueOr("");
+    our_cloud_provider_ = GetEnvVar(OUR_ENV_CLOUD_PROVIDER).ValueOr("");
+    our_ak_ = GetEnvVar(OUR_ENV_ACCESS_KEY).ValueOr("");
+    our_sk_ = GetEnvVar(OUR_ENV_SECRET_KEY).ValueOr("");
+
+    address_ = GetEnvVar(ALIYUN_ARN_ENV_ADDRESS).ValueOr("");
+    region_ = GetEnvVar(ALIYUN_ARN_ENV_REGION).ValueOr("");
+    arn_bucket_ = GetEnvVar(ALIYUN_ARN_ENV_BUCKET).ValueOr("");
+    arn_ak_ = GetEnvVar(ALIYUN_ARN_ENV_ACCESS_KEY).ValueOr("");
+    arn_sk_ = GetEnvVar(ALIYUN_ARN_ENV_SECRET_KEY).ValueOr("");
+    role_arn_ = GetEnvVar(ALIYUN_ARN_ENV_ROLE_ARN).ValueOr("");
+    // ExternalId is optional. Empty == not sent (the chain provider's
+    // step-2 body omits the parameter entirely; see
+    // TestAliyunOIDCChainProviderForwardsExternalIdToStep2Only).
+    external_id_ = GetEnvVar(ALIYUN_ARN_ENV_EXTERNAL_ID).ValueOr("");
+
+    if (our_address_.empty() || our_bucket_.empty() || our_cloud_provider_.empty() || our_ak_.empty() ||
+        our_sk_.empty() || address_.empty() || region_.empty() || arn_bucket_.empty() || arn_ak_.empty() ||
+        arn_sk_.empty() || role_arn_.empty()) {
+      GTEST_SKIP() << "Aliyun OIDC chain test requires env vars: " << OUR_ENV_ADDRESS << ", " << OUR_ENV_BUCKET << ", "
+                   << OUR_ENV_REGION << ", " << OUR_ENV_CLOUD_PROVIDER << ", " << OUR_ENV_ACCESS_KEY << ", "
+                   << OUR_ENV_SECRET_KEY << ", " << ALIYUN_ARN_ENV_ADDRESS << ", " << ALIYUN_ARN_ENV_REGION << ", "
+                   << ALIYUN_ARN_ENV_BUCKET << ", " << ALIYUN_ARN_ENV_ACCESS_KEY << ", " << ALIYUN_ARN_ENV_SECRET_KEY
+                   << ", " << ALIYUN_ARN_ENV_ROLE_ARN << " (plus optional " << ALIYUN_ARN_ENV_EXTERNAL_ID << ")";
+    }
+
+    // 4. write_props_ — AKSK against the customer bucket. Same as
+    //    ExternalTableAliyunArnTest: the role_arn flow is exercised on the
+    //    read leg only.
+    api::SetValue(write_props_, PROPERTY_FS_STORAGE_TYPE, "remote");
+    api::SetValue(write_props_, PROPERTY_FS_CLOUD_PROVIDER, kCloudProviderAliyun.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_ADDRESS, address_.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_BUCKET_NAME, arn_bucket_.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_REGION, region_.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_ACCESS_KEY_ID, arn_ak_.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_ACCESS_KEY_VALUE, arn_sk_.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_USE_SSL, "true");
+
+    // 5. read_props_ — extfs.arn.* with role_arn (and optional external_id)
+    //    routed through the OIDC chain provider.
+    api::SetValue(read_props_, "extfs.arn.storage_type", "remote");
+    api::SetValue(read_props_, "extfs.arn.cloud_provider", kCloudProviderAliyun.c_str());
+    api::SetValue(read_props_, "extfs.arn.address", address_.c_str());
+    api::SetValue(read_props_, "extfs.arn.bucket_name", arn_bucket_.c_str());
+    api::SetValue(read_props_, "extfs.arn.region", region_.c_str());
+    api::SetValue(read_props_, "extfs.arn.use_ssl", "true");
+    api::SetValue(read_props_, "extfs.arn.role_arn", role_arn_.c_str());
+    if (!external_id_.empty()) {
+      api::SetValue(read_props_, "extfs.arn.external_id", external_id_.c_str());
+    }
+
+    ASSERT_AND_ASSIGN(write_fs_, GetFileSystem(write_props_));
+    FilesystemCache::getInstance().clean();
+
+    auto ts = std::chrono::steady_clock::now().time_since_epoch().count();
+    test_base_ = "zc/aliyun-oidc-test-" + std::to_string(ts);
+  }
+
+  void TearDown() override {
+    if (write_fs_) {
+      (void)DeleteTestDir(write_fs_, test_base_);
+    }
+    FilesystemCache::getInstance().clean();
+  }
+
+  // FFI properties payload shared by all three formats. Iceberg additionally
+  // needs PROPERTY_ICEBERG_SNAPSHOT_ID; callers append.
+  std::vector<std::pair<std::string, std::string>> BaseProps() const {
+    std::vector<std::pair<std::string, std::string>> props = {
+        {PROPERTY_FS_STORAGE_TYPE, "remote"},    {PROPERTY_FS_CLOUD_PROVIDER, our_cloud_provider_},
+        {PROPERTY_FS_ADDRESS, our_address_},     {PROPERTY_FS_BUCKET_NAME, our_bucket_},
+        {PROPERTY_FS_REGION, our_region_},       {PROPERTY_FS_ACCESS_KEY_ID, our_ak_},
+        {PROPERTY_FS_ACCESS_KEY_VALUE, our_sk_}, {PROPERTY_FS_USE_SSL, "true"},
+        {"extfs.arn.storage_type", "remote"},    {"extfs.arn.cloud_provider", kCloudProviderAliyun},
+        {"extfs.arn.address", address_},         {"extfs.arn.bucket_name", arn_bucket_},
+        {"extfs.arn.region", region_},           {"extfs.arn.use_ssl", "true"},
+        {"extfs.arn.role_arn", role_arn_},
+    };
+    if (!external_id_.empty()) {
+      props.emplace_back("extfs.arn.external_id", external_id_);
+    }
+    return props;
+  }
+
+  arrow::Result<ArnWriteResult> CreateLanceTable(uint64_t num_rows) {
+    ARROW_ASSIGN_OR_RAISE(auto schema, CreateTestSchema({true, true, true, false}));
+    ARROW_ASSIGN_OR_RAISE(auto batch, CreateTestData(schema, 0, false, num_rows, 4, 50, {true, true, true, false}));
+    auto path = test_base_ + "/lance";
+    lance::LanceTableWriter writer(path, schema, write_props_);
+    ARROW_RETURN_NOT_OK(writer.Write(batch));
+    ARROW_ASSIGN_OR_RAISE(auto cgfile, writer.Close());
+    auto explore_dir = "oss://" + address_ + "/" + arn_bucket_ + "/" + path;
+    return ArnWriteResult{std::move(cgfile), schema, num_rows, explore_dir, 0};
+  }
+
+  arrow::Result<ArnWriteResult> CreateIcebergTable(uint64_t num_rows) {
+    auto path = test_base_ + "/iceberg";
+    auto table_uri = "oss://" + arn_bucket_ + "/" + path;
+    ArrowFileSystemConfig write_config;
+    ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
+    auto storage_options = iceberg::ToStorageOptions(write_config);
+
+    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
+    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    if (file_infos.empty()) {
+      return arrow::Status::Invalid("PlanFiles returned no files");
+    }
+    auto milvus_path = iceberg::ToMilvusUri(file_infos[0].data_file_path, address_);
+    api::ColumnGroupFile cg_file{milvus_path, 0, static_cast<int64_t>(file_infos[0].record_count), {}};
+    auto explore_dir = iceberg::ToMilvusUri(table_info.metadata_location, address_);
+    return ArnWriteResult{std::move(cg_file), nullptr, num_rows, explore_dir, table_info.snapshot_id};
+  }
+
+  struct ParquetWriteResult {
+    std::shared_ptr<arrow::Schema> schema;
+    uint64_t num_files;
+    uint64_t rows_per_file;
+    std::string explore_dir;
+  };
+
+  arrow::Result<ParquetWriteResult> CreateParquetFiles(uint64_t num_files, uint64_t rows_per_file) {
+    ARROW_ASSIGN_OR_RAISE(auto schema, CreateTestSchema({true, true, true, false}));
+    auto dir = test_base_ + "/parquet";
+    auto writer_props = ::parquet::WriterProperties::Builder().compression(::parquet::Compression::ZSTD)->build();
+
+    for (uint64_t i = 0; i < num_files; ++i) {
+      ARROW_ASSIGN_OR_RAISE(auto batch, CreateTestData(schema, /*start_offset=*/static_cast<int64_t>(i * rows_per_file),
+                                                       /*randdata=*/false, rows_per_file, /*vector_dim=*/4,
+                                                       /*str_length=*/50, {true, true, true, false}));
+      auto file_path = dir + "/file_" + std::to_string(i) + ".parquet";
+      ARROW_ASSIGN_OR_RAISE(auto sink, write_fs_->OpenOutputStream(file_path));
+      ARROW_ASSIGN_OR_RAISE(auto pq_writer, ::parquet::arrow::FileWriter::Open(*schema, arrow::default_memory_pool(),
+                                                                               sink, writer_props));
+      ARROW_RETURN_NOT_OK(pq_writer->NewBufferedRowGroup());
+      ARROW_RETURN_NOT_OK(pq_writer->WriteRecordBatch(*batch));
+      ARROW_RETURN_NOT_OK(pq_writer->Close());
+      ARROW_RETURN_NOT_OK(sink->Close());
+    }
+    auto explore_dir = "oss://" + address_ + "/" + arn_bucket_ + "/" + dir + "/";
+    return ParquetWriteResult{schema, num_files, rows_per_file, explore_dir};
+  }
+
+  // Our-side
+  std::string our_address_, our_bucket_, our_region_, our_cloud_provider_, our_ak_, our_sk_;
+  // Customer-side
+  std::string address_, region_, arn_bucket_, arn_ak_, arn_sk_, role_arn_, external_id_;
+
+  api::Properties write_props_;
+  api::Properties read_props_;
+  ArrowFileSystemPtr write_fs_;
+  std::string test_base_;
+};
+
+// Lance + OIDC chain end-to-end. Writes with AKSK, reads back through
+// loon_exttable_explore (Rust AliyunOssStoreProvider on step 2 of the
+// chain) + FormatReader.
+TEST_F(ExternalTableAliyunOIDCArnTest, ReadLanceWithOIDCChain) {
+  const uint64_t num_rows = 100;
+  ASSERT_AND_ASSIGN(auto result, CreateLanceTable(num_rows));
+
+  std::cout << "[Aliyun OIDC Test] Lance written to: " << result.cgfile.path << std::endl;
+  std::cout << "[Aliyun OIDC Test] Role ARN: " << role_arn_ << (external_id_.empty() ? "" : " (with external_id)")
+            << std::endl;
+
+  auto manifest_base = test_base_ + "/manifest";
+  auto props = BaseProps();
+
+  std::vector<const char*> c_keys, c_values;
+  c_keys.reserve(props.size());
+  c_values.reserve(props.size());
+  for (const auto& [k, v] : props) {
+    c_keys.push_back(k.c_str());
+    c_values.push_back(v.c_str());
+  }
+  LoonProperties loon_props = {};
+  auto rc = loon_properties_create(c_keys.data(), c_values.data(), c_keys.size(), &loon_props);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+
+  const char* columns_arr[] = {"id", "name", "value"};
+  uint64_t out_num_files = 0;
+  char* out_manifest_path = nullptr;
+  rc = loon_exttable_explore(columns_arr, 3, LOON_FORMAT_LANCE_TABLE, manifest_base.c_str(), result.explore_dir.c_str(),
+                             &loon_props, &out_num_files, &out_manifest_path);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+  ASSERT_GT(out_num_files, 0u);
+
+  LoonManifest* out_manifest = nullptr;
+  rc = loon_exttable_read_manifest(out_manifest_path, &loon_props, &out_manifest);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+  ASSERT_NE(out_manifest, nullptr);
+  ASSERT_EQ(out_manifest->column_groups.num_of_column_groups, 1u);
+  auto* cg = &out_manifest->column_groups.column_group_array[0];
+  ASSERT_EQ(cg->num_of_files, out_num_files);
+
+  std::vector<std::string> columns = {"id", "name", "value"};
+  int64_t total_rows = 0;
+  for (uint64_t f = 0; f < cg->num_of_files; ++f) {
+    auto& loon_file = cg->files[f];
+    api::ColumnGroupFile cgfile;
+    cgfile.path = loon_file.path;
+    cgfile.start_index = loon_file.start_index;
+    cgfile.end_index = loon_file.end_index;
+    if (loon_file.property_keys != nullptr) {
+      for (uint32_t p = 0; p < loon_file.num_properties; ++p) {
+        cgfile.properties[loon_file.property_keys[p]] = loon_file.property_values[p];
+      }
+    }
+    ASSERT_AND_ASSIGN(auto reader, FormatReader::create(result.schema, LOON_FORMAT_LANCE_TABLE, cgfile, read_props_,
+                                                        columns, nullptr));
+    ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
+    for (size_t i = 0; i < rg_infos.size(); ++i) {
+      ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(i));
+      total_rows += batch->num_rows();
+    }
+  }
+  ASSERT_EQ(total_rows, static_cast<int64_t>(num_rows));
+
+  loon_manifest_destroy(out_manifest);
+  free(out_manifest_path);
+  loon_properties_free(&loon_props);
+}
+
+// Parquet variant — the format that surfaced the original prod bug
+// (PlainFormat::explore goes through the C++ aws-sdk-cpp filesystem, i.e.
+// `AliyunOIDCAssumeRoleChainProvider`, NOT the Rust opendal path that
+// Lance/Iceberg take). A dedicated parquet test makes it impossible for a
+// future refactor to "fix Lance/Iceberg" while leaving the parquet path
+// regressed.
+TEST_F(ExternalTableAliyunOIDCArnTest, ReadTwoParquetFilesWithOIDCChain) {
+  const uint64_t num_files = 2;
+  const uint64_t rows_per_file = 50;
+  const uint64_t total_rows = num_files * rows_per_file;
+
+  ASSERT_AND_ASSIGN(auto result, CreateParquetFiles(num_files, rows_per_file));
+
+  std::cout << "[Aliyun OIDC Test] Parquet explore dir: " << result.explore_dir << std::endl;
+
+  auto manifest_base = test_base_ + "/manifest";
+  auto props = BaseProps();
+
+  std::vector<const char*> c_keys, c_values;
+  c_keys.reserve(props.size());
+  c_values.reserve(props.size());
+  for (const auto& [k, v] : props) {
+    c_keys.push_back(k.c_str());
+    c_values.push_back(v.c_str());
+  }
+  LoonProperties loon_props = {};
+  auto rc = loon_properties_create(c_keys.data(), c_values.data(), c_keys.size(), &loon_props);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+
+  const char* columns_arr[] = {"id", "name", "value"};
+  uint64_t out_num_files = 0;
+  char* out_manifest_path = nullptr;
+  rc = loon_exttable_explore(columns_arr, 3, LOON_FORMAT_PARQUET, manifest_base.c_str(), result.explore_dir.c_str(),
+                             &loon_props, &out_num_files, &out_manifest_path);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+  ASSERT_EQ(out_num_files, num_files);
+
+  LoonManifest* out_manifest = nullptr;
+  rc = loon_exttable_read_manifest(out_manifest_path, &loon_props, &out_manifest);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+  auto* cg = &out_manifest->column_groups.column_group_array[0];
+  ASSERT_EQ(cg->num_of_files, num_files);
+
+  // get_file_info verifies the per-file row count via the same role_arn flow.
+  for (uint64_t f = 0; f < cg->num_of_files; ++f) {
+    auto& loon_file = cg->files[f];
+    uint64_t per_file_rows = 0;
+    rc = loon_exttable_get_file_info(LOON_FORMAT_PARQUET, loon_file.path, &loon_props, &per_file_rows);
+    ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+    ASSERT_EQ(per_file_rows, rows_per_file);
+  }
+
+  std::vector<std::string> columns = {"id", "name", "value"};
+  int64_t total_rows_read = 0;
+  for (uint64_t f = 0; f < cg->num_of_files; ++f) {
+    auto& loon_file = cg->files[f];
+    api::ColumnGroupFile cgfile;
+    cgfile.path = loon_file.path;
+    cgfile.start_index = loon_file.start_index;
+    cgfile.end_index = loon_file.end_index;
+    if (loon_file.property_keys != nullptr) {
+      for (uint32_t p = 0; p < loon_file.num_properties; ++p) {
+        cgfile.properties[loon_file.property_keys[p]] = loon_file.property_values[p];
+      }
+    }
+    ASSERT_AND_ASSIGN(auto reader,
+                      FormatReader::create(result.schema, LOON_FORMAT_PARQUET, cgfile, read_props_, columns, nullptr));
+    ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
+    for (size_t i = 0; i < rg_infos.size(); ++i) {
+      ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(i));
+      total_rows_read += batch->num_rows();
+    }
+  }
+  ASSERT_EQ(total_rows_read, static_cast<int64_t>(total_rows));
 
   loon_manifest_destroy(out_manifest);
   free(out_manifest_path);


### PR DESCRIPTION
This makes Aliyun per-tenant role access work with the two-step OIDC flow we actually need in production: first use the pod’s OIDC identity to assume the Zilliz-side role, then use those temporary credentials to assume the customer role.

It wires the same idea through the C++ OSS path and the Rust Lance/Iceberg paths, including forwarding ExternalId to the second AssumeRole call only. Lance also gets refresh support based on load_frequency so long-running reads don’t keep using expired Aliyun STS credentials.