### PR TITLE
fix:[3.0] cherry-pick #518 and #522 to 3.0

### DIFF
--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -16,7 +16,6 @@
 
 #include <cstdint>
 #include <string>
-#include <functional>
 #include <memory>
 #include <vector>
 #include <map>
@@ -88,24 +87,52 @@ class Updates {
 };
 
 /**
- * @brief Resolver function type
+ * @brief Resolver interface for conflict resolution between read and latest manifests.
  *
- * Resolves conflicts between read manifest and latest manifest using recorded changes.
+ * A Resolver implementation reconciles the manifest read when a transaction began
+ * with the most recent committed manifest, producing the manifest that will be
+ * written by the commit.
  *
- * @param read_manifest The manifest read when transaction began
- * @param read_version The version of the read manifest
- * @param latest_manifest The most recent committed manifest at the time of conflict resolution (may differ from
- * read_manifest if concurrent commits occurred)
- * @param latest_version The version of the latest manifest
- * @param updates The recorded changes in this transaction
- * @return Resolved manifest or error status
+ * Resolver instances are expected to be stateless and shared (typically static
+ * globals). The caller must keep the Resolver alive for the lifetime of any
+ * Transaction that references it.
  */
-using Resolver =
-    std::function<arrow::Result<std::shared_ptr<Manifest>>(const std::shared_ptr<Manifest>& read_manifest,
-                                                           int64_t read_version,
-                                                           const std::shared_ptr<Manifest>& latest_manifest,
-                                                           int64_t latest_version,
-                                                           const Updates& updates)>;
+class Resolver {
+  public:
+  virtual ~Resolver() = default;
+
+  /**
+   * @brief Resolve a commit.
+   *
+   * @param read_manifest The manifest read when the transaction began
+   * @param read_version The version of the read manifest
+   * @param latest_manifest The most recent committed manifest at conflict-resolution time
+   *        (may be null if the implementation reported requireLatest() == false and the
+   *        commit detected version drift; never null when read_version == latest_version
+   *        or when requireLatest() == true)
+   * @param latest_version The version of the latest manifest
+   * @param updates The recorded changes in this transaction
+   * @return Resolved manifest or error status
+   */
+  [[nodiscard]] virtual arrow::Result<std::shared_ptr<Manifest>> resolve(
+      const std::shared_ptr<Manifest>& read_manifest,
+      int64_t read_version,
+      const std::shared_ptr<Manifest>& latest_manifest,
+      int64_t latest_version,
+      const Updates& updates) const = 0;
+
+  /**
+   * @brief Whether this resolver needs the latest manifest contents loaded.
+   *
+   * When false, the transaction commit logic will skip reading manifest-N.avro
+   * from storage on version drift and pass a null latest_manifest to resolve().
+   * Implementations that ignore latest_manifest (or only use it when versions
+   * match, in which case the read is unnecessary) should return false to avoid
+   * spurious commit failures from transient read errors on an otherwise-unused
+   * manifest file.
+   */
+  [[nodiscard]] virtual bool requireLatest() const = 0;
+};
 
 // ==================== Helper Functions ====================
 
@@ -128,25 +155,30 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
  * @brief Unified resolver that merges changes with latest_manifest
  *
  * This resolver merges all changes (appended files, added column groups, delta logs, stats)
- * into the latest_manifest, effectively merging concurrent changes.
+ * into the latest_manifest, effectively merging concurrent changes. requireLatest() == true.
  */
-extern Resolver MergeResolver;
+extern const Resolver& MergeResolver;
 
 /**
  * @brief Resolver that applies updates to read_manifest, overwriting any concurrent changes
  *
  * This resolver applies all changes (appended files, added column groups, delta logs, stats)
  * into the read_manifest, ignoring any concurrent changes in latest_manifest.
+ * requireLatest() == false — the commit logic skips reading manifest-N.avro on version drift.
  */
-extern Resolver OverwriteResolver;
+extern const Resolver& OverwriteResolver;
 
 /**
  * @brief Resolver that fails if latest version differs from read version
  *
- * This resolver checks if there were concurrent changes by comparing versions.
- * If read_version equals latest_version, it applies updates to the manifest.
+ * When read_version equals latest_version, applies updates to latest_manifest (or
+ * read_manifest if latest_manifest is null). When versions differ, returns a
+ * TxnResolutionFailed error without touching latest_manifest.
+ *
+ * requireLatest() == false: it is safe for Commit() to skip reading manifest-N.avro on
+ * version drift, since the resolver only inspects manifests when versions match.
  */
-extern Resolver FailResolver;
+extern const Resolver& FailResolver;
 
 class Transaction {
   public:
@@ -154,7 +186,10 @@ class Transaction {
   // @param fs Filesystem to use
   // @param base_path Base path for the storage
   // @param version Version to read from (default: LATEST = fetch greatest version)
-  // @param resolver Resolver function for conflict resolution (default: FailResolver)
+  // @param resolver Resolver for conflict resolution (default: FailResolver). The
+  //        Transaction stores a non-owning pointer to this object; the caller MUST keep
+  //        the resolver alive for the lifetime of the returned Transaction. Do not pass
+  //        a temporary.
   // @param retry_limit Maximum number of retry attempts on commit conflicts (default: 1)
   static arrow::Result<std::unique_ptr<Transaction>> Open(const milvus_storage::ArrowFileSystemPtr& fs,
                                                           const std::string& base_path,
@@ -260,8 +295,8 @@ class Transaction {
   int64_t read_version_;
   std::shared_ptr<Manifest> read_manifest_;
   std::string base_path_;
-  Updates updates_;    ///< Transaction updates tracked for resolver
-  Resolver resolver_;  ///< Resolver function for conflict resolution
+  Updates updates_;           ///< Transaction updates tracked for resolver
+  const Resolver* resolver_;  ///< Non-owning pointer to the resolver supplied at Open()
   milvus_storage::ArrowFileSystemPtr fs_;
   uint32_t retry_limit_;  ///< Maximum number of retry attempts on commit conflicts
 };

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -49,17 +49,17 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
     }
 
     // Select resolver based on resolve_id
-    Resolver resolver;
+    const Resolver* resolver = nullptr;
     switch (resolve_id) {
       case LOON_TRANSACTION_RESOLVE_MERGE:
-        resolver = MergeResolver;
+        resolver = &MergeResolver;
         break;
       case LOON_TRANSACTION_RESOLVE_OVERWRITE:
-        resolver = OverwriteResolver;
+        resolver = &OverwriteResolver;
         break;
       case LOON_TRANSACTION_RESOLVE_FAIL:
       default:
-        resolver = FailResolver;
+        resolver = &FailResolver;
         break;
     }
 
@@ -68,7 +68,8 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
     if (!fs_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
     }
-    auto transaction_result = Transaction::Open(fs_result.ValueOrDie(), base_path, read_version, resolver, retry_limit);
+    auto transaction_result =
+        Transaction::Open(fs_result.ValueOrDie(), base_path, read_version, *resolver, retry_limit);
     if (!transaction_result.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, transaction_result.status().ToString());
     }

--- a/cpp/src/ffi/segment_reader_c.cpp
+++ b/cpp/src/ffi/segment_reader_c.cpp
@@ -178,7 +178,7 @@ LoonFFIResult loon_segment_reader_take(LoonSegmentReaderHandle handle,
     auto table = std::move(result).ValueOrDie();
 
     // Convert Table to RecordBatchReader, then export as ArrowArrayStream
-    auto batch_reader = std::make_shared<arrow::TableBatchReader>(*table);
+    auto batch_reader = std::make_shared<arrow::TableBatchReader>(std::move(table));
     auto status = arrow::ExportRecordBatchReader(batch_reader, out_stream);
     if (!status.ok()) {
       RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -249,40 +249,68 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
   return base;
 }
 
-// ==================== Helper Resolver Functions ====================
+// ==================== Built-in Resolver Implementations ====================
 
-Resolver MergeResolver = [](const std::shared_ptr<Manifest>& /*read_manifest*/,
-                            int64_t /*read_version*/,
-                            const std::shared_ptr<Manifest>& latest_manifest,
-                            int64_t /*latest_version*/,
-                            const Updates& updates) -> arrow::Result<std::shared_ptr<Manifest>> {
-  return applyUpdates(latest_manifest, updates);
-};
+namespace {
 
-Resolver OverwriteResolver = [](const std::shared_ptr<Manifest>& read_manifest,
-                                int64_t /*read_version*/,
-                                const std::shared_ptr<Manifest>& /*latest_manifest*/,
-                                int64_t /*latest_version*/,
-                                const Updates& updates) -> arrow::Result<std::shared_ptr<Manifest>> {
-  return applyUpdates(read_manifest, updates);
-};
-
-Resolver FailResolver = [](const std::shared_ptr<Manifest>& /*read_manifest*/,
-                           int64_t read_version,
-                           const std::shared_ptr<Manifest>& latest_manifest,
-                           int64_t latest_version,
-                           const Updates& updates) -> arrow::Result<std::shared_ptr<Manifest>> {
-  // Check if read_version equals latest_version (no concurrent changes)
-  if (read_version == latest_version) {
+class MergeResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& /*read_manifest*/,
+                                                   int64_t /*read_version*/,
+                                                   const std::shared_ptr<Manifest>& latest_manifest,
+                                                   int64_t /*latest_version*/,
+                                                   const Updates& updates) const override {
     return applyUpdates(latest_manifest, updates);
   }
 
-  return milvus_storage::MakeExtendError(
-      milvus_storage::ExtendStatusCode::TxnResolutionFailed,
-      fmt::format("FailResolver: concurrent transaction detected, [read_version={}][latest_version={}]", read_version,
-                  latest_version),
-      "");
+  [[nodiscard]] bool requireLatest() const override { return true; }
 };
+
+class OverwriteResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& read_manifest,
+                                                   int64_t /*read_version*/,
+                                                   const std::shared_ptr<Manifest>& /*latest_manifest*/,
+                                                   int64_t /*latest_version*/,
+                                                   const Updates& updates) const override {
+    return applyUpdates(read_manifest, updates);
+  }
+
+  [[nodiscard]] bool requireLatest() const override { return false; }
+};
+
+class FailResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& read_manifest,
+                                                   int64_t read_version,
+                                                   const std::shared_ptr<Manifest>& latest_manifest,
+                                                   int64_t latest_version,
+                                                   const Updates& updates) const override {
+    if (read_version == latest_version) {
+      // When versions match, Transaction::Commit supplies read_manifest_ as latest_manifest
+      // without a disk read; fall back to read_manifest if latest_manifest is null.
+      return applyUpdates(latest_manifest ? latest_manifest : read_manifest, updates);
+    }
+
+    return milvus_storage::MakeExtendError(
+        milvus_storage::ExtendStatusCode::TxnResolutionFailed,
+        fmt::format("FailResolver: concurrent transaction detected, [read_version={}][latest_version={}]", read_version,
+                    latest_version),
+        "");
+  }
+
+  [[nodiscard]] bool requireLatest() const override { return false; }
+};
+
+const MergeResolverImpl g_merge_resolver;
+const OverwriteResolverImpl g_overwrite_resolver;
+const FailResolverImpl g_fail_resolver;
+
+}  // namespace
+
+const Resolver& MergeResolver = g_merge_resolver;
+const Resolver& OverwriteResolver = g_overwrite_resolver;
+const Resolver& FailResolver = g_fail_resolver;
 
 // ==================== Transaction Implementation ====================
 
@@ -326,7 +354,7 @@ Transaction::Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
       base_path_(base_path),
       read_manifest_(nullptr),
       updates_(),
-      resolver_(resolver),
+      resolver_(&resolver),
       fs_(fs),
       retry_limit_(retry_limit) {}
 
@@ -342,7 +370,10 @@ arrow::Result<int64_t> Transaction::Commit() {
     return arrow::Status::Invalid("Cannot commit: no updates recorded");
   }
 
-  // Lambda to reload latest manifest and return version and manifest
+  // Lambda to reload latest manifest and return version and manifest.
+  // Skips the disk read for manifest-N.avro when the resolver declares it doesn't
+  // need latest_manifest contents (issue #49069: avoid spurious commit failures on
+  // transient read errors of an otherwise-unused manifest file).
   auto reload_latest_manifest = [this]() -> arrow::Result<std::pair<int64_t, std::shared_ptr<Manifest>>> {
     ARROW_ASSIGN_OR_RAISE(auto latest_version, get_latest_version());
 
@@ -350,6 +381,13 @@ arrow::Result<int64_t> Transaction::Commit() {
     if (latest_version == read_version_) {
       // Latest version is the same as read version, use read_manifest as latest_manifest
       latest_manifest = read_manifest_;
+    } else if (!resolver_->requireLatest()) {
+      // Resolver won't touch latest_manifest on version drift; skip the read.
+      LOG_STORAGE_DEBUG_ << fmt::format(
+          "Manifest version drift detected, skipping latest manifest read: "
+          "[read_version={}][latest_version={}]",
+          read_version_, latest_version);
+      latest_manifest = nullptr;
     } else {
       // Latest version differs, load the latest manifest
       LOG_STORAGE_DEBUG_ << fmt::format("Manifest version drift detected: [read_version={}][latest_version={}]",
@@ -369,7 +407,8 @@ arrow::Result<int64_t> Transaction::Commit() {
     std::shared_ptr<Manifest> latest_manifest = latest_result.second;
 
     // Always call resolver to get merged manifest
-    auto resolved_manifest_result = resolver_(read_manifest_, read_version_, latest_manifest, latest_version, updates_);
+    auto resolved_manifest_result =
+        resolver_->resolve(read_manifest_, read_version_, latest_manifest, latest_version, updates_);
     if (!resolved_manifest_result.ok()) {
       return resolved_manifest_result.status();
     }

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -306,6 +306,129 @@ TEST_F(TransactionTest, ConflictResolveOverwriteTest) {
   }
 }
 
+// Regression for issue #49069: when the resolver doesn't need the latest manifest,
+// Commit() must not block on reading manifest-N.avro from storage. A transient read
+// failure on an otherwise-unused manifest used to fail an entire successful commit.
+TEST_F(TransactionTest, CommitSkipsUnusedLatestManifestReadForOverwrite) {
+  // Make a baseline tree with two manifests written by separate transactions.
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v1.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v2.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // Open at read_version=1 so a subsequent commit sees version drift (latest=2).
+  ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, 1, OverwriteResolver));
+
+  // Corrupt manifest-2.avro so any attempt to read it fails. The filename still
+  // exists so get_latest_version() still reports 2 and the drift branch fires.
+  Manifest::CleanCache();
+  std::string manifest_2_path = get_manifest_filepath(base_path_, 2);
+  {
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(manifest_2_path));
+    const std::string garbage = "not a valid avro file";
+    ASSERT_STATUS_OK(out->Write(garbage.data(), garbage.size()));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Commit should succeed: OverwriteResolver declares requireLatest() == false,
+  // so Commit() skips reading the (now-corrupt) manifest-2.avro.
+  ASSERT_AND_ASSIGN(auto new_manifest, CreateSampleManifest("/dummy_overwrite.parquet", {"id", "name"}));
+  txn->AppendFiles(new_manifest->columnGroups());
+  ASSERT_AND_ASSIGN(auto committed_version, txn->Commit());
+  ASSERT_EQ(committed_version, 3);
+}
+
+TEST_F(TransactionTest, CommitSkipsUnusedLatestManifestReadForFailOnDrift) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v1.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v2.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, 1, FailResolver));
+
+  Manifest::CleanCache();
+  std::string manifest_2_path = get_manifest_filepath(base_path_, 2);
+  {
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(manifest_2_path));
+    const std::string garbage = "not a valid avro file";
+    ASSERT_STATUS_OK(out->Write(garbage.data(), garbage.size()));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // With version drift, FailResolver reports TxnResolutionFailed without touching
+  // latest_manifest. The corrupt manifest-2.avro must not surface as an IOError.
+  ASSERT_AND_ASSIGN(auto new_manifest, CreateSampleManifest("/dummy_fail.parquet", {"id", "name"}));
+  txn->AppendFiles(new_manifest->columnGroups());
+  auto status = txn->Commit().status();
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), arrow::StatusCode::IOError) << status.ToString();
+  // Sanity check: the error came from the resolver (concurrent transaction), not from
+  // a manifest read failure.
+  EXPECT_TRUE(status.ToString().find("concurrent transaction") != std::string::npos) << status.ToString();
+  EXPECT_TRUE(status.ToString().find("manifest-2.avro") == std::string::npos) << status.ToString();
+}
+
+TEST_F(TransactionTest, CommitStillReadsLatestManifestForMerge) {
+  // Negative test: MergeResolver does need latest_manifest, so a corrupt
+  // manifest-N.avro must still surface as a read error.
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v1.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, CreateSampleManifest("/dummy_v2.parquet", {"id", "name"}));
+    txn->AppendFiles(manifest->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+
+  Manifest::CleanCache();
+  std::string manifest_2_path = get_manifest_filepath(base_path_, 2);
+  {
+    ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(manifest_2_path));
+    const std::string garbage = "not a valid avro file";
+    ASSERT_STATUS_OK(out->Write(garbage.data(), garbage.size()));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  ASSERT_AND_ASSIGN(auto new_manifest, CreateSampleManifest("/dummy_merge.parquet", {"id", "name"}));
+  txn->AppendFiles(new_manifest->columnGroups());
+  auto status = txn->Commit().status();
+  ASSERT_FALSE(status.ok());
+  // The failure must originate from reading the corrupt manifest-2.avro, not from some
+  // unrelated short-circuit: assert the error surfaces the manifest read path.
+  const auto msg = status.ToString();
+  EXPECT_TRUE(msg.find("manifest-2.avro") != std::string::npos || msg.find("deserialize") != std::string::npos ||
+              msg.find("Avro") != std::string::npos)
+      << msg;
+}
+
 TEST_F(TransactionTest, WriteReadByVersion) {
   // initial 5 commit with one column group
   int loop_times = 5;

--- a/cpp/test/ffi/ffi_segment_test.c
+++ b/cpp/test/ffi/ffi_segment_test.c
@@ -1,0 +1,367 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_filesystem_c.h"
+#include "milvus-storage/ffi_internal/v2_packed_writer_c.h"
+#include "test_runner.h"
+#include "ffi_test_env.h"
+
+#include <arrow/c/abi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SEGMENT_TEST_ROOT_PATH "test_filesystem_ffi"
+#define SEGMENT_TEST_BASE_PATH "segment-ffi-test-dir"
+#define PACKED_TEST_BASE_PATH "packed-ffi-test-dir"
+#define PACKED_TEST_PATH_0 "packed-ffi-test-dir/group-0.parquet"
+#define PACKED_TEST_PATH_1 "packed-ffi-test-dir/group-1.parquet"
+
+void field_schema_release(struct ArrowSchema* schema);
+void struct_schema_release(struct ArrowSchema* schema);
+struct ArrowSchema* create_test_struct_schema();
+
+struct ArrowArray* create_test_struct_arrow_array(int64_t* int64_data,
+                                                  int32_t* int32_data,
+                                                  const char** str_data,
+                                                  int length);
+
+static void release_schema(struct ArrowSchema* schema) {
+  if (schema) {
+    if (schema->release) {
+      schema->release(schema);
+    }
+    free(schema);
+  }
+}
+
+static void release_array(struct ArrowArray* array) {
+  if (array) {
+    if (array->release) {
+      array->release(array);
+    }
+    free(array);
+  }
+}
+
+static LoonFFIResult create_test_segment_pp(LoonProperties* pp) {
+  const char* keys[500] = {"writer.policy", "format"};
+  const char* vals[500] = {"single", "parquet"};
+  size_t count = init_test_props(keys, vals, 2, 500, SEGMENT_TEST_ROOT_PATH);
+
+  return loon_properties_create((const char* const*)keys, (const char* const*)vals, count, pp);
+}
+
+static LoonFFIResult create_test_packed_pp(LoonProperties* pp) {
+  const char* keys[500];
+  const char* vals[500];
+  size_t count = init_test_props(keys, vals, 0, 500, SEGMENT_TEST_ROOT_PATH);
+
+  return loon_properties_create((const char* const*)keys, (const char* const*)vals, count, pp);
+}
+
+static void clean_segment_test_path(LoonProperties* pp) {
+  LoonFFIResult rc;
+  FileSystemHandle fs = 0;
+
+  rc = loon_filesystem_get(pp, NULL, 0, &fs);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  clean_test_dir(fs, SEGMENT_TEST_BASE_PATH);
+  clean_test_dir(fs, PACKED_TEST_BASE_PATH);
+
+  loon_filesystem_destroy(fs);
+  loon_reset_context();
+}
+
+static struct ArrowArray* create_segment_test_array(void) {
+  int64_t int64_data[] = {1, 2, 3, 4, 5};
+  int32_t int32_data[] = {25, 30, 35, 40, 45};
+  const char* str_data[] = {"ABC", "BCD", "DDDD", "EEEEEa", "CCCC23123"};
+
+  return create_test_struct_arrow_array(int64_data, int32_data, str_data, 5);
+}
+
+static void assert_stream_first_batch(struct ArrowArrayStream* stream, int64_t expected_rows) {
+  struct ArrowSchema out_schema;
+  struct ArrowArray out_array;
+  int arrow_rc;
+
+  arrow_rc = stream->get_schema(stream, &out_schema);
+  ck_assert_int_eq(0, arrow_rc);
+  ck_assert(out_schema.release != NULL);
+  ck_assert_int_eq(out_schema.n_children, 3);
+  out_schema.release(&out_schema);
+
+  arrow_rc = stream->get_next(stream, &out_array);
+  ck_assert_int_eq(0, arrow_rc);
+  ck_assert(out_array.release != NULL);
+  ck_assert_int_eq(out_array.length, expected_rows);
+  ck_assert_int_eq(out_array.n_children, 3);
+  out_array.release(&out_array);
+}
+
+static void create_committed_segment(LoonProperties* pp) {
+  LoonFFIResult rc;
+  LoonSegmentWriterHandle writer = 0;
+  LoonTransactionHandle txn = 0;
+  LoonSegmentWriteOutput output;
+  int64_t committed_version = 0;
+  struct ArrowSchema* schema = NULL;
+  struct ArrowArray* array = NULL;
+  LoonSegmentWriterConfig config;
+
+  memset(&output, 0, sizeof(output));
+  memset(&config, 0, sizeof(config));
+  config.segment_path = SEGMENT_TEST_BASE_PATH;
+
+  rc = loon_initialize_filesystem_singleton(pp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  schema = create_test_struct_schema();
+  rc = loon_segment_writer_new(schema, &config, pp, &writer);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  release_schema(schema);
+
+  array = create_segment_test_array();
+  rc = loon_segment_writer_write(writer, array);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  release_array(array);
+
+  rc = loon_segment_writer_flush(writer);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  rc = loon_segment_writer_close(writer, &output);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_eq(output.rows_written, 5);
+  ck_assert(output.column_groups != NULL);
+
+  rc = loon_transaction_begin(SEGMENT_TEST_BASE_PATH, pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &txn);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  rc = loon_transaction_append_files(txn, output.column_groups);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  for (size_t i = 0; i < output.num_lob_files; i++) {
+    rc = loon_transaction_add_lob_file(txn, &output.lob_files[i]);
+    ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  }
+
+  rc = loon_transaction_commit(txn, &committed_version);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_gt(committed_version, 0);
+
+  loon_transaction_destroy(txn);
+  loon_segment_writer_destroy(writer);
+  loon_segment_write_output_free(&output);
+  loon_column_groups_destroy(output.column_groups);
+
+  (void)committed_version;
+}
+
+static void test_segment_writer_reader_basic(void) {
+  LoonFFIResult rc;
+  LoonProperties pp;
+  LoonSegmentReaderHandle reader = 0;
+  LoonChunkReaderHandle chunk_reader = 0;
+  struct ArrowSchema* schema = NULL;
+  struct ArrowArrayStream stream;
+  struct ArrowArrayStream take_stream;
+  struct ArrowArrayStream filtered_stream;
+  int64_t row_indices[] = {0, 2, 4};
+  uint64_t number_of_chunks = 0;
+  const char* needed_columns[] = {"int64_field", "int32_field", "string_field"};
+  LoonSegmentReaderConfig reader_config;
+
+  memset(&reader_config, 0, sizeof(reader_config));
+  reader_config.read_buffer_size = 1024;
+
+  rc = create_test_segment_pp(&pp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  clean_segment_test_path(&pp);
+  create_committed_segment(&pp);
+
+  schema = create_test_struct_schema();
+  rc = loon_segment_reader_open(SEGMENT_TEST_BASE_PATH, -1, schema, needed_columns, 3, &reader_config, &pp, &reader);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  release_schema(schema);
+
+  rc = loon_segment_reader_get_chunk_reader(reader, 0, NULL, 0, &chunk_reader);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_get_number_of_chunks(chunk_reader, &number_of_chunks);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_gt(number_of_chunks, 0);
+  loon_chunk_reader_destroy(chunk_reader);
+
+  memset(&stream, 0, sizeof(stream));
+  rc = loon_segment_reader_get_stream(reader, &stream);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  assert_stream_first_batch(&stream, 5);
+  stream.release(&stream);
+
+  memset(&take_stream, 0, sizeof(take_stream));
+  rc = loon_segment_reader_take(reader, row_indices, 3, 0, &take_stream);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  assert_stream_first_batch(&take_stream, 3);
+  take_stream.release(&take_stream);
+
+  memset(&filtered_stream, 0, sizeof(filtered_stream));
+  rc = loon_segment_reader_get_filtered_stream(reader, NULL, &filtered_stream);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  assert_stream_first_batch(&filtered_stream, 5);
+  filtered_stream.release(&filtered_stream);
+
+  loon_segment_reader_destroy(reader);
+  clean_segment_test_path(&pp);
+  loon_properties_free(&pp);
+}
+
+static void test_segment_error_handling(void) {
+  LoonFFIResult rc;
+  struct ArrowArrayStream stream;
+  int64_t row_indices[] = {0};
+  LoonChunkReaderHandle chunk_reader = 0;
+  LoonSegmentWriteOutput output;
+
+  memset(&stream, 0, sizeof(stream));
+  memset(&output, 0, sizeof(output));
+
+  rc = loon_segment_writer_new(NULL, NULL, NULL, NULL);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_writer_write(0, NULL);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_writer_flush(0);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_writer_close(0, &output);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  loon_segment_writer_destroy(0);
+  loon_segment_write_output_free(NULL);
+
+  rc = loon_segment_reader_open(NULL, -1, NULL, NULL, 0, NULL, NULL, NULL);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_reader_get_stream(0, &stream);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_reader_take(0, row_indices, 1, 1, &stream);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_reader_take((LoonSegmentReaderHandle)1, NULL, 0, 1, &stream);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_reader_get_filtered_stream(0, NULL, &stream);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_segment_reader_get_chunk_reader(0, 0, NULL, 0, &chunk_reader);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  loon_segment_reader_destroy(0);
+}
+
+static void test_packed_writer_basic(void) {
+  LoonFFIResult rc;
+  LoonProperties pp;
+  LoonPackedWriterHandle writer = 0;
+  struct ArrowSchema* schema = NULL;
+  struct ArrowArray* array = NULL;
+  const char* paths[] = {PACKED_TEST_PATH_0, PACKED_TEST_PATH_1};
+  int32_t group_offsets[] = {0, 2, 3};
+  int32_t group_indices[] = {0, 1, 2};
+
+  rc = create_test_packed_pp(&pp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  clean_segment_test_path(&pp);
+
+  schema = create_test_struct_schema();
+  rc = loon_packed_writer_new(paths, 2, group_offsets, group_indices, 3, schema, &pp, 1024 * 1024, &writer);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  release_schema(schema);
+
+  array = create_segment_test_array();
+  rc = loon_packed_writer_write(writer, array);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  release_array(array);
+
+  rc = loon_packed_writer_close(writer);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  loon_packed_writer_destroy(writer);
+
+  clean_segment_test_path(&pp);
+  loon_properties_free(&pp);
+}
+
+static void test_packed_writer_error_handling(void) {
+  LoonFFIResult rc;
+  LoonProperties pp;
+  LoonPackedWriterHandle writer = 0;
+  struct ArrowSchema* schema = NULL;
+  const char* paths[] = {PACKED_TEST_PATH_0};
+  int32_t bad_offsets_start[] = {1, 1};
+  int32_t offsets[] = {0, 1};
+  int32_t bad_indices[] = {100};
+
+  rc = create_test_packed_pp(&pp);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  rc = loon_packed_writer_new(NULL, 0, NULL, NULL, 0, NULL, NULL, 0, NULL);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  schema = create_test_struct_schema();
+  rc = loon_packed_writer_new(paths, 1, bad_offsets_start, offsets, 1, schema, &pp, 0, &writer);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+  release_schema(schema);
+
+  schema = create_test_struct_schema();
+  rc = loon_packed_writer_new(paths, 1, offsets, bad_indices, 1, schema, &pp, 0, &writer);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+  release_schema(schema);
+
+  rc = loon_packed_writer_write(0, NULL);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_packed_writer_close(0);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  loon_packed_writer_destroy(0);
+  loon_properties_free(&pp);
+}
+
+void run_segment_suite(void) {
+  RUN_TEST(test_segment_writer_reader_basic);
+  RUN_TEST(test_segment_error_handling);
+  RUN_TEST(test_packed_writer_basic);
+  RUN_TEST(test_packed_writer_error_handling);
+}

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -28,6 +28,7 @@ void run_manifest_suite(void);
 void run_external_suite(void);
 void run_filesystem_suite(void);
 void run_fiu_suite(void);
+void run_segment_suite(void);
 
 int main(void) {
   loon_thread_pool_singleton(4);
@@ -37,6 +38,7 @@ int main(void) {
   run_reader_suite();
   run_external_suite();
   run_filesystem_suite();
+  run_segment_suite();
   run_fiu_suite();
 
   loon_reset_context();


### PR DESCRIPTION
cherry-pick
- fix: use-after-free in segment take streams (#518) 
- fix: skip unused manifest read in Transaction::Commit (#522)