### PR TITLE
fix: restore credential-aware filesystem cache keys

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <functional>
 #include <list>
+#include <type_traits>
 
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/util/uri.h>
@@ -160,10 +161,10 @@ struct StorageUri {
 // TODO: it's not `arrow` namespace, we should change this struct name.
 // TODO: after chunkmanager(in milvus) removed, we can remove the used key in storage
 struct ArrowFileSystemConfig {
-  std::string address = "localhost:9000";
-  std::string bucket_name = "a-bucket";
-  std::string access_key_id = "minioadmin";
-  std::string access_key_value = "minioadmin";
+  std::string address = "";
+  std::string bucket_name = "";
+  std::string access_key_id = "";
+  std::string access_key_value = "";
 
   // Only applies to the local filesystem.
   // It is used to pin the data directory to a specific path.
@@ -237,21 +238,64 @@ struct ArrowFileSystemConfig {
   /**
    * @brief Get the cache key for this filesystem configuration
    *
-   * The cache key is the combination of address and bucket_name, which
-   * uniquely identifies a filesystem endpoint and bucket combination.
-   *
-   * Identity fields (use_iam, access_key_id, gcp_target_service_account,
-   * role_arn, etc.) are deliberately omitted. Invariant: within a process,
-   * a given (address, bucket) pair always maps to exactly one identity —
-   * a single bucket cannot be legally accessed by two different credentials
-   * (e.g. two GCP service accounts) in the same process. Two configs that
-   * resolve to the same (address, bucket) therefore carry the same identity,
-   * so it's safe (and desirable) to share the cached filesystem instance.
-   *
-   * @return String in format "address/bucket_name"
+   * The cache key includes filesystem location, client behavior, and credential
+   * identity fields. This prevents sharing one cached filesystem across configs
+   * that target the same bucket with different credentials (for example,
+   * different role_arn values).
    */
   [[nodiscard]] std::string GetCacheKey() const {
-    return storage_type == "local" ? root_path : address + "/" + bucket_name;
+    size_t seed = 0;
+    auto hash_combine = [&seed](const auto& value) {
+      using ValueType = std::decay_t<decltype(value)>;
+      seed ^= std::hash<ValueType>{}(value) + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+    };
+
+    hash_combine(storage_type);
+
+    // bypass local
+    if (storage_type == "local") {
+      hash_combine(root_path);
+      return "fs:" + std::to_string(seed);
+    }
+
+    hash_combine(cloud_provider);
+    hash_combine(address);
+    hash_combine(bucket_name);
+    hash_combine(region);
+    hash_combine(use_ssl);
+    hash_combine(ssl_ca_cert);
+    hash_combine(use_virtual_host);
+    hash_combine(request_timeout_ms);
+    hash_combine(max_connections);
+    hash_combine(multi_part_upload_size);
+    hash_combine(tls_min_version);
+    hash_combine(background_writes);
+    hash_combine(use_crc32c_checksum);
+    hash_combine(load_frequency);
+
+    if (cloud_provider == kCloudProviderGCP) {
+      hash_combine(use_iam);
+      if (use_iam) {
+        hash_combine(gcp_target_service_account);
+      } else {
+        hash_combine(access_key_id);
+        hash_combine(access_key_value);
+      }
+    } else if (!role_arn.empty()) {
+      hash_combine(role_arn);
+      hash_combine(session_name);
+      hash_combine(external_id);
+    } else {
+      hash_combine(use_iam);
+      // Azure use the access_key_id as account name.
+      if (!use_iam || cloud_provider == kCloudProviderAzure) {
+        hash_combine(access_key_id);
+        hash_combine(access_key_value);
+      }
+    }
+
+    // return the hash key
+    return "fs:" + std::to_string(seed);
   }
 
   [[nodiscard]] std::string ToString() const {

--- a/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
@@ -16,6 +16,8 @@
 
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <cstdlib>
 #include <fstream>
 #include <cstring>
@@ -24,7 +26,6 @@
 #include <aws/core/config/AWSProfileConfigLoader.h>
 #include <aws/core/platform/Environment.h>
 #include <aws/core/platform/FileSystem.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/FileSystemUtils.h>
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
@@ -77,27 +78,25 @@ AliyunSTSAssumeRoleWebIdentityCredentialsProvider::AliyunSTSAssumeRoleWebIdentit
 
 void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
   if (m_tokenFile.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Token file must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Token file must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved token_file from profile_config or "
-                        "environment variable to be "
-                            << m_tokenFile);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved token_file from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_tokenFile);
   }
 
   if (m_roleArn.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "RoleArn must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] RoleArn must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved role_arn from profile_config or "
-                        "environment variable to be "
-                            << m_roleArn);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved role_arn from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_roleArn);
   }
 
   // not need in [aliyun]
@@ -107,17 +106,15 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
   // }
   // else
   // {
-  //     AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved region from profile_config or environment
-  //     variable to be " << tmpRegion);
+  //     LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved region from profile_config or environment variable to be {}",
+  //                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, tmpRegion);
   // }
 
   if (m_sessionName.empty()) {
     m_sessionName = Aws::Utils::UUID::RandomUUID();
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved session_name from profile_config or "
-                        "environment variable to be "
-                            << m_sessionName);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved session_name from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_sessionName);
   }
 
   Aws::Client::ClientConfiguration config;
@@ -134,7 +131,8 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
 
   m_client = Aws::MakeUnique<AliyunSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
-  AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Creating STS AssumeRole with web identity creds provider.",
+                                   STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
 }
 
 Aws::Auth::AWSCredentials AliyunSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
@@ -149,21 +147,22 @@ Aws::Auth::AWSCredentials AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Get
 }
 
 void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
-  AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Credentials have expired, attempting to renew from STS.");
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials have expired, attempting to renew from STS.",
+                                   STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
 
   Aws::IFStream tokenFile(m_tokenFile.c_str());
   if (tokenFile) {
     Aws::String token((std::istreambuf_iterator<char>(tokenFile)), std::istreambuf_iterator<char>());
     m_token = token;
   } else {
-    AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Can't open token file: {}", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+                                      m_tokenFile);
     return;
   }
   AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_sessionName, m_roleArn, m_token};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
-  AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                      "Successfully retrieved credentials with AWS_ACCESS_KEY: " << result.creds.GetAWSAccessKeyId());
+  LOG_STORAGE_TRACE_ << fmt::format("[{}] Successfully retrieved credentials", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
   m_credentials = result.creds;
 }
 

--- a/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
@@ -14,10 +14,11 @@
 
 #include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/DateTime.h>
 #include <aws/core/utils/UUID.h>
-#include <aws/core/utils/logging/LogMacros.h>
 
 namespace milvus_storage {
 
@@ -48,8 +49,9 @@ AliyunOIDCAssumeRoleChainProvider::AliyunOIDCAssumeRoleChainProvider(const Aws::
   cfg.scheme = Aws::Http::Scheme::HTTPS;
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 
-  AWS_LOGSTREAM_INFO(kLogTag, "Created OIDC chain provider for target_role_arn=" << m_targetRoleArn
-                                                                                 << " session=" << m_targetSessionName);
+  LOG_STORAGE_INFO_ << fmt::format(
+      "[{}] Created OIDC chain provider for target_role_arn={} session={} external_id_set={}", kLogTag, m_targetRoleArn,
+      m_targetSessionName, !m_targetExternalId.empty());
 }
 
 Aws::Auth::AWSCredentials AliyunOIDCAssumeRoleChainProvider::GetAWSCredentials() {
@@ -77,13 +79,15 @@ void AliyunOIDCAssumeRoleChainProvider::RefreshIfExpired() {
 }
 
 void AliyunOIDCAssumeRoleChainProvider::Reload() {
-  AWS_LOGSTREAM_INFO(kLogTag, "Credentials missing or expiring; refreshing via OIDC -> AssumeRole.");
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials missing or expiring; refreshing via OIDC -> AssumeRole.", kLogTag);
 
   // Step 1: inner provider self-refreshes on call.
   Aws::Auth::AWSCredentials inner = m_innerOidc->GetAWSCredentials();
   if (inner.IsEmpty()) {
-    AWS_LOGSTREAM_ERROR(
-        kLogTag, "Inner OIDC step returned empty credentials; cannot chain to target_role_arn=" << m_targetRoleArn);
+    LOG_STORAGE_ERROR_ << fmt::format(
+        "[{}] Inner OIDC step returned empty credentials; cannot chain to "
+        "target_role_arn={}",
+        kLogTag, m_targetRoleArn);
     return;
   }
 
@@ -99,19 +103,20 @@ void AliyunOIDCAssumeRoleChainProvider::Reload() {
   req.roleArn = m_targetRoleArn;
   req.roleSessionName = m_targetSessionName;
   req.externalId = m_targetExternalId;
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Sending chained AssumeRole request; external_id_set={}", kLogTag,
+                                   !req.externalId.empty());
 
   auto res = m_stsClient->GetAssumeRoleCredentials(req);
   if (res.creds.IsEmpty()) {
-    AWS_LOGSTREAM_ERROR(kLogTag,
-                        "Cross-account AssumeRole returned empty credentials; target_role_arn="
-                            << m_targetRoleArn
-                            << " — check the target role's trust policy lists the OIDC step-1 role as Principal");
+    LOG_STORAGE_ERROR_ << fmt::format(
+        "[{}] Cross-account AssumeRole returned empty credentials; target_role_arn={} "
+        "— check the target role's trust policy lists the OIDC step-1 role as Principal",
+        kLogTag, m_targetRoleArn);
     return;
   }
   m_credentials = res.creds;
-  AWS_LOGSTREAM_INFO(kLogTag, "OIDC chain succeeded; target_role_arn="
-                                  << m_targetRoleArn << " expires="
-                                  << m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+  LOG_STORAGE_INFO_ << fmt::format("[{}] OIDC chain succeeded; target_role_arn={} expires={}", kLogTag, m_targetRoleArn,
+                                   m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
@@ -14,6 +14,8 @@
 
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <sstream>
 #include <string>
 
@@ -27,7 +29,6 @@
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/UUID.h>
 #include <aws/core/utils/json/JsonSerializer.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/memory/AWSMemory.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
@@ -117,12 +118,12 @@ bool FetchImdsCreds(ImdsCreds& out) {
   auto list_req = MakeImdsGet(std::string(kImdsHost) + kImdsRoleListPath, v2_token);
   auto list_resp = http->MakeRequest(list_req);
   if (!list_resp || list_resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "IMDS role list request failed; no RAM role attached to this ECS?");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS role list request failed; no RAM role attached to this ECS?", kLogTag);
     return false;
   }
   const auto role_name = std::string(Aws::Utils::StringUtils::Trim(ReadBody(list_resp).c_str()).c_str());
   if (role_name.empty()) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "IMDS returned empty role name");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS returned empty role name", kLogTag);
     return false;
   }
 
@@ -130,18 +131,18 @@ bool FetchImdsCreds(ImdsCreds& out) {
   auto creds_req = MakeImdsGet(creds_url, v2_token);
   auto creds_resp = http->MakeRequest(creds_req);
   if (!creds_resp || creds_resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "IMDS credentials request failed for role " << role_name);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials request failed for role {}", kLogTag, role_name);
     return false;
   }
 
   Aws::Utils::Json::JsonValue json(ReadBody(creds_resp).c_str());
   if (!json.WasParseSuccessful()) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "IMDS credentials JSON parse failed: " << json.GetErrorMessage());
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials JSON parse failed: {}", kLogTag, json.GetErrorMessage());
     return false;
   }
   auto view = json.View();
   if (!view.KeyExists("AccessKeyId") || !view.KeyExists("AccessKeySecret") || !view.KeyExists("SecurityToken")) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "IMDS credentials response missing expected fields");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials response missing expected fields", kLogTag);
     return false;
   }
   out.access_key_id = view.GetString("AccessKeyId");
@@ -164,9 +165,8 @@ AliyunRAMCredentialsProvider::AliyunRAMCredentialsProvider(const Aws::String& ro
   cfg.scheme = Aws::Http::Scheme::HTTPS;
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 
-  AWS_LOGSTREAM_INFO(kLogTag,
-                     "Created RAM provider for role_arn=" << m_roleArn << " session=" << m_roleSessionName
-                                                          << (m_externalId.empty() ? "" : " (with external_id)"));
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Created RAM provider for role_arn={} session={} external_id_set={}", kLogTag,
+                                   m_roleArn, m_roleSessionName, !m_externalId.empty());
 }
 
 Aws::Auth::AWSCredentials AliyunRAMCredentialsProvider::GetAWSCredentials() {
@@ -194,11 +194,11 @@ void AliyunRAMCredentialsProvider::RefreshIfExpired() {
 }
 
 void AliyunRAMCredentialsProvider::Reload() {
-  AWS_LOGSTREAM_INFO(kLogTag, "Credentials missing or expiring; refreshing via IMDS → AssumeRole.");
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials missing or expiring; refreshing via IMDS → AssumeRole.", kLogTag);
 
   ImdsCreds imds;
   if (!FetchImdsCreds(imds)) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "Failed to fetch ECS IMDS credentials");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Failed to fetch ECS IMDS credentials", kLogTag);
     return;
   }
 
@@ -209,16 +209,17 @@ void AliyunRAMCredentialsProvider::Reload() {
   req.roleArn = m_roleArn;
   req.roleSessionName = m_roleSessionName;
   req.externalId = m_externalId;
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Sending AssumeRole request; external_id_set={}", kLogTag,
+                                   !req.externalId.empty());
 
   auto res = m_stsClient->GetAssumeRoleCredentials(req);
   if (res.creds.IsEmpty()) {
-    AWS_LOGSTREAM_ERROR(kLogTag, "AssumeRole returned empty credentials");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] AssumeRole returned empty credentials", kLogTag);
     return;
   }
   m_credentials = res.creds;
-  AWS_LOGSTREAM_INFO(kLogTag, "AssumeRole succeeded; ak="
-                                  << m_credentials.GetAWSAccessKeyId() << " expires="
-                                  << m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
+  LOG_STORAGE_INFO_ << fmt::format("[{}] AssumeRole succeeded; expires={}", kLogTag,
+                                   m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/provider/AliyunRAMSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMSTSClient.cpp
@@ -14,6 +14,8 @@
 
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <cctype>
 #include <cstdint>
 #include <iomanip>
@@ -35,7 +37,6 @@
 #include <aws/core/utils/HashingUtils.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/UUID.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 #include <aws/core/utils/xml/XmlSerializer.h>
 
@@ -77,7 +78,7 @@ AliyunRAMSTSClient::AliyunRAMSTSClient(const Aws::Client::ClientConfiguration& c
   SetErrorMarshaller(Aws::MakeUnique<Aws::Client::XmlErrorMarshaller>(kLogTag));
   // Aliyun STS is region-agnostic; this endpoint is valid from every region.
   m_endpoint = "https://sts.aliyuncs.com/";
-  AWS_LOGSTREAM_INFO(kLogTag, "Creating RAM STS client with endpoint: " << m_endpoint);
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Creating RAM STS client with endpoint: {}", kLogTag, m_endpoint);
 }
 
 AliyunRAMSTSClient::AssumeRoleResult AliyunRAMSTSClient::GetAssumeRoleCredentials(const AssumeRoleRequest& request) {
@@ -102,6 +103,8 @@ AliyunRAMSTSClient::AssumeRoleResult AliyunRAMSTSClient::GetAssumeRoleCredential
   // sending an empty value would still flip the request to the
   // "ExternalId-supplied" branch on Aliyun's side, which fails the policy
   // check, so the explicit non-empty guard matters.
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Preparing AssumeRole request; external_id_set={}", kLogTag,
+                                   !request.externalId.empty());
   if (!request.externalId.empty()) {
     params["ExternalId"] = request.externalId;
   }
@@ -158,7 +161,7 @@ AliyunRAMSTSClient::AssumeRoleResult AliyunRAMSTSClient::GetAssumeRoleCredential
 
   const Aws::String payload = GetResourceWithAWSWebServiceResult(httpRequest).GetPayload();
   if (payload.empty()) {
-    AWS_LOGSTREAM_WARN(kLogTag, "Empty AssumeRole response from " << m_endpoint);
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Empty AssumeRole response from {}", kLogTag, m_endpoint);
     return result;
   }
 
@@ -178,12 +181,12 @@ AliyunRAMSTSClient::AssumeRoleResult AliyunRAMSTSClient::GetAssumeRoleCredential
     resultNode = root.FirstChild("AssumeRoleResponse");
   }
   if (resultNode.IsNull()) {
-    AWS_LOGSTREAM_WARN(kLogTag, "Unexpected AssumeRole response root: " << payload);
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Unexpected AssumeRole response root: {}", kLogTag, payload);
     return result;
   }
   auto credentials = resultNode.FirstChild("Credentials");
   if (credentials.IsNull()) {
-    AWS_LOGSTREAM_WARN(kLogTag, "Missing <Credentials> in AssumeRole response: " << payload);
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Missing <Credentials> in AssumeRole response: {}", kLogTag, payload);
     return result;
   }
 

--- a/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
@@ -16,6 +16,8 @@
 
 #include "milvus-storage/filesystem/s3/provider/AliyunSTSClient.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <climits>
 #include <mutex>
 #include <sstream>
@@ -26,7 +28,6 @@
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpResponse.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/HashingUtils.h>
 #include <aws/core/platform/Environment.h>
@@ -52,9 +53,10 @@ AliyunSTSCredentialsClient::AliyunSTSCredentialsClient(const Aws::Client::Client
     : AWSHttpResourceClient(clientConfiguration, STS_RESOURCE_CLIENT_LOG_TAG) {
   m_aliyunOidcProviderArn = Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN");
   if (m_aliyunOidcProviderArn.empty()) {
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
-                       "oidc role arn must be specified to use STS "
-                       "AssumeRole web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] oidc role arn must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_RESOURCE_CLIENT_LOG_TAG);
     return;
   }
   SetErrorMarshaller(Aws::MakeUnique<Aws::Client::XmlErrorMarshaller>(STS_RESOURCE_CLIENT_LOG_TAG));
@@ -62,7 +64,8 @@ AliyunSTSCredentialsClient::AliyunSTSCredentialsClient(const Aws::Client::Client
   // [aliyun]
   m_endpoint = "https://sts.aliyuncs.com";
 
-  AWS_LOGSTREAM_INFO(STS_RESOURCE_CLIENT_LOG_TAG, "Creating STS ResourceClient with endpoint: " << m_endpoint);
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Creating STS ResourceClient with endpoint: {}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                   m_endpoint);
 }
 
 AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityResult
@@ -120,7 +123,7 @@ AliyunSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
   // Parse credentials
   STSAssumeRoleWithWebIdentityResult result;
   if (credentialsStr.empty()) {
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Get an empty credential from sts");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get an empty credential from sts", STS_RESOURCE_CLIENT_LOG_TAG);
     return result;
   }
 

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -1,8 +1,10 @@
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
+
+#include "milvus-storage/common/log.h"
+
 #include <fstream>
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudSTSClient.h"
 #include <aws/core/platform/Environment.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/utils/UUID.h>
 
@@ -31,48 +33,43 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   }
 
   if (m_tokenFile.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Token file must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Token file must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved token_file from profile_config or "
-                        "environment variable to be "
-                            << m_tokenFile);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved token_file from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_tokenFile);
   }
 
   if (m_roleArn.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "RoleArn must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] RoleArn must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved role_arn from profile_config or "
-                        "environment variable to be "
-                            << m_roleArn);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved role_arn from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_roleArn);
   }
 
   if (m_region.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Region must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Region must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved region from profile_config or "
-                        "environment variable to be "
-                            << m_region);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved region from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_region);
   }
 
   if (m_sessionName.empty()) {
     m_sessionName = Aws::Utils::UUID::RandomUUID();
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved session_name from profile_config or "
-                        "environment variable to be "
-                            << m_sessionName);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved session_name from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_sessionName);
   }
 
   Aws::Client::ClientConfiguration config;
@@ -88,12 +85,12 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
 
   m_client = Aws::MakeUnique<HuaweiCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
-  AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                     "Initialized STS AssumeRole with web identity creds provider."
-                         << " region=" << m_region << ", tokenFile=" << m_tokenFile << ", providerId=" << m_providerId
-                         << ", gracePeriodMs=" << STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD
-                         << ", cooldownNormalSec=" << RELOAD_COOLDOWN_SECONDS
-                         << ", cooldownUrgentSec=" << RELOAD_COOLDOWN_SECONDS_URGENT);
+  LOG_STORAGE_INFO_ << fmt::format(
+      "[{}] Initialized STS AssumeRole with web identity creds provider. region={}, "
+      "tokenFile={}, providerId={}, gracePeriodMs={}, cooldownNormalSec={}, "
+      "cooldownUrgentSec={}",
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_region, m_tokenFile, m_providerId,
+      STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD, RELOAD_COOLDOWN_SECONDS, RELOAD_COOLDOWN_SECONDS_URGENT);
 }
 
 Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
@@ -106,9 +103,10 @@ Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider
   // auth failures. Return empty credentials instead so the error surfaces
   // immediately rather than after an HTTP round-trip.
   if (!m_credentials.IsEmpty() && m_credentials.IsExpired()) {
-    AWS_LOGSTREAM_WARN(
-        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-        "Cached credentials have fully expired; returning empty credentials to avoid silent auth failures.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Cached credentials have fully expired; returning empty credentials to "
+        "avoid silent auth failures.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return {};
   }
   return m_credentials;
@@ -116,10 +114,11 @@ Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider
 
 void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   if (m_credentials.IsEmpty()) {
-    AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Performing initial credential load from STS.");
+    LOG_STORAGE_INFO_ << fmt::format("[{}] Performing initial credential load from STS.",
+                                     STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
   } else {
-    AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Credentials expiring soon, attempting to refresh from STS.");
+    LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials expiring soon, attempting to refresh from STS.",
+                                     STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
   }
 
   Aws::IFStream tokenFile(m_tokenFile.c_str());
@@ -131,9 +130,9 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     m_token = token;
   } else {
     ++m_stsFailureCount;
-    AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Can't open token file: " << m_tokenFile << ", sts_success=" << m_stsSuccessCount.load()
-                                                  << ", sts_failure=" << m_stsFailureCount.load());
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Can't open token file: {}, sts_success={}, sts_failure={}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_tokenFile, m_stsSuccessCount.load(),
+                                      m_stsFailureCount.load());
     m_lastReloadFailed = true;
     m_lastFailedReloadTime = std::chrono::steady_clock::now();
     return;
@@ -150,10 +149,10 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   if (!result.success) {
     ++m_stsFailureCount;
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "STS call failed. has_valid_cached=" << hasExisting << ", retaining existing credentials."
-                                                            << " sts_success=" << m_stsSuccessCount.load()
-                                                            << ", sts_failure=" << m_stsFailureCount.load());
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] STS call failed. has_valid_cached={}, retaining existing credentials. "
+        "sts_success={}, sts_failure={}",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, hasExisting, m_stsSuccessCount.load(), m_stsFailureCount.load());
     m_lastReloadFailed = true;
     m_lastFailedReloadTime = std::chrono::steady_clock::now();
     return;
@@ -162,11 +161,11 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   if (creds.GetAWSAccessKeyId().empty() || creds.GetAWSSecretKey().empty() || creds.GetSessionToken().empty()) {
     ++m_stsFailureCount;
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "STS returned incomplete credentials (missing ak/sk/token). has_valid_cached="
-                           << hasExisting << ", retaining existing credentials."
-                           << " sts_success=" << m_stsSuccessCount.load()
-                           << ", sts_failure=" << m_stsFailureCount.load());
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] STS returned incomplete credentials (missing ak/sk/token). "
+        "has_valid_cached={}, retaining existing credentials. sts_success={}, "
+        "sts_failure={}",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, hasExisting, m_stsSuccessCount.load(), m_stsFailureCount.load());
     m_lastReloadFailed = true;
     m_lastFailedReloadTime = std::chrono::steady_clock::now();
     return;
@@ -175,14 +174,10 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   ++m_stsSuccessCount;
   m_credentials = creds;
   m_lastReloadFailed = false;
-  auto akId = creds.GetAWSAccessKeyId();
-  Aws::String akPrefix = akId.length() > 4 ? akId.substr(0, 4) + "***" : akId;
   auto expiresInMs = (creds.GetExpiration() - Aws::Utils::DateTime::Now()).count();
-  AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                     "Successfully retrieved credentials, ak_prefix=" << akPrefix << ", expires_in_ms=" << expiresInMs
-                                                                      << ", region=" << m_region
-                                                                      << ", sts_success=" << m_stsSuccessCount.load()
-                                                                      << ", sts_failure=" << m_stsFailureCount.load());
+  LOG_STORAGE_INFO_ << fmt::format(
+      "[{}] Successfully retrieved credentials, expires_in_ms={}, region={}, sts_success={}, sts_failure={}",
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, expiresInMs, m_region, m_stsSuccessCount.load(), m_stsFailureCount.load());
 }
 
 bool HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() const {
@@ -215,9 +210,10 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() 
 
   if (IsInCooldown()) {
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    AWS_LOGSTREAM_WARN(
-        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-        "Skipping credential reload — in cooldown after previous failure." << " has_valid_cached=" << hasExisting);
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Skipping credential reload — in cooldown after previous failure. "
+        "has_valid_cached={}",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, hasExisting);
     return;
   }
 

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
@@ -1,4 +1,7 @@
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudSTSClient.h"
+
+#include "milvus-storage/common/log.h"
+
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpResponse.h>
@@ -19,7 +22,8 @@ HuaweiCloudSTSCredentialsClient::HuaweiCloudSTSCredentialsClient(
   SetErrorMarshaller(Aws::MakeUnique<Aws::Client::XmlErrorMarshaller>(STS_RESOURCE_CLIENT_LOG_TAG));
   m_token_endpoint = "https://iam.{region}.myhuaweicloud.com/v3.0/OS-AUTH/id-token/tokens";
   m_httpClient = Aws::Http::CreateHttpClient(clientConfiguration);
-  AWS_LOGSTREAM_INFO(STS_RESOURCE_CLIENT_LOG_TAG, "Creating STS ResourceClient with endpoint: " << m_token_endpoint);
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Creating STS ResourceClient with endpoint: {}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                   m_token_endpoint);
 }
 
 HuaweiCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityResult
@@ -70,51 +74,51 @@ HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     // base class (AWSErrorMarshaller, "Can not retrieve resource"). However, we
     // retain this call to preserve the AWS SDK's built-in retry/backoff mechanism.
     // The response code and headers are still correctly returned for our checks.
-    AWS_LOGSTREAM_INFO(STS_RESOURCE_CLIENT_LOG_TAG,
-                       "Stage 1: Requesting IAM token from OIDC endpoint, region=" << request.region);
+    LOG_STORAGE_INFO_ << fmt::format("[{}] Stage 1: Requesting IAM token from OIDC endpoint, region={}",
+                                     STS_RESOURCE_CLIENT_LOG_TAG, request.region);
     auto awsResult = GetResourceWithAWSWebServiceResult(httpRequest);
     auto responseCode = awsResult.GetResponseCode();
     if (responseCode != Aws::Http::HttpResponseCode::OK && responseCode != Aws::Http::HttpResponseCode::CREATED) {
-      AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
-                         "Failed to get credentials token from Huawei Cloud "
-                         "STS, response code: "
-                             << static_cast<int>(responseCode));
+      LOG_STORAGE_WARNING_ << fmt::format(
+          "[{}] Failed to get credentials token from Huawei Cloud STS, response "
+          "code: {}",
+          STS_RESOURCE_CLIENT_LOG_TAG, static_cast<int>(responseCode));
       return result;
     }
 
     auto responseHeaders = awsResult.GetHeaderValueCollection();
     auto subjectTokenIter = responseHeaders.find("x-subject-token");
     if (subjectTokenIter == responseHeaders.end()) {
-      AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "No x-subject-token in huawei cloud sts response headers");
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] No x-subject-token in huawei cloud sts response headers",
+                                          STS_RESOURCE_CLIENT_LOG_TAG);
       return result;
     }
 
     // Stage 2: Exchange IAM token for temporary AK/SK credentials
-    AWS_LOGSTREAM_INFO(STS_RESOURCE_CLIENT_LOG_TAG,
-                       "Stage 1 succeeded. Stage 2: Exchanging IAM token for temporary AK/SK (duration_seconds=7200)");
+    LOG_STORAGE_INFO_ << fmt::format(
+        "[{}] Stage 1 succeeded. Stage 2: Exchanging IAM token for temporary AK/SK "
+        "(duration_seconds=7200)",
+        STS_RESOURCE_CLIENT_LOG_TAG);
     const Aws::String subjectToken = subjectTokenIter->second;
     auto stsResult = callHuaweiCloudSTS(subjectToken, request);
     if (!stsResult.success) {
-      AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
-                         "Failed to get credentials from Huawei Cloud STS: " << stsResult.errorMessage);
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] Failed to get credentials from Huawei Cloud STS: {}",
+                                          STS_RESOURCE_CLIENT_LOG_TAG, stsResult.errorMessage);
       return result;
     }
 
     result.creds = stsResult.credentials;
     result.success = true;
-    auto akId = result.creds.GetAWSAccessKeyId();
-    Aws::String akPrefix = akId.length() > 4 ? akId.substr(0, 4) + "***" : akId;
-    AWS_LOGSTREAM_INFO(
-        STS_RESOURCE_CLIENT_LOG_TAG,
-        "Stage 2 succeeded. ak_prefix=" << akPrefix << ", expires_in_ms="
-                                        << (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
+    LOG_STORAGE_INFO_ << fmt::format("[{}] Stage 2 succeeded. expires_in_ms={}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                     (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
   } catch (const std::exception& e) {
     result.success = false;
-    AWS_LOGSTREAM_ERROR(STS_RESOURCE_CLIENT_LOG_TAG,
-                        "Exception during Huawei Cloud STS credential retrieval: " << e.what());
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Exception during Huawei Cloud STS credential retrieval: {}",
+                                      STS_RESOURCE_CLIENT_LOG_TAG, e.what());
   } catch (...) {
     result.success = false;
-    AWS_LOGSTREAM_ERROR(STS_RESOURCE_CLIENT_LOG_TAG, "Unknown exception during Huawei Cloud STS credential retrieval");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Unknown exception during Huawei Cloud STS credential retrieval",
+                                      STS_RESOURCE_CLIENT_LOG_TAG);
   }
   return result;
 }
@@ -152,15 +156,16 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   result.success = false;
   if (!resp) {
     result.errorMessage = "Null response from Huawei Cloud STS HTTP request";
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Security token request returned null response");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Security token request returned null response",
+                                        STS_RESOURCE_CLIENT_LOG_TAG);
     return result;
   }
   auto httpResponseCode = resp->GetResponseCode();
   if (httpResponseCode != Aws::Http::HttpResponseCode::OK && httpResponseCode != Aws::Http::HttpResponseCode::CREATED) {
     result.errorMessage = "Huawei Cloud STS security token request failed with HTTP code: " +
                           std::to_string(static_cast<int>(httpResponseCode));
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
-                       "Security token request failed, HTTP code=" << static_cast<int>(httpResponseCode));
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Security token request failed, HTTP code={}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                        static_cast<int>(httpResponseCode));
     return result;
   }
   std::ostringstream oss;

--- a/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
@@ -16,11 +16,12 @@
 
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <fstream>
 
 #include <aws/core/config/AWSProfileConfigLoader.h>
 #include <aws/core/platform/Environment.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/utils/UUID.h>
 
@@ -47,48 +48,43 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   }
 
   if (m_tokenFile.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Token file must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Token file must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved token_file from profile_config or "
-                        "environment variable to be "
-                            << m_tokenFile);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved token_file from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_tokenFile);
   }
 
   if (m_roleArn.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "RoleArn must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] RoleArn must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved role_arn from profile_config or "
-                        "environment variable to be "
-                            << m_roleArn);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved role_arn from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_roleArn);
   }
 
   if (m_region.empty()) {
-    AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                       "Region must be specified to use STS AssumeRole "
-                       "web identity creds provider.");
+    LOG_STORAGE_WARNING_ << fmt::format(
+        "[{}] Region must be specified to use STS AssumeRole web identity creds "
+        "provider.",
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
     return;  // No need to do further constructing
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved region from profile_config or "
-                        "environment variable to be "
-                            << m_region);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved region from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_region);
   }
 
   if (m_sessionName.empty()) {
     m_sessionName = Aws::Utils::UUID::RandomUUID();
   } else {
-    AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                        "Resolved session_name from profile_config or "
-                        "environment variable to be "
-                            << m_sessionName);
+    LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved session_name from profile_config or environment variable to be {}",
+                                      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_sessionName);
   }
 
   Aws::Client::ClientConfiguration config;
@@ -104,7 +100,8 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
 
   m_client = Aws::MakeUnique<TencentCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
-  AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Creating STS AssumeRole with web identity creds provider.",
+                                   STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
 }
 
 Aws::Auth::AWSCredentials TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
@@ -119,7 +116,8 @@ Aws::Auth::AWSCredentials TencentCloudSTSAssumeRoleWebIdentityCredentialsProvide
 }
 
 void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
-  AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Credentials have expired, attempting to renew from STS.");
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials have expired, attempting to renew from STS.",
+                                   STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
 
   Aws::IFStream tokenFile(m_tokenFile.c_str());
   if (tokenFile) {
@@ -129,17 +127,17 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     }
     m_token = token;
   } else {
-    AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Can't open token file: {}", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+                                      m_tokenFile);
     return;
   }
   TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_region, m_providerId, m_token,
                                                                                 m_roleArn, m_sessionName};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
-  AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-                      "Successfully retrieved credentials with AWS_ACCESS_KEY: "
-                          << result.creds.GetAWSAccessKeyId() << ", expiration_count_diff_ms: "
-                          << (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
+  LOG_STORAGE_DEBUG_ << fmt::format("[{}] Successfully retrieved credentials, expiration_count_diff_ms: {}",
+                                    STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+                                    (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
   m_credentials = result.creds;
 }
 

--- a/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
@@ -16,6 +16,8 @@
 
 #include "milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h"
 
+#include "milvus-storage/common/log.h"
+
 #include <mutex>
 #include <sstream>
 
@@ -24,7 +26,6 @@
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpResponse.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/platform/Environment.h>
 #include <aws/core/client/AWSError.h>
@@ -44,7 +45,8 @@ TencentCloudSTSCredentialsClient::TencentCloudSTSCredentialsClient(
   // [tencent cloud]
   m_endpoint = "https://sts.tencentcloudapi.com";
 
-  AWS_LOGSTREAM_INFO(STS_RESOURCE_CLIENT_LOG_TAG, "Creating STS ResourceClient with endpoint: " << m_endpoint);
+  LOG_STORAGE_INFO_ << fmt::format("[{}] Creating STS ResourceClient with endpoint: {}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                   m_endpoint);
 }
 
 TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityResult
@@ -93,7 +95,7 @@ TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
   // Parse credentials
   STSAssumeRoleWithWebIdentityResult result;
   if (credentialsStr.empty()) {
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Get an empty credential from sts");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get an empty credential from sts", STS_RESOURCE_CLIENT_LOG_TAG);
     return result;
   }
 
@@ -101,13 +103,13 @@ TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
   auto json = jsonValue.View();
   auto rootNode = json.GetObject("Response");
   if (rootNode.IsNull()) {
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Get Response from credential result failed");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get Response from credential result failed", STS_RESOURCE_CLIENT_LOG_TAG);
     return result;
   }
 
   auto credentialsNode = rootNode.GetObject("Credentials");
   if (credentialsNode.IsNull()) {
-    AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG, "Get Credentials from Response failed");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get Credentials from Response failed", STS_RESOURCE_CLIENT_LOG_TAG);
     return result;
   }
   result.creds.SetAWSAccessKeyId(credentialsNode.GetString("TmpSecretId"));

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -182,7 +182,9 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
   // 3. Explicit access key / secret key
   if (!config_.role_arn.empty()) {
     LOG_STORAGE_DEBUG_ << "using AssumeRole credentials, cloud_provider=" << config_.cloud_provider
-                       << ", role_arn=" << config_.role_arn << ", load_frequency=" << config_.load_frequency;
+                       << ", role_arn=" << config_.role_arn
+                       << ", external_id_set=" << (config_.external_id.empty() ? "false" : "true")
+                       << ", load_frequency=" << config_.load_frequency;
     if (config_.cloud_provider == kCloudProviderAWS) {
       options.ConfigureAssumeRoleCredentials(config_.role_arn, config_.session_name, config_.external_id,
                                              config_.load_frequency);

--- a/cpp/src/format/iceberg/iceberg_common.cpp
+++ b/cpp/src/format/iceberg/iceberg_common.cpp
@@ -69,9 +69,11 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
 
   const auto& provider = config.cloud_provider;
   LOG_STORAGE_DEBUG_ << fmt::format(
-      "provider={}, endpoint={}, use_ssl={}, use_iam={}, has_aksk={}, role_arn={}, gcp_target_sa={}", provider,
-      config.address, config.use_ssl, config.use_iam, !config.access_key_id.empty() && !config.access_key_value.empty(),
-      config.role_arn.empty() ? "(empty)" : config.role_arn,
+      "provider={}, endpoint={}, use_ssl={}, use_iam={}, has_aksk={}, role_arn={}, external_id_set={}, "
+      "gcp_target_sa={}",
+      provider, config.address, config.use_ssl, config.use_iam,
+      !config.access_key_id.empty() && !config.access_key_value.empty(),
+      config.role_arn.empty() ? "(empty)" : config.role_arn, !config.external_id.empty(),
       config.gcp_target_service_account.empty() ? "(empty)" : config.gcp_target_service_account);
   if (provider == kCloudProviderAWS) {
     if (!config.role_arn.empty()) {

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -44,9 +44,11 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
 
   const auto& provider = config.cloud_provider;
   LOG_STORAGE_DEBUG_ << fmt::format(
-      "provider={}, endpoint={}, use_ssl={}, use_iam={}, has_aksk={}, role_arn={}, gcp_target_sa={}", provider,
-      config.address, config.use_ssl, config.use_iam, !config.access_key_id.empty() && !config.access_key_value.empty(),
-      config.role_arn.empty() ? "(empty)" : config.role_arn,
+      "provider={}, endpoint={}, use_ssl={}, use_iam={}, has_aksk={}, role_arn={}, external_id_set={}, "
+      "gcp_target_sa={}",
+      provider, config.address, config.use_ssl, config.use_iam,
+      !config.access_key_id.empty() && !config.access_key_value.empty(),
+      config.role_arn.empty() ? "(empty)" : config.role_arn, !config.external_id.empty(),
       config.gcp_target_service_account.empty() ? "(empty)" : config.gcp_target_service_account);
   if (provider == kCloudProviderAWS) {
     if (!config.role_arn.empty()) {

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -91,6 +91,7 @@ arrow::Status LanceTableReader::open() {
     auto lance_uri = ToStandardLanceUri(uri_);
     LOG_STORAGE_DEBUG_ << "uri=" << uri_ << ", lance_uri=" << lance_uri << ", alias=" << fs_config.alias
                        << ", role_arn=" << (fs_config.role_arn.empty() ? "(empty)" : fs_config.role_arn)
+                       << ", external_id_set=" << (fs_config.external_id.empty() ? "false" : "true")
                        << ", use_iam=" << fs_config.use_iam;
     dataset_ = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config));
   }

--- a/cpp/test/format/fs_cache_test.cpp
+++ b/cpp/test/format/fs_cache_test.cpp
@@ -103,6 +103,135 @@ TEST_F(FileSystemCacheTest, Basic) {
   EXPECT_EQ(cache.size(), 0);
 }
 
+TEST_F(FileSystemCacheTest, CacheKeyIncludesCredentialIdentity) {
+  ArrowFileSystemConfig base;
+  base.storage_type = "remote";
+  base.cloud_provider = kCloudProviderAWS;
+  base.address = "s3.amazonaws.com";
+  base.bucket_name = "shared-bucket";
+  base.role_arn = "arn:aws:iam::111111111111:role/source";
+  base.session_name = "source-session";
+  base.external_id = "source-external";
+
+  auto different_role = base;
+  different_role.role_arn = "arn:aws:iam::222222222222:role/target";
+  EXPECT_NE(base.GetCacheKey(), different_role.GetCacheKey());
+
+  auto different_external_id = base;
+  different_external_id.external_id = "target-external";
+  EXPECT_NE(base.GetCacheKey(), different_external_id.GetCacheKey());
+
+  ArrowFileSystemConfig static_credentials = base;
+  static_credentials.role_arn.clear();
+  static_credentials.session_name.clear();
+  static_credentials.external_id.clear();
+  static_credentials.access_key_id = "ak-a";
+  static_credentials.access_key_value = "sk-a";
+
+  auto different_secret = static_credentials;
+  different_secret.access_key_value = "sk-b";
+  EXPECT_NE(static_credentials.GetCacheKey(), different_secret.GetCacheKey());
+
+  EXPECT_EQ(static_credentials.GetCacheKey(), static_credentials.GetCacheKey());
+}
+
+TEST_F(FileSystemCacheTest, CacheKeyIgnoresUnusedCredentialFields) {
+  ArrowFileSystemConfig assumed_role;
+  assumed_role.storage_type = "remote";
+  assumed_role.cloud_provider = kCloudProviderAWS;
+  assumed_role.address = "s3.amazonaws.com";
+  assumed_role.bucket_name = "shared-bucket";
+  assumed_role.role_arn = "arn:aws:iam::111111111111:role/source";
+  assumed_role.session_name = "source-session";
+  assumed_role.external_id = "source-external";
+  assumed_role.access_key_id = "ak-a";
+  assumed_role.access_key_value = "sk-a";
+
+  auto different_static_credentials = assumed_role;
+  different_static_credentials.access_key_id = "ak-b";
+  different_static_credentials.access_key_value = "sk-b";
+  different_static_credentials.use_iam = true;
+  EXPECT_EQ(assumed_role.GetCacheKey(), different_static_credentials.GetCacheKey());
+
+  ArrowFileSystemConfig gcp_impersonation;
+  gcp_impersonation.storage_type = "remote";
+  gcp_impersonation.cloud_provider = kCloudProviderGCP;
+  gcp_impersonation.address = "storage.googleapis.com";
+  gcp_impersonation.bucket_name = "shared-bucket";
+  gcp_impersonation.use_iam = true;
+  gcp_impersonation.gcp_target_service_account = "source@project.iam.gserviceaccount.com";
+  gcp_impersonation.access_key_id = "ak-a";
+  gcp_impersonation.access_key_value = "sk-a";
+  gcp_impersonation.load_frequency = 1800;
+
+  auto different_static_credentials_for_gcp = gcp_impersonation;
+  different_static_credentials_for_gcp.access_key_id = "ak-b";
+  different_static_credentials_for_gcp.access_key_value = "sk-b";
+  EXPECT_EQ(gcp_impersonation.GetCacheKey(), different_static_credentials_for_gcp.GetCacheKey());
+
+  auto different_role_arn_for_gcp = gcp_impersonation;
+  different_role_arn_for_gcp.role_arn = "arn:aws:iam::111111111111:role/unused";
+  different_role_arn_for_gcp.session_name = "unused-session";
+  different_role_arn_for_gcp.external_id = "unused-external";
+  EXPECT_EQ(gcp_impersonation.GetCacheKey(), different_role_arn_for_gcp.GetCacheKey());
+}
+
+TEST_F(FileSystemCacheTest, GcpCacheKeyUsesImpersonationIdentityOnly) {
+  ArrowFileSystemConfig base;
+  base.storage_type = "remote";
+  base.cloud_provider = kCloudProviderGCP;
+  base.address = "storage.googleapis.com";
+  base.bucket_name = "shared-bucket";
+  base.use_iam = true;
+  base.gcp_target_service_account = "source@project.iam.gserviceaccount.com";
+  base.load_frequency = 1800;
+
+  auto different_target_sa = base;
+  different_target_sa.gcp_target_service_account = "target@project.iam.gserviceaccount.com";
+  EXPECT_NE(base.GetCacheKey(), different_target_sa.GetCacheKey());
+}
+
+TEST_F(FileSystemCacheTest, CacheKeyIgnoresAlias) {
+  ArrowFileSystemConfig base;
+  base.storage_type = "remote";
+  base.cloud_provider = kCloudProviderAWS;
+  base.address = "s3.amazonaws.com";
+  base.bucket_name = "shared-bucket";
+  base.access_key_id = "ak";
+  base.access_key_value = "sk";
+
+  auto with_alias = base;
+  with_alias.alias = "external-a";
+  EXPECT_EQ(base.GetCacheKey(), with_alias.GetCacheKey());
+}
+
+TEST_F(FileSystemCacheTest, FilesystemCacheSeparatesSameBucketWithDifferentCredentials) {
+  auto make_props = [](const std::string& access_key, const std::string& secret_key) {
+    api::Properties props;
+    props[PROPERTY_FS_ADDRESS] = std::string("s3.amazonaws.com");
+    props[PROPERTY_FS_BUCKET_NAME] = std::string("shared-bucket");
+    props[PROPERTY_FS_STORAGE_TYPE] = std::string("remote");
+    props[PROPERTY_FS_CLOUD_PROVIDER] = std::string(kCloudProviderAWS);
+    props[PROPERTY_FS_ACCESS_KEY_ID] = access_key;
+    props[PROPERTY_FS_ACCESS_KEY_VALUE] = secret_key;
+    return props;
+  };
+
+  auto& cache = FilesystemCache::getInstance();
+  cache.set_capacity(10);
+
+  auto props_a = make_props("ak", "sk-a");
+  auto props_b = make_props("ak", "sk-b");
+
+  ASSERT_AND_ASSIGN(auto fs_a, cache.get(props_a));
+  ASSERT_AND_ASSIGN(auto fs_a_again, cache.get(props_a));
+  ASSERT_AND_ASSIGN(auto fs_b, cache.get(props_b));
+
+  EXPECT_EQ(fs_a, fs_a_again);
+  EXPECT_NE(fs_a, fs_b);
+  EXPECT_EQ(cache.size(), 2u);
+}
+
 TEST_F(FileSystemCacheTest, FileSystemCacheLRUEviction) {
   auto& cache = FilesystemCache::getInstance();
   cache.set_capacity(2);


### PR DESCRIPTION
This fixes the filesystem cache key regression from d7f75df. Before that change, the cache used ArrowFileSystemConfig itself as the key, so multiple config fields were part of the identity. that change switched the cache to a string key based on address/bucket, which made configs for the same bucket reuse one filesystem even when they were using different credentials.

That breaks the cross-tenant and per-tenant cases we now rely on, where the same bucket can be opened with different role_arn, external_id, GCP target service account, or static credentials in the same process. This change makes GetCacheKey include the fields that actually define the filesystem identity, while still ignoring credential fields that are unused by the selected auth path.

Also this commit moves the related AWS SDK logs over to glog so cases where credentials fail to build and the SDK falls back to anonymous credentials are much easier to debug.