### PR TITLE
feat: Add a row group zone map layout for Vortex V2

### DIFF
--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -233,6 +233,10 @@ class VortexFile {
   // otherwise, return vector with uncompressed sizes
   std::vector<uint64_t> GetUncompressedSizes() const;
 
+  std::string RootLayoutEncoding() const;
+  uint64_t RowGroupZoneMapCount() const;
+  bool RowGroupZoneMapDataBeforeZones() const;
+
   private:
   explicit VortexFile(rust::Box<ffi::VortexFile> impl) : impl_(std::move(impl)) {}
 
@@ -301,5 +305,22 @@ inline void PrintIOTrace() { ffi::print_io_trace_ffi(); }
 
 /// IO trace: disable and clear
 inline void DisableIOTrace() { ffi::disable_io_trace_ffi(); }
+
+struct RowGroupZoneMapPruningStats {
+  uint64_t prune_eval_count = 0;
+  uint64_t pruned_row_group_count = 0;
+};
+
+/// Row-group zonemap pruning diagnostics: reset counters.
+inline void ResetRowGroupZoneMapPruningStats() { ffi::reset_row_group_zone_map_pruning_stats_ffi(); }
+
+/// Row-group zonemap pruning diagnostics: return counters since the last reset.
+inline RowGroupZoneMapPruningStats GetRowGroupZoneMapPruningStats() {
+  auto stats = ffi::row_group_zone_map_pruning_stats_ffi();
+  RowGroupZoneMapPruningStats out;
+  out.prune_eval_count = stats.prune_eval_count;
+  out.pruned_row_group_count = stats.pruned_row_group_count;
+  return out;
+}
 
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -14,25 +14,30 @@
 
 mod aliyun_oss_provider;
 mod gcp_impersonation;
-mod lance_bridgeimpl;
 mod predicate_parser;
-mod vortex_bridgeimpl;
 mod iceberg_bridgeimpl;
 mod iceberg_testutil;
+mod lance_bridgeimpl;
+mod vortex_bridgeimpl;
+mod vortex_layout_strategy_v2;
 
 mod filesystem_c;
-use lance_bridgeimpl::*;
-use vortex_bridgeimpl::*;
 use iceberg_bridgeimpl::*;
 use iceberg_testutil::*;
+use lance_bridgeimpl::*;
+use vortex_bridgeimpl::*;
 
 use std::sync::LazyLock;
 
 use vortex::VortexSessionDefault;
-use vortex::io::runtime::tokio::TokioRuntime;
 use vortex::io::runtime::BlockingRuntime;
+use vortex::io::runtime::tokio::TokioRuntime;
 use vortex::io::session::RuntimeSessionExt;
+use vortex::layout::LayoutEncodingRef;
+use vortex::layout::session::LayoutSessionExt;
 use vortex::session::VortexSession;
+
+use crate::vortex_layout_strategy_v2::RowGroupZoneMapLayoutEncoding;
 
 /// Use a multi-thread Tokio runtime so that Vortex IO operations can run concurrently.
 /// max_blocking_threads is set to 64 to match Lance's thread pool size,
@@ -48,8 +53,13 @@ static VORTEX_TOKIO_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 static VORTEX_RT: LazyLock<TokioRuntime> =
     LazyLock::new(|| TokioRuntime::new(VORTEX_TOKIO_RT.handle().clone()));
 
-static VORTEX_SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::default().with_handle(VORTEX_RT.handle()));
+static VORTEX_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+    let session = VortexSession::default().with_handle(VORTEX_RT.handle());
+    session.layouts().register(LayoutEncodingRef::new_ref(
+        RowGroupZoneMapLayoutEncoding.as_ref(),
+    ));
+    session
+});
 
 static TOKIO_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
@@ -94,8 +104,14 @@ pub mod lance_ffi {
         pub unsafe fn write_stream(self: &mut BlockingDataset, stream_ptr: *mut u8) -> Result<()>;
         pub fn get_all_fragment_ids(self: &BlockingDataset) -> Vec<u64>;
         pub fn dataset_delete_rows(dataset: &mut BlockingDataset, predicate: &str) -> Result<()>;
-        pub fn get_fragment_deletion_positions(dataset: &BlockingDataset, fragment_id: u64) -> Result<Vec<u64>>;
-        pub fn get_fragment_physical_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64>;
+        pub fn get_fragment_deletion_positions(
+            dataset: &BlockingDataset,
+            fragment_id: u64,
+        ) -> Result<Vec<u64>>;
+        pub fn get_fragment_physical_row_count(
+            dataset: &BlockingDataset,
+            fragment_id: u64,
+        ) -> Result<u64>;
         pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64>;
         pub unsafe fn get_fragment_schema(
             dataset: &BlockingDataset,
@@ -149,10 +165,7 @@ pub mod lance_ffi {
 
         pub fn count_rows(self: &BlockingScanner) -> Result<u64>;
 
-        pub unsafe fn open_stream(
-            self: &BlockingScanner,
-            out_stream: *mut u8,
-        ) -> Result<()>;
+        pub unsafe fn open_stream(self: &BlockingScanner, out_stream: *mut u8) -> Result<()>;
 
         // Dataset-level take
         pub unsafe fn dataset_take(
@@ -163,13 +176,18 @@ pub mod lance_ffi {
         ) -> Result<()>;
 
     }
-}  // mod lance_ffi
+} // mod lance_ffi
 
 #[cxx::bridge(namespace = "milvus_storage::vortex::ffi")]
 pub mod vortex_ffi {
     struct VortexWriteSummary {
         file_size: u64,
         footer_size: u64,
+    }
+
+    struct RowGroupZoneMapPruningStats {
+        prune_eval_count: u64,
+        pruned_row_group_count: u64,
     }
 
     extern "Rust" {
@@ -231,8 +249,18 @@ pub mod vortex_ffi {
 
         // writer
         type VortexWriter;
-        unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool, format_version: u32, row_group_size: u64) -> Result<Box<VortexWriter>>;
-        unsafe fn write(self: &mut VortexWriter, in_schema: *mut u8, in_array: *mut u8) -> Result<()>;
+        unsafe fn open_writer(
+            fswrapper_ptr: *mut u8,
+            path: &str,
+            enable_stats: bool,
+            format_version: u32,
+            row_group_size: u64,
+        ) -> Result<Box<VortexWriter>>;
+        unsafe fn write(
+            self: &mut VortexWriter,
+            in_schema: *mut u8,
+            in_array: *mut u8,
+        ) -> Result<()>;
         unsafe fn close(self: &mut VortexWriter) -> Result<VortexWriteSummary>;
 
         // reader
@@ -240,11 +268,22 @@ pub mod vortex_ffi {
         fn row_count(self: &VortexFile) -> u64;
         unsafe fn get_schema(self: &VortexFile, out_schema: *mut u8) -> Result<()>;
         fn scan_builder(self: &VortexFile) -> Result<Box<VortexScanBuilder>>;
-        unsafe fn scan_builder_with_schema(self: &VortexFile, in_schema: *mut u8) -> Result<Box<VortexScanBuilder>>;
+        unsafe fn scan_builder_with_schema(
+            self: &VortexFile,
+            in_schema: *mut u8,
+        ) -> Result<Box<VortexScanBuilder>>;
         fn splits(self: &VortexFile) -> Result<Vec<u64>>;
         fn uncompressed_sizes(self: &VortexFile) -> Vec<u64>;
+        fn root_layout_encoding(self: &VortexFile) -> String;
+        fn row_group_zone_map_count(self: &VortexFile) -> Result<u64>;
+        fn row_group_zone_map_data_before_zones(self: &VortexFile) -> Result<bool>;
 
-        unsafe fn open_file(fswrapper_ptr: *mut u8, path: &str, file_size: u64, footer_size: u64) -> Result<Box<VortexFile>>;
+        unsafe fn open_file(
+            fswrapper_ptr: *mut u8,
+            path: &str,
+            file_size: u64,
+            footer_size: u64,
+        ) -> Result<Box<VortexFile>>;
 
         type VortexScanBuilder;
         fn with_filter(self: &mut VortexScanBuilder, filter: Box<Expr>);
@@ -267,6 +306,10 @@ pub mod vortex_ffi {
         fn reset_io_trace_ffi();
         fn print_io_trace_ffi();
         fn disable_io_trace_ffi();
+
+        // Row-group zonemap pruning diagnostics
+        fn reset_row_group_zone_map_pruning_stats_ffi();
+        fn row_group_zone_map_pruning_stats_ffi() -> RowGroupZoneMapPruningStats;
     }
 
     #[repr(u8)]

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -237,6 +237,27 @@ std::vector<uint64_t> VortexFile::GetUncompressedSizes() const {
   return {rs_sizes.begin(), rs_sizes.end()};
 }
 
+std::string VortexFile::RootLayoutEncoding() const {
+  auto rust_str = impl_->root_layout_encoding();
+  return {rust_str.data(), rust_str.length()};
+}
+
+uint64_t VortexFile::RowGroupZoneMapCount() const {
+  try {
+    return impl_->row_group_zone_map_count();
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw VortexException(e.what());
+  }
+}
+
+bool VortexFile::RowGroupZoneMapDataBeforeZones() const {
+  try {
+    return impl_->row_group_zone_map_data_before_zones();
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw VortexException(e.what());
+  }
+}
+
 ScanBuilder& ScanBuilder::WithFilter(expr::Expr&& expr) & {
   impl_->with_filter(std::move(expr).IntoImpl());
   return *this;

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -1,60 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use anyhow::Result;
+use std::ffi::c_void;
+use std::fmt::{Display, Formatter};
 use std::ops::Range;
 use std::sync::Arc;
-use std::fmt::{Display, Formatter};
-use std::ffi::c_void;
-use anyhow::Result;
 
-use arrow_array::{Array, ArrayRef as ArrowArrayRef, RecordBatch, RecordBatchReader, FixedSizeBinaryArray, FixedSizeListArray, UInt8Array};
 use arrow_array::cast::AsArray;
 use arrow_array::ffi::FFI_ArrowSchema;
-use arrow_array::ffi_stream::{FFI_ArrowArrayStream};
-use arrow_data::ffi::{FFI_ArrowArray};
+use arrow_array::ffi_stream::FFI_ArrowArrayStream;
+use arrow_array::{
+    Array, ArrayRef as ArrowArrayRef, FixedSizeBinaryArray, FixedSizeListArray, RecordBatch,
+    RecordBatchReader, UInt8Array,
+};
 use arrow_data::ArrayData;
-use arrow_schema::{Field, ArrowError, DataType, Schema, SchemaRef};
+use arrow_data::ffi::FFI_ArrowArray;
+use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 
-
-use vortex::stats::Precision;
-use vortex::stats::Stat;
 use vortex::ArrayRef;
 use vortex::arrow::{FromArrowArray, IntoArrowArray};
 use vortex::buffer::Buffer;
-use vortex::file::{BlockingWriter, OpenOptionsSessionExt};
-use vortex::scan::ScanBuilder;
-use vortex::dtype::{DType as RustDType, DecimalDType, Nullability, PType as RustPType, FieldName};
 use vortex::dtype::arrow::FromArrowType;
-use vortex::expr::Expression;
-use vortex::io::runtime::tokio::TokioRuntime;
-use vortex::io::runtime::BlockingRuntime;
+use vortex::dtype::{DType as RustDType, DecimalDType, FieldName, Nullability, PType as RustPType};
 use vortex::error::VortexError;
-
-use std::collections::VecDeque;
-use async_trait::async_trait;
-use async_stream::try_stream;
-use futures::{StreamExt as FuturesStreamExt, pin_mut};
+use vortex::expr::Expression;
+use vortex::file::{BlockingWriter, OpenOptionsSessionExt};
+use vortex::io::runtime::BlockingRuntime;
+use vortex::io::runtime::tokio::TokioRuntime;
+use vortex::scan::ScanBuilder;
+use vortex::stats::Precision;
+use vortex::stats::Stat;
 
 use vortex::file::VortexWriteOptions;
 use vortex::file::WriteStrategyBuilder;
-use vortex::IntoArray;
-use vortex::arrays::ChunkedArray;
-use vortex::layout::LayoutStrategy;
-use vortex::layout::LayoutRef as VortexLayoutRef;
-use vortex::layout::segments::SegmentSinkRef;
-use vortex::layout::sequence::{SendableSequentialStream, SequencePointer, SequentialStreamAdapter, SequentialStreamExt};
-use vortex::layout::layouts::flat::writer::FlatLayoutStrategy;
-use vortex::layout::layouts::compressed::CompressingStrategy;
-use vortex::layout::layouts::chunked::writer::ChunkedLayoutStrategy;
-use vortex::layout::layouts::collect::CollectStrategy;
-use vortex::layout::layouts::struct_::writer::StructStrategy;
-use vortex::io::runtime::Handle;
-use vortex::ArrayContext;
 
-use crate::filesystem_c::*;
 use crate::VORTEX_RT;
 use crate::VORTEX_SESSION;
+use crate::filesystem_c::*;
 use crate::vortex_ffi as ffi;
+use crate::vortex_layout_strategy_v2::build_row_group_strategy;
 
 /*
  * Type
@@ -329,7 +314,10 @@ fn is_fixed_size_binary(dt: &DataType) -> bool {
 
 /// Check if schema contains any FixedSizeBinary fields
 fn schema_has_fixed_size_binary(schema: &Schema) -> bool {
-    schema.fields().iter().any(|f| is_fixed_size_binary(f.data_type()))
+    schema
+        .fields()
+        .iter()
+        .any(|f| is_fixed_size_binary(f.data_type()))
 }
 
 /// Convert FixedSizeBinary type to FixedSizeList<u8>
@@ -398,7 +386,9 @@ fn convert_list_to_fixed_size_binary(array: &FixedSizeListArray, byte_width: i32
     let values = array.values();
 
     // Get the u8 child array
-    let u8_array = values.as_any().downcast_ref::<UInt8Array>()
+    let u8_array = values
+        .as_any()
+        .downcast_ref::<UInt8Array>()
         .expect("Expected UInt8 child array");
 
     // Get the underlying buffer directly (zero-copy via Arc)
@@ -414,7 +404,9 @@ fn convert_list_to_fixed_size_binary(array: &FixedSizeListArray, byte_width: i32
         builder = builder.null_bit_buffer(Some(nulls.buffer().clone()));
     }
 
-    let fsb_data = builder.build().expect("Failed to build FixedSizeBinary ArrayData");
+    let fsb_data = builder
+        .build()
+        .expect("Failed to build FixedSizeBinary ArrayData");
     Arc::new(FixedSizeBinaryArray::from(fsb_data))
 }
 
@@ -432,7 +424,9 @@ fn convert_record_batch_from_vortex(batch: &RecordBatch, original_schema: &Schem
         .map(|(col, orig_field)| {
             if let DataType::FixedSizeBinary(byte_width) = orig_field.data_type() {
                 if let DataType::FixedSizeList(_, _) = col.data_type() {
-                    let fsl_array = col.as_any().downcast_ref::<FixedSizeListArray>()
+                    let fsl_array = col
+                        .as_any()
+                        .downcast_ref::<FixedSizeListArray>()
                         .expect("Expected FixedSizeListArray");
                     convert_list_to_fixed_size_binary(fsl_array, *byte_width)
                 } else {
@@ -449,7 +443,9 @@ fn convert_record_batch_from_vortex(batch: &RecordBatch, original_schema: &Schem
 }
 
 /// Convert StructArray: replace FixedSizeBinary columns with FixedSizeList<u8>
-fn convert_struct_array_for_vortex(struct_array: &arrow_array::StructArray) -> arrow_array::StructArray {
+fn convert_struct_array_for_vortex(
+    struct_array: &arrow_array::StructArray,
+) -> arrow_array::StructArray {
     let schema = Schema::new(struct_array.fields().clone());
     if !schema_has_fixed_size_binary(&schema) {
         return struct_array.clone();
@@ -476,7 +472,9 @@ fn convert_struct_array_for_vortex(struct_array: &arrow_array::StructArray) -> a
         .iter()
         .map(|col| {
             if let DataType::FixedSizeBinary(_) = col.data_type() {
-                let fsb_array = col.as_any().downcast_ref::<FixedSizeBinaryArray>()
+                let fsb_array = col
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
                     .expect("Expected FixedSizeBinaryArray");
                 convert_fixed_size_binary_to_list(fsb_array)
             } else {
@@ -485,8 +483,12 @@ fn convert_struct_array_for_vortex(struct_array: &arrow_array::StructArray) -> a
         })
         .collect();
 
-    arrow_array::StructArray::try_new(new_fields.into(), new_columns, struct_array.nulls().cloned())
-        .expect("Failed to create converted StructArray")
+    arrow_array::StructArray::try_new(
+        new_fields.into(),
+        new_columns,
+        struct_array.nulls().cloned(),
+    )
+    .expect("Failed to create converted StructArray")
 }
 
 /*
@@ -499,218 +501,13 @@ pub const VORTEX_BASIC_STATS: &[Stat] = &[
     Stat::Sum,
     Stat::NullCount,
     Stat::NaNCount,
-    Stat::UncompressedSizeInBytes
+    Stat::UncompressedSizeInBytes,
 ];
 
-pub const VORTEX_NON_STATS: &[Stat] = &[
-    Stat::UncompressedSizeInBytes
-];
+pub const VORTEX_NON_STATS: &[Stat] = &[Stat::UncompressedSizeInBytes];
 
 const VORTEX_FORMAT_V1: u32 = 1;
 const VORTEX_FORMAT_V2: u32 = 2;
-
-/// Options for byte-size-based row group splitting.
-#[derive(Clone)]
-struct RowGroupSplitOptions {
-    block_size_minimum: u64,
-    canonicalize: bool,
-}
-
-/// Splits a stream of arrays into row groups based on uncompressed byte size.
-///
-/// Unlike `RepartitionStrategy` which slices incoming chunks into fixed-row-count
-/// pieces via `block_len_multiple`, this strategy keeps incoming chunks intact and
-/// flushes all accumulated data as a single row group when the byte threshold is met.
-struct RowGroupSplitStrategy {
-    child: Arc<dyn LayoutStrategy>,
-    options: RowGroupSplitOptions,
-}
-
-impl RowGroupSplitStrategy {
-    fn new<S: LayoutStrategy>(child: S, options: RowGroupSplitOptions) -> Self {
-        Self {
-            child: Arc::new(child),
-            options,
-        }
-    }
-}
-
-/// Simple accumulator that buffers chunks until a byte-size threshold is reached,
-/// then drains them as size-limited row groups.
-///
-/// Each entry stores (chunk, estimated_bytes) because `nbytes()` on a sliced array
-/// may return the underlying buffer's total size, not the slice's portion.
-struct RowGroupBuffer {
-    data: VecDeque<(vortex::ArrayRef, u64)>,
-    nbytes: u64,
-    block_size_minimum: u64,
-}
-
-impl RowGroupBuffer {
-    fn new(block_size_minimum: u64) -> Self {
-        Self {
-            data: VecDeque::new(),
-            nbytes: 0,
-            block_size_minimum,
-        }
-    }
-
-    fn push(&mut self, chunk: vortex::ArrayRef) {
-        let nbytes = chunk.nbytes() as u64;
-        self.nbytes += nbytes;
-        self.data.push_back((chunk, nbytes));
-    }
-
-    fn have_enough(&self) -> bool {
-        self.nbytes >= self.block_size_minimum
-    }
-
-    fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-
-    /// Drain one row group (~block_size_minimum bytes) from the front of the buffer.
-    /// If a chunk would overshoot the limit, slice it and put the remainder back.
-    fn drain_one_group(&mut self, dtype: &vortex::dtype::DType) -> Option<vortex::ArrayRef> {
-        if self.data.is_empty() {
-            return None;
-        }
-
-        let mut group = Vec::new();
-        let mut group_bytes: u64 = 0;
-
-        while let Some((chunk, est_bytes)) = self.data.pop_front() {
-            let chunk_len = chunk.len();
-            self.nbytes -= est_bytes;
-
-            if group_bytes + est_bytes <= self.block_size_minimum {
-                group_bytes += est_bytes;
-                group.push(chunk);
-                if group_bytes >= self.block_size_minimum {
-                    break;
-                }
-            } else {
-                // This chunk would overshoot — slice to fit
-                let space_left = self.block_size_minimum - group_bytes;
-                let rows_to_take = if est_bytes > 0 {
-                    ((space_left * chunk_len as u64 + est_bytes - 1) / est_bytes) as usize
-                } else {
-                    chunk_len
-                }.max(1).min(chunk_len);
-
-                let left = chunk.slice(0..rows_to_take);
-                group.push(left);
-
-                if rows_to_take < chunk_len {
-                    let right = chunk.slice(rows_to_take..chunk_len);
-                    let right_est = est_bytes * (chunk_len - rows_to_take) as u64 / chunk_len as u64;
-                    self.nbytes += right_est;
-                    self.data.push_front((right, right_est));
-                }
-                break;
-            }
-        }
-
-        let chunked = ChunkedArray::try_new(group, dtype.clone()).ok()?;
-        Some(chunked.to_canonical().into_array())
-    }
-}
-
-#[async_trait]
-impl LayoutStrategy for RowGroupSplitStrategy {
-    async fn write_stream(
-        &self,
-        ctx: ArrayContext,
-        segment_sink: SegmentSinkRef,
-        stream: SendableSequentialStream,
-        eof: SequencePointer,
-        handle: Handle,
-    ) -> vortex::error::VortexResult<VortexLayoutRef> {
-        let dtype = stream.dtype().clone();
-        let stream = if self.options.canonicalize {
-            SequentialStreamAdapter::new(
-                dtype.clone(),
-                stream.map(|chunk| {
-                    let (sequence_id, chunk) = chunk?;
-                    vortex::error::VortexResult::Ok((sequence_id, chunk.to_canonical().into_array()))
-                }),
-            )
-            .sendable()
-        } else {
-            stream
-        };
-
-        let dtype_clone = dtype.clone();
-        let block_size_minimum = self.options.block_size_minimum;
-        let repartitioned_stream = try_stream! {
-            let stream = stream.peekable();
-            pin_mut!(stream);
-            let mut buffer = RowGroupBuffer::new(block_size_minimum);
-
-            // Each input chunk comes from a C++ Write() call via BlockingWriter::push().
-            // The stream closes when C++ calls Close() (BlockingWriter::finish()).
-            while let Some(chunk) = stream.as_mut().next().await {
-                let (sequence_id, chunk) = chunk?;
-                // Create a child sequence pointer for this input chunk.
-                // Each advance() produces a unique, ordered ID (A.0, A.1, ...)
-                // so downstream ChunkedLayoutStrategy can write row groups concurrently
-                // while preserving deterministic ordering in the final file.
-                let mut sp = sequence_id.descend();
-
-                if chunk.len() > 0 {
-                    buffer.push(chunk);
-                }
-
-                // Check if this is the last chunk (writer is closing).
-                let is_eof = stream.as_mut().peek().await.is_none();
-
-                // Drain row groups from the buffer:
-                // - Normally: only drain when accumulated bytes >= block_size_minimum
-                // - At EOF: drain all remaining data as size-limited row groups
-                while buffer.have_enough() || (is_eof && !buffer.is_empty()) {
-                    if let Some(array) = buffer.drain_one_group(&dtype_clone) {
-                        yield (sp.advance(), array)
-                    } else {
-                        break;
-                    }
-                }
-            }
-        };
-
-        self.child
-            .write_stream(
-                ctx,
-                segment_sink,
-                SequentialStreamAdapter::new(dtype, repartitioned_stream).sendable(),
-                eof,
-                handle,
-            )
-            .await
-    }
-
-    fn buffered_bytes(&self) -> u64 {
-        self.child.buffered_bytes()
-    }
-}
-
-fn build_row_group_strategy(row_group_max_size: u64) -> Arc<dyn LayoutStrategy> {
-    let flat = FlatLayoutStrategy { inline_array_node: true, ..Default::default() };
-    let compress_flat = CompressingStrategy::new_btrblocks(flat, false);
-    let chunked_inner = ChunkedLayoutStrategy::new(compress_flat.clone());
-    let validity = CollectStrategy::new(compress_flat);
-    let struct_inner = StructStrategy::new(chunked_inner, validity);
-    let chunked_outer = ChunkedLayoutStrategy::new(struct_inner);
-    // RowGroupSplit is the top-level strategy: it receives the full push stream,
-    // accumulates across batch boundaries, and yields row-group-sized arrays.
-    // Each yield becomes one chunk in the outer ChunkedLayout.
-    Arc::new(RowGroupSplitStrategy::new(
-        chunked_outer,
-        RowGroupSplitOptions {
-            block_size_minimum: row_group_max_size,
-            canonicalize: false,
-        },
-    ))
-}
 
 pub(crate) struct VortexWriter {
     pub fswrapper_ptr: *mut u8,
@@ -721,8 +518,13 @@ pub(crate) struct VortexWriter {
     pub row_group_max_size: u64,
 }
 
-pub(crate) unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stats: bool, format_version: u32, row_group_max_size: u64)
-    -> Result<Box<VortexWriter>, Box<dyn std::error::Error>> {
+pub(crate) unsafe fn open_writer(
+    fswrapper_ptr: *mut u8,
+    path: &str,
+    enable_stats: bool,
+    format_version: u32,
+    row_group_max_size: u64,
+) -> Result<Box<VortexWriter>, Box<dyn std::error::Error>> {
     if format_version == VORTEX_FORMAT_V2 && row_group_max_size == 0 {
         return Err("format_version=V2 requires row_group_max_size > 0".into());
     }
@@ -737,80 +539,93 @@ pub(crate) unsafe fn open_writer(fswrapper_ptr: *mut u8, path: &str, enable_stat
 }
 
 impl VortexWriter {
+    pub(crate) unsafe fn write(&mut self, in_schema: *mut u8, in_array: *mut u8) -> Result<()> {
+        let ffi_array = unsafe { FFI_ArrowArray::from_raw(in_array as *mut FFI_ArrowArray) };
 
-pub(crate) unsafe fn write(&mut self, in_schema: *mut u8, in_array: *mut u8) -> Result<()> {
-    let ffi_array = unsafe {
-        FFI_ArrowArray::from_raw(in_array as *mut FFI_ArrowArray)
-    };
+        let ffi_schema = unsafe { FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema) };
+        let arrow_schema = Schema::try_from(&ffi_schema)?;
 
-    let ffi_schema = unsafe {
-         FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema)
-    };
-    let arrow_schema = Schema::try_from(&ffi_schema)?;
+        let arrow_array_data = arrow_array::array::StructArray::from(
+            unsafe { arrow_array::ffi::from_ffi(ffi_array, &ffi_schema) }
+                .map_err(|e| VortexError::from(e))?,
+        );
 
-    let arrow_array_data = arrow_array::array::StructArray::from(unsafe { arrow_array::ffi::from_ffi(ffi_array, &ffi_schema) }
-        .map_err(|e| VortexError::from(e))?);
+        // Convert FixedSizeBinary columns to FixedSizeList<u8> for Vortex compatibility
+        let converted_array = convert_struct_array_for_vortex(&arrow_array_data);
+        let converted_schema = convert_schema_for_vortex(&arrow_schema);
+        let vortex_schema = RustDType::from_arrow(&converted_schema);
 
-    // Convert FixedSizeBinary columns to FixedSizeList<u8> for Vortex compatibility
-    let converted_array = convert_struct_array_for_vortex(&arrow_array_data);
-    let converted_schema = convert_schema_for_vortex(&arrow_schema);
-    let vortex_schema = RustDType::from_arrow(&converted_schema);
+        // lazy init the inner_writer
+        if self.inner_writer.is_none() {
+            let objw = ObjectStoreWriterCpp::new(self.fswrapper_ptr as *mut c_void, &self.path)
+                .map_err(|e| VortexError::from(e))?;
 
-    // lazy init the inner_writer
-    if self.inner_writer.is_none() {
-        let objw = ObjectStoreWriterCpp::new(self.fswrapper_ptr as *mut c_void, &self.path)
-            .map_err(|e| VortexError::from(e))?;
+            // stats options
+            let stats_options = if self.enable_stats {
+                VORTEX_BASIC_STATS.to_vec()
+            } else {
+                VORTEX_NON_STATS.to_vec()
+            };
+            let strategy = if self.format_version == VORTEX_FORMAT_V2 {
+                build_row_group_strategy(
+                    self.row_group_max_size,
+                    self.enable_stats,
+                    Arc::<[Stat]>::from(stats_options.clone()),
+                )
+            } else {
+                WriteStrategyBuilder::new()
+                    .with_inline_array_node(true)
+                    .build()
+            };
 
-        // stats options
-        let stats_options = if self.enable_stats {
-            VORTEX_BASIC_STATS.to_vec()
-        } else {
-            VORTEX_NON_STATS.to_vec()
-        };
-        let strategy = if self.format_version == VORTEX_FORMAT_V2 {
-            build_row_group_strategy(self.row_group_max_size)
-        } else {
-            WriteStrategyBuilder::new()
-                .with_inline_array_node(true)
-                .build()
-        };
+            let blocking_writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
+                .with_file_statistics(stats_options)
+                .with_strategy(strategy)
+                .blocking(&*VORTEX_RT)
+                .writer(objw, vortex_schema);
 
-        let blocking_writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
-            .with_file_statistics(stats_options)
-            .with_strategy(strategy)
-            .blocking(&*VORTEX_RT)
-            .writer(objw, vortex_schema);
+            self.inner_writer = Some(blocking_writer);
+        }
+        let mut inner_writer = self.inner_writer.take().unwrap();
 
-        self.inner_writer = Some(blocking_writer);
+        inner_writer
+            .push(ArrayRef::from_arrow(&converted_array, false))
+            .map_err(|e| Box::new(VortexError::from(e)))?;
+
+        self.inner_writer = Some(inner_writer);
+        Ok(())
     }
-    let mut inner_writer = self.inner_writer.take().unwrap();
 
-    inner_writer.push(ArrayRef::from_arrow(&converted_array, false))
-        .map_err(|e| Box::new(VortexError::from(e)))?;
+    pub(crate) unsafe fn close(
+        &mut self,
+    ) -> Result<crate::vortex_ffi::VortexWriteSummary, Box<dyn std::error::Error>> {
+        if let Some(w) = self.inner_writer.take() {
+            let summary = w
+                .finish()
+                .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
+            let file_size = summary.size();
 
-    self.inner_writer = Some(inner_writer);
-    Ok(())
-}
+            // Re-serialize the footer to compute the exact footer region size on disk.
+            let footer_size: u64 = summary
+                .footer()
+                .clone()
+                .into_serializer()
+                .serialize()
+                .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?
+                .iter()
+                .map(|b| b.len() as u64)
+                .sum();
 
-pub(crate) unsafe fn close(&mut self) -> Result<crate::vortex_ffi::VortexWriteSummary, Box<dyn std::error::Error>> {
-    if let Some(w) = self.inner_writer.take() {
-        let summary = w.finish().map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
-        let file_size = summary.size();
-
-        // Re-serialize the footer to compute the exact footer region size on disk.
-        let footer_size: u64 = summary.footer().clone()
-            .into_serializer()
-            .serialize()
-            .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?
-            .iter()
-            .map(|b| b.len() as u64)
-            .sum();
-
-        return Ok(crate::vortex_ffi::VortexWriteSummary { file_size, footer_size });
+            return Ok(crate::vortex_ffi::VortexWriteSummary {
+                file_size,
+                footer_size,
+            });
+        }
+        Ok(crate::vortex_ffi::VortexWriteSummary {
+            file_size: 0,
+            footer_size: 0,
+        })
     }
-    Ok(crate::vortex_ffi::VortexWriteSummary { file_size: 0, footer_size: 0 })
-}
-
 }
 
 pub(crate) struct VortexFile {
@@ -831,7 +646,10 @@ impl VortexFile {
         }))
     }
 
-    pub(crate) fn scan_builder_with_schema(&self, in_schema: *mut u8) -> Result<Box<VortexScanBuilder>> {
+    pub(crate) fn scan_builder_with_schema(
+        &self,
+        in_schema: *mut u8,
+    ) -> Result<Box<VortexScanBuilder>> {
         let ffi_schema = unsafe { FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema) };
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
@@ -856,11 +674,11 @@ impl VortexFile {
 
     pub(crate) fn splits(&self) -> Result<Vec<u64>> {
         // get the Vec<Range<u64>> from the inner file
-        let ranges = self.inner.splits()
-            .map_err(|e| VortexError::from(e))?;
+        let ranges = self.inner.splits().map_err(|e| VortexError::from(e))?;
 
         // map each Range<u64> to its end (right-hand side)
-        let ends = ranges.into_iter()
+        let ends = ranges
+            .into_iter()
             .map(|r: Range<u64>| r.end - r.start)
             .collect::<Vec<u64>>();
 
@@ -869,7 +687,7 @@ impl VortexFile {
 
     pub(crate) fn uncompressed_sizes(&self) -> Vec<u64> {
         let stats_opt = self.inner.footer().statistics();
-        
+
         match stats_opt {
             None => vec![],
             Some(arc_slice) => {
@@ -884,23 +702,84 @@ impl VortexFile {
                         Some(v) => v,
                         None => u64::MAX,
                     };
-                    
+
                     sizes.push(byte_size);
                 });
-                
+
                 sizes
             }
         }
     }
 
+    pub(crate) fn root_layout_encoding(&self) -> String {
+        self.inner
+            .footer()
+            .layout()
+            .encoding_id()
+            .as_ref()
+            .to_string()
+    }
+
+    pub(crate) fn row_group_zone_map_count(&self) -> Result<u64> {
+        let root = self.inner.footer().layout();
+        if root.encoding_id().as_ref() != "milvus.v2_zoned_row_group" {
+            return Ok(0);
+        }
+        Ok(root.child(1)?.row_count())
+    }
+
+    pub(crate) fn row_group_zone_map_data_before_zones(&self) -> Result<bool> {
+        let root = self.inner.footer().layout();
+        if root.encoding_id().as_ref() != "milvus.v2_zoned_row_group" {
+            return Ok(false);
+        }
+
+        let data_child = root.child(0)?;
+        let zones_child = root.child(1)?;
+        let mut data_segment_ids = Vec::new();
+        collect_layout_segment_ids(&data_child, &mut data_segment_ids)?;
+        let mut zones_segment_ids = Vec::new();
+        collect_layout_segment_ids(&zones_child, &mut zones_segment_ids)?;
+
+        if data_segment_ids.is_empty() || zones_segment_ids.is_empty() {
+            return Ok(false);
+        }
+
+        let segments = self.inner.footer().segment_map();
+        let max_data_offset = data_segment_ids
+            .iter()
+            .map(|idx| segments[*idx].offset)
+            .max()
+            .expect("checked non-empty data segments");
+        let min_zones_offset = zones_segment_ids
+            .iter()
+            .map(|idx| segments[*idx].offset)
+            .min()
+            .expect("checked non-empty zones segments");
+
+        Ok(max_data_offset < min_zones_offset)
+    }
+}
+
+fn collect_layout_segment_ids(
+    layout: &vortex::layout::LayoutRef,
+    out: &mut Vec<usize>,
+) -> Result<()> {
+    for segment_id in layout.segment_ids() {
+        out.push(usize::try_from(*segment_id)?);
+    }
+    for child in layout.children()? {
+        collect_layout_segment_ids(&child, out)?;
+    }
+    Ok(())
 }
 
 pub(crate) unsafe fn open_file(
     fswrapper_ptr: *mut u8,
     path: &str,
     file_size: u64,
-    footer_size: u64) -> Result<Box<VortexFile>> {
-
+    footer_size: u64,
+) -> Result<Box<VortexFile>> {
     let read_source = ObjectStoreReadSourceCpp::new(fswrapper_ptr as *mut c_void, path, file_size)
         .map_err(VortexError::from)?;
     let mut open_options = VORTEX_SESSION.open_options();
@@ -911,8 +790,8 @@ pub(crate) unsafe fn open_file(
     if footer_size > 0 {
         // Use cached footer size as initial read size to read entire footer in one IO.
         // Add EOF_SIZE for the EOF marker (version + postscript length + magic) that follows the footer.
-        open_options = open_options
-            .with_initial_read_size(footer_size as usize + vortex::file::EOF_SIZE);
+        open_options =
+            open_options.with_initial_read_size(footer_size as usize + vortex::file::EOF_SIZE);
     }
     let file = VORTEX_RT.block_on(async move {
         open_options
@@ -926,8 +805,8 @@ pub(crate) unsafe fn open_file(
 
 pub(crate) struct VortexScanBuilder {
     inner: ScanBuilder<ArrayRef>,
-    output_schema: Option<SchemaRef>,          // Converted schema for Vortex (FixedSizeList<u8>)
-    original_schema: Option<SchemaRef>,        // Original schema from user (may contain FixedSizeBinary)
+    output_schema: Option<SchemaRef>, // Converted schema for Vortex (FixedSizeList<u8>)
+    original_schema: Option<SchemaRef>, // Original schema from user (may contain FixedSizeBinary)
     row_range: Option<Range<u64>>,
 }
 
@@ -1084,14 +963,15 @@ pub(crate) unsafe fn scan_builder_into_stream(
     };
 
     // Wrap with converting reader if schema has FixedSizeBinary
-    let final_reader: Box<dyn RecordBatchReader + Send> = if schema_has_fixed_size_binary(&original_schema) {
-        Box::new(ConvertingRecordBatchReader {
-            inner: Box::new(reader),
-            original_schema,
-        })
-    } else {
-        Box::new(reader)
-    };
+    let final_reader: Box<dyn RecordBatchReader + Send> =
+        if schema_has_fixed_size_binary(&original_schema) {
+            Box::new(ConvertingRecordBatchReader {
+                inner: Box::new(reader),
+                original_schema,
+            })
+        } else {
+            Box::new(reader)
+        };
 
     let stream = FFI_ArrowArrayStream::new(final_reader);
     let out_stream = out_stream as *mut FFI_ArrowArrayStream;
@@ -1113,3 +993,15 @@ pub fn disable_io_trace_ffi() {
     crate::filesystem_c::disable_io_trace();
 }
 
+pub fn reset_row_group_zone_map_pruning_stats_ffi() {
+    crate::vortex_layout_strategy_v2::reset_row_group_zone_map_pruning_stats();
+}
+
+pub fn row_group_zone_map_pruning_stats_ffi() -> crate::vortex_ffi::RowGroupZoneMapPruningStats {
+    let (prune_eval_count, pruned_row_group_count) =
+        crate::vortex_layout_strategy_v2::row_group_zone_map_pruning_stats();
+    crate::vortex_ffi::RowGroupZoneMapPruningStats {
+        prune_eval_count,
+        pruned_row_group_count,
+    }
+}

--- a/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
@@ -1,0 +1,1341 @@
+use std::ops::{BitAnd, Range};
+use std::sync::{Arc, Mutex};
+
+use async_stream::try_stream;
+use async_trait::async_trait;
+use futures::{StreamExt as _, pin_mut};
+use vortex::ArrayContext;
+use vortex::arrays::{PrimitiveArray, StructArray};
+use vortex::buffer::Buffer;
+use vortex::dtype::{
+    DType, Field, FieldName, FieldNames, FieldPath, FieldPathSet, Nullability, PType, StructFields,
+};
+use vortex::error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_err};
+use vortex::expr::pruning::{checked_pruning_expr, field_path_stat_field_name};
+use vortex::expr::{Expression, get_item, root};
+use vortex::io::runtime::Handle;
+use vortex::layout::layouts::chunked::writer::ChunkedLayoutStrategy;
+use vortex::layout::layouts::collect::CollectStrategy;
+use vortex::layout::layouts::compressed::CompressingStrategy;
+use vortex::layout::layouts::flat::writer::FlatLayoutStrategy;
+use vortex::layout::layouts::struct_::writer::StructStrategy;
+use vortex::layout::layouts::zoned::zone_map::{StatsAccumulator, ZoneMap};
+use vortex::layout::segments::{SegmentId, SegmentSinkRef, SegmentSource};
+use vortex::layout::sequence::{
+    SendableSequentialStream, SequencePointer, SequentialArrayStreamExt, SequentialStreamAdapter,
+    SequentialStreamExt,
+};
+use vortex::layout::{
+    IntoLayout, LayoutChildType, LayoutChildren, LayoutEncodingRef, LayoutId, LayoutReader,
+    LayoutReaderRef, LayoutRef, LayoutStrategy, LazyReaderChildren, VTable, vtable,
+};
+use vortex::mask::{Mask, MaskMut};
+use vortex::stats::{Stat, as_stat_bitset_bytes, stats_from_bitset_bytes};
+use vortex::validity::Validity;
+use vortex::{
+    Array, ArrayRef, DeserializeMetadata, IntoArray, MaskFuture, SerializeMetadata, ToCanonical,
+};
+
+const LAYOUT_ID: &str = "milvus.v2_zoned_row_group";
+const METADATA_VERSION: u16 = 1;
+const STATS_VERSION: u16 = 1;
+const RG_BOUNDARIES_FIELD: &str = "__rg_boundaries";
+const RG_START_FIELD: &str = "__rg_start";
+const RG_LEN_FIELD: &str = "__rg_len";
+
+static ROW_GROUP_ZONE_MAP_PRUNE_EVAL_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+static ROW_GROUP_ZONE_MAP_PRUNED_ROW_GROUP_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+pub(crate) fn reset_row_group_zone_map_pruning_stats() {
+    ROW_GROUP_ZONE_MAP_PRUNE_EVAL_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
+    ROW_GROUP_ZONE_MAP_PRUNED_ROW_GROUP_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub(crate) fn row_group_zone_map_pruning_stats() -> (u64, u64) {
+    (
+        ROW_GROUP_ZONE_MAP_PRUNE_EVAL_COUNT.load(std::sync::atomic::Ordering::Relaxed),
+        ROW_GROUP_ZONE_MAP_PRUNED_ROW_GROUP_COUNT.load(std::sync::atomic::Ordering::Relaxed),
+    )
+}
+
+vtable!(RowGroupZoneMap);
+
+#[derive(Debug)]
+pub struct RowGroupZoneMapLayoutEncoding;
+
+#[derive(Clone, Debug)]
+pub struct RowGroupZoneMapLayout {
+    dtype: DType,
+    children: Arc<dyn LayoutChildren>,
+    metadata: RowGroupZoneMapMetadata,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ColumnZoneMetadata {
+    pub field_name: FieldName,
+    pub present_stats: Arc<[Stat]>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct RowGroupZoneMapMetadata {
+    pub version: u16,
+    pub stats_version: u16,
+    pub rg_count: u64,
+    pub columns: Vec<ColumnZoneMetadata>,
+}
+
+impl RowGroupZoneMapMetadata {
+    fn new(rg_count: u64, columns: Vec<ColumnZoneMetadata>) -> Self {
+        Self {
+            version: METADATA_VERSION,
+            stats_version: STATS_VERSION,
+            rg_count,
+            columns,
+        }
+    }
+
+    fn column(&self, field_name: &FieldName) -> Option<&ColumnZoneMetadata> {
+        self.columns
+            .iter()
+            .find(|column| &column.field_name == field_name)
+    }
+}
+
+impl DeserializeMetadata for RowGroupZoneMapMetadata {
+    type Output = Self;
+
+    fn deserialize(metadata: &[u8]) -> VortexResult<Self::Output> {
+        let mut reader = MetadataReader::new(metadata);
+        let version = reader.read_u16()?;
+        let stats_version = reader.read_u16()?;
+        let rg_count = reader.read_u64()?;
+        let column_count = reader.read_u32()? as usize;
+        let mut columns = Vec::with_capacity(column_count);
+
+        for _ in 0..column_count {
+            let field_name = FieldName::from(reader.read_string()?);
+            let stat_bytes = reader.read_bytes()?;
+            let present_stats = Arc::<[Stat]>::from(stats_from_bitset_bytes(stat_bytes));
+            columns.push(ColumnZoneMetadata {
+                field_name,
+                present_stats,
+            });
+        }
+
+        vortex_ensure!(
+            reader.is_done(),
+            "Trailing bytes in {LAYOUT_ID} metadata: {}",
+            reader.remaining()
+        );
+
+        Ok(Self {
+            version,
+            stats_version,
+            rg_count,
+            columns,
+        })
+    }
+}
+
+impl SerializeMetadata for RowGroupZoneMapMetadata {
+    fn serialize(self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&self.version.to_le_bytes());
+        bytes.extend_from_slice(&self.stats_version.to_le_bytes());
+        bytes.extend_from_slice(&self.rg_count.to_le_bytes());
+        bytes.extend_from_slice(&(self.columns.len() as u32).to_le_bytes());
+        for column in self.columns {
+            write_string(&mut bytes, column.field_name.as_ref());
+            let stat_bytes = as_stat_bitset_bytes(&column.present_stats);
+            bytes.extend_from_slice(&(stat_bytes.len() as u16).to_le_bytes());
+            bytes.extend_from_slice(&stat_bytes);
+        }
+        bytes
+    }
+}
+
+struct MetadataReader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> MetadataReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn read_u16(&mut self) -> VortexResult<u16> {
+        let bytes = self.read_exact(2)?;
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_u32(&mut self) -> VortexResult<u32> {
+        let bytes = self.read_exact(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn read_u64(&mut self) -> VortexResult<u64> {
+        let bytes = self.read_exact(8)?;
+        Ok(u64::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        ]))
+    }
+
+    fn read_string(&mut self) -> VortexResult<String> {
+        let bytes = self.read_bytes()?;
+        String::from_utf8(bytes.to_vec())
+            .map_err(|e| vortex_err!("Invalid UTF-8 in {LAYOUT_ID} metadata: {e}"))
+    }
+
+    fn read_bytes(&mut self) -> VortexResult<&'a [u8]> {
+        let len = self.read_u16()? as usize;
+        self.read_exact(len)
+    }
+
+    fn read_exact(&mut self, len: usize) -> VortexResult<&'a [u8]> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or_else(|| vortex_err!("Invalid {LAYOUT_ID} metadata length"))?;
+        if end > self.bytes.len() {
+            vortex_bail!("Truncated {LAYOUT_ID} metadata");
+        }
+        let out = &self.bytes[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len() - self.pos
+    }
+
+    fn is_done(&self) -> bool {
+        self.pos == self.bytes.len()
+    }
+}
+
+fn write_string(bytes: &mut Vec<u8>, value: &str) {
+    let len = u16::try_from(value.len()).vortex_expect("field name too long");
+    bytes.extend_from_slice(&len.to_le_bytes());
+    bytes.extend_from_slice(value.as_bytes());
+}
+
+impl VTable for RowGroupZoneMapVTable {
+    type Layout = RowGroupZoneMapLayout;
+    type Encoding = RowGroupZoneMapLayoutEncoding;
+    type Metadata = RowGroupZoneMapMetadata;
+
+    fn id(_encoding: &Self::Encoding) -> LayoutId {
+        LayoutId::new_ref(LAYOUT_ID)
+    }
+
+    fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {
+        LayoutEncodingRef::new_ref(RowGroupZoneMapLayoutEncoding.as_ref())
+    }
+
+    fn row_count(layout: &Self::Layout) -> u64 {
+        layout.children.child_row_count(0)
+    }
+
+    fn dtype(layout: &Self::Layout) -> &DType {
+        &layout.dtype
+    }
+
+    fn metadata(layout: &Self::Layout) -> Self::Metadata {
+        layout.metadata.clone()
+    }
+
+    fn segment_ids(_layout: &Self::Layout) -> Vec<SegmentId> {
+        vec![]
+    }
+
+    fn nchildren(_layout: &Self::Layout) -> usize {
+        2
+    }
+
+    fn child(layout: &Self::Layout, idx: usize) -> VortexResult<LayoutRef> {
+        match idx {
+            0 => layout.children.child(0, &layout.dtype),
+            1 => layout
+                .children
+                .child(1, &zones_dtype(&layout.dtype, &layout.metadata)?),
+            _ => vortex_bail!("Invalid {LAYOUT_ID} child index: {idx}"),
+        }
+    }
+
+    fn child_type(_layout: &Self::Layout, idx: usize) -> LayoutChildType {
+        match idx {
+            0 => LayoutChildType::Transparent("data".into()),
+            1 => LayoutChildType::Auxiliary("zones".into()),
+            _ => vortex::error::vortex_panic!("Invalid {LAYOUT_ID} child index: {idx}"),
+        }
+    }
+
+    fn new_reader(
+        layout: &Self::Layout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+    ) -> VortexResult<LayoutReaderRef> {
+        Ok(Arc::new(RowGroupZoneMapReader::try_new(
+            layout.clone(),
+            name,
+            segment_source,
+        )?))
+    }
+
+    fn build(
+        _encoding: &Self::Encoding,
+        dtype: &DType,
+        _row_count: u64,
+        metadata: &RowGroupZoneMapMetadata,
+        _segment_ids: Vec<SegmentId>,
+        children: &dyn LayoutChildren,
+        _ctx: ArrayContext,
+    ) -> VortexResult<Self::Layout> {
+        vortex_ensure!(
+            metadata.version == METADATA_VERSION,
+            "Unsupported {LAYOUT_ID} metadata version: {}",
+            metadata.version
+        );
+        vortex_ensure!(
+            metadata.stats_version == STATS_VERSION,
+            "Unsupported {LAYOUT_ID} stats version: {}",
+            metadata.stats_version
+        );
+        vortex_ensure!(
+            children.nchildren() == 2,
+            "{LAYOUT_ID} expected 2 children, got {}",
+            children.nchildren()
+        );
+
+        Ok(RowGroupZoneMapLayout {
+            dtype: dtype.clone(),
+            children: children.to_arc(),
+            metadata: metadata.clone(),
+        })
+    }
+}
+
+impl RowGroupZoneMapLayout {
+    fn new(
+        data: LayoutRef,
+        zones: LayoutRef,
+        metadata: RowGroupZoneMapMetadata,
+    ) -> VortexResult<Self> {
+        let dtype = data.dtype().clone();
+        let expected_zones_dtype = zones_dtype(&dtype, &metadata)?;
+        if zones.dtype() != &expected_zones_dtype {
+            vortex_bail!(
+                "Invalid {LAYOUT_ID} zones dtype: expected {}, got {}",
+                expected_zones_dtype,
+                zones.dtype()
+            );
+        }
+
+        Ok(Self {
+            dtype,
+            children: Arc::new(MilvusLayoutChildren(vec![data, zones])),
+            metadata,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct MilvusLayoutChildren(Vec<LayoutRef>);
+
+impl LayoutChildren for MilvusLayoutChildren {
+    fn to_arc(&self) -> Arc<dyn LayoutChildren> {
+        Arc::new(self.clone())
+    }
+
+    fn child(&self, idx: usize, dtype: &DType) -> VortexResult<LayoutRef> {
+        let Some(child) = self.0.get(idx) else {
+            vortex_bail!("Child index out of bounds: {} of {}", idx, self.0.len());
+        };
+        if child.dtype() != dtype {
+            vortex_bail!("Child dtype mismatch: {} != {}", child.dtype(), dtype);
+        }
+        Ok(child.clone())
+    }
+
+    fn child_row_count(&self, idx: usize) -> u64 {
+        self.0[idx].row_count()
+    }
+
+    fn nchildren(&self) -> usize {
+        self.0.len()
+    }
+}
+
+fn zones_dtype(dtype: &DType, metadata: &RowGroupZoneMapMetadata) -> VortexResult<DType> {
+    let struct_fields = dtype
+        .as_struct_fields_opt()
+        .ok_or_else(|| vortex_err!("{LAYOUT_ID} data dtype must be a struct"))?;
+
+    let mut names: Vec<FieldName> = Vec::with_capacity(metadata.columns.len() + 1);
+    let mut dtypes: Vec<DType> = Vec::with_capacity(metadata.columns.len() + 1);
+
+    for column in &metadata.columns {
+        let column_dtype = struct_fields
+            .field(&column.field_name)
+            .ok_or_else(|| vortex_err!("Missing zonemap column {}", column.field_name))?;
+        names.push(column.field_name.clone());
+        dtypes.push(ZoneMap::dtype_for_stats_table(
+            &column_dtype,
+            &column.present_stats,
+        ));
+    }
+
+    names.push(RG_BOUNDARIES_FIELD.into());
+    dtypes.push(boundary_dtype());
+
+    Ok(DType::Struct(
+        StructFields::new(FieldNames::from(names), dtypes),
+        Nullability::NonNullable,
+    ))
+}
+
+fn boundary_dtype() -> DType {
+    DType::Struct(
+        StructFields::new(
+            FieldNames::from([RG_START_FIELD, RG_LEN_FIELD]),
+            vec![
+                DType::Primitive(PType::U64, Nullability::NonNullable),
+                DType::Primitive(PType::U64, Nullability::NonNullable),
+            ],
+        ),
+        Nullability::NonNullable,
+    )
+}
+
+struct RowGroupZoneMapReader {
+    layout: RowGroupZoneMapLayout,
+    name: Arc<str>,
+    // child[0] is the real data layout; child[1] is the auxiliary zones layout.
+    lazy_children: LazyReaderChildren,
+}
+
+impl RowGroupZoneMapReader {
+    fn try_new(
+        layout: RowGroupZoneMapLayout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+    ) -> VortexResult<Self> {
+        let dtypes = vec![
+            layout.dtype.clone(),
+            zones_dtype(&layout.dtype, &layout.metadata)?,
+        ];
+        let names = vec![name.clone(), format!("{}.zones", name).into()];
+        let lazy_children =
+            LazyReaderChildren::new(layout.children.clone(), dtypes, names, segment_source);
+
+        Ok(Self {
+            layout,
+            name,
+            lazy_children,
+        })
+    }
+
+    fn data_child(&self) -> VortexResult<&LayoutReaderRef> {
+        self.lazy_children.get(0)
+    }
+
+    fn zones_child(&self) -> VortexResult<&LayoutReaderRef> {
+        self.lazy_children.get(1)
+    }
+
+    fn available_stats(&self) -> FieldPathSet {
+        // checked_pruning_expr works in root scope, so expose stats as `col.min`,
+        // `col.max`, etc. even though the stored ZoneMap child uses local names.
+        FieldPathSet::from_iter(self.layout.metadata.columns.iter().flat_map(|column| {
+            column
+                .present_stats
+                .iter()
+                .map(|stat| FieldPath::from_name(column.field_name.clone()).push(stat.name()))
+        }))
+    }
+}
+
+impl LayoutReader for RowGroupZoneMapReader {
+    fn name(&self) -> &Arc<str> {
+        &self.name
+    }
+
+    fn dtype(&self) -> &DType {
+        &self.layout.dtype
+    }
+
+    fn row_count(&self) -> u64 {
+        self.layout.row_count()
+    }
+
+    fn register_splits(
+        &self,
+        field_mask: &[vortex::dtype::FieldMask],
+        row_range: &Range<u64>,
+        splits: &mut std::collections::BTreeSet<u64>,
+    ) -> VortexResult<()> {
+        self.data_child()?
+            .register_splits(field_mask, row_range, splits)
+    }
+
+    fn pruning_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: Mask,
+    ) -> VortexResult<MaskFuture> {
+        // Always preserve pruning behavior from the data child. RowGroupZoneMap pruning
+        // can only further narrow the mask when the filter is safely mappable to one column.
+        let data_eval = self
+            .data_child()?
+            .pruning_evaluation(row_range, expr, mask.clone())?;
+
+        let Some((predicate, column_name, present_stats, required_stats)) =
+            self.pruning_predicate_for_single_column(expr)?
+        else {
+            return Ok(data_eval);
+        };
+
+        let column_dtype = self
+            .layout
+            .dtype
+            .as_struct_fields_opt()
+            .and_then(|fields| fields.field(&column_name))
+            .ok_or_else(|| vortex_err!("Missing zonemap column {column_name}"))?;
+
+        let rg_count = usize::try_from(self.layout.metadata.rg_count)
+            .map_err(|_| vortex_err!("Too many row groups for {LAYOUT_ID}"))?;
+        let zones_child = self.zones_child()?.clone();
+        let zone_expr = get_item(column_name.clone(), root());
+        let boundary_expr = get_item(RG_BOUNDARIES_FIELD, root());
+        // This first version reads the full selected column ZoneMap and full boundary table.
+        // They are small side data compared with row-group payloads, and keeping them whole
+        // avoids a second index just to map row ranges back to row-group ids.
+        let zone_eval = zones_child.projection_evaluation(
+            &(0..self.layout.metadata.rg_count),
+            &zone_expr,
+            MaskFuture::new_true(rg_count),
+        )?;
+        let boundary_eval = zones_child.projection_evaluation(
+            &(0..self.layout.metadata.rg_count),
+            &boundary_expr,
+            MaskFuture::new_true(rg_count),
+        )?;
+
+        let input_mask = mask.clone();
+        let row_range = row_range.clone();
+
+        Ok(MaskFuture::new(mask.len(), async move {
+            let zone_array = zone_eval.await?.to_struct();
+            // Validate that the stored per-column stats table still matches Vortex ZoneMap
+            // shape before evaluating the root-scope pruning predicate against it.
+            let zone_map = ZoneMap::try_new(column_dtype, zone_array, present_stats)?;
+            let stats_view = Self::build_root_stats_view_for_column(&zone_map, &required_stats)?;
+            let rg_prune_mask = predicate
+                .evaluate(&stats_view)?
+                .try_to_mask_fill_null_false()?;
+            ROW_GROUP_ZONE_MAP_PRUNE_EVAL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            ROW_GROUP_ZONE_MAP_PRUNED_ROW_GROUP_COUNT.fetch_add(
+                rg_prune_mask.true_count() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+
+            let boundaries = boundary_eval.await?.to_struct();
+            let starts = boundaries
+                .field_by_name(RG_START_FIELD)?
+                .to_primitive()
+                .as_slice::<u64>()
+                .to_vec();
+            let lens = boundaries
+                .field_by_name(RG_LEN_FIELD)?
+                .to_primitive()
+                .as_slice::<u64>()
+                .to_vec();
+
+            // ZoneMap pruning returns one bit per row group, while LayoutReader must return
+            // one keep bit per requested row. Boundaries bridge those two granularities.
+            let row_keep = Self::expand_rg_prune_mask(&starts, &lens, &rg_prune_mask, &row_range)?;
+            let mut stats_mask = input_mask.bitand(&row_keep);
+            if !stats_mask.all_false() {
+                stats_mask = stats_mask.bitand(&data_eval.await?);
+            }
+            Ok(stats_mask)
+        }))
+    }
+
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<MaskFuture> {
+        self.data_child()?.filter_evaluation(row_range, expr, mask)
+    }
+
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<vortex::layout::ArrayFuture> {
+        self.data_child()?
+            .projection_evaluation(row_range, expr, mask)
+    }
+}
+
+impl RowGroupZoneMapReader {
+    /// Build a conservative pruning plan for one column.
+    ///
+    /// Vortex gives us a root-scope stats predicate. We only use it when all
+    /// required stats belong to one top-level field, because the zones layout stores
+    /// one independent ZoneMap table per column.
+    fn pruning_predicate_for_single_column(
+        &self,
+        expr: &Expression,
+    ) -> VortexResult<
+        Option<(
+            Expression,
+            FieldName,
+            Arc<[Stat]>,
+            vortex::expr::pruning::RequiredStats,
+        )>,
+    > {
+        let Some((predicate, required_stats)) = checked_pruning_expr(expr, &self.available_stats())
+        else {
+            return Ok(None);
+        };
+
+        let Some(column_name) = Self::pruning_expr_selected_field(&required_stats) else {
+            return Ok(None);
+        };
+
+        let Some(column) = self.layout.metadata.column(&column_name) else {
+            return Ok(None);
+        };
+        Ok(Some((
+            predicate,
+            column_name,
+            column.present_stats.clone(),
+            required_stats,
+        )))
+    }
+
+    fn pruning_expr_selected_field(
+        required_stats: &vortex::expr::pruning::RequiredStats,
+    ) -> Option<FieldName> {
+        let mut selected: Option<FieldName> = None;
+        for field_path in required_stats.map().keys() {
+            // The initial implementation supports top-level struct fields only.
+            // Anything nested or synthetic stays on the conservative path.
+            let [Field::Name(field_name)] = field_path.parts() else {
+                return None;
+            };
+            match &selected {
+                Some(selected) if selected != field_name => return None,
+                Some(_) => {}
+                None => selected = Some(field_name.clone()),
+            }
+        }
+        selected
+    }
+
+    fn build_root_stats_view_for_column(
+        zone_map: &ZoneMap,
+        required_stats: &vortex::expr::pruning::RequiredStats,
+    ) -> VortexResult<ArrayRef> {
+        let zone_array = zone_map.array();
+        let mut names = Vec::new();
+        let mut arrays = Vec::new();
+
+        // checked_pruning_expr builds predicates in root stats scope, e.g. `x_max`.
+        // The stored per-column ZoneMap keeps Vortex's local field names, e.g. `max`.
+        // Build a cheap in-memory StructArray that renames ArrayRefs without copying data.
+        for (field_path, stats) in required_stats.map() {
+            for stat in stats {
+                names.push(field_path_stat_field_name(field_path, *stat));
+                arrays.push(zone_array.field_by_name(stat.name())?.clone());
+            }
+        }
+
+        vortex_ensure!(
+            !arrays.is_empty(),
+            "No required stats available for {LAYOUT_ID} pruning"
+        );
+
+        Ok(StructArray::try_new(
+            FieldNames::from(names),
+            arrays,
+            zone_array.len(),
+            Validity::NonNullable,
+        )?
+        .into_array())
+    }
+
+    fn expand_rg_prune_mask(
+        starts: &[u64],
+        lens: &[u64],
+        rg_prune_mask: &Mask,
+        row_range: &Range<u64>,
+    ) -> VortexResult<Mask> {
+        // rg_prune_mask uses ZoneMap semantics: true means "skip this row group".
+        // The returned mask uses scan semantics: true means "keep this row".
+        vortex_ensure!(
+            starts.len() == lens.len(),
+            "RG boundary start/len length mismatch: {} != {}",
+            starts.len(),
+            lens.len()
+        );
+        vortex_ensure!(
+            starts.len() == rg_prune_mask.len(),
+            "RG prune mask length mismatch: {} != {}",
+            starts.len(),
+            rg_prune_mask.len()
+        );
+
+        let mut out = MaskMut::new_true(0);
+        for (rg_idx, (&rg_start, &rg_len)) in starts.iter().zip(lens).enumerate() {
+            let rg_end = rg_start
+                .checked_add(rg_len)
+                .ok_or_else(|| vortex_err!("RG boundary overflow"))?;
+            let start = rg_start.max(row_range.start);
+            let end = rg_end.min(row_range.end);
+            if start >= end {
+                continue;
+            }
+            out.append_n(!rg_prune_mask.value(rg_idx), usize::try_from(end - start)?);
+        }
+
+        let expected_len = usize::try_from(row_range.end - row_range.start)?;
+        vortex_ensure!(
+            out.len() == expected_len,
+            "Expanded RG mask length mismatch: {} != {}",
+            out.len(),
+            expected_len
+        );
+        Ok(out.freeze())
+    }
+}
+
+#[derive(Clone)]
+struct RowGroupSplitOptions {
+    block_size_minimum: u64,
+    canonicalize: bool,
+}
+
+struct RowGroupBuffer {
+    data: std::collections::VecDeque<(ArrayRef, u64)>,
+    nbytes: u64,
+    block_size_minimum: u64,
+}
+
+impl RowGroupBuffer {
+    fn new(block_size_minimum: u64) -> Self {
+        Self {
+            data: std::collections::VecDeque::new(),
+            nbytes: 0,
+            block_size_minimum,
+        }
+    }
+
+    fn push(&mut self, chunk: ArrayRef) {
+        let nbytes = chunk.nbytes() as u64;
+        self.nbytes += nbytes;
+        self.data.push_back((chunk, nbytes));
+    }
+
+    fn have_enough(&self) -> bool {
+        self.nbytes >= self.block_size_minimum
+    }
+
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    fn drain_one_group(&mut self, dtype: &DType) -> Option<ArrayRef> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        let mut group = Vec::new();
+        let mut group_bytes = 0u64;
+
+        while let Some((chunk, est_bytes)) = self.data.pop_front() {
+            let chunk_len = chunk.len();
+            self.nbytes -= est_bytes;
+
+            if group_bytes + est_bytes <= self.block_size_minimum {
+                group_bytes += est_bytes;
+                group.push(chunk);
+                if group_bytes >= self.block_size_minimum {
+                    break;
+                }
+            } else {
+                let space_left = self.block_size_minimum - group_bytes;
+                let rows_to_take = if est_bytes > 0 {
+                    space_left
+                        .saturating_mul(chunk_len as u64)
+                        .div_ceil(est_bytes) as usize
+                } else {
+                    chunk_len
+                }
+                .max(1)
+                .min(chunk_len);
+
+                group.push(chunk.slice(0..rows_to_take));
+
+                if rows_to_take < chunk_len {
+                    let right = chunk.slice(rows_to_take..chunk_len);
+                    let right_est =
+                        est_bytes * (chunk_len - rows_to_take) as u64 / chunk_len as u64;
+                    self.nbytes += right_est;
+                    self.data.push_front((right, right_est));
+                }
+                break;
+            }
+        }
+
+        let chunked = vortex::arrays::ChunkedArray::try_new(group, dtype.clone()).ok()?;
+        Some(chunked.to_canonical().into_array())
+    }
+}
+
+fn split_stream_into_row_groups<F>(
+    stream: SendableSequentialStream,
+    options: RowGroupSplitOptions,
+    on_row_group_emitted: F,
+) -> SendableSequentialStream
+where
+    F: Fn(&ArrayRef) -> VortexResult<()> + Send + 'static,
+{
+    let dtype = stream.dtype().clone();
+    let stream = if options.canonicalize {
+        SequentialStreamAdapter::new(
+            dtype.clone(),
+            stream.map(|chunk| {
+                let (sequence_id, chunk) = chunk?;
+                VortexResult::Ok((sequence_id, chunk.to_canonical().into_array()))
+            }),
+        )
+        .sendable()
+    } else {
+        stream
+    };
+
+    let dtype_clone = dtype.clone();
+    let block_size_minimum = options.block_size_minimum;
+    let row_group_stream = try_stream! {
+        let stream = stream.peekable();
+        pin_mut!(stream);
+        let mut buffer = RowGroupBuffer::new(block_size_minimum);
+
+        while let Some(chunk) = stream.as_mut().next().await {
+            let (sequence_id, chunk) = chunk?;
+            let mut sp = sequence_id.descend();
+
+            if !chunk.is_empty() {
+                buffer.push(chunk);
+            }
+
+            let is_eof = stream.as_mut().peek().await.is_none();
+            while buffer.have_enough() || (is_eof && !buffer.is_empty()) {
+                if let Some(row_group) = buffer.drain_one_group(&dtype_clone) {
+                    on_row_group_emitted(&row_group)?;
+                    yield (sp.advance(), row_group)
+                } else {
+                    break;
+                }
+            }
+        }
+    };
+
+    SequentialStreamAdapter::new(dtype, row_group_stream).sendable()
+}
+
+/// Splits a stream of arrays into byte-size row groups without building zonemap side data.
+///
+/// This strategy is a writer-side stream adapter only: it does not serialize a custom layout
+/// node into the Vortex footer. The emitted row-group arrays are passed to `child`, which
+/// builds the normal V2 data layout tree:
+///
+/// ```text
+/// ChunkedLayout                         // one chunk per row group
+///   StructLayout                        // row group payload
+///     field layouts: Chunked -> Compressed -> Flat
+///     validity layouts: Collect -> Compressed -> Flat
+/// ```
+struct RowGroupSplitStrategy {
+    child: Arc<dyn LayoutStrategy>,
+    options: RowGroupSplitOptions,
+}
+
+impl RowGroupSplitStrategy {
+    fn new(child: Arc<dyn LayoutStrategy>, options: RowGroupSplitOptions) -> Self {
+        Self { child, options }
+    }
+}
+
+#[async_trait]
+impl LayoutStrategy for RowGroupSplitStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        stream: SendableSequentialStream,
+        eof: SequencePointer,
+        handle: Handle,
+    ) -> VortexResult<LayoutRef> {
+        let row_group_stream =
+            split_stream_into_row_groups(stream, self.options.clone(), |_: &ArrayRef| Ok(()));
+
+        self.child
+            .write_stream(ctx, segment_sink, row_group_stream, eof, handle)
+            .await
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.child.buffered_bytes()
+    }
+}
+
+/// Builds the row-group data layout plus a sidecar zonemap layout used for pruning.
+///
+/// Unlike `RowGroupSplitStrategy`, this strategy does serialize a custom root layout. The
+/// root's data child is the same row-grouped V2 data tree produced by `RowGroupSplitStrategy`.
+/// The zones child is a struct with one row per row group: each real column with usable stats
+/// stores a Vortex `ZoneMap` stats table, and `__rg_boundaries` maps row-group pruning results
+/// back to row ranges.
+///
+/// ```text
+/// RowGroupZoneMapLayout                 // encoding: milvus.v2_zoned_row_group
+///   data: ChunkedLayout                 // one chunk per row group
+///     StructLayout
+///       field layouts: Chunked -> Compressed -> Flat
+///       validity layouts: Collect -> Compressed -> Flat
+///   zones: StructLayout                 // one row per row group
+///     <column>: Compressed -> Flat      // per-column ZoneMap stats table
+///     __rg_boundaries: Compressed -> Flat
+/// ```
+pub struct RowGroupZoneMapStrategy {
+    data_child: Arc<dyn LayoutStrategy>,
+    zones_child: Arc<dyn LayoutStrategy>,
+    row_group_options: RowGroupSplitOptions,
+    stats: Arc<[Stat]>,
+    max_variable_length_statistics_size: usize,
+}
+
+impl RowGroupZoneMapStrategy {
+    fn new(
+        data_child: Arc<dyn LayoutStrategy>,
+        zones_child: Arc<dyn LayoutStrategy>,
+        row_group_options: RowGroupSplitOptions,
+        stats: Arc<[Stat]>,
+        max_variable_length_statistics_size: usize,
+    ) -> Self {
+        Self {
+            data_child,
+            zones_child,
+            row_group_options,
+            stats,
+            max_variable_length_statistics_size,
+        }
+    }
+}
+
+struct StatsBuildState {
+    column_names: Vec<FieldName>,
+    accumulators: Vec<StatsAccumulator>,
+    rg_starts: Vec<u64>,
+    rg_lens: Vec<u64>,
+    next_row: u64,
+    stats: Arc<[Stat]>,
+}
+
+impl StatsBuildState {
+    fn new(
+        dtype: &DType,
+        stats: Arc<[Stat]>,
+        max_variable_length_statistics_size: usize,
+    ) -> VortexResult<Self> {
+        let struct_fields = dtype
+            .as_struct_fields_opt()
+            .ok_or_else(|| vortex_err!("{LAYOUT_ID} writer requires struct input"))?;
+        // The boundaries table is a synthetic child under the zones struct.
+        // Reject an input column with the same name so the serialized layout
+        // has an unambiguous column-to-zone-map mapping.
+        if struct_fields.find(RG_BOUNDARIES_FIELD).is_some() {
+            vortex_bail!("Input schema field {RG_BOUNDARIES_FIELD} is reserved by {LAYOUT_ID}");
+        }
+
+        // Keep one Vortex StatsAccumulator per input column. Each accumulator
+        // produces a standalone Vortex-compatible ZoneMap table whose row
+        // count is the number of row groups, rather than building a custom
+        // wide stats table across all columns.
+        let mut column_names = Vec::with_capacity(struct_fields.nfields());
+        let mut accumulators = Vec::with_capacity(struct_fields.nfields());
+        for idx in 0..struct_fields.nfields() {
+            let field_name = struct_fields
+                .field_name(idx)
+                .vortex_expect("field index checked")
+                .clone();
+            let field_dtype = struct_fields
+                .field_by_index(idx)
+                .vortex_expect("field index checked");
+            column_names.push(field_name);
+            accumulators.push(StatsAccumulator::new(
+                &field_dtype,
+                &stats,
+                max_variable_length_statistics_size,
+            ));
+        }
+
+        Ok(Self {
+            column_names,
+            accumulators,
+            rg_starts: Vec::new(),
+            rg_lens: Vec::new(),
+            next_row: 0,
+            stats,
+        })
+    }
+
+    fn push_row_group(&mut self, row_group: &ArrayRef) -> VortexResult<()> {
+        let rg_start = self.next_row;
+        let rg_len = row_group.len() as u64;
+        self.next_row = self
+            .next_row
+            .checked_add(rg_len)
+            .ok_or_else(|| vortex_err!("row count overflow"))?;
+
+        // This is called by split_stream_into_row_groups before the row group
+        // is yielded to the data child strategy. The StructArray clone shares
+        // the same field ArrayRefs as row_group, so computing statistics here
+        // stores them in each field array's statistics cache.
+        //
+        // The zone-map accumulator reads those cached values via
+        // push_chunk_without_compute, matching Vortex ZonedStrategy's
+        // "compute before child write" pattern. Downstream data layout
+        // strategies also receive the same field ArrayRefs and can observe the
+        // cached field-level stats if they consult array.statistics().
+        let struct_row_group = row_group.to_struct();
+        for (field, accumulator) in struct_row_group
+            .fields()
+            .iter()
+            .zip(self.accumulators.iter_mut())
+        {
+            field.statistics().compute_all(&self.stats)?;
+            accumulator.push_chunk_without_compute(field.as_ref())?;
+        }
+
+        self.rg_starts.push(rg_start);
+        self.rg_lens.push(rg_len);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> VortexResult<Option<(StructArray, RowGroupZoneMapMetadata)>> {
+        let rg_count = self.rg_starts.len();
+        let mut zone_names = Vec::new();
+        let mut zone_arrays = Vec::new();
+        let mut metadata_columns = Vec::new();
+
+        // Finalize each per-column accumulator independently. Columns whose
+        // dtype cannot produce any requested stats simply do not get a ZoneMap
+        // child, and are omitted from metadata so pruning treats them as
+        // unavailable.
+        for (column_name, accumulator) in self.column_names.iter().zip(self.accumulators.iter_mut())
+        {
+            let Some(zone_map) = accumulator.as_stats_table() else {
+                continue;
+            };
+            if zone_map.present_stats().is_empty() {
+                continue;
+            }
+            zone_names.push(column_name.clone());
+            zone_arrays.push(zone_map.array().clone().into_array());
+            metadata_columns.push(ColumnZoneMetadata {
+                field_name: column_name.clone(),
+                present_stats: zone_map.present_stats().clone(),
+            });
+        }
+
+        if metadata_columns.is_empty() {
+            return Ok(None);
+        }
+
+        // Keep row-group boundaries separate from per-column ZoneMap tables.
+        // ZoneMap children preserve Vortex's dtype/field semantics, while this
+        // synthetic table only maps RG-level pruning masks back to row ranges.
+        let boundaries = boundary_array(&self.rg_starts, &self.rg_lens)?;
+        zone_names.push(RG_BOUNDARIES_FIELD.into());
+        zone_arrays.push(boundaries.into_array());
+
+        // The zones struct has one row per row group. Metadata records only
+        // the columns that actually have ZoneMap children plus their
+        // present_stats, matching the validation needed by ZoneMap::try_new.
+        let zones = StructArray::try_new(
+            FieldNames::from(zone_names),
+            zone_arrays,
+            rg_count,
+            Validity::NonNullable,
+        )?;
+        let metadata = RowGroupZoneMapMetadata::new(rg_count as u64, metadata_columns);
+        Ok(Some((zones, metadata)))
+    }
+}
+
+fn push_stats_state(
+    stats_state: &Arc<Mutex<StatsBuildState>>,
+    row_group: &ArrayRef,
+) -> VortexResult<()> {
+    stats_state
+        .lock()
+        .map_err(|_| vortex_err!("StatsBuildState mutex poisoned"))?
+        .push_row_group(row_group)
+}
+
+fn boundary_array(starts: &[u64], lens: &[u64]) -> VortexResult<StructArray> {
+    vortex_ensure!(
+        starts.len() == lens.len(),
+        "RG boundary start/len length mismatch: {} != {}",
+        starts.len(),
+        lens.len()
+    );
+    let starts = PrimitiveArray::new(Buffer::copy_from(starts), Validity::NonNullable).into_array();
+    let lens = PrimitiveArray::new(Buffer::copy_from(lens), Validity::NonNullable).into_array();
+    let len = starts.len();
+    StructArray::try_new(
+        FieldNames::from([RG_START_FIELD, RG_LEN_FIELD]),
+        vec![starts, lens],
+        len,
+        Validity::NonNullable,
+    )
+}
+
+#[async_trait]
+impl LayoutStrategy for RowGroupZoneMapStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        stream: SendableSequentialStream,
+        mut eof: SequencePointer,
+        handle: Handle,
+    ) -> VortexResult<LayoutRef> {
+        let dtype = stream.dtype().clone();
+        let stats_state = Arc::new(Mutex::new(StatsBuildState::new(
+            &dtype,
+            self.stats.clone(),
+            self.max_variable_length_statistics_size,
+        )?));
+
+        let stats_state_for_stream = stats_state.clone();
+        let row_group_stream = split_stream_into_row_groups(
+            stream,
+            self.row_group_options.clone(),
+            move |row_group| push_stats_state(&stats_state_for_stream, row_group),
+        );
+
+        let data_eof = eof.split_off();
+        let data_layout = self
+            .data_child
+            .write_stream(
+                ctx.clone(),
+                segment_sink.clone(),
+                row_group_stream,
+                data_eof,
+                handle.clone(),
+            )
+            .await?;
+
+        let Some((zones_array, metadata)) = stats_state
+            .lock()
+            .map_err(|_| vortex_err!("StatsBuildState mutex poisoned"))?
+            .finish()?
+        else {
+            return Ok(data_layout);
+        };
+
+        let zones_stream = zones_array
+            .into_array()
+            .to_array_stream()
+            .sequenced(eof.split_off());
+        let zones_layout = self
+            .zones_child
+            .write_stream(ctx, segment_sink, zones_stream, eof, handle)
+            .await?;
+
+        Ok(RowGroupZoneMapLayout::new(data_layout, zones_layout, metadata)?.into_layout())
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.data_child.buffered_bytes() + self.zones_child.buffered_bytes()
+    }
+}
+
+pub fn build_row_group_strategy(
+    row_group_max_size: u64,
+    enable_zone_map: bool,
+    stats: Arc<[Stat]>,
+) -> Arc<dyn LayoutStrategy> {
+    let data_strategy = build_data_strategy();
+    let row_group_options = RowGroupSplitOptions {
+        block_size_minimum: row_group_max_size,
+        canonicalize: false,
+    };
+
+    if enable_zone_map {
+        Arc::new(RowGroupZoneMapStrategy::new(
+            data_strategy,
+            build_zones_strategy(),
+            row_group_options,
+            stats,
+            64,
+        ))
+    } else {
+        Arc::new(RowGroupSplitStrategy::new(data_strategy, row_group_options))
+    }
+}
+
+fn build_data_strategy() -> Arc<dyn LayoutStrategy> {
+    let flat = FlatLayoutStrategy {
+        inline_array_node: true,
+        ..Default::default()
+    };
+    let compress_flat = CompressingStrategy::new_btrblocks(flat, false);
+    let chunked_inner = ChunkedLayoutStrategy::new(compress_flat.clone());
+    let validity = CollectStrategy::new(compress_flat);
+    let struct_inner = StructStrategy::new(chunked_inner, validity);
+    Arc::new(ChunkedLayoutStrategy::new(struct_inner))
+}
+
+fn build_zones_strategy() -> Arc<dyn LayoutStrategy> {
+    let flat = FlatLayoutStrategy {
+        inline_array_node: false,
+        ..Default::default()
+    };
+    let compress_flat = CompressingStrategy::new_btrblocks(flat, false);
+    let validity = CollectStrategy::new(compress_flat.clone());
+    Arc::new(StructStrategy::new(compress_flat, validity))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vortex::arrays::ChunkedArray;
+    use vortex::buffer::{BitBufferMut, ByteBufferMut};
+    use vortex::expr::{and, gt_eq, lit, lt};
+    use vortex::file::{OpenOptionsSessionExt, VortexWriteOptions};
+    use vortex::stream::ArrayStreamExt;
+
+    #[test]
+    fn metadata_roundtrip() {
+        let metadata = RowGroupZoneMapMetadata::new(
+            3,
+            vec![ColumnZoneMetadata {
+                field_name: "a".into(),
+                present_stats: Arc::from([Stat::Max, Stat::Min]),
+            }],
+        );
+
+        let roundtrip =
+            RowGroupZoneMapMetadata::deserialize(&metadata.clone().serialize()).unwrap();
+        assert_eq!(roundtrip, metadata);
+    }
+
+    #[test]
+    fn expand_partial_row_range() {
+        let starts = vec![0, 10, 20];
+        let lens = vec![10, 10, 10];
+        let rg_prune = Mask::from_buffer(BitBufferMut::from_iter([true, false, true]).freeze());
+        let expanded =
+            RowGroupZoneMapReader::expand_rg_prune_mask(&starts, &lens, &rg_prune, &(5..25))
+                .unwrap();
+
+        assert_eq!(expanded.len(), 20);
+        for idx in 0..5 {
+            assert!(!expanded.value(idx));
+        }
+        for idx in 5..15 {
+            assert!(expanded.value(idx));
+        }
+        for idx in 15..20 {
+            assert!(!expanded.value(idx));
+        }
+    }
+
+    fn i32_struct_chunk(values: &[i32]) -> VortexResult<ArrayRef> {
+        let len = values.len();
+        let values =
+            PrimitiveArray::new(Buffer::copy_from(values), Validity::NonNullable).into_array();
+        Ok(StructArray::try_new(
+            FieldNames::from(["x"]),
+            vec![values],
+            len,
+            Validity::NonNullable,
+        )?
+        .into_array())
+    }
+
+    #[tokio::test]
+    async fn scan_filter_uses_row_group_zone_map_pruning() -> VortexResult<()> {
+        reset_row_group_zone_map_pruning_stats();
+
+        let chunks = vec![
+            i32_struct_chunk(&(0..10).collect::<Vec<_>>())?,
+            i32_struct_chunk(&(100..110).collect::<Vec<_>>())?,
+            i32_struct_chunk(&(200..210).collect::<Vec<_>>())?,
+        ];
+        let dtype = chunks[0].dtype().clone();
+        let row_group_max_size = chunks[0].nbytes() as u64;
+        let input = ChunkedArray::try_new(chunks, dtype.clone())?.into_array();
+
+        let stats = Arc::<[Stat]>::from([Stat::Min, Stat::Max]);
+        let mut buffer = ByteBufferMut::empty();
+        VortexWriteOptions::new(crate::VORTEX_SESSION.clone())
+            .with_file_statistics(stats.to_vec())
+            .with_strategy(build_row_group_strategy(
+                row_group_max_size,
+                true,
+                stats.clone(),
+            ))
+            .write(&mut buffer, input.to_array_stream())
+            .await?;
+
+        let file = crate::VORTEX_SESSION.open_options().open_buffer(buffer)?;
+        let layout = file.footer().layout();
+        assert_eq!(layout.encoding_id().as_ref(), LAYOUT_ID);
+        assert_eq!(layout.child(1)?.row_count(), 3);
+
+        let filter = and(
+            gt_eq(get_item("x", root()), lit(100i32)),
+            lt(get_item("x", root()), lit(110i32)),
+        );
+        let result = file
+            .scan()?
+            .with_filter(filter)
+            .into_array_stream()?
+            .read_all()
+            .await?;
+
+        assert_eq!(result.len(), 10);
+        let x = result
+            .to_struct()
+            .field_by_name("x")?
+            .clone()
+            .to_primitive();
+        assert_eq!(x.as_slice::<i32>(), &(100..110).collect::<Vec<_>>());
+
+        let (prune_evals, pruned_row_groups) = row_group_zone_map_pruning_stats();
+        assert!(
+            prune_evals > 0,
+            "expected scan filter to evaluate row-group zonemap pruning"
+        );
+        assert!(
+            pruned_row_groups > 0,
+            "expected row-group zonemap pruning to drop at least one row group"
+        );
+        Ok(())
+    }
+}

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -1,0 +1,394 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include <arrow/api.h>
+#include <arrow/array.h>
+#include <arrow/array/concatenate.h>
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+
+#include <boost/filesystem/operations.hpp>
+
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/vortex/vortex_format_reader.h"
+#include "milvus-storage/format/vortex/vortex_writer.h"
+#include "test_env.h"
+
+namespace milvus_storage {
+
+using namespace vortex;
+
+class VortexTestBase : public ::testing::Test {
+  protected:
+  void CommonSetUp(uint32_t format_version) {
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    api::SetValue(properties_, PROPERTY_WRITER_VORTEX_FORMAT_VERSION, std::to_string(format_version).c_str());
+
+    ASSERT_AND_ASSIGN(schema_, CreateTestSchema(needed_columns_));
+    for (int64_t batch_idx = 0; batch_idx < batch_count_; ++batch_idx) {
+      ASSERT_AND_ASSIGN(auto rb, MakeTestData(batch_idx * rows_per_batch_, rows_per_batch_));
+      record_batches_.emplace_back(std::move(rb));
+    }
+
+    ASSERT_AND_ASSIGN(file_system_, GetFileSystem(properties_));
+  }
+
+  void TearDown() override {
+    auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
+    if (storage_type == "local" || storage_type.empty()) {
+      boost::filesystem::remove_all(test_file_name_);
+    }
+  }
+
+  protected:
+  [[nodiscard]] inline int64_t recordBatchsRows() const { return batch_count_ * rows_per_batch_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> MakeTestData(int64_t start_offset, size_t num_rows) {
+    return CreateTestData(schema_, start_offset, false, num_rows, 4, 50, needed_columns_);
+  }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> ChunkedArrayToRecordBatch(
+      const std::shared_ptr<arrow::ChunkedArray>& chunkedarray) {
+    auto chunk_size = chunkedarray->num_chunks();
+    if (chunk_size == 1) {
+      return arrow::RecordBatch::FromStructArray(chunkedarray->chunk(0));
+    }
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> rbs;
+    for (int i = 0; i < chunk_size; ++i) {
+      ARROW_ASSIGN_OR_RAISE(auto rb, arrow::RecordBatch::FromStructArray(chunkedarray->chunk(i)));
+      rbs.emplace_back(rb);
+    }
+
+    return arrow::ConcatenateRecordBatches(rbs);
+  }
+
+  const std::vector<std::string>& data_columns() const { return data_columns_; }
+
+  protected:
+  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<arrow::fs::FileSystem> file_system_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches_;
+  const char* test_file_name_ = "test-file.vx";
+  api::Properties properties_;
+
+  private:
+  const std::array<bool, 4> needed_columns_ = {true, true, true, false};
+  const std::vector<std::string> data_columns_ = {"id", "name", "value"};
+  const int64_t rows_per_batch_ = 1024;
+  const int64_t batch_count_ = 4;
+};
+
+// Parameterized fixture: runs each test for both V1 and V2 format
+class VortexBasicTest : public VortexTestBase, public ::testing::WithParamInterface<uint32_t> {
+  void SetUp() override { CommonSetUp(GetParam()); }
+};
+
+INSTANTIATE_TEST_SUITE_P(V1V2,
+                         VortexBasicTest,
+                         ::testing::Values(1, 2),
+                         [](const ::testing::TestParamInfo<uint32_t>& info) {
+                           return "V" + std::to_string(info.param);
+                         });
+
+TEST_P(VortexBasicTest, TestBasicWrite) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  for (const auto& rb : record_batches_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
+}
+
+TEST_P(VortexBasicTest, TestBasicRead) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  for (const auto& rb : record_batches_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+
+  ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+  ASSERT_EQ(3, rb->num_columns());
+  ASSERT_EQ(arrow::Type::INT64, rb->column(0)->type_id());
+  ASSERT_EQ(arrow::Type::STRING, rb->column(1)->type_id());
+  ASSERT_EQ(arrow::Type::DOUBLE, rb->column(2)->type_id());
+
+  auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
+  auto value_array = std::dynamic_pointer_cast<arrow::DoubleArray>(rb->column(2));
+
+  for (int i = 0; i < id_array->length(); ++i) {
+    ASSERT_EQ(id_array->Value(i), static_cast<int64_t>(i));
+    ASSERT_DOUBLE_EQ(value_array->Value(i), static_cast<double>(i) * 1.5);
+  }
+}
+
+TEST_P(VortexBasicTest, TestEmptyWriteRead) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  ASSERT_AND_ASSIGN(auto empty_rb, MakeTestData(0, 0));
+  ASSERT_TRUE(vx_writer.Write(empty_rb).ok());
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(0, cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_EQ(0, vx_reader.rows());
+
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, vx_reader.rows()));
+  ASSERT_EQ(0, chunked_array->num_chunks());
+}
+
+TEST_P(VortexBasicTest, TestReaderProjection) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  for (const auto& rb : record_batches_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
+
+  // all projection
+  {
+    auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
+    ASSERT_STATUS_OK(vx_reader.open());
+    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
+
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+    ASSERT_EQ(3, rb->num_columns());
+    ASSERT_EQ(arrow::Type::INT64, rb->column(0)->type_id());
+    ASSERT_EQ(arrow::Type::STRING, rb->column(1)->type_id());
+    ASSERT_EQ(arrow::Type::DOUBLE, rb->column(2)->type_id());
+  }
+
+  // projection with different order
+  {
+    auto projection_schema = arrow::schema({
+        schema_->field(2),
+        schema_->field(1),
+        schema_->field(0),
+    });
+
+    auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
+                                                std::vector<std::string>{"value", "name", "id"});
+    ASSERT_STATUS_OK(vx_reader.open());
+    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
+
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+    ASSERT_EQ(3, rb->num_columns());
+
+    ASSERT_EQ(arrow::Type::DOUBLE, rb->column(0)->type_id());
+    ASSERT_EQ(arrow::Type::STRING, rb->column(1)->type_id());
+    ASSERT_EQ(arrow::Type::INT64, rb->column(2)->type_id());
+  }
+
+  // single projection
+  {
+    auto projection_schema = arrow::schema({schema_->field(0)});
+
+    auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
+                                                std::vector<std::string>{"id"});
+    ASSERT_STATUS_OK(vx_reader.open());
+    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
+
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+    ASSERT_EQ(1, rb->num_columns());
+
+    ASSERT_EQ(arrow::Type::INT64, rb->column(0)->type_id());
+  }
+
+  // empty projection
+  {
+    auto projection_schema = arrow::schema({});
+    auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
+                                                std::vector<std::string>{});
+    ASSERT_STATUS_OK(vx_reader.open());
+    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
+
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+    ASSERT_EQ(3, rb->num_columns());
+  }
+}
+
+TEST_P(VortexBasicTest, TestBasicTake) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  for (const auto& rb : record_batches_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
+
+  auto take_verify = [&](vortex::VortexFormatReader& vx_reader, const std::vector<int64_t>& row_indices,
+                         int64_t expect_rows) {
+    ASSERT_AND_ASSIGN(auto table, vx_reader.take(row_indices));
+    ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
+
+    ASSERT_EQ(expect_rows, rb->num_rows());
+    ASSERT_EQ(1, rb->num_columns());
+
+    ASSERT_EQ(arrow::Type::INT64, rb->column(0)->type_id());
+    auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
+    for (size_t i = 0; i < rb->num_rows(); i++) {
+      ASSERT_EQ(id_array->Value(i), row_indices[i]);
+    }
+  };
+
+  auto projection_schema = arrow::schema({schema_->field(0)});
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"id"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  ASSERT_AND_ASSIGN(auto one_random_row, GenerateSortedUniqueArray(1, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto random_rows, GenerateSortedUniqueArray(100, recordBatchsRows()));
+  std::vector<int64_t> all_rows(recordBatchsRows());
+  std::iota(all_rows.begin(), all_rows.end(), 0);
+
+  // take single row
+  take_verify(vx_reader, one_random_row, 1);
+  // 100 random rows
+  take_verify(vx_reader, random_rows, 100);
+  // boundary Testing
+  take_verify(vx_reader, {0, recordBatchsRows() - 1}, 2);
+  // take all range
+  take_verify(vx_reader, all_rows, recordBatchsRows());
+  // Note: vortex 0.56+ does not gracefully handle out-of-range indices (panics instead of returning error),
+  // so we removed the out-of-range index tests.
+}
+
+TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+
+  for (const auto& rb : record_batches_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+
+  auto vx_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto vx_file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(vx_footer_size, 0u);
+  ASSERT_GT(vx_file_size, vx_footer_size);
+
+  // Verify file_size matches actual file
+  ASSERT_AND_ASSIGN(auto file, file_system_->OpenInputFile(test_file_name_));
+  ASSERT_AND_ASSIGN(auto actual_file_size, file->GetSize());
+  EXPECT_EQ(vx_file_size, static_cast<uint64_t>(actual_file_size));
+
+  // Read EOF (last 8 bytes): [version 2B][postscript_len 2B][magic "VTXF" 4B]
+  ASSERT_AND_ASSIGN(auto eof_buf, file->ReadAt(actual_file_size - 8, 8));
+  const uint8_t* eof = eof_buf->data();
+
+  // Verify magic
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(eof + 4), 4), "VTXF");
+
+  // Get postscript_len from EOF
+  uint16_t postscript_len = 0;
+  std::memcpy(&postscript_len, eof + 2, 2);
+
+  // Read postscript to get the earliest segment offset (= start of footer)
+  int64_t postscript_offset = actual_file_size - 8 - postscript_len;
+  ASSERT_GT(postscript_offset, 0);
+
+  std::cout << "vx_footer_size: " << vx_footer_size << std::endl;
+  std::cout << "postscript_len: " << postscript_len << std::endl;
+
+  // The footer spans from the earliest segment to the end of file.
+  // The postscript contains segment descriptors with absolute offsets.
+  // We can parse the postscript flatbuffer to find the earliest offset,
+  // but a simpler sanity check: footer_size must be > postscript_len + 8 (postscript + EOF)
+  // and footer_size must be < file_size - 4 (exclude file header magic).
+  EXPECT_GT(vx_footer_size, static_cast<uint64_t>(postscript_len) + 8)
+      << "footer_size should include postscript + EOF + segment data";
+  EXPECT_LT(vx_footer_size, vx_file_size - 4) << "footer_size should be less than file_size minus header magic";
+}
+
+TEST_P(VortexBasicTest, FooterSizeNotMatch) {
+  // Write a vortex file
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+  for (const auto& rb : record_batches_) {
+    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  }
+  ASSERT_TRUE(vx_writer.Flush().ok());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  auto vx_footer_size2 = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto vx_file_size2 = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(vx_footer_size2, 0u);
+  ASSERT_GT(vx_file_size2, vx_footer_size2);
+
+  auto verify_read = [&](uint64_t footer_size) {
+    auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+    auto vxfile =
+        VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size2, footer_size);
+    ASSERT_EQ(vxfile.RowCount(), static_cast<uint64_t>(recordBatchsRows()));
+
+    auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
+                                                vx_file_size2, footer_size);
+    ASSERT_STATUS_OK(vx_reader.open());
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
+    ASSERT_EQ(3, rb->num_columns());
+
+    auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
+    for (int i = 0; i < id_array->length(); ++i) {
+      ASSERT_EQ(id_array->Value(i), static_cast<int64_t>(i));
+    }
+  };
+
+  verify_read(1);
+
+  // Case 2: footer_size too large (= file_size, reads entire file as initial read).
+  // Vortex clamps to min(initial_read_size, file_size). Extra bytes get cached as segments.
+  verify_read(vx_file_size2);
+}
+
+}  // namespace milvus_storage

--- a/cpp/test/format/vortex/vortex_v2_test.cpp
+++ b/cpp/test/format/vortex/vortex_v2_test.cpp
@@ -13,60 +13,53 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <random>
-#include <set>
 #include <vector>
-#include <cstdint>
-#include <cstring>
 
-#include <arrow/filesystem/filesystem.h>
-#include <arrow/filesystem/localfs.h>
 #include <arrow/api.h>
-#include <arrow/array/builder_binary.h>
-#include <arrow/array/builder_primitive.h>
-#include <arrow/type_fwd.h>
 #include <arrow/array.h>
-#include <arrow/record_batch.h>
-#include <arrow/builder.h>
-#include <arrow/type.h>
-#include <arrow/util/key_value_metadata.h>
-#include <arrow/table.h>
+#include <arrow/array/builder_binary.h>
 #include <arrow/array/concatenate.h>
+#include <arrow/builder.h>
+#include <arrow/c/bridge.h>
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <arrow/type_fwd.h>
+#include <arrow/util/key_value_metadata.h>
 
-#include "test_env.h"
-#include "milvus-storage/common/arrow_util.h"
-#include "milvus-storage/common/lrucache.h"
+#include <boost/filesystem/operations.hpp>
+
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/observable.h"
-#include "milvus-storage/format/vortex/vortex_writer.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
-
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
+#include "milvus-storage/format/vortex/vortex_writer.h"
+#include "test_env.h"
 
 namespace milvus_storage {
 
 using namespace vortex;
 
-class VortexTestBase : public ::testing::Test {
+// V2-specific fixture: always uses format_version=2
+class VortexV2Test : public ::testing::Test {
   protected:
-  void CommonSetUp(uint32_t format_version) {
-    schema_ = arrow::Table::FromRecordBatches({makeRecordBatch(0, 0, 0)}).ValueOrDie()->schema();
-    record_bacths_ = makeRecordBatchs();
-    columngroup_ = std::make_shared<api::ColumnGroup>();
-
-    columngroup_->format = LOON_FORMAT_VORTEX;
-    columngroup_->files = {{.path = test_file_name_}};
-    columngroup_->columns = {"int32", "int64", "binary"};
-
+  void SetUp() override {
     ASSERT_STATUS_OK(InitTestProperties(properties_));
+    api::SetValue(properties_, PROPERTY_WRITER_VORTEX_FORMAT_VERSION, "2");
 
-    format_version_ = format_version;
-    api::SetValue(properties_, PROPERTY_WRITER_VORTEX_FORMAT_VERSION, std::to_string(format_version_).c_str());
+    ASSERT_AND_ASSIGN(schema_, CreateTestSchema(needed_columns_));
+    for (int64_t batch_idx = 0; batch_idx < batch_count_; ++batch_idx) {
+      ASSERT_AND_ASSIGN(auto rb, CreateTestData(schema_, batch_idx * rows_per_batch_, false, rows_per_batch_, 4, 50,
+                                                needed_columns_));
+      record_batches_.emplace_back(std::move(rb));
+    }
 
-    file_system_ = std::make_shared<arrow::fs::LocalFileSystem>();
+    ASSERT_AND_ASSIGN(file_system_, GetFileSystem(properties_));
   }
 
   void TearDown() override {
@@ -76,116 +69,7 @@ class VortexTestBase : public ::testing::Test {
     }
   }
 
-  protected:
-  std::vector<std::shared_ptr<arrow::RecordBatch>> makeRecordBatchs() {
-    std::vector<std::shared_ptr<arrow::RecordBatch>> rbs;
-    uint32_t offset_each_loop = 0;
-
-    // offset: [0, 0, 100, 300 ..., 3600]
-    // count : [0, 100, 200, ..., 900]
-    for (int i = 0; i < record_batch_len_; i++) {
-      rbs.emplace_back(makeRecordBatch(offset_each_loop, count_each_loop_ * i, rand_strlen_));
-      offset_each_loop += (count_each_loop_ * i);
-    }
-    return rbs;
-  }
-
-  [[nodiscard]] inline int64_t recordBatchsRows() const {
-    return (count_each_loop_ * (record_batch_len_ - 1)) * record_batch_len_ / 2;
-  }
-
-  [[nodiscard]] inline size_t recordBatchsSize() const { return record_bacths_.size(); }
-
-  template <typename T>
-  std::vector<T> randomNumbers(T maxVal, T size) {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-
-    // Generate unique random numbers using a set
-    std::set<T> unique_numbers;
-    std::uniform_int_distribution<T> dis(0, maxVal);
-    while (unique_numbers.size() < static_cast<size_t>(size)) {
-      unique_numbers.insert(dis(gen));
-    }
-
-    // Convert to sorted vector (std::set is already sorted)
-    return std::vector<T>(unique_numbers.begin(), unique_numbers.end());
-  }
-
-  template <typename T>
-  std::vector<T> rangeNumbers(T start, T end) {
-    std::vector<T> numbers;
-
-    for (T i = start; i < end; ++i) {
-      numbers.emplace_back(i);
-    }
-
-    return numbers;
-  }
-
-  std::shared_ptr<arrow::RecordBatch> makeRecordBatch(uint32_t offset, uint32_t count, uint32_t str_len) {
-    arrow::Int32Builder int_builder;
-    arrow::Int64Builder int64_builder;
-    arrow::StringBuilder binary_builder;
-
-    std::vector<int32_t> int32_values;
-    std::vector<int64_t> int64_values;
-    std::vector<std::basic_string<char>> binary_values;
-
-    for (int i = offset; i < offset + count; i++) {
-      int32_values.emplace_back(i);
-      int64_values.emplace_back(i);
-      binary_values.emplace_back(random_string(str_len));
-    }
-
-    int_builder.AppendValues(int32_values).ok();
-    int64_builder.AppendValues(int64_values).ok();
-    binary_builder.AppendValues(binary_values).ok();
-
-    std::shared_ptr<arrow::Array> int_array;
-    std::shared_ptr<arrow::Array> int64_array;
-    std::shared_ptr<arrow::Array> str_array;
-
-    int_builder.Finish(&int_array).ok();
-    int64_builder.Finish(&int64_array).ok();
-    binary_builder.Finish(&str_array).ok();
-
-    std::vector<std::shared_ptr<arrow::Array>> arrays = {int_array, int64_array, str_array};
-    auto schema = arrow::schema(
-        {arrow::field("int32", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
-         arrow::field("int64", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
-         arrow::field("binary", arrow::binary(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"300"}))});
-    return arrow::RecordBatch::Make(schema, count, arrays);
-  }
-
-  std::string random_string(size_t size) {
-    std::string str;
-    str.resize(size);
-
-    static std::random_device rd;
-    static std::mt19937_64 gen(rd());
-    static std::uniform_int_distribution<uint64_t> dis;
-
-    const size_t num_blocks = size / sizeof(uint64_t);
-    const size_t remainder = size % sizeof(uint64_t);
-
-    // treat the string as an array of uint64_t and fill 8 bytes at a time
-    auto p = reinterpret_cast<uint64_t*>(&str[0]);
-    for (size_t i = 0; i < num_blocks; ++i) {
-      p[i] = dis(gen);
-    }
-
-    // deal the remainder bytes
-    if (remainder > 0) {
-      uint64_t last_block = dis(gen);
-      char* last_chars = reinterpret_cast<char*>(&last_block);
-      for (size_t i = 0; i < remainder; ++i) {
-        str[size - remainder + i] = last_chars[i];
-      }
-    }
-
-    return str;
-  }
+  [[nodiscard]] int64_t recordBatchsRows() const { return batch_count_ * rows_per_batch_; }
 
   arrow::Result<std::shared_ptr<arrow::RecordBatch>> ChunkedArrayToRecordBatch(
       const std::shared_ptr<arrow::ChunkedArray>& chunkedarray) {
@@ -203,321 +87,132 @@ class VortexTestBase : public ::testing::Test {
     return arrow::ConcatenateRecordBatches(rbs);
   }
 
+  const std::vector<std::string>& data_columns() const { return data_columns_; }
+
   protected:
-  std::shared_ptr<api::ColumnGroup> columngroup_;
   std::shared_ptr<arrow::Schema> schema_;
   std::shared_ptr<arrow::fs::FileSystem> file_system_;
-  std::vector<std::shared_ptr<arrow::RecordBatch>> record_bacths_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches_;
   const char* test_file_name_ = "test-file.vx";
   api::Properties properties_;
-  uint32_t format_version_ = 1;
 
   private:
-  uint32_t count_each_loop_ = 100;
-  uint32_t rand_strlen_ = 100;
-  uint32_t record_batch_len_ = 10;
+  const std::array<bool, 4> needed_columns_ = {true, true, true, false};
+  const std::vector<std::string> data_columns_ = {"id", "name", "value"};
+  // Keep the common test_env schema/data shape, but make each V2 test file large
+  // enough to cross the minimum validated row-group size (128KB).
+  const int64_t rows_per_batch_ = 8192;
+  const int64_t batch_count_ = 4;
 };
 
-// Parameterized fixture: runs each test for both V1 and V2 format
-class VortexBasicTest : public VortexTestBase, public ::testing::WithParamInterface<uint32_t> {
-  void SetUp() override { CommonSetUp(GetParam()); }
-};
+TEST_F(VortexV2Test, TestV2StatsEnabledUsesRowGroupZoneMapLayout) {
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS, "true");
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(128 * 1024).c_str());
 
-INSTANTIATE_TEST_SUITE_P(V1V2,
-                         VortexBasicTest,
-                         ::testing::Values(1, 2),
-                         [](const ::testing::TestParamInfo<uint32_t>& info) {
-                           return "V" + std::to_string(info.param);
-                         });
-
-TEST_P(VortexBasicTest, TestBasicWrite) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-
-  for (const auto& rb : record_bacths_) {
+  for (const auto& rb : record_batches_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
-
-  ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
-  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
-}
-
-TEST_P(VortexBasicTest, TestBasicRead) {
-  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-
-  for (const auto& rb : record_bacths_) {
-    ASSERT_TRUE(vx_writer.Write(rb).ok());
-  }
-
   ASSERT_TRUE(vx_writer.Flush().ok());
   ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
   ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 
-  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
-                                              std::vector<std::string>{"int32", "int64", "binary"});
+  auto vx_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto vx_file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+  auto vxfile =
+      VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size, vx_footer_size);
+
+  ASSERT_EQ(vxfile.RootLayoutEncoding(), "milvus.v2_zoned_row_group");
+  ASSERT_TRUE(vxfile.RowGroupZoneMapDataBeforeZones());
+  auto splits = vxfile.Splits();
+  ASSERT_GT(splits.size(), 1u);
+  ASSERT_EQ(vxfile.RowGroupZoneMapCount(), splits.size());
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
+                                              vx_file_size, vx_footer_size);
   ASSERT_STATUS_OK(vx_reader.open());
   ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
-
   ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-  ASSERT_EQ(3, rb->num_columns());
-  ASSERT_EQ(arrow::Type::INT32, rb->column(0)->type_id());
-  ASSERT_EQ(arrow::Type::INT64, rb->column(1)->type_id());
-
-  auto i32array = std::dynamic_pointer_cast<arrow::Int32Array>(rb->column(0));
-  auto i64array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(1));
-
-  for (int i = 0; i < i32array->length(); ++i) {
-    ASSERT_EQ(i32array->Value(i), (int32_t)i);
-    ASSERT_EQ(i64array->Value(i), (int64_t)i);
+  auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
+  for (int i = 0; i < id_array->length(); ++i) {
+    ASSERT_EQ(id_array->Value(i), static_cast<int64_t>(i));
   }
 }
 
-TEST_P(VortexBasicTest, TestEmptyWriteRead) {
+TEST_F(VortexV2Test, TestV2StatsDisabledUsesPlainRowGroupLayout) {
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS, "false");
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(128 * 1024).c_str());
+
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-
-  auto empty_rb = makeRecordBatch(0, 0, 0);
-  ASSERT_TRUE(vx_writer.Write(empty_rb).ok());
-
-  ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
-  ASSERT_EQ(0, cgfile.end_index);
-
-  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
-                                              std::vector<std::string>{"int32", "int64", "binary"});
-  ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_EQ(0, vx_reader.rows());
-
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, vx_reader.rows()));
-  ASSERT_EQ(0, chunked_array->num_chunks());
-}
-
-TEST_P(VortexBasicTest, TestReaderProjection) {
-  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-
-  for (const auto& rb : record_bacths_) {
+  for (const auto& rb : record_batches_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
-
   ASSERT_TRUE(vx_writer.Flush().ok());
   ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
   ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 
-  // all projection
-  {
-    auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
-                                                std::vector<std::string>{"int32", "int64", "binary"});
-    ASSERT_STATUS_OK(vx_reader.open());
-    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
+  auto vx_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto vx_file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+  auto vxfile =
+      VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size, vx_footer_size);
 
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
-    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
-    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-    ASSERT_EQ(3, rb->num_columns());
-    ASSERT_EQ(arrow::Type::INT32, rb->column(0)->type_id());
-    ASSERT_EQ(arrow::Type::INT64, rb->column(1)->type_id());
-    ASSERT_EQ(arrow::Type::BINARY, rb->column(2)->type_id());
-  }
+  ASSERT_NE(vxfile.RootLayoutEncoding(), "milvus.v2_zoned_row_group");
+  ASSERT_FALSE(vxfile.RowGroupZoneMapDataBeforeZones());
+  ASSERT_EQ(vxfile.RowGroupZoneMapCount(), 0u);
+  ASSERT_GT(vxfile.Splits().size(), 1u);
 
-  // projection with different order
-  {
-    auto projection_schema = arrow::schema({
-        arrow::field("int64", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"})),
-        arrow::field("binary", arrow::binary(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"300"})),
-        arrow::field("int32", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
-    });
-
-    auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
-                                                std::vector<std::string>{"int64", "binary", "int32"});
-    ASSERT_STATUS_OK(vx_reader.open());
-    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
-
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
-    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
-    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-    ASSERT_EQ(3, rb->num_columns());
-
-    ASSERT_EQ(arrow::Type::INT64, rb->column(0)->type_id());
-    ASSERT_EQ(arrow::Type::BINARY, rb->column(1)->type_id());
-    ASSERT_EQ(arrow::Type::INT32, rb->column(2)->type_id());
-  }
-
-  // single projection
-  {
-    auto projection_schema = arrow::schema(
-        {arrow::field("int64", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"200"}))});
-
-    auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
-                                                std::vector<std::string>{"int64"});
-    ASSERT_STATUS_OK(vx_reader.open());
-    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
-
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
-    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
-    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-    ASSERT_EQ(1, rb->num_columns());
-
-    ASSERT_EQ(arrow::Type::INT64, rb->column(0)->type_id());
-  }
-
-  // empty projection
-  {
-    auto projection_schema = arrow::schema({});
-    auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
-                                                std::vector<std::string>{});
-    ASSERT_STATUS_OK(vx_reader.open());
-    ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
-
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
-    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
-    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-    ASSERT_EQ(3, rb->num_columns());
-  }
-}
-
-TEST_P(VortexBasicTest, TestBasicTake) {
-  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-
-  for (const auto& rb : record_bacths_) {
-    ASSERT_TRUE(vx_writer.Write(rb).ok());
-  }
-
-  ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
-  ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
-
-  auto take_verify = [&](vortex::VortexFormatReader& vx_reader, const std::vector<int64_t>& row_indices,
-                         int64_t expect_rows) {
-    ASSERT_AND_ASSIGN(auto table, vx_reader.take(row_indices));
-    ASSERT_AND_ASSIGN(auto rb, table->CombineChunksToBatch());
-
-    ASSERT_EQ(expect_rows, rb->num_rows());
-    ASSERT_EQ(1, rb->num_columns());
-
-    ASSERT_EQ(arrow::Type::INT32, rb->column(0)->type_id());
-    auto i32array = std::dynamic_pointer_cast<arrow::Int32Array>(rb->column(0));
-    for (size_t i = 0; i < rb->num_rows(); i++) {
-      ASSERT_EQ(i32array->Value(i), (int32_t)row_indices[i]);
-    }
-  };
-
-  auto projection_schema = arrow::schema(
-      {arrow::field("int32", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
-
-  auto vx_reader = vortex::VortexFormatReader(file_system_, projection_schema, test_file_name_, properties_,
-                                              std::vector<std::string>{"int32"});
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
+                                              vx_file_size, vx_footer_size);
   ASSERT_STATUS_OK(vx_reader.open());
-  // take single row
-  take_verify(vx_reader, randomNumbers<int64_t>(recordBatchsRows() - 1, 1), 1);
-  // 100 randowm rows
-  take_verify(vx_reader, randomNumbers<int64_t>(recordBatchsRows() - 1, 100), 100);
-  // boundary Testing
-  take_verify(vx_reader, {0, recordBatchsRows() - 1}, 2);
-  // take all range
-  take_verify(vx_reader, rangeNumbers<int64_t>(0, recordBatchsRows()), recordBatchsRows());
-  // Note: vortex 0.56+ does not gracefully handle out-of-range indices (panics instead of returning error),
-  // so we removed the out-of-range index tests.
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(recordBatchsRows(), rb->num_rows());
 }
 
-TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
-  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+TEST_F(VortexV2Test, TestV2RowGroupZoneMapFilterScan) {
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS, "true");
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(128 * 1024).c_str());
 
-  for (const auto& rb : record_bacths_) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+  for (const auto& rb : record_batches_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
-
   ASSERT_TRUE(vx_writer.Flush().ok());
   ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
 
   auto vx_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
   auto vx_file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
-  ASSERT_GT(vx_footer_size, 0u);
-  ASSERT_GT(vx_file_size, vx_footer_size);
+  auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+  auto vxfile =
+      VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size, vx_footer_size);
+  ASSERT_EQ(vxfile.RootLayoutEncoding(), "milvus.v2_zoned_row_group");
 
-  // Verify file_size matches actual file
-  ASSERT_AND_ASSIGN(auto file, file_system_->OpenInputFile(test_file_name_));
-  ASSERT_AND_ASSIGN(auto actual_file_size, file->GetSize());
-  EXPECT_EQ(vx_file_size, static_cast<uint64_t>(actual_file_size));
+  auto scan_builder = vxfile.CreateScanBuilder();
+  scan_builder.WithFilter(expr::and_(expr::gt_eq(expr::column("id"), expr::literal(scalar::int64(1200))),
+                                     expr::lt(expr::column("id"), expr::literal(scalar::int64(1300)))));
+  scan_builder.WithProjection(expr::select(std::vector<std::string_view>{"id"}, expr::root()));
+  scan_builder.WithRowRange(1000, 1500);
 
-  // Read EOF (last 8 bytes): [version 2B][postscript_len 2B][magic "VTXF" 4B]
-  ASSERT_AND_ASSIGN(auto eof_buf, file->ReadAt(actual_file_size - 8, 8));
-  const uint8_t* eof = eof_buf->data();
+  ArrowArrayStream array_stream = std::move(scan_builder).IntoStream();
+  ASSERT_AND_ASSIGN(auto chunked_array, arrow::ImportChunkedArray(&array_stream));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(rb->num_rows(), 100);
+  ASSERT_EQ(rb->num_columns(), 1);
 
-  // Verify magic
-  ASSERT_EQ(std::string(reinterpret_cast<const char*>(eof + 4), 4), "VTXF");
-
-  // Get postscript_len from EOF
-  uint16_t postscript_len = 0;
-  std::memcpy(&postscript_len, eof + 2, 2);
-
-  // Read postscript to get the earliest segment offset (= start of footer)
-  int64_t postscript_offset = actual_file_size - 8 - postscript_len;
-  ASSERT_GT(postscript_offset, 0);
-
-  std::cout << "vx_footer_size: " << vx_footer_size << std::endl;
-  std::cout << "postscript_len: " << postscript_len << std::endl;
-
-  // The footer spans from the earliest segment to the end of file.
-  // The postscript contains segment descriptors with absolute offsets.
-  // We can parse the postscript flatbuffer to find the earliest offset,
-  // but a simpler sanity check: footer_size must be > postscript_len + 8 (postscript + EOF)
-  // and footer_size must be < file_size - 4 (exclude file header magic).
-  EXPECT_GT(vx_footer_size, static_cast<uint64_t>(postscript_len) + 8)
-      << "footer_size should include postscript + EOF + segment data";
-  EXPECT_LT(vx_footer_size, vx_file_size - 4) << "footer_size should be less than file_size minus header magic";
-}
-
-TEST_P(VortexBasicTest, FooterSizeNotMatch) {
-  // Write a vortex file
-  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-  for (const auto& rb : record_bacths_) {
-    ASSERT_TRUE(vx_writer.Write(rb).ok());
+  auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
+  for (int i = 0; i < id_array->length(); ++i) {
+    ASSERT_EQ(id_array->Value(i), static_cast<int64_t>(1200 + i));
   }
-  ASSERT_TRUE(vx_writer.Flush().ok());
-  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
-  auto vx_footer_size2 = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
-  auto vx_file_size2 = cgfile.Get<uint64_t>(api::kPropertyFileSize);
-  ASSERT_GT(vx_footer_size2, 0u);
-  ASSERT_GT(vx_file_size2, vx_footer_size2);
-
-  auto verify_read = [&](uint64_t footer_size) {
-    auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
-    auto vxfile =
-        VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size2, footer_size);
-    ASSERT_EQ(vxfile.RowCount(), static_cast<uint64_t>(recordBatchsRows()));
-
-    auto vx_reader =
-        vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
-                                   std::vector<std::string>{"int32", "int64", "binary"}, vx_file_size2, footer_size);
-    ASSERT_STATUS_OK(vx_reader.open());
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
-    ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
-    ASSERT_EQ(recordBatchsRows(), rb->num_rows());
-    ASSERT_EQ(3, rb->num_columns());
-
-    auto i32array = std::dynamic_pointer_cast<arrow::Int32Array>(rb->column(0));
-    for (int i = 0; i < i32array->length(); ++i) {
-      ASSERT_EQ(i32array->Value(i), (int32_t)i);
-    }
-  };
-
-  verify_read(1);
-
-  // Case 2: footer_size too large (= file_size, reads entire file as initial read).
-  // Vortex clamps to min(initial_read_size, file_size). Extra bytes get cached as segments.
-  verify_read(vx_file_size2);
 }
-
-// V2-specific fixture: always uses format_version=2
-class VortexV2Test : public VortexTestBase {
-  void SetUp() override { CommonSetUp(2); }
-};
 
 TEST_F(VortexV2Test, TestV2RowGroupWrite) {
   api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(128 * 1024).c_str());
 
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
-  for (const auto& rb : record_bacths_) {
+  for (const auto& rb : record_batches_) {
     ASSERT_TRUE(vx_writer.Write(rb).ok());
   }
   ASSERT_TRUE(vx_writer.Flush().ok());
@@ -527,8 +222,7 @@ TEST_F(VortexV2Test, TestV2RowGroupWrite) {
   auto total_rows = recordBatchsRows();
 
   // --- blocking_read: full scan ---
-  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_,
-                                              std::vector<std::string>{"int32", "int64", "binary"});
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
   ASSERT_STATUS_OK(vx_reader.open());
   ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, total_rows));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
@@ -536,11 +230,11 @@ TEST_F(VortexV2Test, TestV2RowGroupWrite) {
   ASSERT_EQ(total_rows, rb->num_rows());
   ASSERT_EQ(3, rb->num_columns());
 
-  auto i32array = std::dynamic_pointer_cast<arrow::Int32Array>(rb->column(0));
-  auto i64array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(1));
-  for (int i = 0; i < i32array->length(); ++i) {
-    ASSERT_EQ(i32array->Value(i), (int32_t)i);
-    ASSERT_EQ(i64array->Value(i), (int64_t)i);
+  auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
+  auto value_array = std::dynamic_pointer_cast<arrow::DoubleArray>(rb->column(2));
+  for (int i = 0; i < id_array->length(); ++i) {
+    ASSERT_EQ(id_array->Value(i), static_cast<int64_t>(i));
+    ASSERT_DOUBLE_EQ(value_array->Value(i), static_cast<double>(i) * 1.5);
   }
 
   // --- get_chunk: per row-group read ---
@@ -551,26 +245,25 @@ TEST_F(VortexV2Test, TestV2RowGroupWrite) {
     ASSERT_AND_ASSIGN(auto chunk_rb, vx_reader.get_chunk(static_cast<int>(i)));
     ASSERT_EQ(chunk_rb->num_rows(), rg_infos[i].end_offset - rg_infos[i].start_offset)
         << "rg[" << i << "] row count mismatch";
-    auto chunk_i32 = std::dynamic_pointer_cast<arrow::Int32Array>(chunk_rb->column(0));
-    ASSERT_EQ(chunk_i32->Value(0), static_cast<int32_t>(offset)) << "rg[" << i << "] first value mismatch";
+    auto chunk_id = std::dynamic_pointer_cast<arrow::Int64Array>(chunk_rb->column(0));
+    ASSERT_EQ(chunk_id->Value(0), static_cast<int64_t>(offset)) << "rg[" << i << "] first value mismatch";
     offset += chunk_rb->num_rows();
   }
   ASSERT_EQ(offset, total_rows);
 
   // --- take: random access ---
-  auto proj_schema = arrow::schema(
-      {arrow::field("int32", arrow::int32(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto proj_schema = arrow::schema({schema_->field(0)});
   auto take_reader = vortex::VortexFormatReader(file_system_, proj_schema, test_file_name_, properties_,
-                                                std::vector<std::string>{"int32"});
+                                                std::vector<std::string>{"id"});
   ASSERT_STATUS_OK(take_reader.open());
 
   std::vector<int64_t> take_indices = {0, 42, total_rows / 2, total_rows - 1};
   ASSERT_AND_ASSIGN(auto table, take_reader.take(take_indices));
   ASSERT_AND_ASSIGN(auto take_rb, table->CombineChunksToBatch());
   ASSERT_EQ(take_rb->num_rows(), static_cast<int64_t>(take_indices.size()));
-  auto take_i32 = std::dynamic_pointer_cast<arrow::Int32Array>(take_rb->column(0));
+  auto take_id = std::dynamic_pointer_cast<arrow::Int64Array>(take_rb->column(0));
   for (size_t i = 0; i < take_indices.size(); ++i) {
-    ASSERT_EQ(take_i32->Value(i), static_cast<int32_t>(take_indices[i]));
+    ASSERT_EQ(take_id->Value(i), take_indices[i]);
   }
 
   // --- read_with_range: partial range read ---
@@ -584,8 +277,8 @@ TEST_F(VortexV2Test, TestV2RowGroupWrite) {
     if (!range_batch)
       break;
     if (range_rows == 0) {
-      auto range_i32 = std::dynamic_pointer_cast<arrow::Int32Array>(range_batch->column(0));
-      ASSERT_EQ(range_i32->Value(0), static_cast<int32_t>(range_start));
+      auto range_id = std::dynamic_pointer_cast<arrow::Int64Array>(range_batch->column(0));
+      ASSERT_EQ(range_id->Value(0), static_cast<int64_t>(range_start));
     }
     range_rows += range_batch->num_rows();
   }
@@ -595,7 +288,7 @@ TEST_F(VortexV2Test, TestV2RowGroupWrite) {
 // Test that inline_array_node enables sub-segment range reads.
 // Writes FSB(512) data, takes 1 row, and asserts IO read bytes are small.
 // Only runs in cloud (S3) environment where FilesystemMetrics are available.
-TEST_P(VortexBasicTest, TestInlineArrayNodeSubSegmentRead) {
+TEST_F(VortexV2Test, TestInlineArrayNodeSubSegmentRead) {
   if (!IsCloudEnv()) {
     GTEST_SKIP() << "Sub-segment IO test requires cloud environment with FilesystemMetrics";
   }

--- a/docs/vortex-v2-row-group-zonemap-layout-plan.md
+++ b/docs/vortex-v2-row-group-zonemap-layout-plan.md
@@ -1,0 +1,450 @@
+# Vortex V2 Row Group ZoneMap Layout Plan
+
+**Status**: implementation-aligned design note
+**Date**: 2026-05-12
+**Baseline commit**: `cee4a7f feat: add Vortex V2 format reader and writer with row-group layout support`
+**Primary code scope**: `cpp/src/format/bridge/rust/src`
+**Test scope**: `cpp/test/format/vortex/vortex_v2_test.cpp`
+**Out of scope**: do not patch `cpp/src/format/bridge/rust/_vortex_patched/vortex-*`
+
+---
+
+## 1. Background
+
+The Vortex V2 writer already writes byte-size row groups. Its data layout is built from row-group chunks:
+
+```text
+Root: ChunkedLayout
+  RG0: StructLayout
+    col_a: ChunkedLayout -> BtrBlocks -> Flat(inline_array_node=true)
+    col_b: ChunkedLayout -> BtrBlocks -> Flat(inline_array_node=true)
+    ...
+  RG1: StructLayout
+  ...
+```
+
+This layout keeps row-group data physically grouped, which is good for sequential scans. The missing piece was row-group-level pruning. Without row-group ZoneMaps, selective scans still need to read row groups that cannot match the filter.
+
+The default Vortex strategy has a different shape. It builds a top-level `StructStrategy`, then each column uses `RepartitionStrategy -> ZonedStrategy -> data/zones`. Those ZoneMaps are part of each column layout and are based on fixed row counts, not on the V2 byte-size row groups. Reusing the default layout directly would not preserve the desired V2 physical data order.
+
+The core design is to reuse Vortex per-column `ZoneMap` semantics and change only the root layout plus the physical placement of zone data. The stats table dtype, fields, truncation markers, and pruning predicate semantics stay Vortex-compatible. The Milvus-specific code is responsible for V2 row-group granularity, moving all zones after all data segments, and expanding a row-group mask into a row mask.
+
+## 2. Target Layout
+
+Logical layout:
+
+```text
+Root: milvus.v2_zoned_row_group
+  data: ChunkedLayout<RG StructLayout>
+    RG0 data
+    RG1 data
+    RG2 data
+    ...
+  zones: StructLayout / container
+    col_a: Vortex-compatible ZoneMap table, one row per RG
+    col_b: Vortex-compatible ZoneMap table, one row per RG
+    ...
+    __rg_boundaries:
+      __rg_start: u64
+      __rg_len:   u64
+```
+
+Physical segment order:
+
+```text
+RG0 data segments
+RG1 data segments
+RG2 data segments
+...
+all per-column ZoneMap segments
+RG boundary segments
+footer
+```
+
+The important properties are:
+
+- All row-group data segments are written before any zone or boundary segment.
+- ZoneMap data is inside the Vortex file and participates in the Vortex layout tree.
+- Per-column stats tables use `ZoneMap::dtype_for_stats_table(column_dtype, present_stats)`.
+- Per-column stats tables can be validated with `ZoneMap::try_new`.
+- Pruning uses Vortex `checked_pruning_expr` and evaluates the resulting predicate on a Vortex-compatible stats view.
+- The custom reader only selects the relevant column ZoneMap, applies conservative expression mapping, combines masks, reads `__rg_boundaries`, and expands row-group results to row results.
+- Zone granularity is one row per V2 row group, not a fixed row count such as 8192 rows.
+
+## 3. Current Implementation
+
+The implementation lives in:
+
+```text
+cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
+```
+
+The custom layout pieces are named:
+
+```text
+RowGroupZoneMapLayoutEncoding
+RowGroupZoneMapLayout
+RowGroupZoneMapVTable
+RowGroupZoneMapReader
+RowGroupZoneMapStrategy
+```
+
+The encoding id remains:
+
+```text
+milvus.v2_zoned_row_group
+```
+
+This id is the Milvus custom Vortex format boundary. A generic Vortex reader that has not registered this encoding should fail to open the file. The Milvus bridge registers the encoding in `VORTEX_SESSION`.
+
+V2 strategy selection is unified through:
+
+```rust
+build_row_group_strategy(row_group_max_size, enable_zone_map, stats)
+```
+
+The bridge caller passes `enable_zone_map = enable_stats` for V2. There is no extra environment variable, feature flag, or `v2_zonemap` switch. The enable condition is exactly:
+
+```text
+enable_stats && format_version == VORTEX_FORMAT_V2
+```
+
+When `enable_stats=false`, the writer keeps the plain V2 row-group layout and does not emit the custom root layout. If stats are enabled but no column can produce usable ZoneMap stats, the writer also falls back to the plain data layout.
+
+## 4. Layout Contract
+
+### 4.1 Children
+
+```text
+child[0] = data
+  type = Transparent("data")
+  dtype = original struct dtype
+  row_count = file row count
+
+child[1] = zones
+  type = Auxiliary("zones")
+  dtype = Struct {
+    col_a: ZoneMap::dtype_for_stats_table(dtype(col_a), present_stats(col_a)),
+    col_b: ZoneMap::dtype_for_stats_table(dtype(col_b), present_stats(col_b)),
+    ...
+    __rg_boundaries: Struct {
+      __rg_start: u64,
+      __rg_len:   u64,
+    }
+  }
+  row_count = row group count
+```
+
+The zones child is not an external sidecar and is not a flattened wide stats table. Each real column with usable stats owns a complete Vortex-compatible `ZoneMap` stats table. The synthetic `__rg_boundaries` table is separate from all per-column stats tables.
+
+### 4.2 Metadata
+
+Current metadata contains:
+
+- `version: u16`
+- `stats_version: u16`
+- `rg_count: u64`
+- `columns: Vec<ColumnZoneMetadata>`
+- For each column: `field_name` and `present_stats`
+
+The current bridge implementation maps top-level struct fields by name. If nested field paths are added later, that should be a metadata versioned change.
+
+The metadata does not store all row-group start and length values. Those live in the `__rg_boundaries` table to avoid footer growth proportional to the row-group count.
+
+### 4.3 Reserved Fields
+
+The input schema must not contain a top-level field named:
+
+```text
+__rg_boundaries
+```
+
+That name is reserved for the synthetic boundary table under the zones child. A conflict is rejected by the writer.
+
+## 5. ZoneMap Table Design
+
+For each column with usable stats:
+
+```text
+zones.<column>:
+  min
+  min_is_truncated
+  max
+  max_is_truncated
+  null_count
+  nan_count
+  ...
+```
+
+The exact field set is determined by Vortex:
+
+```rust
+ZoneMap::dtype_for_stats_table(column_dtype, present_stats)
+```
+
+Stats are accumulated with Vortex `StatsAccumulator`. This preserves Vortex field names and string/binary truncation semantics, including `min_is_truncated` and `max_is_truncated`.
+
+The boundary table is independent:
+
+```text
+zones.__rg_boundaries:
+  __rg_start: u64
+  __rg_len:   u64
+```
+
+The boundary table is used only to expand a row-group-level pruning result into a row-level keep mask. It is never mixed into the per-column `ZoneMap` table shape.
+
+## 6. Writer Flow
+
+The V2 writer uses two internal strategies:
+
+```text
+RowGroupSplitStrategy
+  split stream into byte-size row groups
+  write only the normal V2 data layout
+
+RowGroupZoneMapStrategy
+  split stream into byte-size row groups
+  write the normal V2 data layout as child[0]
+  write per-column ZoneMaps and boundaries as child[1]
+  return RowGroupZoneMapLayout
+```
+
+`RowGroupZoneMapStrategy` flow:
+
+```text
+input stream
+  -> split by uncompressed byte size
+  -> for each row group in order:
+       compute requested stats for each top-level field
+       append one stats row to that column's StatsAccumulator
+       append one row to __rg_boundaries
+       yield the row group to the data child
+
+data_layout = write data child first with data_eof = eof.split_off()
+zones_layout = write zones child after the data child
+return RowGroupZoneMapLayout(data_layout, zones_layout, metadata)
+```
+
+The physical order is enforced with `SequencePointer::split_off()`:
+
+```text
+data child consumes the data_eof sequence
+zones child consumes the later eof sequence
+```
+
+This is what guarantees:
+
+```text
+all data segments < all zone/boundary segments
+```
+
+## 7. Reader Flow
+
+`RowGroupZoneMapReader` delegates non-pruning behavior to the data child:
+
+```text
+projection_evaluation(row_range, expr, mask)
+  -> data_child.projection_evaluation(row_range, expr, mask)
+
+filter_evaluation(row_range, expr, mask)
+  -> data_child.filter_evaluation(row_range, expr, mask)
+
+register_splits(field_mask, row_range, splits)
+  -> data_child.register_splits(field_mask, row_range, splits)
+```
+
+Pruning flow:
+
+```text
+1. Ask data_child.pruning_evaluation(...) for the base pruning result.
+2. Build root-scope available_stats from metadata, for example col_a.min and col_a.max.
+3. Call checked_pruning_expr(expr, available_stats).
+4. If the expression is not safely stats-prunable, return the data child result.
+5. Require all stats used by the pruning expression to belong to one column.
+6. Build a temporary root-scope stats view over the column-local ZoneMap arrays, for example `col_a_max -> zones.col_a.max`.
+7. Load zones.<column> and validate it with ZoneMap::try_new.
+8. Evaluate the pruning predicate on that temporary stats view to get a row-group prune mask.
+9. Load __rg_boundaries and expand the row-group prune mask into a row keep mask.
+10. Intersect the input mask, the ZoneMap-derived row keep mask, and the data child result.
+```
+
+The stats predicate returns `true` for a row group that can be skipped. `LayoutReader::pruning_evaluation` returns a row keep mask. Expansion therefore inverts the row-group prune bit:
+
+```text
+rg_keep = !rg_prune
+row_keep = expand_by(__rg_start, __rg_len, rg_keep, row_range)
+```
+
+Partial row ranges are handled by intersecting each row-group boundary with the requested `row_range`. The expanded mask length must exactly match `row_range.end - row_range.start`.
+
+## 8. Expression Support
+
+The first implementation is intentionally conservative:
+
+- Single-column predicates can use the matching column ZoneMap.
+- Multiple conjuncts already split by Vortex scan can be handled independently and intersected by the scan pipeline.
+- A predicate is pruned only when `checked_pruning_expr` and the required stats reduce it to one column scope.
+- Cross-column `AND` can still benefit when Vortex scan has already split it into independent conjuncts that are evaluated separately.
+- Cross-column comparisons, `OR`, unsupported functions, missing stats, unsupported types, and unsafe rewrites return the data child pruning result.
+
+The implementation does not introduce a custom wide-table expression evaluator and does not redefine Vortex stats scope.
+
+## 9. Why Not a Wide Stats Table
+
+A rejected alternative was a single wide stats table:
+
+```text
+col_a_min
+col_a_max
+col_b_min
+col_b_max
+...
+```
+
+That shape can be made semantically equivalent, but it would redefine Vortex's stats table layout. It would need more glue code for dtype construction, field naming, truncation markers, and validation. It also prevents directly validating each column with `ZoneMap::try_new`.
+
+The per-column table design is closer to Vortex `ZonedLayout`:
+
+```text
+one column -> one Vortex-compatible ZoneMap stats table
+```
+
+The only differences are row-group granularity and physical placement.
+
+## 10. Other Rejected Alternatives
+
+### External Sidecar ZoneMap
+
+Rejected because Vortex would not see the sidecar through the layout tree, so `LayoutReader::pruning_evaluation` would not use it in the native scan path.
+
+### ZoneMap Inside Each Row Group
+
+Rejected because it would produce interleaved physical layout:
+
+```text
+RG0 data
+RG0 zones
+RG1 data
+RG1 zones
+...
+```
+
+That breaks the desired continuous data region for sequential scans.
+
+### Wrapping V2 Root With Built-In ZonedLayout
+
+Rejected because built-in `ZonedLayout` uses fixed `zone_len` semantics, while V2 row groups are byte-size and have variable row counts. Wrapping the struct root also does not naturally produce one Vortex-compatible ZoneMap table per real column.
+
+### Patching Vortex
+
+Not needed. The required extension points are public: layout encoding, layout reader, session registration, `ZoneMap`, and `StatsAccumulator`.
+
+## 11. Tests
+
+### Implemented C++ gtests
+
+The main behavioral coverage is in `cpp/test/format/vortex/vortex_v2_test.cpp`:
+
+```text
+VortexV2Test.TestV2StatsEnabledUsesRowGroupZoneMapLayout
+VortexV2Test.TestV2StatsDisabledUsesPlainRowGroupLayout
+VortexV2Test.TestV2RowGroupZoneMapFilterScan
+```
+
+These tests cover:
+
+- `enable_stats=true` with V2 writes root encoding `milvus.v2_zoned_row_group`.
+- `enable_stats=false` with V2 keeps the plain row-group layout.
+- The row-group count matches scan splits.
+- Data segments are physically before zone and boundary segments.
+- C++ filtered scan over V2 RowGroupZoneMap data returns correct rows.
+
+Bridge inspection helpers used by the tests:
+
+```text
+VortexFile::RootLayoutEncoding()
+VortexFile::RowGroupZoneMapCount()
+VortexFile::RowGroupZoneMapDataBeforeZones()
+```
+
+### Implemented Rust Unit Coverage
+
+The Rust module also keeps focused unit coverage for:
+
+- metadata serialization roundtrip
+- partial `row_range` row-group mask expansion
+- scan filter path using row-group ZoneMap pruning
+
+The C++ gtests remain the required integration coverage because the user-facing writer and reader path is C++.
+
+### Additional Coverage To Preserve Or Extend
+
+ZoneMap compatibility:
+
+- Numeric, string, and nullable columns produce per-column zones tables whose dtype equals `ZoneMap::dtype_for_stats_table`.
+- `min_is_truncated` and `max_is_truncated` match Vortex builder semantics.
+- `ZoneMap::try_new` validates each per-column zones table.
+
+Physical layout:
+
+- Write at least three row groups and verify every data segment offset is less than every zone or boundary segment offset.
+- Verify `__rg_boundaries` covers the full file without gaps or overlaps.
+
+Pruning behavior:
+
+- Single-column range filters skip impossible row groups.
+- Unsupported expressions, missing stats, unsupported types, and complex cross-column expressions are conservative and do not prune.
+- Partial `row_range` expansion has correct length and boundaries.
+
+Compatibility:
+
+- Registered `milvus.v2_zoned_row_group` encoding can read the file.
+- Missing encoding fails with a diagnostic error.
+- `enable_stats=false` keeps the current V2 layout unchanged.
+
+## 12. Implementation Checklist
+
+Implemented:
+
+- `vortex_layout_strategy_v2.rs` defines the custom layout, metadata, reader, and writer strategy.
+- `VORTEX_SESSION` registers `RowGroupZoneMapLayoutEncoding`.
+- `vortex_bridgeimpl.rs` uses the unified `build_row_group_strategy`.
+- V2 ZoneMap enablement is controlled only by `enable_stats && format_version == VORTEX_FORMAT_V2`.
+- V2 stats-disabled writes keep the plain row-group layout.
+- Per-column Vortex-compatible ZoneMap stats tables are generated with `StatsAccumulator`.
+- `__rg_boundaries` is stored as a separate zones child field.
+- Data child is written before zones child with `SequencePointer::split_off()`.
+- The reader delegates projection/filter/splits to the data child.
+- The reader uses `checked_pruning_expr` plus a temporary root-scope stats view for safe single-column pruning.
+- C++ gtests cover enabled layout, disabled fallback, physical ordering, and filtered scan correctness.
+
+Not in scope for the first implementation:
+
+- Custom wide-table stats evaluation.
+- Aggressive cross-column pruning.
+- Patching Vortex internals.
+- A separate V2 ZoneMap environment variable or feature flag.
+
+## 13. Final Recommendation
+
+The implemented design is the recommended design:
+
+```text
+milvus.v2_zoned_row_group
+  data: current V2 ChunkedLayout<RG StructLayout>
+  zones: Struct/container
+    col_a: Vortex-compatible ZoneMap table, one row per RG
+    col_b: Vortex-compatible ZoneMap table, one row per RG
+    ...
+    __rg_boundaries: __rg_start/__rg_len table, one row per RG
+```
+
+This satisfies the original requirements without patching Vortex:
+
+- The data region is physically continuous.
+- ZoneMap data stays inside the Vortex file.
+- Stats dtype, fields, truncation markers, and pruning semantics match Vortex per-column `ZoneMap`.
+- Pruning reuses `checked_pruning_expr` and evaluates its predicate on Vortex-compatible ZoneMap stats arrays.
+- Zone granularity matches V2 byte-size row groups.
+- The Milvus bridge can evolve this custom Vortex format independently.


### PR DESCRIPTION
The default `ZoneMapLayout` keeps stats under the data layout. That works for a simple zoned layout, but it is not a great fit for our V2 row group layout. It can leave holes between columns, and each column's stats may end up scattered around the physical data layout instead of being grouped together as one pruning-friendly structure.

```
ZoneMapLayout childs:

  - 0: data
  - 1: stats

  which produce interleaved physical layout:

  - RG0 data
  - RG0 zones
  - RG1 data
  - RG1 zones
    ...
```


This adds a dedicated `RowGroupZoneMapLayout` for Vortex V2. The main row group data stays in the existing V2 chunked layout, while all row group zonemap data is written into a compact sidecar layout. That keeps the data path clean and gives scans a single place to read per-row-group stats for pruning.

```
  milvus.v2_zoned_row_group
    data: current V2 ChunkedLayout<RG StructLayout>
    zones: Struct/container
      col_a: Vortex-compatible ZoneMap table, one row per RG
      col_b: Vortex-compatible ZoneMap table, one row per RG
      ...
      __rg_boundaries: __rg_start/__rg_len table, one row per RG
```

The boundary table lets the reader map row-group-level pruning results back to the requested row range, so we can prune whole row groups without changing the normal scan/projection behavior. This also wires the new layout into the Rust bridge and adds V2 coverage for row group splitting, zonemap layout shape, and filter pruning.