### PR TITLE
feat: add predicate pushdown for Vortex format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ python/.venv/
 python/venv/
 python/env/
 .claude/
+.worktrees/

--- a/cpp/benchmark/CMakeLists.txt
+++ b/cpp/benchmark/CMakeLists.txt
@@ -11,6 +11,7 @@ set(BENCHMARK_SOURCES
 list(APPEND BENCHMARK_SOURCES
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_format_write.cpp
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_format_read.cpp
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_predicate.cpp
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_v2_v3.cpp
 )
 

--- a/cpp/benchmark/benchmark_predicate.cpp
+++ b/cpp/benchmark/benchmark_predicate.cpp
@@ -1,0 +1,267 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark_format_common.h"
+
+#include <iomanip>
+#include <sstream>
+#include <thread>
+#include <arrow/table.h>
+#include "milvus-storage/thread_pool.h"
+#include "milvus-storage/filesystem/observable.h"
+
+namespace milvus_storage::benchmark {
+
+using namespace milvus_storage::api;
+
+//=============================================================================
+// Predicate Pushdown Benchmark
+//
+// Args: [sorted, selectivity_pct, predicate_col]
+//   sorted: 0 = unsorted (random), 1 = sorted (sequential)
+//   selectivity_pct: 0 = no predicate, 10 = keep 10%, 50 = keep 50%, 90 = keep 90%
+//   predicate_col: 0 = int64 (id), 1 = string (name)
+//=============================================================================
+
+/// Zero-pad an integer to a fixed width string
+static std::string ZeroPad(int64_t val, int width) {
+  std::ostringstream oss;
+  oss << std::setw(width) << std::setfill('0') << val;
+  return oss.str();
+}
+
+class PredicateBenchmark : public FormatBenchFixtureBase<> {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    FormatBenchFixtureBase<>::SetUp(st);
+    schema_ = GetLoaderSchema();
+  }
+
+  void TearDown(::benchmark::State& st) override {
+    schema_.reset();
+    ThreadPoolHolder::Release();
+    FormatBenchFixtureBase<>::TearDown(st);
+  }
+
+  protected:
+  /// Build a RecordBatch with zero-padded names.
+  /// Both sorted and unsorted use the SAME values (id=0..N-1, name="name_00000"..),
+  /// so predicates have identical selectivity. The only difference is row order:
+  /// sorted = sequential, unsorted = shuffled. This isolates the effect of
+  /// data ordering (zone-map pruning) from predicate selectivity.
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreatePaddedBatch(const std::shared_ptr<arrow::Schema>& schema,
+                                                                       const DataSizeConfig& config,
+                                                                       bool sorted) {
+    int64_t num_rows = static_cast<int64_t>(config.num_rows);
+    int pad_width = static_cast<int>(std::to_string(num_rows - 1).size());
+
+    // Generate row indices: 0..N-1, then optionally shuffle
+    std::vector<int64_t> indices(num_rows);
+    std::iota(indices.begin(), indices.end(), 0);
+    if (!sorted) {
+      std::mt19937 rng(42);  // fixed seed for reproducibility
+      std::shuffle(indices.begin(), indices.end(), rng);
+    }
+
+    arrow::Int64Builder id_builder;
+    arrow::StringBuilder name_builder;
+    arrow::DoubleBuilder value_builder;
+    arrow::ListBuilder vector_builder(arrow::default_memory_pool(), std::make_shared<arrow::FloatBuilder>());
+    auto& float_builder = *static_cast<arrow::FloatBuilder*>(vector_builder.value_builder());
+
+    ARROW_RETURN_NOT_OK(id_builder.Reserve(num_rows));
+    ARROW_RETURN_NOT_OK(name_builder.Reserve(num_rows));
+    ARROW_RETURN_NOT_OK(value_builder.Reserve(num_rows));
+
+    for (int64_t row = 0; row < num_rows; ++row) {
+      int64_t i = indices[row];
+      ARROW_RETURN_NOT_OK(id_builder.Append(i));
+      ARROW_RETURN_NOT_OK(name_builder.Append("name_" + ZeroPad(i, pad_width)));
+      ARROW_RETURN_NOT_OK(value_builder.Append(i * 1.5));
+
+      ARROW_RETURN_NOT_OK(vector_builder.Append());
+      for (size_t d = 0; d < config.vector_dim; ++d) {
+        ARROW_RETURN_NOT_OK(float_builder.Append(static_cast<float>(i * config.vector_dim + d)));
+      }
+    }
+
+    std::shared_ptr<arrow::Array> id_arr, name_arr, value_arr, vector_arr;
+    ARROW_RETURN_NOT_OK(id_builder.Finish(&id_arr));
+    ARROW_RETURN_NOT_OK(name_builder.Finish(&name_arr));
+    ARROW_RETURN_NOT_OK(value_builder.Finish(&value_arr));
+    ARROW_RETURN_NOT_OK(vector_builder.Finish(&vector_arr));
+
+    return arrow::RecordBatch::Make(schema, num_rows, {id_arr, name_arr, value_arr, vector_arr});
+  }
+
+  arrow::Status PrepareTestData(const std::string& format,
+                                bool sorted,
+                                std::shared_ptr<ColumnGroups>& out_cgs,
+                                std::string& out_path,
+                                int64_t& out_num_rows) {
+    out_path = GetUniquePath(format + "_predicate_test");
+
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSinglePolicy(format, schema_));
+
+    auto writer = Writer::create(out_path, schema_, std::move(policy), properties_);
+    if (!writer) {
+      return arrow::Status::Invalid("Failed to create writer");
+    }
+
+    auto data_config = DataSizeConfig::Medium();
+    ARROW_ASSIGN_OR_RAISE(auto batch, CreatePaddedBatch(schema_, data_config, sorted));
+    out_num_rows = batch->num_rows();
+    ARROW_RETURN_NOT_OK(writer->write(batch));
+    ARROW_ASSIGN_OR_RAISE(out_cgs, writer->close());
+    return arrow::Status::OK();
+  }
+
+  /// Build predicate string. For sorted data with padded names,
+  /// lexicographic and numeric order match.
+  static std::string BuildPredicate(int selectivity_pct, int predicate_col, int64_t num_rows) {
+    if (selectivity_pct <= 0 || selectivity_pct >= 100) {
+      return "";
+    }
+
+    int64_t threshold = num_rows * (100 - selectivity_pct) / 100;
+
+    if (predicate_col == 0) {
+      return "id > " + std::to_string(threshold);
+    } else {
+      int pad_width = static_cast<int>(std::to_string(num_rows - 1).size());
+      return "name > 'name_" + ZeroPad(threshold, pad_width) + "'";
+    }
+  }
+
+  std::shared_ptr<FilesystemMetrics> GetFsMetrics() {
+    auto observable = std::dynamic_pointer_cast<Observable>(fs_);
+    return observable ? observable->GetMetrics() : nullptr;
+  }
+
+  std::shared_ptr<arrow::Schema> schema_;
+};
+
+// Args: [sorted, selectivity_pct, predicate_col]
+BENCHMARK_DEFINE_F(PredicateBenchmark, ReadWithPredicate)(::benchmark::State& st) {
+  bool sorted = st.range(0) != 0;
+  int selectivity_pct = static_cast<int>(st.range(1));
+  int predicate_col = static_cast<int>(st.range(2));
+
+  std::string format = LOON_FORMAT_VORTEX;
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+
+  MemoryConfig memory_config = MemoryConfig::Default();
+  ConfigureMemory(memory_config);
+  ThreadPoolHolder::WithSingleton(1);
+
+  std::shared_ptr<ColumnGroups> cgs;
+  std::string path;
+  int64_t num_rows = 0;
+  BENCH_ASSERT_STATUS_OK(PrepareTestData(format, sorted, cgs, path, num_rows), st);
+
+  std::string predicate = BuildPredicate(selectivity_pct, predicate_col, num_rows);
+  auto fs_metrics = GetFsMetrics();
+
+  int64_t total_rows_read = 0;
+  int64_t total_bytes_read = 0;
+  int64_t total_io_bytes = 0;
+  int64_t total_io_count = 0;
+
+  for (auto _ : st) {
+    if (fs_metrics) {
+      fs_metrics->Reset();
+    }
+
+    auto reader = Reader::create(cgs, schema_, nullptr, properties_);
+    BENCH_ASSERT_NOT_NULL(reader, st);
+
+    std::shared_ptr<arrow::RecordBatchReader> batch_reader;
+    if (predicate.empty()) {
+      BENCH_ASSERT_AND_ASSIGN(batch_reader, reader->get_record_batch_reader(), st);
+    } else {
+      BENCH_ASSERT_AND_ASSIGN(batch_reader, reader->get_record_batch_reader(predicate), st);
+    }
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      BENCH_ASSERT_STATUS_OK(batch_reader->ReadNext(&batch), st);
+      if (!batch)
+        break;
+      total_rows_read += batch->num_rows();
+      total_bytes_read += CalculateRawDataSize(batch);
+    }
+
+    if (fs_metrics) {
+      total_io_bytes += fs_metrics->GetReadBytes();
+      total_io_count += fs_metrics->GetReadCount();
+    }
+  }
+
+  // Report metrics
+  ReportThroughput(st, total_bytes_read, total_rows_read);
+
+  double iters = static_cast<double>(st.iterations());
+
+  // Selectivity
+  double actual_selectivity = (iters > 0 && num_rows > 0)
+                                  ? static_cast<double>(total_rows_read) / (iters * static_cast<double>(num_rows))
+                                  : 0.0;
+  st.counters["selectivity"] = ::benchmark::Counter(actual_selectivity, ::benchmark::Counter::kDefaults);
+
+  // I/O metrics
+  if (total_io_bytes > 0) {
+    st.counters["io_bytes_per_iter"] =
+        ::benchmark::Counter(static_cast<double>(total_io_bytes) / iters, ::benchmark::Counter::kDefaults);
+    st.counters["io_count_per_iter"] =
+        ::benchmark::Counter(static_cast<double>(total_io_count) / iters, ::benchmark::Counter::kDefaults);
+  }
+
+  // CPU time ratio (CPU time / wall time) — measures CPU utilization
+  // Google Benchmark reports both Time (wall) and CPU columns;
+  // cpu_time_ratio > 1.0 means multi-threaded CPU usage.
+  // We don't need to compute it manually — the Time and CPU columns suffice.
+
+  // Label
+  std::string col_name = (predicate_col == 0) ? "int64" : "string";
+  std::string label = format + "/" + (sorted ? "sorted" : "unsorted") + "/";
+  if (selectivity_pct == 0) {
+    label += "no_predicate";
+  } else {
+    label += col_name + "_" + std::to_string(selectivity_pct) + "pct";
+  }
+  label += "/" + GetDataDescription();
+  st.SetLabel(label);
+}
+
+BENCHMARK_REGISTER_F(PredicateBenchmark, ReadWithPredicate)
+    ->ArgsProduct({
+        {0, 1},           // sorted: unsorted(0), sorted(1)
+        {0, 10, 50, 90},  // selectivity: no_predicate(0), 10%, 50%, 90%
+        {0}               // predicate_col: int64(0)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_REGISTER_F(PredicateBenchmark, ReadWithPredicate)
+    ->ArgsProduct({
+        {0, 1},        // sorted: unsorted(0), sorted(1)
+        {10, 50, 90},  // selectivity: 10%, 50%, 90%
+        {1}            // predicate_col: string(1)
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+}  // namespace milvus_storage::benchmark

--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -58,7 +58,8 @@ class ColumnGroupReader {
       const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
       const std::vector<std::string>& needed_columns,
       const milvus_storage::api::Properties& properties,
-      const std::function<std::string(const std::string&)>& key_retriever);
+      const std::function<std::string(const std::string&)>& key_retriever,
+      const std::string& predicate = "");
 };
 
 }  // namespace milvus_storage::api

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -86,6 +86,9 @@ class FormatReader {
   // get the file schema of this reader (always derived from file metadata, not projected)
   [[nodiscard]] virtual std::shared_ptr<arrow::Schema> get_schema() const = 0;
 
+  // set a predicate string for filtering (default no-op for formats that don't support it)
+  virtual void set_predicate(const std::string& /*predicate*/) {}
+
   // create format reader
   static arrow::Result<std::shared_ptr<FormatReader>> create(
       const std::shared_ptr<arrow::Schema>& read_schema,

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -57,6 +57,8 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
 
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
+  void set_predicate(const std::string& predicate) override;
+
   // get the row ranges(splits) of the file
   inline std::vector<uint64_t> row_ranges() const { return vxfile_->Splits(); }
 
@@ -88,6 +90,7 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   uint64_t logical_chunk_rows_;
   std::vector<RowGroupInfo> row_group_infos_;
   std::unique_ptr<VortexFile> vxfile_;
+  std::unique_ptr<expr::Expr> parsed_predicate_;
 };
 
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
  "parquet 56.2.0",
  "rand 0.9.2",
  "regex",
- "sqlparser",
+ "sqlparser 0.58.0",
  "tempfile",
  "tokio",
  "url",
@@ -2050,7 +2050,7 @@ dependencies = [
  "parquet 56.2.0",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.58.0",
  "tokio",
  "web-time",
 ]
@@ -2231,7 +2231,7 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.58.0",
 ]
 
 [[package]]
@@ -2566,7 +2566,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.58.0",
 ]
 
 [[package]]
@@ -6395,6 +6395,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "snafu",
+ "sqlparser 0.55.0",
  "take_mut",
  "tempfile",
  "tokio",
@@ -6985,6 +6986,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4521174166bac1ff04fe16ef4524c70144cd29682a45978978ca3d7f4e0be11"
+dependencies = [
+ "log",
+ "recursive",
 ]
 
 [[package]]

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -78,6 +78,9 @@ hmac = "0.12"
 sha1 = "0.10"
 base64 = "0.22"
 
+# SQL predicate parsing
+sqlparser = "0.55"
+
 # CXX bridge
 cxx = "1.0.184"
 

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -152,6 +152,8 @@ Expr and_(Expr lhs, Expr rhs);
 Expr or_(Expr lhs, Expr rhs);
 Expr checked_add(Expr lhs, Expr rhs);
 Expr select(const std::vector<std::string_view>& fields, Expr child);
+/// Parse a SQL predicate string into a Vortex expression.
+Expr parse_predicate(const std::string& predicate);
 }  // namespace expr
 
 class ScanBuilder;

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 #include <cstdint>
+#include <optional>
 #include <type_traits>
 #include <vector>
 #include <stdexcept>
@@ -152,8 +153,22 @@ Expr and_(Expr lhs, Expr rhs);
 Expr or_(Expr lhs, Expr rhs);
 Expr checked_add(Expr lhs, Expr rhs);
 Expr select(const std::vector<std::string_view>& fields, Expr child);
+
+/// Column metadata passed to predicate parsing. `type_tag` mirrors the small
+/// Rust-side enum:
+///   0=Int, 1=UInt, 2=Float, 3=Utf8, 4=Bool, 5=Other.
+struct PredicateColumn {
+  std::string name;
+  uint8_t type_tag;
+};
+
 /// Parse a SQL predicate string into a Vortex expression.
-Expr parse_predicate(const std::string& predicate);
+///
+/// Returns std::nullopt when no usable filter remains after best-effort
+/// translation. Throws VortexException for hard errors (syntax error,
+/// unknown column, empty input). Warnings about dropped sub-expressions
+/// are emitted to stderr inside the Rust parser.
+std::optional<Expr> parse_predicate(const std::string& predicate, const std::vector<PredicateColumn>& schema);
 }  // namespace expr
 
 class ScanBuilder;

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -203,8 +203,16 @@ pub mod vortex_ffi {
         fn and_(lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr>;
         fn or_(lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr>;
         fn checked_add(lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr>;
-        fn parse_predicate_string(predicate: &str) -> Result<Box<Expr>>;
         fn select(fields: Vec<String>, child: Box<Expr>) -> Box<Expr>;
+
+        type ParsedPredicate;
+        fn parse_predicate_string(
+            predicate: &str,
+            column_names: Vec<String>,
+            column_type_tags: Vec<u8>,
+        ) -> Result<Box<ParsedPredicate>>;
+        fn has_filter(self: &ParsedPredicate) -> bool;
+        fn take_filter(self: &mut ParsedPredicate) -> Box<Expr>;
 
         // writer
         type VortexWriter;

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -15,6 +15,7 @@
 mod aliyun_oss_provider;
 mod gcp_impersonation;
 mod lance_bridgeimpl;
+mod predicate_parser;
 mod vortex_bridgeimpl;
 mod iceberg_bridgeimpl;
 mod iceberg_testutil;
@@ -202,6 +203,7 @@ pub mod vortex_ffi {
         fn and_(lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr>;
         fn or_(lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr>;
         fn checked_add(lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr>;
+        fn parse_predicate_string(predicate: &str) -> Result<Box<Expr>>;
         fn select(fields: Vec<String>, child: Box<Expr>) -> Box<Expr>;
 
         // writer

--- a/cpp/src/format/bridge/rust/src/predicate_parser.rs
+++ b/cpp/src/format/bridge/rust/src/predicate_parser.rs
@@ -1,0 +1,318 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Parses a SQL WHERE-clause predicate string into a `vortex::expr::Expression`.
+//!
+//! The predicate is wrapped in `SELECT * FROM t WHERE <predicate>` so that
+//! `sqlparser` can parse it as valid SQL. The WHERE clause AST is then
+//! converted into a Vortex expression tree.
+
+use anyhow::{bail, Result};
+use sqlparser::ast::{
+    BinaryOperator, Expr as SqlExpr, SetExpr, Statement, UnaryOperator, Value,
+};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::Parser;
+use vortex::expr::{self, Expression};
+
+/// Parse a SQL predicate string into a Vortex `Expression`.
+///
+/// The predicate should be a valid SQL WHERE-clause expression, e.g.:
+/// - `"age > 30"`
+/// - `"status IN (1, 2, 3)"`
+/// - `"(a > 1 OR b > 2) AND c = 3"`
+pub fn parse_predicate(predicate: &str) -> Result<Expression> {
+    let predicate = predicate.trim();
+    if predicate.is_empty() {
+        bail!("empty predicate");
+    }
+
+    let sql = format!("SELECT * FROM t WHERE {predicate}");
+    let dialect = GenericDialect {};
+    let statements = Parser::parse_sql(&dialect, &sql)
+        .map_err(|e| anyhow::anyhow!("failed to parse predicate: {e}"))?;
+
+    let statement = statements
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no statement parsed"))?;
+
+    let where_expr = extract_where(statement)?;
+    convert_expr(&where_expr)
+}
+
+/// Extract the WHERE clause expression from a parsed SELECT statement.
+fn extract_where(stmt: Statement) -> Result<SqlExpr> {
+    match stmt {
+        Statement::Query(query) => match *query.body {
+            SetExpr::Select(select) => select
+                .selection
+                .ok_or_else(|| anyhow::anyhow!("no WHERE clause found")),
+            _ => bail!("unexpected query body"),
+        },
+        _ => bail!("unexpected statement type"),
+    }
+}
+
+/// Convert a sqlparser AST expression into a Vortex expression.
+fn convert_expr(sql_expr: &SqlExpr) -> Result<Expression> {
+    match sql_expr {
+        // Column reference: bare or quoted identifier
+        SqlExpr::Identifier(ident) => {
+            Ok(expr::get_item(ident.value.clone(), expr::root()))
+        }
+
+        // Literal values
+        SqlExpr::Value(val) => convert_value(&val.value),
+
+        // Unary operators: NOT, negative sign
+        SqlExpr::UnaryOp { op, expr: operand } => match op {
+            UnaryOperator::Not => {
+                let inner = convert_expr(operand)?;
+                Ok(expr::not(inner))
+            }
+            UnaryOperator::Minus => {
+                // Negative literal: apply sign to the inner value
+                match operand.as_ref() {
+                    SqlExpr::Value(val) => convert_negative_value(&val.value),
+                    _ => bail!("unsupported unary minus on non-literal expression"),
+                }
+            }
+            _ => bail!("unsupported unary operator: {op}"),
+        },
+
+        // Binary operators: comparison, logical
+        SqlExpr::BinaryOp { left, op, right } => {
+            let lhs = convert_expr(left)?;
+            let rhs = convert_expr(right)?;
+            match op {
+                BinaryOperator::Eq => Ok(expr::eq(lhs, rhs)),
+                BinaryOperator::NotEq => Ok(expr::not_eq(lhs, rhs)),
+                BinaryOperator::Gt => Ok(expr::gt(lhs, rhs)),
+                BinaryOperator::GtEq => Ok(expr::gt_eq(lhs, rhs)),
+                BinaryOperator::Lt => Ok(expr::lt(lhs, rhs)),
+                BinaryOperator::LtEq => Ok(expr::lt_eq(lhs, rhs)),
+                BinaryOperator::And => Ok(expr::and(lhs, rhs)),
+                BinaryOperator::Or => Ok(expr::or(lhs, rhs)),
+                _ => bail!("unsupported binary operator: {op}"),
+            }
+        }
+
+        // Parenthesized expressions: (expr)
+        SqlExpr::Nested(inner) => convert_expr(inner),
+
+        // IN list: column IN (1, 2, 3)
+        SqlExpr::InList {
+            expr: target,
+            list,
+            negated,
+        } => {
+            let col = convert_expr(target)?;
+            if list.is_empty() {
+                bail!("empty IN list");
+            }
+            // Build: col = v1 OR col = v2 OR ...
+            let mut result: Option<Expression> = None;
+            for item in list {
+                let val = convert_expr(item)?;
+                let cmp = expr::eq(col.clone(), val);
+                result = Some(match result {
+                    None => cmp,
+                    Some(acc) => expr::or(acc, cmp),
+                });
+            }
+            let result = result.unwrap();
+            if *negated {
+                Ok(expr::not(result))
+            } else {
+                Ok(result)
+            }
+        }
+
+        // Function calls are not supported
+        SqlExpr::Function(f) => {
+            bail!("unsupported expression: function call `{}`", f.name)
+        }
+
+        _ => bail!("unsupported expression: {sql_expr}"),
+    }
+}
+
+/// Convert a sqlparser Value to a Vortex literal expression.
+fn convert_value(val: &Value) -> Result<Expression> {
+    match val {
+        Value::Number(s, _is_long) => {
+            // Try integer first, then float
+            if let Ok(i) = s.parse::<i64>() {
+                Ok(expr::lit(i))
+            } else if let Ok(f) = s.parse::<f64>() {
+                Ok(expr::lit(f))
+            } else {
+                bail!("cannot parse number: {s}")
+            }
+        }
+        Value::SingleQuotedString(s) => Ok(expr::lit(s.as_str())),
+        Value::DoubleQuotedString(s) => Ok(expr::lit(s.as_str())),
+        Value::Boolean(b) => Ok(expr::lit(*b)),
+        Value::Null => {
+            // Represent NULL as is_null on root — but this is unusual in
+            // predicates. For now, bail.
+            bail!("NULL literal not supported in predicates")
+        }
+        _ => bail!("unsupported literal value: {val}"),
+    }
+}
+
+/// Convert a negated sqlparser Value to a Vortex literal expression.
+fn convert_negative_value(val: &Value) -> Result<Expression> {
+    match val {
+        Value::Number(s, _) => {
+            if let Ok(i) = s.parse::<i64>() {
+                Ok(expr::lit(-i))
+            } else if let Ok(f) = s.parse::<f64>() {
+                Ok(expr::lit(-f))
+            } else {
+                bail!("cannot parse negative number: -{s}")
+            }
+        }
+        _ => bail!("unsupported negative literal: -{val}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: parse must succeed.
+    fn must_parse(predicate: &str) -> Expression {
+        parse_predicate(predicate).unwrap_or_else(|e| panic!("parse failed for '{predicate}': {e}"))
+    }
+
+    /// Count expression tree nodes by examining Debug output for "vtable:" occurrences.
+    fn count_nodes(expr: &Expression) -> usize {
+        let dbg = format!("{expr:?}");
+        dbg.matches("vtable:").count()
+    }
+
+    #[test]
+    fn test_simple_comparison() {
+        // age > 30 => binary(get_item(root), literal) — 4 nodes
+        let expr = must_parse("age > 30");
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn test_all_digit_column() {
+        // "1" > 10 => binary(get_item(root), literal) — 4 nodes
+        let expr = must_parse("\"1\" > 10");
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn test_and_expression() {
+        // a > 1 AND b < 2 => binary(binary(gi(root),lit), binary(gi(root),lit)) — 9 nodes
+        let expr = must_parse("a > 1 AND b < 2");
+        assert_eq!(count_nodes(&expr), 9);
+    }
+
+    #[test]
+    fn test_or_expression() {
+        // a > 1 OR b < 2 => same structure as AND
+        let expr = must_parse("a > 1 OR b < 2");
+        assert_eq!(count_nodes(&expr), 9);
+    }
+
+    #[test]
+    fn test_not_expression() {
+        // NOT a > 1 => not(binary(gi,lit)) — 5 nodes
+        let expr = must_parse("NOT a > 1");
+        assert_eq!(count_nodes(&expr), 5);
+    }
+
+    #[test]
+    fn test_in_list_integers() {
+        // status IN (1, 2, 3) => or(or(eq(gi,lit), eq(gi,lit)), eq(gi,lit))
+        // Each eq has gi(root)+lit = 4 nodes, 3 eqs = 12, plus 2 or = 14
+        let expr = must_parse("status IN (1, 2, 3)");
+        assert_eq!(count_nodes(&expr), 14);
+    }
+
+    #[test]
+    fn test_in_list_strings() {
+        let expr = must_parse("color IN ('red', 'blue', 'green')");
+        assert_eq!(count_nodes(&expr), 14);
+    }
+
+    #[test]
+    fn test_nested_parentheses() {
+        // (a > 1 OR b > 2) AND c = 3
+        // or(gt(gi(root),lit), gt(gi(root),lit)) = 1+4+4 = 9
+        // eq(gi(root),lit) = 4
+        // and(or_tree, eq_tree) = 1+9+4 = 14
+        let expr = must_parse("(a > 1 OR b > 2) AND c = 3");
+        assert_eq!(count_nodes(&expr), 14);
+    }
+
+    #[test]
+    fn test_negative_integer() {
+        // x = -10 => binary(get_item(root), literal) — 4 nodes
+        let expr = must_parse("x = -10");
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn test_negative_float() {
+        let expr = must_parse("x > -3.14");
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn test_float_comparison() {
+        let expr = must_parse("price >= 19.99");
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn test_operator_precedence() {
+        // a = 1 OR b = 2 AND c = 3
+        // SQL precedence: AND binds tighter => a = 1 OR (b = 2 AND c = 3)
+        // Top-level is OR with 2 children: eq(a,1) and and(eq(b,2),eq(c,3))
+        // eq=4 nodes each, and=1+4+4=9, or=1+4+9=14 — but "and" wraps two eqs
+        // Actually: or( eq(gi(root),lit), and(eq(gi(root),lit), eq(gi(root),lit)) )
+        // = 1(or) + 4(eq) + 1(and) + 4(eq) + 4(eq) = 14
+        let _expr = must_parse("a = 1 OR b = 2 AND c = 3");
+        // Just verify it parses; the structure is correct if sqlparser handles
+        // standard SQL operator precedence.
+        assert_eq!(count_nodes(&_expr), 14);
+    }
+
+    #[test]
+    fn test_unsupported_function_call() {
+        let result = parse_predicate("UPPER(name) = 'FOO'");
+        assert!(result.is_err(), "function call should fail");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("function") || err.contains("unsupported"),
+            "error should mention function: {err}"
+        );
+    }
+
+    #[test]
+    fn test_empty_predicate() {
+        let result = parse_predicate("");
+        assert!(result.is_err(), "empty predicate should fail");
+        let result2 = parse_predicate("   ");
+        assert!(result2.is_err(), "whitespace-only predicate should fail");
+    }
+}

--- a/cpp/src/format/bridge/rust/src/predicate_parser.rs
+++ b/cpp/src/format/bridge/rust/src/predicate_parser.rs
@@ -12,181 +12,344 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Parses a SQL WHERE-clause predicate string into a `vortex::expr::Expression`.
-//!
-//! The predicate is wrapped in `SELECT * FROM t WHERE <predicate>` so that
-//! `sqlparser` can parse it as valid SQL. The WHERE clause AST is then
-//! converted into a Vortex expression tree.
-
 use anyhow::{bail, Result};
-use sqlparser::ast::{
-    BinaryOperator, Expr as SqlExpr, SetExpr, Statement, UnaryOperator, Value,
-};
+use sqlparser::ast::{BinaryOperator, Expr as SqlExpr, UnaryOperator, Value};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
+use sqlparser::tokenizer::Token;
+use std::collections::HashMap;
 use vortex::expr::{self, Expression};
 
-/// Parse a SQL predicate string into a Vortex `Expression`.
-///
-/// The predicate should be a valid SQL WHERE-clause expression, e.g.:
-/// - `"age > 30"`
-/// - `"status IN (1, 2, 3)"`
-/// - `"(a > 1 OR b > 2) AND c = 3"`
-pub fn parse_predicate(predicate: &str) -> Result<Expression> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColumnType {
+    Int,
+    UInt,
+    Float,
+    Utf8,
+    Bool,
+    Other,
+    // Only set internally when no schema is supplied; literal type checks
+    // are skipped against columns of this type.
+    Unchecked,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LitType {
+    Int,
+    Float,
+    IntFloat,
+    Utf8,
+    Bool,
+}
+
+enum Out {
+    Ok(Expression),
+    OkCol { expr: Expression, col_ty: ColumnType },
+    OkLit { expr: Expression, lit_ty: LitType },
+    Drop,
+}
+
+pub fn parse_predicate(predicate: &str) -> Result<Option<Expression>> {
+    parse_predicate_with_schema(predicate, &[])
+}
+
+pub fn parse_predicate_with_schema(
+    predicate: &str,
+    schema: &[(String, ColumnType)],
+) -> Result<Option<Expression>> {
     let predicate = predicate.trim();
     if predicate.is_empty() {
         bail!("empty predicate");
     }
-
-    let sql = format!("SELECT * FROM t WHERE {predicate}");
     let dialect = GenericDialect {};
-    let statements = Parser::parse_sql(&dialect, &sql)
+    let mut parser = Parser::new(&dialect)
+        .try_with_sql(predicate)
+        .map_err(|e| anyhow::anyhow!("failed to tokenize predicate: {e}"))?;
+    let sql_expr = parser
+        .parse_expr()
         .map_err(|e| anyhow::anyhow!("failed to parse predicate: {e}"))?;
-
-    let statement = statements
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("no statement parsed"))?;
-
-    let where_expr = extract_where(statement)?;
-    convert_expr(&where_expr)
-}
-
-/// Extract the WHERE clause expression from a parsed SELECT statement.
-fn extract_where(stmt: Statement) -> Result<SqlExpr> {
-    match stmt {
-        Statement::Query(query) => match *query.body {
-            SetExpr::Select(select) => select
-                .selection
-                .ok_or_else(|| anyhow::anyhow!("no WHERE clause found")),
-            _ => bail!("unexpected query body"),
-        },
-        _ => bail!("unexpected statement type"),
+    // parse_expr stops at the first unconsumed token; reject trailing input.
+    let next = parser.peek_token();
+    if next.token != Token::EOF {
+        bail!("unexpected trailing input after expression: {}", next.token);
     }
+
+    let cols: HashMap<&str, ColumnType> =
+        schema.iter().map(|(n, t)| (n.as_str(), *t)).collect();
+    let schema_present = !schema.is_empty();
+    let out = convert_expr(&sql_expr, &cols, schema_present)?;
+    Ok(match out {
+        Out::Ok(e) | Out::OkCol { expr: e, .. } | Out::OkLit { expr: e, .. } => Some(e),
+        Out::Drop => None,
+    })
 }
 
-/// Convert a sqlparser AST expression into a Vortex expression.
-fn convert_expr(sql_expr: &SqlExpr) -> Result<Expression> {
+fn warn(msg: impl AsRef<str>) {
+    eprintln!("predicate: {}", msg.as_ref());
+}
+
+fn convert_expr(
+    sql_expr: &SqlExpr,
+    cols: &HashMap<&str, ColumnType>,
+    schema_present: bool,
+) -> Result<Out> {
     match sql_expr {
-        // Column reference: bare or quoted identifier
         SqlExpr::Identifier(ident) => {
-            Ok(expr::get_item(ident.value.clone(), expr::root()))
-        }
-
-        // Literal values
-        SqlExpr::Value(val) => convert_value(&val.value),
-
-        // Unary operators: NOT, negative sign
-        SqlExpr::UnaryOp { op, expr: operand } => match op {
-            UnaryOperator::Not => {
-                let inner = convert_expr(operand)?;
-                Ok(expr::not(inner))
-            }
-            UnaryOperator::Minus => {
-                // Negative literal: apply sign to the inner value
-                match operand.as_ref() {
-                    SqlExpr::Value(val) => convert_negative_value(&val.value),
-                    _ => bail!("unsupported unary minus on non-literal expression"),
-                }
-            }
-            _ => bail!("unsupported unary operator: {op}"),
-        },
-
-        // Binary operators: comparison, logical
-        SqlExpr::BinaryOp { left, op, right } => {
-            let lhs = convert_expr(left)?;
-            let rhs = convert_expr(right)?;
-            match op {
-                BinaryOperator::Eq => Ok(expr::eq(lhs, rhs)),
-                BinaryOperator::NotEq => Ok(expr::not_eq(lhs, rhs)),
-                BinaryOperator::Gt => Ok(expr::gt(lhs, rhs)),
-                BinaryOperator::GtEq => Ok(expr::gt_eq(lhs, rhs)),
-                BinaryOperator::Lt => Ok(expr::lt(lhs, rhs)),
-                BinaryOperator::LtEq => Ok(expr::lt_eq(lhs, rhs)),
-                BinaryOperator::And => Ok(expr::and(lhs, rhs)),
-                BinaryOperator::Or => Ok(expr::or(lhs, rhs)),
-                _ => bail!("unsupported binary operator: {op}"),
-            }
-        }
-
-        // Parenthesized expressions: (expr)
-        SqlExpr::Nested(inner) => convert_expr(inner),
-
-        // IN list: column IN (1, 2, 3)
-        SqlExpr::InList {
-            expr: target,
-            list,
-            negated,
-        } => {
-            let col = convert_expr(target)?;
-            if list.is_empty() {
-                bail!("empty IN list");
-            }
-            // Build: col = v1 OR col = v2 OR ...
-            let mut result: Option<Expression> = None;
-            for item in list {
-                let val = convert_expr(item)?;
-                let cmp = expr::eq(col.clone(), val);
-                result = Some(match result {
-                    None => cmp,
-                    Some(acc) => expr::or(acc, cmp),
+            let name = ident.value.as_str();
+            if !schema_present {
+                return Ok(Out::OkCol {
+                    expr: expr::get_item(ident.value.clone(), expr::root()),
+                    col_ty: ColumnType::Unchecked,
                 });
             }
-            let result = result.unwrap();
-            if *negated {
-                Ok(expr::not(result))
-            } else {
-                Ok(result)
+            match cols.get(name) {
+                Some(&ty) => Ok(Out::OkCol {
+                    expr: expr::get_item(ident.value.clone(), expr::root()),
+                    col_ty: ty,
+                }),
+                None => bail!("unknown column: {name}"),
             }
         }
-
-        // Function calls are not supported
+        SqlExpr::Value(v) => Ok(convert_value(&v.value)),
+        SqlExpr::UnaryOp { op, expr: operand } => match op {
+            UnaryOperator::Not => {
+                let inner = convert_expr(operand, cols, schema_present)?;
+                Ok(match inner {
+                    Out::Drop => Out::Drop,
+                    other => match extract_expr(other) {
+                        Some(e) => Out::Ok(expr::not(e)),
+                        None => Out::Drop,
+                    },
+                })
+            }
+            UnaryOperator::Minus => match operand.as_ref() {
+                SqlExpr::Value(v) => Ok(convert_negative_value(&v.value)),
+                _ => {
+                    warn("unsupported unary minus on non-literal expression");
+                    Ok(Out::Drop)
+                }
+            },
+            other => {
+                warn(format!("unsupported unary operator: {other}"));
+                Ok(Out::Drop)
+            }
+        },
+        SqlExpr::BinaryOp { left, op, right } => {
+            let lhs = convert_expr(left, cols, schema_present)?;
+            let rhs = convert_expr(right, cols, schema_present)?;
+            match op {
+                BinaryOperator::And => Ok(combine_and(lhs, rhs)),
+                BinaryOperator::Or => Ok(combine_or(lhs, rhs)),
+                BinaryOperator::Eq
+                | BinaryOperator::NotEq
+                | BinaryOperator::Gt
+                | BinaryOperator::GtEq
+                | BinaryOperator::Lt
+                | BinaryOperator::LtEq => Ok(combine_cmp(op.clone(), lhs, rhs)),
+                other => {
+                    warn(format!("unsupported binary operator: {other}"));
+                    Ok(Out::Drop)
+                }
+            }
+        }
+        SqlExpr::Nested(inner) => convert_expr(inner, cols, schema_present),
+        SqlExpr::InList { expr: target, list, negated } => {
+            convert_in_list(target, list, *negated, cols, schema_present)
+        }
         SqlExpr::Function(f) => {
-            bail!("unsupported expression: function call `{}`", f.name)
+            warn(format!("unsupported function call: {}", f.name));
+            Ok(Out::Drop)
         }
-
-        _ => bail!("unsupported expression: {sql_expr}"),
+        other => {
+            warn(format!("unsupported expression: {other}"));
+            Ok(Out::Drop)
+        }
     }
 }
 
-/// Convert a sqlparser Value to a Vortex literal expression.
-fn convert_value(val: &Value) -> Result<Expression> {
-    match val {
-        Value::Number(s, _is_long) => {
-            // Try integer first, then float
-            if let Ok(i) = s.parse::<i64>() {
-                Ok(expr::lit(i))
-            } else if let Ok(f) = s.parse::<f64>() {
-                Ok(expr::lit(f))
-            } else {
-                bail!("cannot parse number: {s}")
+fn convert_in_list(
+    target: &SqlExpr,
+    list: &[SqlExpr],
+    negated: bool,
+    cols: &HashMap<&str, ColumnType>,
+    schema_present: bool,
+) -> Result<Out> {
+    let target_out = convert_expr(target, cols, schema_present)?;
+    let (target_expr, target_col_ty) = match target_out {
+        Out::OkCol { expr, col_ty } => (expr, Some(col_ty)),
+        Out::Ok(expr) => (expr, None),
+        Out::OkLit { .. } => {
+            warn("IN target must be a column reference");
+            return Ok(Out::Drop);
+        }
+        Out::Drop => return Ok(Out::Drop),
+    };
+    if list.is_empty() {
+        warn("empty IN list");
+        return Ok(Out::Drop);
+    }
+    let mut acc: Option<Expression> = None;
+    for item in list {
+        let item_out = convert_expr(item, cols, schema_present)?;
+        let item_expr = match item_out {
+            Out::OkLit { expr, lit_ty } => {
+                if let Some(col_ty) = target_col_ty {
+                    if !type_compatible(col_ty, lit_ty) {
+                        warn(format!(
+                            "type mismatch in IN list: column type {col_ty:?} vs literal type {lit_ty:?}"
+                        ));
+                        return Ok(Out::Drop);
+                    }
+                }
+                expr
             }
-        }
-        Value::SingleQuotedString(s) => Ok(expr::lit(s.as_str())),
-        Value::DoubleQuotedString(s) => Ok(expr::lit(s.as_str())),
-        Value::Boolean(b) => Ok(expr::lit(*b)),
-        Value::Null => {
-            // Represent NULL as is_null on root — but this is unusual in
-            // predicates. For now, bail.
-            bail!("NULL literal not supported in predicates")
-        }
-        _ => bail!("unsupported literal value: {val}"),
+            Out::Ok(e) | Out::OkCol { expr: e, .. } => e,
+            Out::Drop => return Ok(Out::Drop),
+        };
+        let cmp = expr::eq(target_expr.clone(), item_expr);
+        acc = Some(match acc {
+            None => cmp,
+            Some(prev) => expr::or(prev, cmp),
+        });
+    }
+    let combined = acc.expect("non-empty IN list checked above");
+    Ok(Out::Ok(if negated { expr::not(combined) } else { combined }))
+}
+
+fn combine_and(lhs: Out, rhs: Out) -> Out {
+    match (extract_expr(lhs), extract_expr(rhs)) {
+        (Some(l), Some(r)) => Out::Ok(expr::and(l, r)),
+        (Some(l), None) => Out::Ok(l),
+        (None, Some(r)) => Out::Ok(r),
+        (None, None) => Out::Drop,
     }
 }
 
-/// Convert a negated sqlparser Value to a Vortex literal expression.
-fn convert_negative_value(val: &Value) -> Result<Expression> {
+fn combine_or(lhs: Out, rhs: Out) -> Out {
+    match (extract_expr(lhs), extract_expr(rhs)) {
+        (Some(l), Some(r)) => Out::Ok(expr::or(l, r)),
+        _ => Out::Drop,
+    }
+}
+
+fn combine_cmp(op: BinaryOperator, lhs: Out, rhs: Out) -> Out {
+    let type_ok = match (&lhs, &rhs) {
+        (Out::OkCol { col_ty, .. }, Out::OkLit { lit_ty, .. })
+        | (Out::OkLit { lit_ty, .. }, Out::OkCol { col_ty, .. }) => {
+            type_compatible(*col_ty, *lit_ty)
+        }
+        (Out::OkCol { col_ty: a, .. }, Out::OkCol { col_ty: b, .. }) => {
+            column_to_column_compat(*a, *b)
+        }
+        _ => true,
+    };
+    if !type_ok {
+        warn(format!("type mismatch in comparison: {op}"));
+        return Out::Drop;
+    }
+    match (extract_expr(lhs), extract_expr(rhs)) {
+        (Some(l), Some(r)) => match op {
+            BinaryOperator::Eq => Out::Ok(expr::eq(l, r)),
+            BinaryOperator::NotEq => Out::Ok(expr::not_eq(l, r)),
+            BinaryOperator::Gt => Out::Ok(expr::gt(l, r)),
+            BinaryOperator::GtEq => Out::Ok(expr::gt_eq(l, r)),
+            BinaryOperator::Lt => Out::Ok(expr::lt(l, r)),
+            BinaryOperator::LtEq => Out::Ok(expr::lt_eq(l, r)),
+            _ => unreachable!("non-comparison operator routed to combine_cmp"),
+        },
+        _ => Out::Drop,
+    }
+}
+
+fn extract_expr(o: Out) -> Option<Expression> {
+    match o {
+        Out::Ok(e) | Out::OkCol { expr: e, .. } | Out::OkLit { expr: e, .. } => Some(e),
+        Out::Drop => None,
+    }
+}
+
+fn type_compatible(col: ColumnType, lit: LitType) -> bool {
+    match (col, lit) {
+        (ColumnType::Unchecked, _) => true,
+        (ColumnType::Int | ColumnType::UInt, LitType::Int | LitType::IntFloat) => true,
+        (ColumnType::Float, LitType::Int | LitType::Float | LitType::IntFloat) => true,
+        (ColumnType::Utf8, LitType::Utf8) => true,
+        (ColumnType::Bool, LitType::Bool) => true,
+        _ => false,
+    }
+}
+
+fn column_to_column_compat(a: ColumnType, b: ColumnType) -> bool {
+    if a == b {
+        return true;
+    }
+    if matches!(a, ColumnType::Unchecked) || matches!(b, ColumnType::Unchecked) {
+        return true;
+    }
+    matches!(
+        (a, b),
+        (ColumnType::Int, ColumnType::UInt)
+            | (ColumnType::UInt, ColumnType::Int)
+            | (ColumnType::Int, ColumnType::Float)
+            | (ColumnType::Float, ColumnType::Int)
+            | (ColumnType::UInt, ColumnType::Float)
+            | (ColumnType::Float, ColumnType::UInt)
+    )
+}
+
+fn convert_value(val: &Value) -> Out {
     match val {
         Value::Number(s, _) => {
             if let Ok(i) = s.parse::<i64>() {
-                Ok(expr::lit(-i))
-            } else if let Ok(f) = s.parse::<f64>() {
-                Ok(expr::lit(-f))
-            } else {
-                bail!("cannot parse negative number: -{s}")
+                return Out::OkLit { expr: expr::lit(i), lit_ty: LitType::Int };
             }
+            if let Ok(f) = s.parse::<f64>() {
+                let lit_ty = if f.fract() == 0.0 {
+                    LitType::IntFloat
+                } else {
+                    LitType::Float
+                };
+                return Out::OkLit { expr: expr::lit(f), lit_ty };
+            }
+            Out::Drop
         }
-        _ => bail!("unsupported negative literal: -{val}"),
+        Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => Out::OkLit {
+            expr: expr::lit(s.as_str()),
+            lit_ty: LitType::Utf8,
+        },
+        Value::Boolean(b) => Out::OkLit {
+            expr: expr::lit(*b),
+            lit_ty: LitType::Bool,
+        },
+        Value::Null => Out::Drop,
+        _ => Out::Drop,
+    }
+}
+
+fn convert_negative_value(val: &Value) -> Out {
+    match val {
+        Value::Number(s, _) => {
+            if let Ok(i) = s.parse::<i64>() {
+                return Out::OkLit {
+                    expr: expr::lit(-i),
+                    lit_ty: LitType::Int,
+                };
+            }
+            if let Ok(f) = s.parse::<f64>() {
+                let neg = -f;
+                let lit_ty = if neg.fract() == 0.0 {
+                    LitType::IntFloat
+                } else {
+                    LitType::Float
+                };
+                return Out::OkLit {
+                    expr: expr::lit(neg),
+                    lit_ty,
+                };
+            }
+            Out::Drop
+        }
+        _ => Out::Drop,
     }
 }
 
@@ -194,56 +357,64 @@ fn convert_negative_value(val: &Value) -> Result<Expression> {
 mod tests {
     use super::*;
 
-    /// Helper: parse must succeed.
-    fn must_parse(predicate: &str) -> Expression {
-        parse_predicate(predicate).unwrap_or_else(|e| panic!("parse failed for '{predicate}': {e}"))
+    fn test_schema() -> Vec<(String, ColumnType)> {
+        vec![
+            ("age".into(), ColumnType::Int),
+            ("name".into(), ColumnType::Utf8),
+        ]
     }
 
-    /// Count expression tree nodes by examining Debug output for "vtable:" occurrences.
+    fn must_parse(predicate: &str) -> Expression {
+        parse_predicate(predicate)
+            .unwrap_or_else(|e| panic!("parse failed for '{predicate}': {e}"))
+            .unwrap_or_else(|| panic!("parse yielded no filter for '{predicate}'"))
+    }
+
+    fn must_parse_with(predicate: &str, schema: &[(String, ColumnType)]) -> Expression {
+        parse_predicate_with_schema(predicate, schema)
+            .unwrap_or_else(|e| panic!("parse failed for '{predicate}': {e}"))
+            .unwrap_or_else(|| panic!("parse yielded no filter for '{predicate}'"))
+    }
+
     fn count_nodes(expr: &Expression) -> usize {
         let dbg = format!("{expr:?}");
         dbg.matches("vtable:").count()
     }
 
+    // ---------- Original schema-less smoke tests ----------
+
     #[test]
     fn test_simple_comparison() {
-        // age > 30 => binary(get_item(root), literal) — 4 nodes
         let expr = must_parse("age > 30");
         assert_eq!(count_nodes(&expr), 4);
     }
 
     #[test]
     fn test_all_digit_column() {
-        // "1" > 10 => binary(get_item(root), literal) — 4 nodes
         let expr = must_parse("\"1\" > 10");
         assert_eq!(count_nodes(&expr), 4);
     }
 
     #[test]
     fn test_and_expression() {
-        // a > 1 AND b < 2 => binary(binary(gi(root),lit), binary(gi(root),lit)) — 9 nodes
         let expr = must_parse("a > 1 AND b < 2");
         assert_eq!(count_nodes(&expr), 9);
     }
 
     #[test]
     fn test_or_expression() {
-        // a > 1 OR b < 2 => same structure as AND
         let expr = must_parse("a > 1 OR b < 2");
         assert_eq!(count_nodes(&expr), 9);
     }
 
     #[test]
     fn test_not_expression() {
-        // NOT a > 1 => not(binary(gi,lit)) — 5 nodes
         let expr = must_parse("NOT a > 1");
         assert_eq!(count_nodes(&expr), 5);
     }
 
     #[test]
     fn test_in_list_integers() {
-        // status IN (1, 2, 3) => or(or(eq(gi,lit), eq(gi,lit)), eq(gi,lit))
-        // Each eq has gi(root)+lit = 4 nodes, 3 eqs = 12, plus 2 or = 14
         let expr = must_parse("status IN (1, 2, 3)");
         assert_eq!(count_nodes(&expr), 14);
     }
@@ -256,17 +427,12 @@ mod tests {
 
     #[test]
     fn test_nested_parentheses() {
-        // (a > 1 OR b > 2) AND c = 3
-        // or(gt(gi(root),lit), gt(gi(root),lit)) = 1+4+4 = 9
-        // eq(gi(root),lit) = 4
-        // and(or_tree, eq_tree) = 1+9+4 = 14
         let expr = must_parse("(a > 1 OR b > 2) AND c = 3");
         assert_eq!(count_nodes(&expr), 14);
     }
 
     #[test]
     fn test_negative_integer() {
-        // x = -10 => binary(get_item(root), literal) — 4 nodes
         let expr = must_parse("x = -10");
         assert_eq!(count_nodes(&expr), 4);
     }
@@ -285,34 +451,191 @@ mod tests {
 
     #[test]
     fn test_operator_precedence() {
-        // a = 1 OR b = 2 AND c = 3
-        // SQL precedence: AND binds tighter => a = 1 OR (b = 2 AND c = 3)
-        // Top-level is OR with 2 children: eq(a,1) and and(eq(b,2),eq(c,3))
-        // eq=4 nodes each, and=1+4+4=9, or=1+4+9=14 — but "and" wraps two eqs
-        // Actually: or( eq(gi(root),lit), and(eq(gi(root),lit), eq(gi(root),lit)) )
-        // = 1(or) + 4(eq) + 1(and) + 4(eq) + 4(eq) = 14
-        let _expr = must_parse("a = 1 OR b = 2 AND c = 3");
-        // Just verify it parses; the structure is correct if sqlparser handles
-        // standard SQL operator precedence.
-        assert_eq!(count_nodes(&_expr), 14);
+        let expr = must_parse("a = 1 OR b = 2 AND c = 3");
+        assert_eq!(count_nodes(&expr), 14);
+    }
+
+    // ---------- New three-state behavior tests ----------
+
+    #[test]
+    fn unsupported_function_call_yields_drop() {
+        // Schema-less: function call is unsupported -> filter is None.
+        let r = parse_predicate("UPPER(name) = 'FOO'").unwrap();
+        assert!(r.is_none());
     }
 
     #[test]
-    fn test_unsupported_function_call() {
-        let result = parse_predicate("UPPER(name) = 'FOO'");
-        assert!(result.is_err(), "function call should fail");
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("function") || err.contains("unsupported"),
-            "error should mention function: {err}"
-        );
+    fn empty_predicate_is_err() {
+        assert!(parse_predicate("").is_err());
+        assert!(parse_predicate("   ").is_err());
     }
 
     #[test]
-    fn test_empty_predicate() {
-        let result = parse_predicate("");
-        assert!(result.is_err(), "empty predicate should fail");
-        let result2 = parse_predicate("   ");
-        assert!(result2.is_err(), "whitespace-only predicate should fail");
+    fn err_on_syntax_error() {
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("age >", &schema);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn err_on_unknown_column() {
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("missing > 1", &schema);
+        assert!(r.is_err(), "unknown column must be Err");
+    }
+
+    #[test]
+    fn err_on_unknown_column_inside_and() {
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("age > 1 AND missing = 'x'", &schema);
+        assert!(r.is_err(), "unknown column anywhere is hard error");
+    }
+
+    #[test]
+    fn drop_unsupported_function_in_and() {
+        let schema = test_schema();
+        let expr = must_parse_with("age > 1 AND UPPER(name) = 'X'", &schema);
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn drop_type_mismatch_in_and() {
+        let schema = test_schema();
+        let expr = must_parse_with("age > 1 AND name = 5", &schema);
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn drop_propagates_to_whole_or() {
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("age > 1 OR UPPER(name) = 'X'", &schema).unwrap();
+        assert!(r.is_none(), "OR with Drop child becomes Drop");
+    }
+
+    #[test]
+    fn drop_under_not_drops_whole() {
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("NOT UPPER(name) = 'X'", &schema).unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn integer_literal_compatible_with_float_column() {
+        let schema = vec![("score".into(), ColumnType::Float)];
+        let r = parse_predicate_with_schema("score > 5", &schema).unwrap();
+        assert!(r.is_some());
+    }
+
+    #[test]
+    fn float_with_fractional_part_drops_int_compare() {
+        let schema = test_schema(); // age is Int
+        let expr = must_parse_with("age = 1.5 AND age > 0", &schema);
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn legacy_no_schema_helper_still_works() {
+        let r = parse_predicate("a > 1 AND b = 'x'").unwrap();
+        assert!(r.is_some());
+    }
+
+    #[test]
+    fn utf8_column_with_single_quoted_string_literal() {
+        let schema = vec![("name".into(), ColumnType::Utf8)];
+        let r = parse_predicate_with_schema("name = 'name_50'", &schema).unwrap();
+        assert!(r.is_some());
+    }
+
+    // ---------- Edge cases on the SQL expression string ----------
+
+    #[test]
+    fn edge_unbalanced_paren_is_err() {
+        let schema = test_schema();
+        assert!(parse_predicate_with_schema("(age > 1", &schema).is_err());
+    }
+
+    #[test]
+    fn edge_empty_in_list_drops() {
+        let schema = test_schema();
+        // sqlparser-rs may reject `IN ()` at parse time; treat either parse-err
+        // or drop-with-no-filter as acceptable.
+        match parse_predicate_with_schema("age IN ()", &schema) {
+            Err(_) => {}
+            Ok(None) => {}
+            Ok(Some(_)) => panic!("empty IN list should not produce a usable filter"),
+        }
+    }
+
+    #[test]
+    fn edge_quoted_column_with_space_unknown() {
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("\"my col\" > 1", &schema);
+        assert!(r.is_err(), "unknown quoted column must be Err");
+    }
+
+    #[test]
+    fn edge_literal_on_lhs() {
+        let schema = test_schema();
+        // `1 < age` — sqlparser accepts; both sides have a known shape; should
+        // translate cleanly.
+        let expr = must_parse_with("1 < age", &schema);
+        assert_eq!(count_nodes(&expr), 4);
+    }
+
+    #[test]
+    fn edge_double_not() {
+        let schema = test_schema();
+        let expr = must_parse_with("NOT NOT age > 1", &schema);
+        // not(not(binary(gi(root), lit))) — 6 nodes
+        assert_eq!(count_nodes(&expr), 6);
+    }
+
+    #[test]
+    fn edge_column_eq_column_compatible() {
+        let schema = vec![
+            ("a".into(), ColumnType::Int),
+            ("b".into(), ColumnType::Int),
+        ];
+        let expr = must_parse_with("a = b", &schema);
+        assert_eq!(count_nodes(&expr), 5);
+    }
+
+    #[test]
+    fn edge_sql_comment_in_predicate() {
+        let schema = test_schema();
+        // sqlparser strips `--` line comments. Should parse cleanly.
+        let r = parse_predicate_with_schema("age > 1 -- ignored\n", &schema).unwrap();
+        assert!(r.is_some());
+    }
+
+    #[test]
+    fn edge_extra_statement_is_err() {
+        // `1=1; DROP TABLE x` — parse_expr should stop after the first
+        // expression and reject the rest as trailing tokens.
+        let schema = test_schema();
+        let r = parse_predicate_with_schema("1=1; DROP TABLE x", &schema);
+        assert!(r.is_err(), "trailing statement must fail to parse");
+    }
+
+    #[test]
+    fn edge_bool_column_with_bool_literal() {
+        let schema = vec![("flag".into(), ColumnType::Bool)];
+        let r = parse_predicate_with_schema("flag = true", &schema).unwrap();
+        assert!(r.is_some());
+    }
+
+    #[test]
+    fn edge_negated_in_list() {
+        let schema = vec![("age".into(), ColumnType::Int)];
+        let r = parse_predicate_with_schema("age NOT IN (1, 2)", &schema).unwrap();
+        assert!(r.is_some());
+    }
+
+    #[test]
+    fn edge_all_digit_column_schema_aware() {
+        // Column names that look like integers must be addressable via quoting.
+        let schema = vec![("1".into(), ColumnType::Int)];
+        let expr = must_parse_with("\"1\" = 1", &schema);
+        assert_eq!(count_nodes(&expr), 4);
     }
 }

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -98,12 +98,25 @@ Expr select(const std::vector<std::string_view>& fields, Expr child) {
   return Expr(ffi::select(rs_fields, std::move(child).IntoImpl()));
 }
 
-Expr parse_predicate(const std::string& predicate) {
-  try {
-    return Expr(ffi::parse_predicate_string(rust::Str(predicate.data(), predicate.length())));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw VortexException(e.what());
+std::optional<Expr> parse_predicate(const std::string& predicate, const std::vector<PredicateColumn>& schema) {
+  rust::Vec<rust::String> names;
+  rust::Vec<uint8_t> tags;
+  for (const auto& c : schema) {
+    names.push_back(rust::String(c.name));
+    tags.push_back(c.type_tag);
   }
+  rust::Box<ffi::ParsedPredicate> parsed = [&] {
+    try {
+      return ffi::parse_predicate_string(rust::Str(predicate.data(), predicate.length()), std::move(names),
+                                         std::move(tags));
+    } catch (const rust::cxxbridge1::Error& e) {
+      throw VortexException(e.what());
+    }
+  }();
+  if (!parsed->has_filter()) {
+    return std::nullopt;
+  }
+  return Expr(parsed->take_filter());
 }
 
 }  // namespace expr

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -98,6 +98,14 @@ Expr select(const std::vector<std::string_view>& fields, Expr child) {
   return Expr(ffi::select(rs_fields, std::move(child).IntoImpl()));
 }
 
+Expr parse_predicate(const std::string& predicate) {
+  try {
+    return Expr(ffi::parse_predicate_string(rust::Str(predicate.data(), predicate.length())));
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw VortexException(e.what());
+  }
+}
+
 }  // namespace expr
 
 namespace scalar {

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -233,9 +233,54 @@ binary_op!(and, _);
 binary_op!(or, _);
 binary_op!(checked_add);
 
-pub(crate) fn parse_predicate_string(predicate: &str) -> anyhow::Result<Box<Expr>> {
-    let vortex_expr = crate::predicate_parser::parse_predicate(predicate)?;
-    Ok(Box::new(Expr { inner: vortex_expr }))
+pub(crate) struct ParsedPredicate {
+    filter: Option<Expression>,
+}
+
+pub(crate) fn parse_predicate_string(
+    predicate: &str,
+    column_names: Vec<String>,
+    column_type_tags: Vec<u8>,
+) -> anyhow::Result<Box<ParsedPredicate>> {
+    use crate::predicate_parser::ColumnType;
+    if column_names.len() != column_type_tags.len() {
+        anyhow::bail!(
+            "schema length mismatch: {} names vs {} tags",
+            column_names.len(),
+            column_type_tags.len()
+        );
+    }
+    let schema: Vec<(String, ColumnType)> = column_names
+        .into_iter()
+        .zip(column_type_tags.into_iter())
+        .map(|(n, t)| {
+            let ct = match t {
+                0 => ColumnType::Int,
+                1 => ColumnType::UInt,
+                2 => ColumnType::Float,
+                3 => ColumnType::Utf8,
+                4 => ColumnType::Bool,
+                _ => ColumnType::Other,
+            };
+            (n, ct)
+        })
+        .collect();
+    let filter = crate::predicate_parser::parse_predicate_with_schema(predicate, &schema)?;
+    Ok(Box::new(ParsedPredicate { filter }))
+}
+
+impl ParsedPredicate {
+    pub(crate) fn has_filter(&self) -> bool {
+        self.filter.is_some()
+    }
+
+    pub(crate) fn take_filter(&mut self) -> Box<Expr> {
+        let f = self
+            .filter
+            .take()
+            .expect("take_filter called when no filter is present");
+        Box::new(Expr { inner: f })
+    }
 }
 
 pub(crate) fn select(fields: Vec<String>, child: Box<Expr>) -> Box<Expr> {

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -233,6 +233,11 @@ binary_op!(and, _);
 binary_op!(or, _);
 binary_op!(checked_add);
 
+pub(crate) fn parse_predicate_string(predicate: &str) -> anyhow::Result<Box<Expr>> {
+    let vortex_expr = crate::predicate_parser::parse_predicate(predicate)?;
+    Ok(Box::new(Expr { inner: vortex_expr }))
+}
+
 pub(crate) fn select(fields: Vec<String>, child: Box<Expr>) -> Box<Expr> {
     Box::new(Expr {
         inner: vortex::expr::select(

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -184,7 +184,11 @@ arrow::Status ColumnGroupReaderImpl::open() {
     ARROW_ASSIGN_OR_RAISE(auto format_reader, FormatReader::create(schema_, column_group_->format, cg_file, properties_,
                                                                    needed_columns_, key_retriever_));
     if (!predicate_.empty()) {
-      format_reader->set_predicate(predicate_);
+      try {
+        format_reader->set_predicate(predicate_);
+      } catch (const std::exception& e) {
+        return arrow::Status::Invalid(fmt::format("Failed to set predicate '{}': {}", predicate_, e.what()));
+      }
     }
     ARROW_ASSIGN_OR_RAISE(auto row_group_in_file, format_reader->get_row_group_infos());
     if (row_group_in_file.empty()) {

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -65,7 +65,8 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
                         const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
                         const milvus_storage::api::Properties& properties,
                         const std::vector<std::string>& needed_columns,
-                        const std::function<std::string(const std::string&)>& key_retriever);
+                        const std::function<std::string(const std::string&)>& key_retriever,
+                        const std::string& predicate = "");
 
   ~ColumnGroupReaderImpl() override = default;
 
@@ -93,6 +94,7 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
   milvus_storage::api::Properties properties_;
   std::vector<std::string> needed_columns_;
   std::function<std::string(const std::string&)> key_retriever_;
+  std::string predicate_;
 
   // will be initialized after call open()
   std::vector<ChunkInfo> chunk_infos_;
@@ -107,7 +109,8 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
     const std::vector<std::string>& needed_columns,
     const milvus_storage::api::Properties& properties,
-    const std::function<std::string(const std::string&)>& key_retriever) {
+    const std::function<std::string(const std::string&)>& key_retriever,
+    const std::string& predicate) {
   std::unique_ptr<ColumnGroupReader> reader = nullptr;
   if (!column_group) {
     return arrow::Status::Invalid("Column group cannot be null");
@@ -137,7 +140,7 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     out_schema = std::make_shared<arrow::Schema>(fields);
   }
   reader = std::make_unique<milvus_storage::api::ColumnGroupReaderImpl>(out_schema, column_group, properties,
-                                                                        filtered_columns, key_retriever);
+                                                                        filtered_columns, key_retriever, predicate);
   ARROW_RETURN_NOT_OK(reader->open());
   return std::move(reader);
 }
@@ -156,12 +159,14 @@ ColumnGroupReaderImpl::ColumnGroupReaderImpl(const std::shared_ptr<arrow::Schema
                                              const std::shared_ptr<api::ColumnGroup>& column_group,
                                              const api::Properties& properties,
                                              const std::vector<std::string>& needed_columns,
-                                             const std::function<std::string(const std::string&)>& key_retriever)
+                                             const std::function<std::string(const std::string&)>& key_retriever,
+                                             const std::string& predicate)
     : schema_(schema),
       column_group_(column_group),
       properties_(properties),
       needed_columns_(needed_columns),
-      key_retriever_(key_retriever) {}
+      key_retriever_(key_retriever),
+      predicate_(predicate) {}
 
 arrow::Status ColumnGroupReaderImpl::open() {
   const auto& cg_files = column_group_->files;
@@ -178,6 +183,9 @@ arrow::Status ColumnGroupReaderImpl::open() {
 
     ARROW_ASSIGN_OR_RAISE(auto format_reader, FormatReader::create(schema_, column_group_->format, cg_file, properties_,
                                                                    needed_columns_, key_retriever_));
+    if (!predicate_.empty()) {
+      format_reader->set_predicate(predicate_);
+    }
     ARROW_ASSIGN_OR_RAISE(auto row_group_in_file, format_reader->get_row_group_infos());
     if (row_group_in_file.empty()) {
       continue;
@@ -280,7 +288,10 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> ColumnGroupReaderImpl::get_ch
 
   ARROW_ASSIGN_OR_RAISE(auto rb, format_readers_[chunk_info.file_index]->get_chunk(chunk_info.row_group_index_in_file));
 
-  if (chunk_info.row_offset_in_row_group != 0 || chunk_info.number_of_rows != rb->num_rows()) {
+  // With predicate, Vortex's WithRowRange + WithFilter already produced the
+  // correct subset — skip slicing since filtered row counts don't match
+  // pre-filter chunk metadata.
+  if (predicate_.empty() && (chunk_info.row_offset_in_row_group != 0 || chunk_info.number_of_rows != rb->num_rows())) {
     rb = rb->Slice(chunk_info.row_offset_in_row_group, chunk_info.number_of_rows);
   }
 

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -140,6 +140,12 @@ arrow::Status VortexFormatReader::open() {
 
 std::shared_ptr<arrow::Schema> VortexFormatReader::get_schema() const { return file_schema_; }
 
+void VortexFormatReader::set_predicate(const std::string& predicate) {
+  if (!predicate.empty()) {
+    parsed_predicate_ = std::make_unique<expr::Expr>(expr::parse_predicate(predicate));
+  }
+}
+
 arrow::Result<std::vector<RowGroupInfo>> VortexFormatReader::get_row_group_infos() {
   assert(vxfile_);
   return row_group_infos_;
@@ -149,8 +155,14 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::get_chunk
   assert(vxfile_);
   ARROW_ASSIGN_OR_RAISE(auto chunkedarray, blocking_read(row_group_infos_[row_group_index].start_offset,
                                                          row_group_infos_[row_group_index].end_offset));
-  assert(chunkedarray != nullptr && chunkedarray->num_chunks() == 1);
+  assert(chunkedarray != nullptr);
 
+  // Predicate filtering may produce 0 chunks (all rows filtered out)
+  if (chunkedarray->num_chunks() == 0) {
+    return arrow::RecordBatch::MakeEmpty(file_schema_);
+  }
+
+  assert(chunkedarray->num_chunks() == 1);
   ARROW_ASSIGN_OR_RAISE(auto rb, arrow::RecordBatch::FromStructArray(chunkedarray->chunk(0)));
   return rb;
 }
@@ -213,6 +225,10 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start, uin
   if (read_schema_) {
     ARROW_ASSIGN_OR_RAISE(auto c_arrow_schema, export_c_arrow_schema(read_schema_));
     scan_builder.WithOutputSchema(c_arrow_schema);
+  }
+
+  if (parsed_predicate_) {
+    scan_builder.WithFilter(*parsed_predicate_);
   }
 
   scan_builder.WithRowRange(row_start, row_end);

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -30,6 +30,35 @@
 
 namespace milvus_storage::vortex {
 
+namespace {
+uint8_t arrow_type_to_tag(const arrow::DataType& dt) {
+  switch (dt.id()) {
+    case arrow::Type::INT8:
+    case arrow::Type::INT16:
+    case arrow::Type::INT32:
+    case arrow::Type::INT64:
+      return 0;  // Int
+    case arrow::Type::UINT8:
+    case arrow::Type::UINT16:
+    case arrow::Type::UINT32:
+    case arrow::Type::UINT64:
+      return 1;  // UInt
+    case arrow::Type::HALF_FLOAT:
+    case arrow::Type::FLOAT:
+    case arrow::Type::DOUBLE:
+      return 2;  // Float
+    case arrow::Type::STRING:
+    case arrow::Type::LARGE_STRING:
+    case arrow::Type::STRING_VIEW:
+      return 3;  // Utf8 — Vortex round-trips arrow::utf8() back as STRING_VIEW
+    case arrow::Type::BOOL:
+      return 4;  // Bool
+    default:
+      return 5;  // Other
+  }
+}
+}  // namespace
+
 static inline expr::Expr build_projection(const std::vector<std::string>& ncs) {
   return expr::select(std::vector<std::string_view>(ncs.begin(), ncs.end()), expr::root());
 }
@@ -141,8 +170,20 @@ arrow::Status VortexFormatReader::open() {
 std::shared_ptr<arrow::Schema> VortexFormatReader::get_schema() const { return file_schema_; }
 
 void VortexFormatReader::set_predicate(const std::string& predicate) {
-  if (!predicate.empty()) {
-    parsed_predicate_ = std::make_unique<expr::Expr>(expr::parse_predicate(predicate));
+  if (predicate.empty()) {
+    return;
+  }
+  if (!file_schema_) {
+    throw VortexException("predicate set before file schema is available");
+  }
+  std::vector<expr::PredicateColumn> schema;
+  schema.reserve(file_schema_->num_fields());
+  for (const auto& field : file_schema_->fields()) {
+    schema.push_back({field->name(), arrow_type_to_tag(*field->type())});
+  }
+  auto maybe_expr = expr::parse_predicate(predicate, schema);
+  if (maybe_expr.has_value()) {
+    parsed_predicate_ = std::make_unique<expr::Expr>(std::move(*maybe_expr));
   }
 }
 

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -493,7 +493,7 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
     REGISTER_PROPERTY(PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS,
                       PropertyType::BOOL,
                       "Whether to enable statistics collection in Vortex writer.",
-                      false,
+                      true,
                       ValidatePropertyType()),
 
     // --- reader properties define ---

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -34,6 +34,7 @@
 #include <arrow/util/iterator.h>
 #include <parquet/properties.h>
 #include <fmt/format.h>
+#include <glog/logging.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
 
 #include "milvus-storage/common/config.h"
@@ -59,7 +60,8 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
                           const std::shared_ptr<arrow::Schema>& schema,
                           const std::vector<std::string>& needed_columns,
                           const Properties& properties,
-                          const std::function<std::string(const std::string&)>& key_retriever)
+                          const std::function<std::string(const std::string&)>& key_retriever,
+                          const std::string& predicate = "")
       : column_groups_(column_groups),
         schema_(schema),
         needed_columns_(needed_columns),
@@ -67,6 +69,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
         out_schema_(nullptr),
         properties_(properties),
         key_retriever_callback_(key_retriever),
+        predicate_(predicate),
         number_of_chunks_per_cg_(column_groups.size()),
         chunk_readers_(column_groups.size()),
 
@@ -89,11 +92,19 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
         milvus_storage::api::GetValueNoError<int64_t>(properties_, PROPERTY_READER_RECORD_BATCH_MAX_ROWS);
     parallelism_ = milvus_storage::ThreadPoolHolder::GetParallelism();
 
+    // Predicate pushdown only supported for single column group.
+    // Multi-CG filtering requires row-index tracking for cross-CG alignment.
+    if (!predicate_.empty() && column_groups_.size() > 1) {
+      LOG(WARNING) << "Predicate pushdown is not supported for multi-column-group reads, ignoring predicate";
+      predicate_.clear();
+    }
+
     // Create chunk readers for each column group
     bool already_set_total_rows = false;
     for (size_t i = 0; i < column_groups_.size(); ++i) {
-      ARROW_ASSIGN_OR_RAISE(chunk_readers_[i], ColumnGroupReader::create(schema_, column_groups_[i], needed_columns_,
-                                                                         properties_, key_retriever_callback_));
+      ARROW_ASSIGN_OR_RAISE(chunk_readers_[i],
+                            ColumnGroupReader::create(schema_, column_groups_[i], needed_columns_, properties_,
+                                                      key_retriever_callback_, predicate_));
       number_of_chunks_per_cg_[i] = chunk_readers_[i]->total_number_of_chunks();
       if (number_of_chunks_per_cg_[i] == 0) {
         return arrow::Status::Invalid(
@@ -222,15 +233,46 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
    * @param batch The record batch pointer specified to read.
    */
   arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out_batch) override {
-    // load data into buffer until reaching memory limit or all data loaded
-    ARROW_RETURN_NOT_OK(load_internal());
+    // Load data, retrying if predicate filtering drained all rows in a batch
+    // but more chunks remain.
+    while (true) {
+      ARROW_RETURN_NOT_OK(load_internal());
 
-    assert(current_offset_ <= end_of_offset_);
+      // EOF check: two paths depending on whether predicate is active.
+      // Without predicate: current_offset_ tracks exact row count and matches end_of_offset_.
+      // With predicate: filtered rows make current_offset_ < end_of_offset_, so we rely
+      // on chunk exhaustion + empty queues to detect EOF.
+      if (predicate_.empty()) {
+        assert(current_offset_ <= end_of_offset_);
+        if (current_offset_ == end_of_offset_) {
+          *out_batch = nullptr;
+          return arrow::Status::OK();
+        }
+      }
 
-    // end of data
-    if (current_offset_ == end_of_offset_) {
-      *out_batch = nullptr;
-      return arrow::Status::OK();
+      // Check if any queue has data
+      bool has_data = false;
+      for (size_t i = 0; i < column_groups_.size(); ++i) {
+        if (!current_rbs_[i].empty()) {
+          has_data = true;
+          break;
+        }
+      }
+      if (has_data)
+        break;
+
+      // Queues empty — check if more chunks to load
+      bool more_chunks = false;
+      for (size_t i = 0; i < column_groups_.size(); ++i) {
+        if (current_cg_chunk_indices_[i] < number_of_chunks_per_cg_[i]) {
+          more_chunks = true;
+          break;
+        }
+      }
+      if (!more_chunks) {
+        *out_batch = nullptr;
+        return arrow::Status::OK();
+      }
     }
 
     // begin to callculate the number of rows to return
@@ -372,18 +414,29 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
       }
     }
 
-    // Execute I/O: one get_chunks() call per column group with all accumulated chunks
+    // Execute I/O
     for (size_t cg_idx = 0; cg_idx < loaded_chunk_indices_.size(); ++cg_idx) {
       if (loaded_chunk_indices_[cg_idx].empty()) {
         continue;
       }
 
-      ARROW_ASSIGN_OR_RAISE(auto record_batchs,
-                            chunk_readers_[cg_idx]->get_chunks(loaded_chunk_indices_[cg_idx], parallelism_));
-
-      for (const auto& record_batch : record_batchs) {
-        assert(record_batch);
-        current_rbs_[cg_idx].push(record_batch);
+      if (!predicate_.empty()) {
+        // Predicate path: read chunks individually via get_chunk() to avoid
+        // the chunk-slicing in get_chunks()/read_chunks_from_files(), which
+        // assumes pre-filter row counts.
+        for (auto chunk_idx : loaded_chunk_indices_[cg_idx]) {
+          ARROW_ASSIGN_OR_RAISE(auto rb, chunk_readers_[cg_idx]->get_chunk(chunk_idx));
+          if (rb && rb->num_rows() > 0) {
+            current_rbs_[cg_idx].push(rb);
+          }
+        }
+      } else {
+        ARROW_ASSIGN_OR_RAISE(auto record_batchs,
+                              chunk_readers_[cg_idx]->get_chunks(loaded_chunk_indices_[cg_idx], parallelism_));
+        for (const auto& record_batch : record_batchs) {
+          assert(record_batch);
+          current_rbs_[cg_idx].push(record_batch);
+        }
       }
 
       loaded_chunk_indices_[cg_idx].clear();
@@ -400,6 +453,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
   std::shared_ptr<arrow::Schema> out_schema_;
   Properties properties_;
   std::function<std::string(const std::string&)> key_retriever_callback_;
+  std::string predicate_;
 
   size_t end_of_offset_;                         // end offset of the data to read
   std::vector<size_t> number_of_chunks_per_cg_;  // total number of chunks for each column group
@@ -648,7 +702,7 @@ class ReaderImpl : public Reader {
    * @brief Performs a full table scan with optional filtering and buffering
    */
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> get_record_batch_reader(
-      const std::string& /*predicate*/) const override {
+      const std::string& predicate) const override {
     // empty column groups
     if (cgs_->size() == 0) {
       if (schema_) {
@@ -678,7 +732,7 @@ class ReaderImpl : public Reader {
     }
 
     auto reader = std::make_shared<PackedRecordBatchReader>(needed_column_groups, projected_schema, resolved_columns,
-                                                            properties_, key_retriever_callback_);
+                                                            properties_, key_retriever_callback_, predicate);
     ARROW_RETURN_NOT_OK(reader->open());
     return reader;
   }

--- a/cpp/test/filter/predicate_pushdown_test.cpp
+++ b/cpp/test/filter/predicate_pushdown_test.cpp
@@ -1,0 +1,174 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <arrow/api.h>
+#include <arrow/filesystem/localfs.h>
+
+#include "test_env.h"
+#include "milvus-storage/writer.h"
+#include "milvus-storage/reader.h"
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/manifest.h"
+
+namespace milvus_storage::test {
+
+using namespace milvus_storage::api;
+
+class PredicatePushdownTest : public ::testing::TestWithParam<std::string> {
+  protected:
+  void SetUp() override {
+    Manifest::CleanCache();
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+
+    base_path_ = GetTestBasePath("predicate-pushdown-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
+
+    format_ = GetParam();
+
+    // Build schema: age (int64), name (utf8)
+    schema_ = arrow::schema({
+        arrow::field("age", arrow::int64(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"100"})),
+        arrow::field("name", arrow::utf8(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"101"})),
+    });
+
+    // Build test data: 100 rows, age=0..99, name="name_0".."name_99"
+    arrow::Int64Builder age_builder;
+    arrow::StringBuilder name_builder;
+    for (int64_t i = 0; i < kNumRows; ++i) {
+      ASSERT_TRUE(age_builder.Append(i).ok());
+      ASSERT_TRUE(name_builder.Append("name_" + std::to_string(i)).ok());
+    }
+    std::shared_ptr<arrow::Array> age_array, name_array;
+    ASSERT_TRUE(age_builder.Finish(&age_array).ok());
+    ASSERT_TRUE(name_builder.Finish(&name_array).ok());
+    test_batch_ = arrow::RecordBatch::Make(schema_, kNumRows, {age_array, name_array});
+
+    // Write data using the Writer API
+    ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format_, schema_));
+    auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+    ASSERT_NE(writer, nullptr);
+    ASSERT_TRUE(writer->write(test_batch_).ok());
+    auto cgs_result = writer->close();
+    ASSERT_TRUE(cgs_result.ok()) << cgs_result.status().ToString();
+    cgs_ = std::move(cgs_result).ValueOrDie();
+  }
+
+  void TearDown() override { ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_)); }
+
+  int64_t CountRowsWithPredicate(const std::string& predicate) {
+    auto reader = Reader::create(cgs_, schema_, nullptr, properties_);
+    auto batch_reader_result = reader->get_record_batch_reader(predicate);
+    if (!batch_reader_result.ok()) {
+      ADD_FAILURE() << "get_record_batch_reader failed: " << batch_reader_result.status().ToString();
+      return -1;
+    }
+    auto batch_reader = std::move(batch_reader_result).ValueOrDie();
+
+    int64_t total_rows = 0;
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      auto status = batch_reader->ReadNext(&batch);
+      if (!status.ok()) {
+        ADD_FAILURE() << "ReadNext failed: " << status.ToString();
+        return -1;
+      }
+      if (batch == nullptr) {
+        break;
+      }
+      total_rows += batch->num_rows();
+    }
+    return total_rows;
+  }
+
+  static constexpr int64_t kNumRows = 100;
+  std::string format_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::shared_ptr<arrow::Schema> schema_;
+  std::string base_path_;
+  std::shared_ptr<arrow::RecordBatch> test_batch_;
+  std::shared_ptr<ColumnGroups> cgs_;
+  Properties properties_;
+};
+
+// age > 90 -> rows 91..99 = 9 rows (vortex only)
+TEST_P(PredicatePushdownTest, GreaterThanFilter) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age > 90"), 9);
+}
+
+// age >= 20 AND age < 30 -> 10 rows (vortex only)
+TEST_P(PredicatePushdownTest, RangeFilter) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age >= 20 AND age < 30"), 10);
+}
+
+// age = 42 -> 1 row (vortex only)
+TEST_P(PredicatePushdownTest, EqualsFilter) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age = 42"), 1);
+}
+
+// age IN (10, 20, 30) -> 3 rows (vortex only)
+TEST_P(PredicatePushdownTest, InFilter) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age IN (10, 20, 30)"), 3);
+}
+
+// name = 'name_50' -> 1 row (vortex only)
+TEST_P(PredicatePushdownTest, StringFilter) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("name = 'name_50'"), 1);
+}
+
+// empty predicate -> all 100 rows (both formats)
+TEST_P(PredicatePushdownTest, NoPredicateReturnsAll) { EXPECT_EQ(CountRowsWithPredicate(""), kNumRows); }
+
+// age > 1000 -> 0 rows (vortex only)
+TEST_P(PredicatePushdownTest, NoMatchReturnsEmpty) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age > 1000"), 0);
+}
+
+// parquet ignores predicate -> still returns all 100 rows
+TEST_P(PredicatePushdownTest, ParquetIgnoresPredicate) {
+  if (format_ != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "This test is parquet-specific";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age > 90"), kNumRows);
+}
+
+INSTANTIATE_TEST_SUITE_P(Formats, PredicatePushdownTest, ::testing::Values(LOON_FORMAT_VORTEX, LOON_FORMAT_PARQUET));
+
+}  // namespace milvus_storage::test

--- a/cpp/test/filter/predicate_pushdown_test.cpp
+++ b/cpp/test/filter/predicate_pushdown_test.cpp
@@ -100,6 +100,14 @@ class PredicatePushdownTest : public ::testing::TestWithParam<std::string> {
     return total_rows;
   }
 
+  // Returns the arrow::Status produced when opening the reader with the given
+  // predicate. Used to assert hard-error scenarios.
+  arrow::Status OpenStatusWithPredicate(const std::string& predicate) {
+    auto reader = Reader::create(cgs_, schema_, nullptr, properties_);
+    auto batch_reader_result = reader->get_record_batch_reader(predicate);
+    return batch_reader_result.status();
+  }
+
   static constexpr int64_t kNumRows = 100;
   std::string format_;
   std::shared_ptr<arrow::fs::FileSystem> fs_;
@@ -167,6 +175,53 @@ TEST_P(PredicatePushdownTest, ParquetIgnoresPredicate) {
     GTEST_SKIP() << "This test is parquet-specific";
   }
   EXPECT_EQ(CountRowsWithPredicate("age > 90"), kNumRows);
+}
+
+// Conjunct drop: AND with one unsupported branch (function call) still pushes
+// down the supported branch. Result mirrors `age > 90` alone -> 9 rows.
+TEST_P(PredicatePushdownTest, ConjunctDropUnsupportedFunction) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age > 90 AND UPPER(name) = 'X'"), 9);
+}
+
+// Conjunct drop: type mismatch (utf8 column vs int literal) is dropped, the
+// supported `age > 90` branch survives.
+TEST_P(PredicatePushdownTest, ConjunctDropTypeMismatch) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age > 90 AND name = 5"), 9);
+}
+
+// OR with one unsupported branch cannot soundly drop a disjunct, so the whole
+// filter degrades to no filter and all rows are returned.
+TEST_P(PredicatePushdownTest, OrWithUnsupportedDegradesToAll) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  EXPECT_EQ(CountRowsWithPredicate("age > 90 OR UPPER(name) = 'X'"), kNumRows);
+}
+
+// Unknown column is a hard error.
+TEST_P(PredicatePushdownTest, UnknownColumnFails) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  auto status = OpenStatusWithPredicate("missing = 1");
+  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(status.message().find("unknown column") != std::string::npos)
+      << "unexpected error message: " << status.message();
+}
+
+// SQL syntax error is a hard error.
+TEST_P(PredicatePushdownTest, SyntaxErrorFails) {
+  if (format_ != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Predicate pushdown only supported for vortex format";
+  }
+  auto status = OpenStatusWithPredicate("age >");
+  EXPECT_FALSE(status.ok());
 }
 
 INSTANTIATE_TEST_SUITE_P(Formats, PredicatePushdownTest, ::testing::Values(LOON_FORMAT_VORTEX, LOON_FORMAT_PARQUET));

--- a/cpp/tools/loon.cpp
+++ b/cpp/tools/loon.cpp
@@ -21,8 +21,10 @@
 //                   --columns col1,col2,...  [--prop key=value ...]
 //   loon describe   <manifest_path> [--prop key=value ...]
 //   loon read       <manifest_path> --columns col1,col2,...
-//                   [--take pos1,pos2,...] [--prop key=value ...]
+//                   [--take pos1,pos2,...] [--predicate "expr"]
+//                   [--verbose] [--prop key=value ...]
 
+#include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
@@ -38,6 +40,7 @@
 #include "milvus-storage/manifest.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/format/format_reader.h"
+#include "milvus-storage/reader.h"
 #include "milvus-storage/transaction/transaction.h"
 #include "milvus-storage/format/lance/lance_common.h"
 #include <folly/dynamic.h>
@@ -46,6 +49,9 @@
 #include "iceberg_bridge.h"
 #include "lance_bridge.h"
 
+using milvus_storage::FilesystemCache;
+using milvus_storage::FormatReader;
+using milvus_storage::StorageUri;
 using milvus_storage::api::ColumnGroup;
 using milvus_storage::api::ColumnGroupFile;
 using milvus_storage::api::ColumnGroups;
@@ -53,18 +59,17 @@ using milvus_storage::api::GetValue;
 using milvus_storage::api::kPropertyMetadata;
 using milvus_storage::api::Manifest;
 using milvus_storage::api::Properties;
+using milvus_storage::api::Reader;
 using milvus_storage::api::SetValue;
 using milvus_storage::api::transaction::Transaction;
-using milvus_storage::FilesystemCache;
-using milvus_storage::FormatReader;
-using milvus_storage::StorageUri;
 
 // ─── helpers ─────────────────────────────────────────────────────────
 
 /// Resolve a local path to absolute (no-op for URIs with scheme).
 static std::string ResolvePath(const std::string& path) {
   // Skip URI-style paths (s3://..., gs://..., etc.)
-  if (path.find("://") != std::string::npos) return path;
+  if (path.find("://") != std::string::npos)
+    return path;
   return std::filesystem::absolute(path).string();
 }
 
@@ -92,8 +97,7 @@ static void PrintBatch(const std::shared_ptr<arrow::RecordBatch>& batch) {
   std::cout << batch->schema()->ToString() << std::endl;
   std::cout << "  rows: " << batch->num_rows() << std::endl;
   for (int c = 0; c < batch->num_columns(); ++c) {
-    std::cout << "  " << batch->schema()->field(c)->name() << ": "
-              << batch->column(c)->ToString() << std::endl;
+    std::cout << "  " << batch->schema()->field(c)->name() << ": " << batch->column(c)->ToString() << std::endl;
   }
 }
 
@@ -101,8 +105,7 @@ static void PrintTable(const std::shared_ptr<arrow::Table>& table) {
   std::cout << table->schema()->ToString() << std::endl;
   std::cout << "  rows: " << table->num_rows() << std::endl;
   for (int c = 0; c < table->num_columns(); ++c) {
-    std::cout << "  " << table->schema()->field(c)->name() << ": "
-              << table->column(c)->ToString() << std::endl;
+    std::cout << "  " << table->schema()->field(c)->name() << ": " << table->column(c)->ToString() << std::endl;
   }
 }
 
@@ -111,8 +114,7 @@ static void ApplyProps(Properties& properties, const std::vector<std::string>& p
   for (const auto& kv : props) {
     auto eq = kv.find('=');
     if (eq == std::string::npos) {
-      std::cerr << "Warning: ignoring malformed --prop '" << kv
-                << "' (expected key=value)" << std::endl;
+      std::cerr << "Warning: ignoring malformed --prop '" << kv << "' (expected key=value)" << std::endl;
       continue;
     }
     SetValue(properties, kv.substr(0, eq).c_str(), kv.substr(eq + 1).c_str());
@@ -145,24 +147,20 @@ static int DoDemoTable(int argc, char** argv) {
 
   if (type.empty() || path.empty()) {
     std::cerr << "Usage: loon demo-table --type <type> --path <dir>"
-              << " [--rows N] [--deletes pos1,pos2,...] [--prop key=value ...]"
-              << std::endl;
+              << " [--rows N] [--deletes pos1,pos2,...] [--prop key=value ...]" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Types: iceberg" << std::endl;
     std::cerr << std::endl;
     std::cerr << "Creates a demo table with schema (id int64, name string,"
               << " value float64)." << std::endl;
-    std::cerr << R"(Data: id=0..N-1, name="row_0".."row_{N-1}", value=id*1.5)"
-              << std::endl;
+    std::cerr << R"(Data: id=0..N-1, name="row_0".."row_{N-1}", value=id*1.5)" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "For cloud storage, pass extfs.* properties via --prop."
-              << std::endl;
+    std::cerr << "For cloud storage, pass extfs.* properties via --prop." << std::endl;
     return 1;
   }
 
   if (type != "iceberg") {
-    std::cerr << "Error: unsupported type '" << type
-              << "'. Supported: iceberg" << std::endl;
+    std::cerr << "Error: unsupported type '" << type << "'. Supported: iceberg" << std::endl;
     return 1;
   }
 
@@ -194,8 +192,7 @@ static int DoDemoTable(int argc, char** argv) {
     }
 
     bool with_deletes = !deletes.empty();
-    auto info = milvus_storage::iceberg::CreateTestTable(
-        table_path, rows, with_deletes, deletes, storage_options);
+    auto info = milvus_storage::iceberg::CreateTestTable(table_path, rows, with_deletes, deletes, storage_options);
 
     std::cout << "Created iceberg table:" << std::endl;
     std::cout << "  path:              " << table_path << std::endl;
@@ -206,7 +203,8 @@ static int DoDemoTable(int argc, char** argv) {
     if (with_deletes) {
       std::cout << "  deletes:           [";
       for (size_t i = 0; i < deletes.size(); ++i) {
-        if (i > 0) std::cout << ",";
+        if (i > 0)
+          std::cout << ",";
         std::cout << deletes[i];
       }
       std::cout << "]" << std::endl;
@@ -220,9 +218,8 @@ static int DoDemoTable(int argc, char** argv) {
 
 // ─── explore helpers (from exttable_c.cpp pattern) ───────────────────
 
-static arrow::Result<std::vector<ColumnGroupFile>> ExploreParquetOrVortex(
-    const std::string& source,
-    const Properties& properties) {
+static arrow::Result<std::vector<ColumnGroupFile>> ExploreParquetOrVortex(const std::string& source,
+                                                                          const Properties& properties) {
   // Resolve explore_dir: if URI, extract key
   std::string resolved_dir = source;
   StorageUri explore_uri;
@@ -232,8 +229,7 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreParquetOrVortex(
     resolved_dir = explore_uri.key;
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto fs,
-      FilesystemCache::getInstance().get(properties, source));
+  ARROW_ASSIGN_OR_RAISE(auto fs, FilesystemCache::getInstance().get(properties, source));
 
   arrow::fs::FileSelector selector;
   selector.base_dir = resolved_dir;
@@ -252,36 +248,31 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreParquetOrVortex(
     uri_base.bucket_name = explore_uri.bucket_name;
   } else if (!is_local) {
     uri_base.scheme = fs->type_name();
-    ARROW_ASSIGN_OR_RAISE(uri_base.address,
-        GetValue<std::string>(properties, PROPERTY_FS_ADDRESS));
-    ARROW_ASSIGN_OR_RAISE(uri_base.bucket_name,
-        GetValue<std::string>(properties, PROPERTY_FS_BUCKET_NAME));
+    ARROW_ASSIGN_OR_RAISE(uri_base.address, GetValue<std::string>(properties, PROPERTY_FS_ADDRESS));
+    ARROW_ASSIGN_OR_RAISE(uri_base.bucket_name, GetValue<std::string>(properties, PROPERTY_FS_BUCKET_NAME));
   }
 
   std::vector<ColumnGroupFile> files;
   for (const auto& fi : file_infos) {
-    if (fi.type() != arrow::fs::FileType::File) continue;
+    if (fi.type() != arrow::fs::FileType::File)
+      continue;
     if (is_local && explore_uri.scheme.empty()) {
       // For local files, use the absolute path directly.
       // SubTreeFileSystem at "/" strips the leading /, so prepend it.
       std::string abs_path = "/" + fi.path();
-      files.emplace_back(ColumnGroupFile{
-          std::move(abs_path), -1, -1, {}});
+      files.emplace_back(ColumnGroupFile{std::move(abs_path), -1, -1, {}});
     } else {
       uri_base.key = fi.path();
       ARROW_ASSIGN_OR_RAISE(auto file_uri, StorageUri::Make(uri_base));
-      files.emplace_back(ColumnGroupFile{
-          std::move(file_uri), -1, -1, {}});
+      files.emplace_back(ColumnGroupFile{std::move(file_uri), -1, -1, {}});
     }
   }
   return files;
 }
 
-static arrow::Result<std::vector<ColumnGroupFile>> ExploreLance(
-    const std::string& source,
-    const Properties& properties) {
-  ARROW_ASSIGN_OR_RAISE(auto fs_config,
-      FilesystemCache::resolve_config(properties, source));
+static arrow::Result<std::vector<ColumnGroupFile>> ExploreLance(const std::string& source,
+                                                                const Properties& properties) {
+  ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, source));
 
   std::string resolved_dir = source;
   auto uri_res = StorageUri::Parse(source);
@@ -289,44 +280,38 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreLance(
     resolved_dir = uri_res->key;
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto lance_base_uri,
-      milvus_storage::lance::BuildLanceBaseUri(fs_config, resolved_dir));
+  ARROW_ASSIGN_OR_RAISE(auto lance_base_uri, milvus_storage::lance::BuildLanceBaseUri(fs_config, resolved_dir));
   auto storage_options = milvus_storage::lance::ToStorageOptions(fs_config);
 
-  auto dataset = milvus_storage::lance::BlockingDataset::Open(
-      lance_base_uri, storage_options);
+  auto dataset = milvus_storage::lance::BlockingDataset::Open(lance_base_uri, storage_options);
   auto fragment_ids = dataset->GetAllFragmentIds();
 
   std::vector<ColumnGroupFile> files;
   for (auto frag_id : fragment_ids) {
     auto row_count = dataset->GetFragmentRowCount(frag_id);
-    files.emplace_back(ColumnGroupFile{
-        milvus_storage::lance::MakeLanceUri(
-            milvus_storage::lance::ToMilvusLanceUri(lance_base_uri, fs_config.address), frag_id),
-        0,
-        static_cast<int64_t>(row_count),
-        {}});
+    files.emplace_back(
+        ColumnGroupFile{milvus_storage::lance::MakeLanceUri(
+                            milvus_storage::lance::ToMilvusLanceUri(lance_base_uri, fs_config.address), frag_id),
+                        0,
+                        static_cast<int64_t>(row_count),
+                        {}});
   }
   return files;
 }
 
-static arrow::Result<std::vector<ColumnGroupFile>> ExploreIceberg(
-    const std::string& source,
-    const Properties& properties) {
-  ARROW_ASSIGN_OR_RAISE(auto fs_config,
-      FilesystemCache::resolve_config(properties, source));
+static arrow::Result<std::vector<ColumnGroupFile>> ExploreIceberg(const std::string& source,
+                                                                  const Properties& properties) {
+  ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, source));
   auto storage_options = milvus_storage::iceberg::ToStorageOptions(fs_config);
 
-  ARROW_ASSIGN_OR_RAISE(auto snapshot_str,
-      GetValue<std::string>(properties, PROPERTY_ICEBERG_SNAPSHOT_ID));
+  ARROW_ASSIGN_OR_RAISE(auto snapshot_str, GetValue<std::string>(properties, PROPERTY_ICEBERG_SNAPSHOT_ID));
   int64_t snapshot_id = std::stoll(snapshot_str);
 
   // Convert Milvus URI to standard format for iceberg-rust
   ARROW_ASSIGN_OR_RAISE(auto parsed_uri, StorageUri::Parse(source));
   ARROW_ASSIGN_OR_RAISE(auto iceberg_uri, StorageUri::Make(parsed_uri, false));
 
-  auto file_infos = milvus_storage::iceberg::PlanFiles(
-      iceberg_uri, snapshot_id, storage_options);
+  auto file_infos = milvus_storage::iceberg::PlanFiles(iceberg_uri, snapshot_id, storage_options);
 
   std::vector<ColumnGroupFile> files;
   files.reserve(file_infos.size());
@@ -338,11 +323,9 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreIceberg(
       file_props[kPropertyMetadata] =
           milvus_storage::iceberg::ConvertDeleteMetadataPaths(info.delete_metadata_json, fs_config.address);
     }
-    files.emplace_back(ColumnGroupFile{
-        std::move(milvus_path),
-        0,
-        static_cast<int64_t>(info.record_count - info.num_deleted_rows),
-        std::move(file_props)});
+    files.emplace_back(ColumnGroupFile{std::move(milvus_path), 0,
+                                       static_cast<int64_t>(info.record_count - info.num_deleted_rows),
+                                       std::move(file_props)});
   }
   return files;
 }
@@ -376,15 +359,11 @@ static int DoCreate(int argc, char** argv) {
               << "--target <base_path> --columns col1,col2,... "
               << "[--prop key=value ...]" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Formats: parquet, vortex, lance-table, iceberg-table"
-              << std::endl;
+    std::cerr << "Formats: parquet, vortex, lance-table, iceberg-table" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "For iceberg-table, --prop iceberg.snapshot_id=N is required."
-              << std::endl;
-    std::cerr << "The --source is the metadata.json path for iceberg-table,"
-              << std::endl;
-    std::cerr << "or the data directory for parquet/vortex/lance-table."
-              << std::endl;
+    std::cerr << "For iceberg-table, --prop iceberg.snapshot_id=N is required." << std::endl;
+    std::cerr << "The --source is the metadata.json path for iceberg-table," << std::endl;
+    std::cerr << "or the data directory for parquet/vortex/lance-table." << std::endl;
     return 1;
   }
 
@@ -403,16 +382,14 @@ static int DoCreate(int argc, char** argv) {
     if (format == LOON_FORMAT_LANCE_TABLE) {
       auto res = ExploreLance(source, properties);
       if (!res.ok()) {
-        std::cerr << "Error exploring lance: " << res.status().ToString()
-                  << std::endl;
+        std::cerr << "Error exploring lance: " << res.status().ToString() << std::endl;
         return 1;
       }
       files = std::move(*res);
     } else if (format == LOON_FORMAT_ICEBERG_TABLE) {
       auto res = ExploreIceberg(source, properties);
       if (!res.ok()) {
-        std::cerr << "Error exploring iceberg: " << res.status().ToString()
-                  << std::endl;
+        std::cerr << "Error exploring iceberg: " << res.status().ToString() << std::endl;
         return 1;
       }
       files = std::move(*res);
@@ -420,15 +397,13 @@ static int DoCreate(int argc, char** argv) {
       // parquet or vortex
       auto res = ExploreParquetOrVortex(source, properties);
       if (!res.ok()) {
-        std::cerr << "Error exploring " << format << ": "
-                  << res.status().ToString() << std::endl;
+        std::cerr << "Error exploring " << format << ": " << res.status().ToString() << std::endl;
         return 1;
       }
       files = std::move(*res);
     }
 
-    std::cout << "Explored " << files.size() << " file(s) from " << source
-              << std::endl;
+    std::cout << "Explored " << files.size() << " file(s) from " << source << std::endl;
     for (size_t i = 0; i < files.size(); ++i) {
       std::cout << "  [" << i << "] " << files[i].path;
       if (files[i].end_index > 0) {
@@ -443,21 +418,18 @@ static int DoCreate(int argc, char** argv) {
     // 2. Get filesystem for target
     auto fs_res = FilesystemCache::getInstance().get(properties);
     if (!fs_res.ok()) {
-      std::cerr << "Error getting filesystem: " << fs_res.status().ToString()
-                << std::endl;
+      std::cerr << "Error getting filesystem: " << fs_res.status().ToString() << std::endl;
       return 1;
     }
     auto fs = *fs_res;
 
     // 3. Build ColumnGroup and commit manifest via Transaction
     ColumnGroups cgs;
-    cgs.push_back(std::make_shared<ColumnGroup>(
-        ColumnGroup{.columns = columns, .format = format, .files = files}));
+    cgs.push_back(std::make_shared<ColumnGroup>(ColumnGroup{.columns = columns, .format = format, .files = files}));
 
     auto tx_res = Transaction::Open(fs, target);
     if (!tx_res.ok()) {
-      std::cerr << "Error opening transaction: " << tx_res.status().ToString()
-                << std::endl;
+      std::cerr << "Error opening transaction: " << tx_res.status().ToString() << std::endl;
       return 1;
     }
     auto tx = std::move(*tx_res);
@@ -465,8 +437,7 @@ static int DoCreate(int argc, char** argv) {
 
     auto commit_res = tx->Commit();
     if (!commit_res.ok()) {
-      std::cerr << "Error committing: " << commit_res.status().ToString()
-                << std::endl;
+      std::cerr << "Error committing: " << commit_res.status().ToString() << std::endl;
       return 1;
     }
     auto version = *commit_res;
@@ -485,17 +456,15 @@ static int DoCreate(int argc, char** argv) {
 // ─── describe ─────────────────────────────────────────────────────────
 
 /// Read and deserialize a manifest file, returning the Manifest object.
-static arrow::Result<std::shared_ptr<Manifest>> ReadManifest(
-    const std::string& manifest_path, const Properties& properties) {
-  ARROW_ASSIGN_OR_RAISE(auto fs,
-      FilesystemCache::getInstance().get(properties, manifest_path));
+static arrow::Result<std::shared_ptr<Manifest>> ReadManifest(const std::string& manifest_path,
+                                                             const Properties& properties) {
+  ARROW_ASSIGN_OR_RAISE(auto fs, FilesystemCache::getInstance().get(properties, manifest_path));
   return Manifest::ReadFrom(fs, manifest_path);
 }
 
 static int DoDescribe(int argc, char** argv) {
   if (argc < 1) {
-    std::cerr << "Usage: loon describe <manifest_path> [--prop key=value ...]"
-              << std::endl;
+    std::cerr << "Usage: loon describe <manifest_path> [--prop key=value ...]" << std::endl;
     return 1;
   }
   std::string manifest_path = argv[0];
@@ -524,9 +493,7 @@ static int DoDescribe(int argc, char** argv) {
     auto manifest = *manifest_res;
 
     // Build folly::dynamic tree
-    folly::dynamic root = folly::dynamic::object
-        ("path", manifest_path)
-        ("version", manifest->version());
+    folly::dynamic root = folly::dynamic::object("path", manifest_path)("version", manifest->version());
 
     // Column groups
     folly::dynamic cg_arr = folly::dynamic::array;
@@ -536,10 +503,8 @@ static int DoDescribe(int argc, char** argv) {
 
       folly::dynamic file_arr = folly::dynamic::array;
       for (auto& f : cg->files) {
-        folly::dynamic fobj = folly::dynamic::object
-            ("path", f.path)
-            ("start_index", f.start_index)
-            ("end_index", f.end_index);
+        folly::dynamic fobj =
+            folly::dynamic::object("path", f.path)("start_index", f.start_index)("end_index", f.end_index);
         auto meta_it = f.properties.find(kPropertyMetadata);
         if (meta_it != f.properties.end()) {
           fobj["metadata"] = meta_it->second;
@@ -549,20 +514,16 @@ static int DoDescribe(int argc, char** argv) {
         file_arr.push_back(std::move(fobj));
       }
 
-      cg_arr.push_back(folly::dynamic::object
-          ("format", cg->format)
-          ("columns", std::move(cols))
-          ("files", std::move(file_arr)));
+      cg_arr.push_back(
+          folly::dynamic::object("format", cg->format)("columns", std::move(cols))("files", std::move(file_arr)));
     }
     root["column_groups"] = std::move(cg_arr);
 
     // Delta logs
     folly::dynamic dl_arr = folly::dynamic::array;
     for (auto& dl : manifest->deltaLogs()) {
-      dl_arr.push_back(folly::dynamic::object
-          ("path", dl.path)
-          ("type", static_cast<int>(dl.type))
-          ("num_entries", dl.num_entries));
+      dl_arr.push_back(
+          folly::dynamic::object("path", dl.path)("type", static_cast<int>(dl.type))("num_entries", dl.num_entries));
     }
     root["delta_logs"] = std::move(dl_arr);
 
@@ -573,9 +534,7 @@ static int DoDescribe(int argc, char** argv) {
       for (auto& p : stat.paths) paths.push_back(p);
       folly::dynamic meta = folly::dynamic::object;
       for (auto& [mk, mv] : stat.metadata) meta[mk] = mv;
-      stats_obj[key] = folly::dynamic::object
-          ("paths", std::move(paths))
-          ("metadata", std::move(meta));
+      stats_obj[key] = folly::dynamic::object("paths", std::move(paths))("metadata", std::move(meta));
     }
     root["stats"] = std::move(stats_obj);
 
@@ -584,11 +543,8 @@ static int DoDescribe(int argc, char** argv) {
     for (auto& idx : manifest->indexes()) {
       folly::dynamic props = folly::dynamic::object;
       for (auto& [pk, pv] : idx.properties) props[pk] = pv;
-      idx_arr.push_back(folly::dynamic::object
-          ("column_name", idx.column_name)
-          ("index_type", idx.index_type)
-          ("path", idx.path)
-          ("properties", std::move(props)));
+      idx_arr.push_back(folly::dynamic::object("column_name", idx.column_name)("index_type", idx.index_type)(
+          "path", idx.path)("properties", std::move(props)));
     }
     root["indexes"] = std::move(idx_arr);
 
@@ -607,13 +563,16 @@ static int DoDescribe(int argc, char** argv) {
 static int DoRead(int argc, char** argv) {
   if (argc < 1) {
     std::cerr << "Usage: loon read <manifest_path> --columns col1,col2,..."
-              << " [--take pos1,pos2,...] [--prop key=value ...]" << std::endl;
+              << " [--take pos1,pos2,...] [--predicate \"expr\"]"
+              << " [--verbose] [--prop key=value ...]" << std::endl;
     return 1;
   }
   std::string manifest_path = argv[0];
   std::vector<std::string> columns;
   std::vector<int64_t> take_positions;
   std::vector<std::string> extra_props;
+  std::string predicate;
+  bool verbose = false;
 
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
@@ -621,6 +580,10 @@ static int DoRead(int argc, char** argv) {
       columns = Split(argv[++i], ',');
     } else if (arg == "--take" && i + 1 < argc) {
       take_positions = ParseInt64List(argv[++i]);
+    } else if (arg == "--predicate" && i + 1 < argc) {
+      predicate = argv[++i];
+    } else if (arg == "--verbose") {
+      verbose = true;
     } else if (arg == "--prop" && i + 1 < argc) {
       extra_props.emplace_back(argv[++i]);
     }
@@ -629,6 +592,11 @@ static int DoRead(int argc, char** argv) {
   if (columns.empty()) {
     std::cerr << "Error: --columns is required" << std::endl;
     return 1;
+  }
+
+  if (!take_positions.empty() && !predicate.empty()) {
+    std::cerr << "Warning: --take and --predicate cannot be used together, ignoring --predicate" << std::endl;
+    predicate.clear();
   }
 
   try {
@@ -649,88 +617,115 @@ static int DoRead(int argc, char** argv) {
     auto manifest = *manifest_res;
 
     // 2. Print manifest summary
-    auto& cgs = manifest->columnGroups();
+    auto& cgs_ref = manifest->columnGroups();
     std::cout << "Manifest: " << manifest_path << std::endl;
     std::cout << "  version: " << manifest->version() << std::endl;
-    std::cout << "  column_groups: " << cgs.size() << std::endl;
-    for (size_t gi = 0; gi < cgs.size(); ++gi) {
-      auto& cg = cgs[gi];
-      std::cout << "  [" << gi << "] format=" << cg->format
-                << "  columns=[";
+    std::cout << "  column_groups: " << cgs_ref.size() << std::endl;
+
+    int64_t total_unfiltered = 0;
+    for (size_t gi = 0; gi < cgs_ref.size(); ++gi) {
+      auto& cg = cgs_ref[gi];
+      std::cout << "  [" << gi << "] format=" << cg->format << "  columns=[";
       for (size_t ci = 0; ci < cg->columns.size(); ++ci) {
-        if (ci > 0) std::cout << ",";
+        if (ci > 0)
+          std::cout << ",";
         std::cout << cg->columns[ci];
       }
       std::cout << "]  files=" << cg->files.size() << std::endl;
       for (size_t fi = 0; fi < cg->files.size(); ++fi) {
         auto& f = cg->files[fi];
-        std::cout << "    file[" << fi << "] path=" << f.path
-                  << "  range=[" << f.start_index << "," << f.end_index << ")"
+        std::cout << "    file[" << fi << "] path=" << f.path << "  range=[" << f.start_index << "," << f.end_index
+                  << ")"
                   << "  has_metadata=" << (f.properties.count(kPropertyMetadata) > 0 ? "true" : "false") << std::endl;
         auto meta_it = f.properties.find(kPropertyMetadata);
         if (meta_it != f.properties.end()) {
           std::cout << "    metadata: " << meta_it->second << std::endl;
         }
+        total_unfiltered += (f.end_index - f.start_index);
       }
     }
 
-    // 3. Read data via FormatReader per file in each column group
+    // 3. Read data via high-level Reader API
+    auto cgs = std::make_shared<ColumnGroups>(cgs_ref);
+    auto needed = std::make_shared<std::vector<std::string>>(columns);
+    auto reader = Reader::create(cgs, nullptr, needed, properties);
+    if (!reader) {
+      std::cerr << "Error: failed to create Reader" << std::endl;
+      return 1;
+    }
+
     int64_t grand_total = 0;
-    for (size_t gi = 0; gi < cgs.size(); ++gi) {
-      auto& cg = cgs[gi];
-      for (size_t fi = 0; fi < cg->files.size(); ++fi) {
-        auto& f = cg->files[fi];
-        auto reader_res = milvus_storage::FormatReader::create(
-            nullptr, cg->format, f, properties, columns, nullptr);
-        if (!reader_res.ok()) {
-          std::cerr << "Error creating reader for file[" << fi << "]: "
-                    << reader_res.status().ToString() << std::endl;
+
+    if (!take_positions.empty()) {
+      // Random access via reader->take()
+      std::cout << "--- take [";
+      for (size_t ti = 0; ti < take_positions.size(); ++ti) {
+        if (ti > 0)
+          std::cout << ",";
+        std::cout << take_positions[ti];
+      }
+      std::cout << "] ---" << std::endl;
+
+      auto start = std::chrono::high_resolution_clock::now();
+      auto table_res = reader->take(take_positions);
+      auto elapsed = std::chrono::high_resolution_clock::now() - start;
+
+      if (!table_res.ok()) {
+        std::cerr << "Error in take(): " << table_res.status().ToString() << std::endl;
+        return 1;
+      }
+      if (!verbose) {
+        PrintTable(*table_res);
+      }
+      grand_total = (*table_res)->num_rows();
+
+      if (verbose) {
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+        std::cout << "read_time_ms: " << ms << std::endl;
+      }
+    } else {
+      // Sequential read with optional predicate
+      auto start = std::chrono::high_resolution_clock::now();
+      auto batch_reader_res = reader->get_record_batch_reader(predicate);
+      if (!batch_reader_res.ok()) {
+        std::cerr << "Error creating batch reader: " << batch_reader_res.status().ToString() << std::endl;
+        return 1;
+      }
+      auto batch_reader = *batch_reader_res;
+
+      std::shared_ptr<arrow::RecordBatch> batch;
+      int batch_idx = 0;
+      while (true) {
+        auto st = batch_reader->ReadNext(&batch);
+        if (!st.ok()) {
+          std::cerr << "Error reading batch: " << st.ToString() << std::endl;
           return 1;
         }
-        auto reader = *reader_res;
-
-        if (!take_positions.empty()) {
-          // Random access
-          std::cout << "--- take [";
-          for (size_t ti = 0; ti < take_positions.size(); ++ti) {
-            if (ti > 0) std::cout << ",";
-            std::cout << take_positions[ti];
-          }
-          std::cout << "] ---" << std::endl;
-
-          auto table_res = reader->take(take_positions);
-          if (!table_res.ok()) {
-            std::cerr << "Error in take(): "
-                      << table_res.status().ToString() << std::endl;
-            return 1;
-          }
-          PrintTable(*table_res);
-          grand_total += (*table_res)->num_rows();
-        } else {
-          // Sequential read via get_chunk
-          auto rg_res = reader->get_row_group_infos();
-          if (!rg_res.ok()) {
-            std::cerr << "Error getting row groups: "
-                      << rg_res.status().ToString() << std::endl;
-            return 1;
-          }
-          auto rg_infos = *rg_res;
-          int64_t file_total = 0;
-          for (size_t rg = 0; rg < rg_infos.size(); ++rg) {
-            auto batch_res = reader->get_chunk(rg);
-            if (!batch_res.ok()) {
-              std::cerr << "Error reading chunk " << rg << ": "
-                        << batch_res.status().ToString() << std::endl;
-              return 1;
-            }
-            auto batch = *batch_res;
-            std::cout << "--- cg[" << gi << "] file[" << fi
-                      << "] rg[" << rg << "] ---" << std::endl;
-            PrintBatch(batch);
-            file_total += batch->num_rows();
-          }
-          grand_total += file_total;
+        if (!batch)
+          break;
+        if (!verbose) {
+          std::cout << "--- batch[" << batch_idx << "] ---" << std::endl;
+          PrintBatch(batch);
         }
+        grand_total += batch->num_rows();
+        ++batch_idx;
+      }
+      auto elapsed = std::chrono::high_resolution_clock::now() - start;
+
+      if (verbose) {
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+        std::cout << "read_time_ms: " << ms << std::endl;
+        std::cout << "total_rows: " << grand_total << std::endl;
+        if (!predicate.empty()) {
+          std::cout << "predicate: " << predicate << std::endl;
+          std::cout << "total_unfiltered: " << total_unfiltered << std::endl;
+          if (total_unfiltered > 0) {
+            double selectivity = static_cast<double>(grand_total) / static_cast<double>(total_unfiltered);
+            std::cout << "selectivity: " << selectivity << std::endl;
+          }
+        }
+        FilesystemCache::getInstance().clean();
+        return 0;
       }
     }
     std::cout << "total_rows: " << grand_total << std::endl;
@@ -746,81 +741,69 @@ static int DoRead(int argc, char** argv) {
 // ─── main ────────────────────────────────────────────────────────────
 
 static void PrintUsage() {
-  std::cerr
-      << "Usage: loon <command> [args...]" << std::endl
-      << std::endl
-      << "Commands:" << std::endl
-      << "  demo-table  Create a demo table for testing."
-      << std::endl
-      << "  create      Explore an external data source and commit a manifest."
-      << std::endl
-      << "  describe    Dump a manifest file as formatted JSON."
-      << std::endl
-      << "  read        Read data from a manifest (sequential or random access)."
-      << std::endl
-      << std::endl
-      << "demo-table:" << std::endl
-      << "  loon demo-table --type <type> --path <dir> \\" << std::endl
-      << "                  [--rows N] [--deletes pos1,pos2,...]" << std::endl
-      << std::endl
-      << "  Types: iceberg" << std::endl
-      << std::endl
-      << "create:" << std::endl
-      << "  loon create --format <format> --source <uri> \\" << std::endl
-      << "                   --target <base_path> --columns col1,col2,... \\"
-      << std::endl
-      << "                   [--prop key=value ...]" << std::endl
-      << std::endl
-      << "  Formats: parquet, vortex, lance-table, iceberg-table" << std::endl
-      << std::endl
-      << "  For iceberg-table:" << std::endl
-      << "    --source is the metadata.json path" << std::endl
-      << "    --prop iceberg.snapshot_id=N is required" << std::endl
-      << std::endl
-      << "  For parquet/vortex:" << std::endl
-      << "    --source is the directory containing data files" << std::endl
-      << std::endl
-      << "  For lance-table:" << std::endl
-      << "    --source is the lance dataset directory" << std::endl
-      << std::endl
-      << "describe:" << std::endl
-      << "  loon describe <manifest_path> [--prop key=value ...]"
-      << std::endl
-      << std::endl
-      << "read:" << std::endl
-      << "  loon read <manifest_path> --columns col1,col2,... \\"
-      << std::endl
-      << "                 [--take pos1,pos2,...] [--prop key=value ...]"
-      << std::endl
-      << std::endl
-      << "Examples:" << std::endl
-      << "  # Explore an Iceberg table and create a manifest" << std::endl
-      << "  loon create --format iceberg-table \\" << std::endl
-      << "    --source /data/iceberg/metadata/v1.metadata.json \\"
-      << std::endl
-      << "    --target /tmp/my_manifest \\" << std::endl
-      << "    --columns id,name,value \\" << std::endl
-      << "    --prop iceberg.snapshot_id=1" << std::endl
-      << std::endl
-      << "  # Explore a parquet directory and create a manifest" << std::endl
-      << "  loon create --format parquet \\" << std::endl
-      << "    --source /data/parquets/ \\" << std::endl
-      << "    --target /tmp/my_manifest \\" << std::endl
-      << "    --columns id,name,value" << std::endl
-      << std::endl
-      << "  # Describe a manifest (dump as JSON)" << std::endl
-      << "  loon describe /tmp/my_manifest/_metadata/manifest-1.avro"
-      << std::endl
-      << std::endl
-      << "  # Read all data from the manifest" << std::endl
-      << "  loon read /tmp/my_manifest/_metadata/manifest-1.avro \\"
-      << std::endl
-      << "    --columns id,name,value" << std::endl
-      << std::endl
-      << "  # Random access (take)" << std::endl
-      << "  loon read /tmp/my_manifest/_metadata/manifest-1.avro \\"
-      << std::endl
-      << "    --columns id,name --take 0,5,10,15" << std::endl;
+  std::cerr << "Usage: loon <command> [args...]" << std::endl
+            << std::endl
+            << "Commands:" << std::endl
+            << "  demo-table  Create a demo table for testing." << std::endl
+            << "  create      Explore an external data source and commit a manifest." << std::endl
+            << "  describe    Dump a manifest file as formatted JSON." << std::endl
+            << "  read        Read data from a manifest (sequential or random access)." << std::endl
+            << std::endl
+            << "demo-table:" << std::endl
+            << "  loon demo-table --type <type> --path <dir> \\" << std::endl
+            << "                  [--rows N] [--deletes pos1,pos2,...]" << std::endl
+            << std::endl
+            << "  Types: iceberg" << std::endl
+            << std::endl
+            << "create:" << std::endl
+            << "  loon create --format <format> --source <uri> \\" << std::endl
+            << "                   --target <base_path> --columns col1,col2,... \\" << std::endl
+            << "                   [--prop key=value ...]" << std::endl
+            << std::endl
+            << "  Formats: parquet, vortex, lance-table, iceberg-table" << std::endl
+            << std::endl
+            << "  For iceberg-table:" << std::endl
+            << "    --source is the metadata.json path" << std::endl
+            << "    --prop iceberg.snapshot_id=N is required" << std::endl
+            << std::endl
+            << "  For parquet/vortex:" << std::endl
+            << "    --source is the directory containing data files" << std::endl
+            << std::endl
+            << "  For lance-table:" << std::endl
+            << "    --source is the lance dataset directory" << std::endl
+            << std::endl
+            << "describe:" << std::endl
+            << "  loon describe <manifest_path> [--prop key=value ...]" << std::endl
+            << std::endl
+            << "read:" << std::endl
+            << "  loon read <manifest_path> --columns col1,col2,... \\" << std::endl
+            << "                 [--take pos1,pos2,...] [--predicate \"expr\"] \\" << std::endl
+            << "                 [--verbose] [--prop key=value ...]" << std::endl
+            << std::endl
+            << "Examples:" << std::endl
+            << "  # Explore an Iceberg table and create a manifest" << std::endl
+            << "  loon create --format iceberg-table \\" << std::endl
+            << "    --source /data/iceberg/metadata/v1.metadata.json \\" << std::endl
+            << "    --target /tmp/my_manifest \\" << std::endl
+            << "    --columns id,name,value \\" << std::endl
+            << "    --prop iceberg.snapshot_id=1" << std::endl
+            << std::endl
+            << "  # Explore a parquet directory and create a manifest" << std::endl
+            << "  loon create --format parquet \\" << std::endl
+            << "    --source /data/parquets/ \\" << std::endl
+            << "    --target /tmp/my_manifest \\" << std::endl
+            << "    --columns id,name,value" << std::endl
+            << std::endl
+            << "  # Describe a manifest (dump as JSON)" << std::endl
+            << "  loon describe /tmp/my_manifest/_metadata/manifest-1.avro" << std::endl
+            << std::endl
+            << "  # Read all data from the manifest" << std::endl
+            << "  loon read /tmp/my_manifest/_metadata/manifest-1.avro \\" << std::endl
+            << "    --columns id,name,value" << std::endl
+            << std::endl
+            << "  # Random access (take)" << std::endl
+            << "  loon read /tmp/my_manifest/_metadata/manifest-1.avro \\" << std::endl
+            << "    --columns id,name --take 0,5,10,15" << std::endl;
 }
 
 int main(int argc, char** argv) {

--- a/docs/predicate-pushdown-benchmark.md
+++ b/docs/predicate-pushdown-benchmark.md
@@ -1,0 +1,160 @@
+# Predicate Pushdown Benchmark Results
+
+## Setup
+
+- **Format**: Vortex 0.56.0
+- **Data**: 40,960 rows, schema `{id: int64, name: utf8, value: float64, vector: list<float32>[128]}`
+- **Column group**: Single CG (predicate pushdown requires single CG)
+- **Threads**: 1
+- **Data generation**: Both sorted and unsorted use the **same values**
+  (`id = 0..40959`, `name = "name_00000".."name_40959"`, zero-padded).
+  Unsorted data is shuffled with a fixed seed. This ensures identical
+  predicate selectivity — the only variable is row ordering.
+- **Machine**: Apple M-series, 8 cores, local SSD
+
+## Int64 Predicate (`id > threshold`)
+
+| Data | Predicate | Time (ms) | CPU (ms) | I/O (MB) | Selectivity | Rows/s |
+|------|-----------|-----------|----------|----------|-------------|--------|
+| Unsorted | None | 21.1 | 19.4 | 17.7 | 1.00 | 1.94M |
+| Unsorted | 10% | 26.4 | 20.9 | 19.4 | 0.10 | 156K |
+| Unsorted | 50% | 46.5 | 36.8 | 19.4 | 0.50 | 451K |
+| Unsorted | 90% | 51.4 | 46.0 | 19.4 | 0.90 | 718K |
+| Sorted | None | 17.6 | 15.9 | 16.2 | 1.00 | 2.33M |
+| Sorted | 10% | **10.7** | **9.1** | **4.8** | 0.10 | 384K |
+| Sorted | 50% | 18.8 | 16.1 | 10.5 | 0.50 | 1.09M |
+| Sorted | 90% | 25.9 | 21.2 | 17.8 | 0.90 | 1.42M |
+
+## String Predicate (`name > 'name_XXXXX'`)
+
+| Data | Predicate | Time (ms) | CPU (ms) | I/O (MB) | Selectivity | Rows/s |
+|------|-----------|-----------|----------|----------|-------------|--------|
+| Unsorted | 10% | 27.2 | 22.1 | 19.4 | 0.10 | 150K |
+| Unsorted | 50% | 45.1 | 38.2 | 19.4 | 0.50 | 456K |
+| Unsorted | 90% | 57.2 | 49.0 | 19.4 | 0.90 | 648K |
+| Sorted | 10% | **11.7** | **10.1** | **4.8** | 0.10 | 350K |
+| Sorted | 50% | 20.4 | 17.4 | 10.5 | 0.50 | 1.00M |
+| Sorted | 90% | 29.4 | 23.5 | 17.8 | 0.90 | 1.26M |
+
+## Analysis
+
+### 1. Zone-map pruning requires sorted data — same values, different order
+
+Since sorted and unsorted use the same values (just reordered), we can
+directly measure the impact of data ordering on zone-map pruning:
+
+| Selectivity | Sorted I/O | Unsorted I/O | I/O saved | Sorted time | Unsorted time | Speedup |
+|-------------|-----------|-------------|-----------|-------------|---------------|---------|
+| 10% (int64) | **4.8 MB** | 19.4 MB | **75%** | **10.7 ms** | 26.4 ms | **2.5x** |
+| 50% (int64) | 10.5 MB | 19.4 MB | 46% | 18.8 ms | 46.5 ms | 2.5x |
+| 90% (int64) | 17.8 MB | 19.4 MB | 8% | 25.9 ms | 51.4 ms | 2.0x |
+
+For sorted data at 10% selectivity, zone-map pruning eliminates 75% of
+I/O. For unsorted data, I/O is constant at 19.4 MB regardless of
+selectivity — all zones must be read because every zone spans the full
+value range.
+
+### 2. Unsorted data: predicate overhead scales with selectivity
+
+On unsorted data, I/O is constant (19.4 MB, +10% over the 17.7 MB
+baseline due to zone-map statistics reads), but wall time increases
+with selectivity:
+
+| Selectivity | Time (ms) | Overhead vs no-predicate |
+|-------------|-----------|------------------------|
+| No predicate | 21.1 | — |
+| 10% | 26.4 | +25% |
+| 50% | 46.5 | +120% |
+| 90% | 51.4 | +144% |
+
+The overhead comes from per-row predicate evaluation. More matching rows
+means more output materialization work. Even at 10% selectivity (most rows
+filtered), the predicate adds 25% overhead because all rows must be
+evaluated even though only 10% are returned.
+
+### 3. Sorted data: predicate speeds up reads at low selectivity
+
+| Selectivity | Time (ms) | vs no-predicate |
+|-------------|-----------|-----------------|
+| No predicate | 17.6 | — |
+| 10% | **10.7** | **39% faster** |
+| 50% | 18.8 | 7% slower |
+| 90% | 25.9 | 47% slower |
+
+At 10% selectivity, zone-map pruning skips enough zones that the total
+work (I/O + evaluation) is less than a full scan. At 50%, the break-even
+point: pruning saves some I/O but evaluation overhead offsets it. At 90%,
+nearly all zones are read plus evaluation overhead makes it slower.
+
+### 4. String vs int64: comparable I/O, slightly higher CPU
+
+With zero-padded names, zone-map pruning is equally effective for both
+types — identical I/O at every selectivity level:
+
+| Selectivity | int64 I/O | string I/O | int64 time | string time | string overhead |
+|-------------|----------|-----------|------------|-------------|-----------------|
+| Sorted 10% | 4.8 MB | 4.8 MB | 10.7 ms | 11.7 ms | +9% |
+| Sorted 50% | 10.5 MB | 10.5 MB | 18.8 ms | 20.4 ms | +9% |
+| Sorted 90% | 17.8 MB | 17.8 MB | 25.9 ms | 29.4 ms | +14% |
+| Unsorted 10% | 19.4 MB | 19.4 MB | 26.4 ms | 27.2 ms | +3% |
+| Unsorted 50% | 19.4 MB | 19.4 MB | 46.5 ms | 45.1 ms | -3% |
+| Unsorted 90% | 19.4 MB | 19.4 MB | 51.4 ms | 57.2 ms | +11% |
+
+String predicates are **9-14% slower** than int64 on sorted data due to
+string comparison cost. On unsorted data, the difference is smaller (±3-11%)
+because I/O overhead dominates.
+
+### 5. CPU utilization
+
+| Scenario | Wall (ms) | CPU (ms) | CPU/Wall | Note |
+|----------|-----------|----------|----------|------|
+| Sorted, no pred | 17.6 | 15.9 | 0.90 | Baseline |
+| Sorted, int64 10% | 10.7 | 9.1 | 0.85 | Less total work |
+| Sorted, int64 90% | 25.9 | 21.2 | 0.82 | CPU-bound evaluation |
+| Unsorted, no pred | 21.1 | 19.4 | 0.92 | Baseline |
+| Unsorted, int64 10% | 26.4 | 20.9 | 0.79 | I/O dominates |
+| Unsorted, int64 90% | 51.4 | 46.0 | 0.90 | CPU-heavy evaluation |
+| Unsorted, string 90% | 57.2 | 49.0 | 0.86 | String eval costlier |
+
+CPU/Wall ratio is 0.79-0.92 across all scenarios. The workload is
+CPU-bound on local SSD. With remote storage, the ratio would drop
+significantly as I/O latency dominates.
+
+### 6. I/O reduction vs selectivity (sorted data)
+
+| Selectivity | I/O (MB) | I/O ratio vs full scan | Expected ratio |
+|-------------|----------|----------------------|----------------|
+| 100% (none) | 16.2 | 1.00x | 1.00x |
+| 90% | 17.8 | 1.10x | ~0.90x |
+| 50% | 10.5 | 0.65x | ~0.50x |
+| 10% | 4.8 | 0.30x | ~0.10x |
+
+I/O reduction is sublinear — at 10% selectivity, actual I/O is 30% of
+full scan (not 10%). Zone-map pruning operates at zone granularity:
+boundary zones containing a mix of matching/non-matching rows are read
+fully. The 90% case reads *more* than baseline because zone-map
+statistics overhead (+1.6 MB) exceeds the small I/O savings from
+pruning the bottom 10%.
+
+## Recommendations
+
+1. **Sort data by the primary filter column** before writing to Vortex.
+   Same data, sorted vs unsorted: 2.5x faster at 10% selectivity,
+   75% less I/O. This is the single most impactful optimization.
+
+2. **Predicate pushdown breaks even at ~50% selectivity** on sorted data.
+   Below 50%, it's faster than a full scan. Above 50%, the evaluation
+   overhead exceeds the I/O savings. Consider skipping pushdown for
+   broad predicates.
+
+3. **On unsorted data, pushdown adds 25-144% overhead** with zero I/O
+   benefit. Consider a heuristic to detect poor zone-map pruning potential
+   (e.g., check if min/max spans the full value range) and skip pushdown.
+
+4. **String predicates perform within 9-14% of int64** when data is sorted
+   and strings have consistent lexicographic ordering (zero-padded).
+   Zone-map pruning is equally effective for both types.
+
+5. **For remote storage**, the I/O reduction from zone-map pruning will
+   have a much larger impact. The 75% I/O reduction at 10% selectivity
+   translates to proportional latency and cost reduction.


### PR DESCRIPTION
See #512

Implement predicate pushdown for Vortex files using sqlparser-rs
to parse SQL WHERE-clause predicates into native Vortex expressions.
The predicate string from get_record_batch_reader(predicate) is
parsed once in Rust, converted to a vortex::expr::Expression, and
applied via ScanBuilder::WithFilter() for zone-map pruning and
row-level filtering. No expression tree crosses the FFI boundary.

Changes:
- Rust: sqlparser-based predicate parser (comparisons, AND/OR/NOT,
  IN lists, quoted column names for all-digit fields)
- CXX bridge: expr::parse_predicate() for one-time parse,
  ScanBuilder integration
- C++: predicate plumbing through Reader -> PackedRecordBatchReader
  -> ColumnGroupReader -> FormatReader::set_predicate()
- VortexFormatReader: parse once in set_predicate(), apply by-ref
  in read() via WithFilter()
- Single CG only; multi-CG logs warning and ignores predicate
- Parquet/Lance/Iceberg: no-op (default set_predicate)
- Handle empty filtered results from Vortex scan
- loon read: add --predicate and --verbose flags
- Benchmark: sorted vs unsorted, int64 vs string predicates,
  filesystem I/O metrics

Benchmark highlights (40K rows, Vortex, local SSD):
- Sorted + 10% selectivity: 75% I/O reduction, 2.5x faster
- String predicates within 9-14% of int64 on sorted data
- Unsorted data: predicate adds overhead with no pruning benefit