### PR TITLE
enhance: use writer.format for writer format property

### DIFF
--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -14,7 +14,6 @@
     loon_properties_free;
 
     # Property key constants
-    loon_properties_format;
     loon_properties_fs_address;
     loon_properties_fs_bucket_name;
     loon_properties_fs_access_key_id;
@@ -40,6 +39,7 @@
     loon_properties_fs_external_id;
     loon_properties_fs_load_frequency;
     loon_properties_writer_policy;
+    loon_properties_writer_format;
     loon_properties_writer_schema_base_patterns;
     loon_properties_writer_size_base_macs;
     loon_properties_writer_size_base_mcig;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -12,7 +12,6 @@ _loon_properties_get
 _loon_properties_free
 
 # Property key constants
-_loon_properties_format
 _loon_properties_fs_address
 _loon_properties_fs_bucket_name
 _loon_properties_fs_access_key_id
@@ -38,6 +37,7 @@ _loon_properties_fs_session_name
 _loon_properties_fs_external_id
 _loon_properties_fs_load_frequency
 _loon_properties_writer_policy
+_loon_properties_writer_format
 _loon_properties_writer_schema_base_patterns
 _loon_properties_writer_size_base_macs
 _loon_properties_writer_size_base_mcig

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -74,9 +74,6 @@ FFI_EXPORT void loon_ffi_free_result(LoonFFIResult* result);
 
 // ==================== Properties C Interface ====================
 
-// --- Global property definitions ---
-FFI_EXPORT extern const char* loon_properties_format;
-
 // --- Export FS property keys ---
 FFI_EXPORT extern const char* loon_properties_fs_address;
 FFI_EXPORT extern const char* loon_properties_fs_bucket_name;
@@ -108,6 +105,7 @@ FFI_EXPORT extern const char* loon_properties_fs_use_crc32c_checksum;
 
 // --- Export Writer property keys ---
 FFI_EXPORT extern const char* loon_properties_writer_policy;
+FFI_EXPORT extern const char* loon_properties_writer_format;
 FFI_EXPORT extern const char* loon_properties_writer_schema_base_patterns;
 FFI_EXPORT extern const char* loon_properties_writer_size_base_macs;
 FFI_EXPORT extern const char* loon_properties_writer_size_base_mcig;

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -63,9 +63,6 @@ struct PropertyInfo {
   std::optional<PropertiesValidator> validator;
 };
 
-// --- Global property definitions ---
-#define PROPERTY_FORMAT "format"
-
 // --- Define FS property keys ---
 // Standard filesystem properties (fs.*)
 // These configure the default filesystem for the storage instance
@@ -129,6 +126,7 @@ struct PropertyInfo {
 
 // --- Define Writer property keys ---
 #define PROPERTY_WRITER_POLICY "writer.policy"
+#define PROPERTY_WRITER_FORMAT "writer.format"
 #define PROPERTY_WRITER_SCHEMA_BASE_PATTERNS "writer.split.schema_based.patterns"
 #define PROPERTY_WRITER_SIZE_BASE_MACS "writer.split.size_based.max_avg_column_size"
 #define PROPERTY_WRITER_SIZE_BASE_MCIG "writer.split.size_based.max_columns_in_group"

--- a/cpp/include/milvus-storage/segment/segment_writer.h
+++ b/cpp/include/milvus-storage/segment/segment_writer.h
@@ -46,7 +46,7 @@ struct SegmentWriterConfig {
   std::map<int64_t, lob_column::LobColumnConfig> lob_columns;
 
   // storage properties (filesystem config, compression, column group policy, etc.)
-  // must include PROPERTY_WRITER_POLICY and PROPERTY_FORMAT for ColumnGroupPolicy
+  // must include PROPERTY_WRITER_POLICY and PROPERTY_WRITER_FORMAT for ColumnGroupPolicy
   // see writer.h for available policy options:
   //   - LOON_COLUMN_GROUP_POLICY_SINGLE: all columns in one group
   //   - LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED: group by column name patterns

--- a/cpp/src/ffi/properties_c.cpp
+++ b/cpp/src/ffi/properties_c.cpp
@@ -32,9 +32,6 @@
 using namespace milvus_storage;
 using namespace milvus_storage::api;
 
-// --- Global property definitions ---
-const char* loon_properties_format = PROPERTY_FORMAT;
-
 // --- Define FS property keys ---
 const char* loon_properties_fs_address = PROPERTY_FS_ADDRESS;
 const char* loon_properties_fs_bucket_name = PROPERTY_FS_BUCKET_NAME;
@@ -66,6 +63,7 @@ const char* loon_properties_fs_use_crc32c_checksum = PROPERTY_FS_USE_CRC32C_CHEC
 
 // --- Define Writer property keys ---
 const char* loon_properties_writer_policy = PROPERTY_WRITER_POLICY;
+const char* loon_properties_writer_format = PROPERTY_WRITER_FORMAT;
 const char* loon_properties_writer_schema_base_patterns = PROPERTY_WRITER_SCHEMA_BASE_PATTERNS;
 const char* loon_properties_writer_size_base_macs = PROPERTY_WRITER_SIZE_BASE_MACS;
 const char* loon_properties_writer_size_base_mcig = PROPERTY_WRITER_SIZE_BASE_MCIG;

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -256,15 +256,6 @@ static PropertiesValidator ValidatePropertyRange(T min, T max) {
   }
 
 static std::unordered_map<std::string, PropertyInfo> property_infos = {
-    // --- global properties define ---
-    REGISTER_PROPERTY(PROPERTY_FORMAT,
-                      PropertyType::STRING,
-                      "The format of the storage. Options: parquet, vortex, lance-table, iceberg-table.",
-                      LOON_FORMAT_PARQUET,
-                      ValidatePropertyType() + ValidatePropertyEnum<std::string>(LOON_FORMAT_PARQUET,
-                                                                                 LOON_FORMAT_VORTEX,
-                                                                                 LOON_FORMAT_LANCE_TABLE,
-                                                                                 LOON_FORMAT_ICEBERG_TABLE)),
     // --- fs properties define ---
     REGISTER_PROPERTY(PROPERTY_FS_ADDRESS,
                       PropertyType::STRING,
@@ -424,6 +415,14 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       ValidatePropertyType() + ValidatePropertyEnum<std::string>(LOON_COLUMN_GROUP_POLICY_SINGLE,
                                                                                  LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED,
                                                                                  LOON_COLUMN_GROUP_POLICY_SIZE_BASED)),
+    REGISTER_PROPERTY(
+        PROPERTY_WRITER_FORMAT,
+        PropertyType::STRING,
+        "The default format for writer column groups. Options: parquet, vortex, lance-table, iceberg-table.",
+        LOON_FORMAT_PARQUET,
+        ValidatePropertyType() +
+            ValidatePropertyEnum<std::string>(
+                LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX, LOON_FORMAT_LANCE_TABLE, LOON_FORMAT_ICEBERG_TABLE)),
     REGISTER_PROPERTY(PROPERTY_WRITER_SCHEMA_BASE_PATTERNS,
                       PropertyType::VECTOR_STR,
                       "The column group patterns for the schema_based policy.",

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -116,7 +116,7 @@ ColumnGroupPolicy::ColumnGroupPolicy(std::shared_ptr<arrow::Schema> schema, cons
 arrow::Result<std::unique_ptr<ColumnGroupPolicy>> ColumnGroupPolicy::create_column_group_policy(
     const Properties& properties_map, const std::shared_ptr<arrow::Schema>& schema) {
   ARROW_ASSIGN_OR_RAISE(auto policy_name, GetValue<std::string>(properties_map, PROPERTY_WRITER_POLICY));
-  ARROW_ASSIGN_OR_RAISE(auto policy_format, GetValue<std::string>(properties_map, PROPERTY_FORMAT));
+  ARROW_ASSIGN_OR_RAISE(auto policy_format, GetValue<std::string>(properties_map, PROPERTY_WRITER_FORMAT));
 
   if (policy_name == LOON_COLUMN_GROUP_POLICY_SINGLE) {
     return std::make_unique<SingleColumnGroupPolicy>(schema, policy_format);

--- a/cpp/test/api_properties_test.cpp
+++ b/cpp/test/api_properties_test.cpp
@@ -2,8 +2,9 @@
 
 #include <gtest/gtest.h>
 
-#include "milvus-storage/properties.h"
+#include "milvus-storage/common/config.h"
 #include "milvus-storage/ffi_c.h"
+#include "milvus-storage/properties.h"
 #include <string>
 #include <cstdint>
 #include <optional>
@@ -18,20 +19,25 @@ TEST_F(APIPropertiesTest, basic) {
 
   // Test get default value
   EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_WRITER_COMPRESSION), "zstd");
+  EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_WRITER_FORMAT), LOON_FORMAT_PARQUET);
   EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_COMPRESSION_LEVEL), 5);
   EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_BUFFER_SIZE), 32 * 1024 * 1024);
   EXPECT_TRUE(GetValueNoError<bool>(pp, PROPERTY_WRITER_ENABLE_DICTIONARY));
 
   // Test set & get properties
   EXPECT_EQ(SetValue(pp, PROPERTY_WRITER_COMPRESSION, "gzip"), std::nullopt);
+  EXPECT_EQ(SetValue(pp, PROPERTY_WRITER_FORMAT, LOON_FORMAT_VORTEX), std::nullopt);
   EXPECT_EQ(SetValue(pp, PROPERTY_WRITER_COMPRESSION_LEVEL, "3"), std::nullopt);
   EXPECT_EQ(SetValue(pp, PROPERTY_WRITER_BUFFER_SIZE, "67108864"), std::nullopt);
   EXPECT_EQ(SetValue(pp, PROPERTY_WRITER_ENABLE_DICTIONARY, "false"), std::nullopt);
 
   EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_WRITER_COMPRESSION), "gzip");
+  EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_WRITER_FORMAT), LOON_FORMAT_VORTEX);
   EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_COMPRESSION_LEVEL), 3);
   EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_BUFFER_SIZE), 64 * 1024 * 1024);
   EXPECT_FALSE(GetValueNoError<bool>(pp, PROPERTY_WRITER_ENABLE_DICTIONARY));
+
+  EXPECT_STREQ(loon_properties_writer_format, PROPERTY_WRITER_FORMAT);
 }
 
 TEST_F(APIPropertiesTest, parquet_reader_prebuffer_properties) {

--- a/cpp/test/ffi/ffi_external_test.c
+++ b/cpp/test/ffi/ffi_external_test.c
@@ -88,7 +88,7 @@ static bool find_first_file(
 
 // Helper function to create test properties
 LoonFFIResult create_test_external_pp(LoonProperties* rp, const char* format) {
-  const char* keys[500] = {"format"};
+  const char* keys[500] = {"writer.format"};
   const char* vals[500] = {format ? format : "parquet"};
   size_t count = init_test_props(keys, vals, 1, 500, TEST_ROOT_PATH);
 

--- a/cpp/test/ffi/ffi_segment_test.c
+++ b/cpp/test/ffi/ffi_segment_test.c
@@ -57,7 +57,7 @@ static void release_array(struct ArrowArray* array) {
 }
 
 static LoonFFIResult create_test_segment_pp(LoonProperties* pp) {
-  const char* keys[500] = {"writer.policy", "format"};
+  const char* keys[500] = {"writer.policy", "writer.format"};
   const char* vals[500] = {"single", "parquet"};
   size_t count = init_test_props(keys, vals, 2, 500, SEGMENT_TEST_ROOT_PATH);
 

--- a/cpp/test/segment/segment_reader_text_test.cpp
+++ b/cpp/test/segment/segment_reader_text_test.cpp
@@ -65,7 +65,7 @@ class SegmentReaderTextTest : public ::testing::Test {
     writer_config_.lob_columns[101] = text_config;
     ASSERT_STATUS_OK(InitTestProperties(writer_config_.properties));
     writer_config_.properties[PROPERTY_WRITER_POLICY] = LOON_COLUMN_GROUP_POLICY_SINGLE;
-    writer_config_.properties[PROPERTY_FORMAT] = LOON_FORMAT_PARQUET;
+    writer_config_.properties[PROPERTY_WRITER_FORMAT] = LOON_FORMAT_PARQUET;
 
     // configure reader
     reader_config_.lob_columns = writer_config_.lob_columns;

--- a/cpp/test/segment/segment_writer_test.cpp
+++ b/cpp/test/segment/segment_writer_test.cpp
@@ -67,7 +67,7 @@ class SegmentWriterTest : public ::testing::Test {
     // properties for ColumnGroupPolicy (single policy - all columns in one group)
     ASSERT_STATUS_OK(InitTestProperties(config_.properties));
     config_.properties[PROPERTY_WRITER_POLICY] = LOON_COLUMN_GROUP_POLICY_SINGLE;
-    config_.properties[PROPERTY_FORMAT] = LOON_FORMAT_PARQUET;
+    config_.properties[PROPERTY_WRITER_FORMAT] = LOON_FORMAT_PARQUET;
   }
 
   void TearDown() override {
@@ -513,7 +513,7 @@ TEST_F(SegmentWriterTest, SchemaWithoutLobColumns) {
   boost::filesystem::create_directories(test_dir_ + "/no_text");
   ASSERT_STATUS_OK(InitTestProperties(no_text_config.properties));
   no_text_config.properties[PROPERTY_WRITER_POLICY] = LOON_COLUMN_GROUP_POLICY_SINGLE;
-  no_text_config.properties[PROPERTY_FORMAT] = LOON_FORMAT_PARQUET;
+  no_text_config.properties[PROPERTY_WRITER_FORMAT] = LOON_FORMAT_PARQUET;
 
   auto writer_result = SegmentWriter::Create(fs_, no_text_schema, no_text_config);
   ASSERT_TRUE(writer_result.ok()) << writer_result.status().message();

--- a/cpp/test/test_env.cpp
+++ b/cpp/test/test_env.cpp
@@ -345,7 +345,7 @@ arrow::Result<std::unique_ptr<ColumnGroupPolicy>> CreateSinglePolicy(const std::
                                                                      const std::shared_ptr<arrow::Schema>& schema) {
   auto properties = milvus_storage::api::Properties{};
   SetValue(properties, PROPERTY_WRITER_POLICY, LOON_COLUMN_GROUP_POLICY_SINGLE);
-  SetValue(properties, PROPERTY_FORMAT, format.c_str());
+  SetValue(properties, PROPERTY_WRITER_FORMAT, format.c_str());
 
   return ColumnGroupPolicy::create_column_group_policy(properties, schema);
 }
@@ -356,7 +356,7 @@ arrow::Result<std::unique_ptr<ColumnGroupPolicy>> CreateSchemaBasePolicy(const s
   auto properties = milvus_storage::api::Properties{};
   SetValue(properties, PROPERTY_WRITER_POLICY, LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED);
   SetValue(properties, PROPERTY_WRITER_SCHEMA_BASE_PATTERNS, patterns.c_str());
-  SetValue(properties, PROPERTY_FORMAT, format.c_str());
+  SetValue(properties, PROPERTY_WRITER_FORMAT, format.c_str());
 
   return ColumnGroupPolicy::create_column_group_policy(properties, schema);
 }
@@ -369,7 +369,7 @@ arrow::Result<std::unique_ptr<ColumnGroupPolicy>> CreateSizeBasePolicy(int64_t m
   SetValue(properties, PROPERTY_WRITER_POLICY, LOON_COLUMN_GROUP_POLICY_SIZE_BASED);
   SetValue(properties, PROPERTY_WRITER_SIZE_BASE_MACS, std::to_string(max_avg_column_size).c_str());
   SetValue(properties, PROPERTY_WRITER_SIZE_BASE_MCIG, std::to_string(max_columns_in_group).c_str());
-  SetValue(properties, PROPERTY_FORMAT, format.c_str());
+  SetValue(properties, PROPERTY_WRITER_FORMAT, format.c_str());
 
   return ColumnGroupPolicy::create_column_group_policy(properties, schema);
 }

--- a/docs/multi-format-benchmark-design.md
+++ b/docs/multi-format-benchmark-design.md
@@ -48,7 +48,7 @@ arrow::Result<std::unique_ptr<api::ColumnGroupPolicy>> CreateSinglePolicy(
     const std::shared_ptr<arrow::Schema>& schema);
 
 // Set format in properties
-SetValue(properties, PROPERTY_FORMAT, format.c_str());
+SetValue(properties, PROPERTY_WRITER_FORMAT, format.c_str());
 ```
 
 ## Proposed Benchmarks

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -102,7 +102,6 @@ _ffi.cdef(
     void loon_properties_free(LoonProperties* properties);
 
     // Property key constants
-    extern const char* loon_properties_format;
     extern const char* loon_properties_fs_address;
     extern const char* loon_properties_fs_bucket_name;
     extern const char* loon_properties_fs_access_key_id;
@@ -128,6 +127,7 @@ _ffi.cdef(
     extern const char* loon_properties_fs_external_id;
     extern const char* loon_properties_fs_load_frequency;
     extern const char* loon_properties_writer_policy;
+    extern const char* loon_properties_writer_format;
     extern const char* loon_properties_writer_schema_base_patterns;
     extern const char* loon_properties_writer_size_base_macs;
     extern const char* loon_properties_writer_size_base_mcig;

--- a/python/milvus_storage/properties.py
+++ b/python/milvus_storage/properties.py
@@ -8,7 +8,6 @@ from ._ffi import get_ffi, get_library
 
 # Mapping from Python attribute names to C symbol names
 _PROPERTY_KEY_MAPPING = {
-    "FORMAT": "loon_properties_format",
     "FS_ADDRESS": "loon_properties_fs_address",
     "FS_BUCKET_NAME": "loon_properties_fs_bucket_name",
     "FS_ACCESS_KEY_ID": "loon_properties_fs_access_key_id",
@@ -34,6 +33,7 @@ _PROPERTY_KEY_MAPPING = {
     "FS_EXTERNAL_ID": "loon_properties_fs_external_id",
     "FS_LOAD_FREQUENCY": "loon_properties_fs_load_frequency",
     "WRITER_POLICY": "loon_properties_writer_policy",
+    "WRITER_FORMAT": "loon_properties_writer_format",
     "WRITER_SCHEMA_BASE_PATTERNS": "loon_properties_writer_schema_base_patterns",
     "WRITER_SIZE_BASE_MACS": "loon_properties_writer_size_base_macs",
     "WRITER_SIZE_BASE_MCIG": "loon_properties_writer_size_base_mcig",

--- a/python/tests/test_properties.py
+++ b/python/tests/test_properties.py
@@ -31,11 +31,11 @@ class TestPropertyKeys:
         assert isinstance(key, str)
         assert len(key) > 0
 
-    def test_format(self):
-        """Test FORMAT property key."""
-        key = PropertyKeys.FORMAT
+    def test_writer_format(self):
+        """Test WRITER_FORMAT property key."""
+        key = PropertyKeys.WRITER_FORMAT
         assert isinstance(key, str)
-        assert len(key) > 0
+        assert key == "writer.format"
 
     def test_caching(self):
         """Test that property keys are cached."""
@@ -78,6 +78,7 @@ class TestPropertyKeys:
         """Test all Writer property keys are accessible."""
         keys = [
             PropertyKeys.WRITER_POLICY,
+            PropertyKeys.WRITER_FORMAT,
             PropertyKeys.WRITER_SCHEMA_BASE_PATTERNS,
             PropertyKeys.WRITER_SIZE_BASE_MACS,
             PropertyKeys.WRITER_SIZE_BASE_MCIG,

--- a/tests/config.py
+++ b/tests/config.py
@@ -203,8 +203,8 @@ class TestConfig:
             if "region" in config:
                 props[PropertyKeys.FS_REGION] = config["region"]
 
-        # Format
-        props[PropertyKeys.FORMAT] = self.format
+        # Writer format
+        props[PropertyKeys.WRITER_FORMAT] = self.format
 
         # Extra properties
         props.update({k: str(v) for k, v in extra_props.items()})


### PR DESCRIPTION
This renames the old generic `format` property to `writer.format` so it matches writer.policy and makes the setting’s scope clearer. It also updates the property registry, writer lookup path, C/FFI and Python exports, tests, and docs so everything consistently uses the writer-scoped key.