### PR TITLE
fix:[2.6] use std::call_once to eliminate TOCTOU race in S3 initialization(#415)

### DIFF
--- a/cpp/src/filesystem/s3/s3_fs.cpp
+++ b/cpp/src/filesystem/s3/s3_fs.cpp
@@ -15,6 +15,8 @@
 #include "milvus-storage/filesystem/s3/s3_fs.h"
 
 #include <cstdlib>
+#include <mutex>
+#include <sstream>
 
 #include <curl/curl.h>
 #include <aws/core/auth/AWSCredentials.h>
@@ -168,7 +170,8 @@ class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
 };
 
 void S3FileSystemProducer::InitS3() {
-  if (!IsS3Initialized()) {
+  static std::once_flag s3_init_flag;
+  std::call_once(s3_init_flag, [this]() {
     S3GlobalOptions global_options;
     global_options.log_level = LogLevel_Map[config_.log_level];
 
@@ -205,7 +208,7 @@ void S3FileSystemProducer::InitS3() {
         throw std::invalid_argument("ArrowFileSystem failed to finalize S3: " + status.ToString());
       }
     });
-  }
+  });
 }
 
 arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus-storage/pull/415

  The old code checks IsS3Initialized() then calls InitializeS3(), but
  there's a window between the check and the call where another thread
  can slip through. When that happens the second thread gets back
  "S3 was already initialized" as an Invalid status, which we treat as
  a hard error and throw. This crashes Spark tasks that hit InitS3()
  concurrently through the FilesystemCache -> S3FileSystemProducer path.

  Replace the if-guard with a static std::once_flag and std::call_once
  so the init block runs exactly once and all other threads just wait
  for it to finish. This matches the same pattern already used inside
  AwsInstance::EnsureInitialized() in s3_global.cpp.