### PR TITLE
fix: skip unused manifest read in Transaction::Commit

### DIFF
--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -16,7 +16,6 @@
 
 #include <cstdint>
 #include <string>
-#include <functional>
 #include <memory>
 #include <vector>
 #include <map>
@@ -88,24 +87,52 @@ class Updates {
 };
 
 /**
- * @brief Resolver function type
+ * @brief Resolver interface for conflict resolution between read and latest manifests.
  *
- * Resolves conflicts between read manifest and latest manifest using recorded changes.
+ * A Resolver implementation reconciles the manifest read when a transaction began
+ * with the most recent committed manifest, producing the manifest that will be
+ * written by the commit.
  *
- * @param read_manifest The manifest read when transaction began
- * @param read_version The version of the read manifest
- * @param latest_manifest The most recent committed manifest at the time of conflict resolution (may differ from
- * read_manifest if concurrent commits occurred)
- * @param latest_version The version of the latest manifest
- * @param updates The recorded changes in this transaction
- * @return Resolved manifest or error status
+ * Resolver instances are expected to be stateless and shared (typically static
+ * globals). The caller must keep the Resolver alive for the lifetime of any
+ * Transaction that references it.
  */
-using Resolver =
-    std::function<arrow::Result<std::shared_ptr<Manifest>>(const std::shared_ptr<Manifest>& read_manifest,
-                                                           int64_t read_version,
-                                                           const std::shared_ptr<Manifest>& latest_manifest,
-                                                           int64_t latest_version,
-                                                           const Updates& updates)>;
+class Resolver {
+  public:
+  virtual ~Resolver() = default;
+
+  /**
+   * @brief Resolve a commit.
+   *
+   * @param read_manifest The manifest read when the transaction began
+   * @param read_version The version of the read manifest
+   * @param latest_manifest The most recent committed manifest at conflict-resolution time
+   *        (may be null if the implementation reported requireLatest() == false and the
+   *        commit detected version drift; never null when read_version == latest_version
+   *        or when requireLatest() == true)
+   * @param latest_version The version of the latest manifest
+   * @param updates The recorded changes in this transaction
+   * @return Resolved manifest or error status
+   */
+  [[nodiscard]] virtual arrow::Result<std::shared_ptr<Manifest>> resolve(
+      const std::shared_ptr<Manifest>& read_manifest,
+      int64_t read_version,
+      const std::shared_ptr<Manifest>& latest_manifest,
+      int64_t latest_version,
+      const Updates& updates) const = 0;
+
+  /**
+   * @brief Whether this resolver needs the latest manifest contents loaded.
+   *
+   * When false, the transaction commit logic will skip reading manifest-N.avro
+   * from storage on version drift and pass a null latest_manifest to resolve().
+   * Implementations that ignore latest_manifest (or only use it when versions
+   * match, in which case the read is unnecessary) should return false to avoid
+   * spurious commit failures from transient read errors on an otherwise-unused
+   * manifest file.
+   */
+  [[nodiscard]] virtual bool requireLatest() const = 0;
+};
 
 // ==================== Helper Functions ====================
 
@@ -128,25 +155,30 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
  * @brief Unified resolver that merges changes with latest_manifest
  *
  * This resolver merges all changes (appended files, added column groups, delta logs, stats)
- * into the latest_manifest, effectively merging concurrent changes.
+ * into the latest_manifest, effectively merging concurrent changes. requireLatest() == true.
  */
-extern Resolver MergeResolver;
+extern const Resolver& MergeResolver;
 
 /**
  * @brief Resolver that applies updates to read_manifest, overwriting any concurrent changes
  *
  * This resolver applies all changes (appended files, added column groups, delta logs, stats)
  * into the read_manifest, ignoring any concurrent changes in latest_manifest.
+ * requireLatest() == false — the commit logic skips reading manifest-N.avro on version drift.
  */
-extern Resolver OverwriteResolver;
+extern const Resolver& OverwriteResolver;
 
 /**
  * @brief Resolver that fails if latest version differs from read version
  *
- * This resolver checks if there were concurrent changes by comparing versions.
- * If read_version equals latest_version, it applies updates to the manifest.
+ * When read_version equals latest_version, applies updates to latest_manifest (or
+ * read_manifest if latest_manifest is null). When versions differ, returns a
+ * TxnResolutionFailed error without touching latest_manifest.
+ *
+ * requireLatest() == false: it is safe for Commit() to skip reading manifest-N.avro on
+ * version drift, since the resolver only inspects manifests when versions match.
  */
-extern Resolver FailResolver;
+extern const Resolver& FailResolver;
 
 class Transaction {
   public:
@@ -154,7 +186,10 @@ class Transaction {
   // @param fs Filesystem to use
   // @param base_path Base path for the storage
   // @param version Version to read from (default: LATEST = fetch greatest version)
-  // @param resolver Resolver function for conflict resolution (default: FailResolver)
+  // @param resolver Resolver for conflict resolution (default: FailResolver). The
+  //        Transaction stores a non-owning pointer to this object; the caller MUST keep
+  //        the resolver alive for the lifetime of the returned Transaction. Do not pass
+  //        a temporary.
   // @param retry_limit Maximum number of retry attempts on commit conflicts (default: 1)
   static arrow::Result<std::unique_ptr<Transaction>> Open(const milvus_storage::ArrowFileSystemPtr& fs,
                                                           const std::string& base_path,
@@ -260,8 +295,8 @@ class Transaction {
   int64_t read_version_;
   std::shared_ptr<Manifest> read_manifest_;
   std::string base_path_;
-  Updates updates_;    ///< Transaction updates tracked for resolver
-  Resolver resolver_;  ///< Resolver function for conflict resolution
+  Updates updates_;           ///< Transaction updates tracked for resolver
+  const Resolver* resolver_;  ///< Non-owning pointer to the resolver supplied at Open()
   milvus_storage::ArrowFileSystemPtr fs_;
   uint32_t retry_limit_;  ///< Maximum number of retry attempts on commit conflicts
 };

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -49,17 +49,17 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
     }
 
     // Select resolver based on resolve_id
-    Resolver resolver;
+    const Resolver* resolver = nullptr;
     switch (resolve_id) {
       case LOON_TRANSACTION_RESOLVE_MERGE:
-        resolver = MergeResolver;
+        resolver = &MergeResolver;
         break;
       case LOON_TRANSACTION_RESOLVE_OVERWRITE:
-        resolver = OverwriteResolver;
+        resolver = &OverwriteResolver;
         break;
       case LOON_TRANSACTION_RESOLVE_FAIL:
       default:
-        resolver = FailResolver;
+        resolver = &FailResolver;
         break;
     }
 
@@ -68,7 +68,8 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
     if (!fs_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
     }
-    auto transaction_result = Transaction::Open(fs_result.ValueOrDie(), base_path, read_version, resolver, retry_limit);
+    auto transaction_result =
+        Transaction::Open(fs_result.ValueOrDie(), base_path, read_version, *resolver, retry_limit);
     if (!transaction_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, transaction_result.status().ToString());
     }

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -249,40 +249,68 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
   return base;
 }
 
-// ==================== Helper Resolver Functions ====================
+// ==================== Built-in Resolver Implementations ====================
 
-Resolver MergeResolver = [](const std::shared_ptr<Manifest>& /*read_manifest*/,
-                            int64_t /*read_version*/,
-                            const std::shared_ptr<Manifest>& latest_manifest,
-                            int64_t /*latest_version*/,
-                            const Updates& updates) -> arrow::Result<std::shared_ptr<Manifest>> {
-  return applyUpdates(latest_manifest, updates);
-};
+namespace {
 
-Resolver OverwriteResolver = [](const std::shared_ptr<Manifest>& read_manifest,
-                                int64_t /*read_version*/,
-                                const std::shared_ptr<Manifest>& /*latest_manifest*/,
-                                int64_t /*latest_version*/,
-                                const Updates& updates) -> arrow::Result<std::shared_ptr<Manifest>> {
-  return applyUpdates(read_manifest, updates);
-};
-
-Resolver FailResolver = [](const std::shared_ptr<Manifest>& /*read_manifest*/,
-                           int64_t read_version,
-                           const std::shared_ptr<Manifest>& latest_manifest,
-                           int64_t latest_version,
-                           const Updates& updates) -> arrow::Result<std::shared_ptr<Manifest>> {
-  // Check if read_version equals latest_version (no concurrent changes)
-  if (read_version == latest_version) {
+class MergeResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& /*read_manifest*/,
+                                                   int64_t /*read_version*/,
+                                                   const std::shared_ptr<Manifest>& latest_manifest,
+                                                   int64_t /*latest_version*/,
+                                                   const Updates& updates) const override {
     return applyUpdates(latest_manifest, updates);
   }
 
-  return milvus_storage::MakeExtendError(
-      milvus_storage::ExtendStatusCode::TxnResolutionFailed,
-      fmt::format("FailResolver: concurrent transaction detected, [read_version={}][latest_version={}]", read_version,
-                  latest_version),
-      "");
+  [[nodiscard]] bool requireLatest() const override { return true; }
 };
+
+class OverwriteResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& read_manifest,
+                                                   int64_t /*read_version*/,
+                                                   const std::shared_ptr<Manifest>& /*latest_manifest*/,
+                                                   int64_t /*latest_version*/,
+                                                   const Updates& updates) const override {
+    return applyUpdates(read_manifest, updates);
+  }
+
+  [[nodiscard]] bool requireLatest() const override { return false; }
+};
+
+class FailResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& read_manifest,
+                                                   int64_t read_version,
+                                                   const std::shared_ptr<Manifest>& latest_manifest,
+                                                   int64_t latest_version,
+                                                   const Updates& updates) const override {
+    if (read_version == latest_version) {
+      // When versions match, Transaction::Commit supplies read_manifest_ as latest_manifest
+      // without a disk read; fall back to read_manifest if latest_manifest is null.
+      return applyUpdates(latest_manifest ? latest_manifest : read_manifest, updates);
+    }
+
+    return milvus_storage::MakeExtendError(
+        milvus_storage::ExtendStatusCode::TxnResolutionFailed,
+        fmt::format("FailResolver: concurrent transaction detected, [read_version={}][latest_version={}]", read_version,
+                    latest_version),
+        "");
+  }
+
+  [[nodiscard]] bool requireLatest() const override { return false; }
+};
+
+const MergeResolverImpl g_merge_resolver;
+const OverwriteResolverImpl g_overwrite_resolver;
+const FailResolverImpl g_fail_resolver;
+
+}  // namespace
+
+const Resolver& MergeResolver = g_merge_resolver;
+const Resolver& OverwriteResolver = g_overwrite_resolver;
+const Resolver& FailResolver = g_fail_resolver;
 
 // ==================== Transaction Implementation ====================
 
@@ -326,7 +354,7 @@ Transaction::Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
       base_path_(base_path),
       read_manifest_(nullptr),
       updates_(),
-      resolver_(resolver),
+      resolver_(&resolver),
       fs_(fs),
       retry_limit_(retry_limit) {}
 
@@ -342,7 +370,10 @@ arrow::Result<int64_t> Transaction::Commit() {
     return arrow::Status::Invalid("Cannot commit: no updates recorded");
   }
 
-  // Lambda to reload latest manifest and return version and manifest
+  // Lambda to reload latest manifest and return version and manifest.
+  // Skips the disk read for manifest-N.avro when the resolver declares it doesn't
+  // need latest_manifest contents (issue #49069: avoid spurious commit failures on
+  // transient read errors of an otherwise-unused manifest file).
   auto reload_latest_manifest = [this]() -> arrow::Result<std::pair<int64_t, std::shared_ptr<Manifest>>> {
     ARROW_ASSIGN_OR_RAISE(auto latest_version, get_latest_version());
 
@@ -350,6 +381,13 @@ arrow::Result<int64_t> Transaction::Commit() {
     if (latest_version == read_version_) {
       // Latest version is the same as read version, use read_manifest as latest_manifest
       latest_manifest = read_manifest_;
+    } else if (!resolver_->requireLatest()) {
+      // Resolver won't touch latest_manifest on version drift; skip the read.
+      LOG_STORAGE_DEBUG_ << fmt::format(
+          "Manifest version drift detected, skipping latest manifest read: "
+          "[read_version={}][latest_version={}]",
+          read_version_, latest_version);
+      latest_manifest = nullptr;
     } else {
       // Latest version differs, load the latest manifest
       LOG_STORAGE_DEBUG_ << fmt::format("Manifest version drift detected: [read_version={}][latest_version={}]",
@@ -369,7 +407,8 @@ arrow::Result<int64_t> Transaction::Commit() {
     std::shared_ptr<Manifest> latest_manifest = latest_result.second;
 
     // Always call resolver to get merged manifest
-    auto resolved_manifest_result = resolver_(read_manifest_, read_version_, latest_manifest, latest_version, updates_);
+    auto resolved_manifest_result =
+        resolver_->resolve(read_manifest_, read_version_, latest_manifest, latest_version, updates_);
     if (!resolved_manifest_result.ok()) {
       return resolved_manifest_result.status();
     }

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -306,6 +306,129 @@ TEST_F(TransactionTest, ConflictResolveOverwriteTest) {
   }
 }
 
+// Regression for issue #49069: when the resolver doesn't need the latest manifest,
+// Commit() must not block on reading manifest-N.avro from storage. A transient read
+// failure on an otherwise-unused manifest used to fail an entire successful commit.
+TEST_F(TransactionTest, CommitSkipsUnusedLatestManifestReadForOverwrite) {
+  // Make a baseline tree with two manifests written by separate transactions.
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v1.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v2.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // Open at read_version=1 so a subsequent commit sees version drift (latest=2).
+  ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, 1, OverwriteResolver));
+
+  // Corrupt manifest-2.avro so any attempt to read it fails. The filename still
+  // exists so get_latest_version() still reports 2 and the drift branch fires.
+  Manifest::CleanCache();
+  std::string manifest_2_path = get_manifest_filepath(base_path_, 2);
+  {
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(manifest_2_path));
+    const std::string garbage = "not a valid avro file";
+    ASSERT_STATUS_OK(out->Write(garbage.data(), garbage.size()));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Commit should succeed: OverwriteResolver declares requireLatest() == false,
+  // so Commit() skips reading the (now-corrupt) manifest-2.avro.
+  ASSERT_AND_ASSIGN(auto new_manifest, CreateSampleManifest("/dummy_overwrite.parquet", {"id", "name"}));
+  txn->AppendFiles(new_manifest->columnGroups());
+  ASSERT_AND_ASSIGN(auto committed_version, txn->Commit());
+  ASSERT_EQ(committed_version, 3);
+}
+
+TEST_F(TransactionTest, CommitSkipsUnusedLatestManifestReadForFailOnDrift) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v1.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v2.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, 1, FailResolver));
+
+  Manifest::CleanCache();
+  std::string manifest_2_path = get_manifest_filepath(base_path_, 2);
+  {
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(manifest_2_path));
+    const std::string garbage = "not a valid avro file";
+    ASSERT_STATUS_OK(out->Write(garbage.data(), garbage.size()));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // With version drift, FailResolver reports TxnResolutionFailed without touching
+  // latest_manifest. The corrupt manifest-2.avro must not surface as an IOError.
+  ASSERT_AND_ASSIGN(auto new_manifest, CreateSampleManifest("/dummy_fail.parquet", {"id", "name"}));
+  txn->AppendFiles(new_manifest->columnGroups());
+  auto status = txn->Commit().status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), arrow::StatusCode::IOError) << status.ToString();
+  // Sanity check: the error came from the resolver (concurrent transaction), not from
+  // a manifest read failure.
+  EXPECT_TRUE(status.ToString().find("concurrent transaction") != std::string::npos) << status.ToString();
+  EXPECT_TRUE(status.ToString().find("manifest-2.avro") == std::string::npos) << status.ToString();
+}
+
+TEST_F(TransactionTest, CommitStillReadsLatestManifestForMerge) {
+  // Negative test: MergeResolver does need latest_manifest, so a corrupt
+  // manifest-N.avro must still surface as a read error.
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v1.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v2.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+
+  Manifest::CleanCache();
+  std::string manifest_2_path = get_manifest_filepath(base_path_, 2);
+  {
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(manifest_2_path));
+    const std::string garbage = "not a valid avro file";
+    ASSERT_STATUS_OK(out->Write(garbage.data(), garbage.size()));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  ASSERT_AND_ASSIGN(auto new_manifest, CreateSampleManifest("/dummy_merge.parquet", {"id", "name"}));
+  txn->AppendFiles(new_manifest->columnGroups());
+  auto status = txn->Commit().status();
+  ASSERT_FALSE(status.ok());
+  // The failure must originate from reading the corrupt manifest-2.avro, not from some
+  // unrelated short-circuit: assert the error surfaces the manifest read path.
+  const auto msg = status.ToString();
+  EXPECT_TRUE(msg.find("manifest-2.avro") != std::string::npos || msg.find("deserialize") != std::string::npos ||
+              msg.find("Avro") != std::string::npos)
+      << msg;
+}
+
 TEST_F(TransactionTest, WriteReadByVersion) {
   // initial 5 commit with one column group
   int loop_times = 5;


### PR DESCRIPTION
See #521

Related: milvus-io/milvus#49069 (production trace).

Background

Transaction::Commit reads manifest-N.avro from object storage whenever
get_latest_version() differs from read_version_, even when the active
resolver does not consume latest_manifest. When that read transiently
fails (slow S3, eventual consistency, etc.), an otherwise-successful
commit fails with an IOError, even though the resolver would not have
used the manifest. This was observed in production: a sync retry on a
healthy segment hit this code path, the read failed transiently, and
the commit errored. The segment continued syncing successfully
afterward, confirming the manifest existed.

Change

Promote Resolver from std::function<...> to an abstract class with
two virtual methods:
  - resolve(...): same signature as before
  - requireLatest(): declares whether the resolver consumes
                     latest_manifest

Built-in resolvers tag themselves:
  - MergeResolver:     requireLatest() == true
  - OverwriteResolver: requireLatest() == false
  - FailResolver:      requireLatest() == false  (only inspects
                       latest_manifest when versions match, in which
                       case Commit already short-circuits to
                       read_manifest_)

In Transaction::Commit, the version-drift branch now consults
resolver_->requireLatest(): if false, skip the read of
manifest-N.avro and pass nullptr as latest_manifest.

API note

Resolver is now a polymorphic base class instead of a std::function
alias. External callers that pass lambdas or std::bind objects
directly will need to subclass Resolver. In-tree callers and FFI
bridge updated.

Test plan
  - Three regression tests in api_transaction_test.cpp use on-disk
    manifest corruption to exercise the three resolver paths
  - OverwriteResolver: commit succeeds despite corrupt manifest-2
  - FailResolver:      commit returns TxnResolutionFailed (not
                       IOError); error message confirms it came from
                       the resolver, not a manifest read
  - MergeResolver:     commit still surfaces the read failure
                       (negative test); assertion verifies the error
                       came from the manifest read path
  - Full milvus_test transaction suite passes (28/28, 1 unrelated
    skip)
  - Full Test_FFI suite passes (70/70)