### PR TITLE
enhance: make input file opens lazy and count real reads

### DIFF
--- a/cpp/include/milvus-storage/filesystem/observable.h
+++ b/cpp/include/milvus-storage/filesystem/observable.h
@@ -165,6 +165,7 @@ class MetricsInputStream : public arrow::io::InputStream {
   arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
     ARROW_ASSIGN_OR_RAISE(auto bytes_read, stream_->Read(nbytes, out));
     if (bytes_read > 0) {
+      metrics_->IncrementReadCount();
       metrics_->IncrementReadBytes(bytes_read);
     }
     return bytes_read;
@@ -173,6 +174,7 @@ class MetricsInputStream : public arrow::io::InputStream {
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
     ARROW_ASSIGN_OR_RAISE(auto buffer, stream_->Read(nbytes));
     if (buffer && buffer->size() > 0) {
+      metrics_->IncrementReadCount();
       metrics_->IncrementReadBytes(buffer->size());
     }
     return buffer;
@@ -214,6 +216,7 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
     ARROW_ASSIGN_OR_RAISE(auto bytes_read, file_->Read(nbytes, out));
     if (bytes_read > 0) {
+      metrics_->IncrementReadCount();
       metrics_->IncrementReadBytes(bytes_read);
     }
     return bytes_read;
@@ -222,6 +225,7 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
     ARROW_ASSIGN_OR_RAISE(auto buffer, file_->Read(nbytes));
     if (buffer && buffer->size() > 0) {
+      metrics_->IncrementReadCount();
       metrics_->IncrementReadBytes(buffer->size());
     }
     return buffer;
@@ -251,6 +255,7 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     ARROW_ASSIGN_OR_RAISE(auto bytes_read, file_->ReadAt(position, nbytes, out));
     if (bytes_read > 0) {
+      metrics_->IncrementReadCount();
       metrics_->IncrementReadBytes(bytes_read);
     }
     return bytes_read;
@@ -259,6 +264,7 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
     ARROW_ASSIGN_OR_RAISE(auto buffer, file_->ReadAt(position, nbytes));
     if (buffer && buffer->size() > 0) {
+      metrics_->IncrementReadCount();
       metrics_->IncrementReadBytes(buffer->size());
     }
     return buffer;
@@ -267,20 +273,29 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
                                                           int64_t position,
                                                           int64_t nbytes) override {
-    if (nbytes > 0) {
-      metrics_->IncrementReadCount();
-    }
-    return file_->ReadAsync(io_context, position, nbytes);
+    return file_->ReadAsync(io_context, position, nbytes)
+        .Then([metrics = metrics_](const std::shared_ptr<arrow::Buffer>& buffer) {
+          if (buffer && buffer->size() > 0) {
+            metrics->IncrementReadCount();
+            metrics->IncrementReadBytes(buffer->size());
+          }
+          return buffer;
+        });
   }
 
   std::vector<arrow::Future<std::shared_ptr<arrow::Buffer>>> ReadManyAsync(
       const arrow::io::IOContext& io_context, const std::vector<arrow::io::ReadRange>& ranges) override {
-    for (const auto& range : ranges) {
-      if (range.length > 0) {
-        metrics_->IncrementReadCount();
-      }
+    auto futures = file_->ReadManyAsync(io_context, ranges);
+    for (auto& future : futures) {
+      future = future.Then([metrics = metrics_](const std::shared_ptr<arrow::Buffer>& buffer) {
+        if (buffer && buffer->size() > 0) {
+          metrics->IncrementReadCount();
+          metrics->IncrementReadBytes(buffer->size());
+        }
+        return buffer;
+      });
     }
-    return file_->ReadManyAsync(io_context, ranges);
+    return futures;
   }
 
   arrow::Status WillNeed(const std::vector<arrow::io::ReadRange>& ranges) override { return file_->WillNeed(ranges); }

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <optional>
 
 #include "milvus-storage/filesystem/azure/azurefs.h"
@@ -836,30 +837,13 @@ class ObjectInputFile final : public io::RandomAccessFile {
         content_length_(size) {}
 
   Status Init() {
-    if (content_length_ != kNoSize) {
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize) {
       // When the user provides the file size we don't validate that its a file. This is
       // only a read so its not a big deal if the user makes a mistake.
-      DCHECK_GE(content_length_, 0);
-      return Status::OK();
+      DCHECK_GE(content_length, 0);
     }
-    try {
-      // To open an ObjectInputFile the Blob must exist and it must not represent
-      // a directory. Additionally we need to know the file size.
-      auto properties = blob_client_->GetProperties();
-      if (MetadataIndicatesIsDirectory(properties.Value.Metadata)) {
-        return NotAFile(location_);
-      }
-      content_length_ = properties.Value.BlobSize;
-      metadata_ = PropertiesToMetadata(properties.Value);
-      return Status::OK();
-    } catch (const Storage::StorageException& exception) {
-      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
-        return PathNotFound(location_);
-      }
-      return ExceptionToStatus(
-          exception, "GetProperties failed for '", blob_client_->GetUrl(),
-          "'. Cannot initialise an ObjectInputFile without knowing the file size.");
-    }
+    return Status::OK();
   }
 
   Status CheckClosed(const char* action) const {
@@ -870,11 +854,11 @@ class ObjectInputFile final : public io::RandomAccessFile {
   }
 
   Status CheckPosition(int64_t position, const char* action) const {
-    DCHECK_GE(content_length_, 0);
     if (position < 0) {
       return Status::Invalid("Cannot ", action, " from negative position");
     }
-    if (position > content_length_) {
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize && position > content_length) {
       return Status::IOError("Cannot ", action, " past end of file");
     }
     return Status::OK();
@@ -883,12 +867,15 @@ class ObjectInputFile final : public io::RandomAccessFile {
   // RandomAccessFile APIs
 
   Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata() override {
+    RETURN_NOT_OK(CheckClosed("read metadata"));
+    RETURN_NOT_OK(EnsureProperties(/*need_metadata=*/true));
+    std::lock_guard<std::mutex> lock(metadata_mutex_);
     return metadata_;
   }
 
   Future<std::shared_ptr<const KeyValueMetadata>> ReadMetadataAsync(
       const io::IOContext& io_context) override {
-    return metadata_;
+    return Future<std::shared_ptr<const KeyValueMetadata>>::MakeFinished(ReadMetadata());
   }
 
   Status Close() override {
@@ -906,7 +893,8 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
   Result<int64_t> GetSize() override {
     RETURN_NOT_OK(CheckClosed("size"));
-    return content_length_;
+    RETURN_NOT_OK(EnsureProperties(/*need_metadata=*/false));
+    return GetCachedContentLength();
   }
 
   Status Seek(int64_t position) override {
@@ -919,9 +907,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
   Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     RETURN_NOT_OK(CheckClosed("read"));
-    RETURN_NOT_OK(CheckPosition(position, "read"));
-
-    nbytes = std::min(nbytes, content_length_ - position);
+    ARROW_ASSIGN_OR_RAISE(nbytes, GetReadSize(position, nbytes));
     if (nbytes == 0) {
       return 0;
     }
@@ -931,9 +917,17 @@ class ObjectInputFile final : public io::RandomAccessFile {
     Storage::Blobs::DownloadBlobToOptions download_options;
     download_options.Range = range;
     try {
-      return blob_client_
-          ->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options)
-          .Value.ContentRange.Length.Value();
+      auto result =
+          blob_client_->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes,
+                                   download_options);
+      const auto bytes_read = result.Value.ContentRange.Length.Value();
+      if (bytes_read < 0 || bytes_read > nbytes) {
+        return Status::IOError("Unexpected DownloadTo Content-Range length ",
+                               bytes_read, " for range read of ", nbytes,
+                               " bytes");
+      }
+      RETURN_NOT_OK(CacheContentLengthFromRead(result.Value));
+      return bytes_read;
     } catch (const Storage::StorageException& exception) {
       return ExceptionToStatus(
           exception, "DownloadTo from '", blob_client_->GetUrl(), "' at position ",
@@ -944,10 +938,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
   Result<std::shared_ptr<Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
     RETURN_NOT_OK(CheckClosed("read"));
-    RETURN_NOT_OK(CheckPosition(position, "read"));
-
-    // No need to allocate more than the remaining number of bytes
-    nbytes = std::min(nbytes, content_length_ - position);
+    ARROW_ASSIGN_OR_RAISE(nbytes, GetReadSize(position, nbytes));
 
     ARROW_ASSIGN_OR_RAISE(auto buffer,
                           AllocateResizableBuffer(nbytes, io_context_.pool()));
@@ -972,6 +963,75 @@ class ObjectInputFile final : public io::RandomAccessFile {
     return buffer;
   }
 
+  Result<int64_t> GetReadSize(int64_t position, int64_t nbytes) const {
+    if (position < 0) {
+      return Status::Invalid("Cannot read from negative position");
+    }
+    if (nbytes < 0) {
+      return Status::Invalid("Cannot read negative number of bytes");
+    }
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize) {
+      if (position > content_length) {
+        return Status::IOError("Cannot read past end of file");
+      }
+      nbytes = std::min(nbytes, content_length - position);
+    }
+    return nbytes;
+  }
+
+  Status EnsureProperties(bool need_metadata) {
+    if (GetCachedContentLength() != kNoSize && (!need_metadata || HasCachedMetadata())) {
+      return Status::OK();
+    }
+
+    try {
+      auto properties = blob_client_->GetProperties();
+      if (MetadataIndicatesIsDirectory(properties.Value.Metadata)) {
+        return NotAFile(location_);
+      }
+      auto content_length = properties.Value.BlobSize;
+      auto metadata = PropertiesToMetadata(properties.Value);
+      {
+        std::lock_guard<std::mutex> lock(metadata_mutex_);
+        metadata_ = std::move(metadata);
+      }
+      SetCachedContentLength(content_length);
+      return Status::OK();
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        return PathNotFound(location_);
+      }
+      return ExceptionToStatus(exception, "GetProperties failed for '",
+                               blob_client_->GetUrl(), "'.");
+    }
+  }
+
+  Status CacheContentLengthFromRead(
+      const Blobs::Models::DownloadBlobToResult& result) {
+    if (MetadataIndicatesIsDirectory(result.Details.Metadata)) {
+      return NotAFile(location_);
+    }
+    // DownloadTo doesn't expose all BlobProperties fields, so only cache size
+    // from read responses. ReadMetadata() still uses GetProperties().
+    DCHECK_GE(result.BlobSize, 0);
+    SetCachedContentLength(result.BlobSize);
+    return Status::OK();
+  }
+
+  int64_t GetCachedContentLength() const {
+    return content_length_.load(std::memory_order_acquire);
+  }
+
+  void SetCachedContentLength(int64_t content_length) {
+    content_length_.store(content_length, std::memory_order_release);
+  }
+
+  bool HasCachedMetadata() const {
+    std::lock_guard<std::mutex> lock(metadata_mutex_);
+    return metadata_ != nullptr;
+  }
+
  private:
   std::shared_ptr<Blobs::BlobClient> blob_client_;
   const io::IOContext io_context_;
@@ -979,7 +1039,8 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
   bool closed_ = false;
   int64_t pos_ = 0;
-  int64_t content_length_ = kNoSize;
+  mutable std::mutex metadata_mutex_;
+  std::atomic<int64_t> content_length_{kNoSize};
   std::shared_ptr<const KeyValueMetadata> metadata_;
 };
 
@@ -3560,7 +3621,6 @@ Status AzureFileSystem::CopyFile(const std::string& src, const std::string& dest
 
 Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
     const std::string& path) {
-  impl_->metrics()->IncrementReadCount();
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenInputFile(location, this));
   return std::make_shared<milvus_storage::MetricsInputStream>(std::move(stream),
@@ -3569,7 +3629,6 @@ Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
 
 Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
     const FileInfo& info) {
-  impl_->metrics()->IncrementReadCount();
   ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenInputFile(info, this));
   return std::make_shared<milvus_storage::MetricsInputStream>(std::move(stream),
                                                               impl_->metrics());
@@ -3577,7 +3636,6 @@ Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
 
 Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
     const std::string& path) {
-  impl_->metrics()->IncrementReadCount();
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   ARROW_ASSIGN_OR_RAISE(auto file, impl_->OpenInputFile(location, this));
   return std::make_shared<milvus_storage::MetricsRandomAccessFile>(std::move(file),
@@ -3586,7 +3644,6 @@ Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
 
 Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
     const FileInfo& info) {
-  impl_->metrics()->IncrementReadCount();
   ARROW_ASSIGN_OR_RAISE(auto file, impl_->OpenInputFile(info, this));
   return std::make_shared<milvus_storage::MetricsRandomAccessFile>(std::move(file),
                                                                    impl_->metrics());

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -1015,7 +1015,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
     // DownloadTo doesn't expose all BlobProperties fields, so only cache size
     // from read responses. ReadMetadata() still uses GetProperties().
     DCHECK_GE(result.BlobSize, 0);
-    SetCachedContentLength(result.BlobSize);
+    SetCachedContentLengthIfAbsent(result.BlobSize);
     return Status::OK();
   }
 
@@ -1025,6 +1025,13 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
   void SetCachedContentLength(int64_t content_length) {
     content_length_.store(content_length, std::memory_order_release);
+  }
+
+  void SetCachedContentLengthIfAbsent(int64_t content_length) {
+    int64_t expected = kNoSize;
+    content_length_.compare_exchange_strong(expected, content_length,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire);
   }
 
   bool HasCachedMetadata() const {

--- a/cpp/src/filesystem/local_fs_producer.cpp
+++ b/cpp/src/filesystem/local_fs_producer.cpp
@@ -53,6 +53,16 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
     return std::make_shared<WrapperType>(std::move(result.ValueOrDie()), metrics_); \
   } while (0)
 
+#define WRAP_WITH_METRICS(call, WrapperType)                                        \
+  do {                                                                              \
+    auto result = call;                                                             \
+    if (!result.ok()) {                                                             \
+      metrics_->IncrementFailedCount();                                             \
+      return result.status();                                                       \
+    }                                                                               \
+    return std::make_shared<WrapperType>(std::move(result.ValueOrDie()), metrics_); \
+  } while (0)
+
   public:
   explicit LocalFileSystemWrapper(const arrow::fs::LocalFileSystemOptions& options)
       : arrow::fs::LocalFileSystem(options), metrics_(std::make_shared<FilesystemMetrics>()) {}
@@ -89,22 +99,19 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
   }
 
   arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override {
-    TRACK_METRICS_AND_WRAP(IncrementReadCount, arrow::fs::LocalFileSystem::OpenInputStream(path), MetricsInputStream);
+    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputStream(path), MetricsInputStream);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const arrow::fs::FileInfo& info) override {
-    TRACK_METRICS_AND_WRAP(IncrementReadCount, arrow::fs::LocalFileSystem::OpenInputStream(info.path()),
-                           MetricsInputStream);
+    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputStream(info.path()), MetricsInputStream);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override {
-    TRACK_METRICS_AND_WRAP(IncrementReadCount, arrow::fs::LocalFileSystem::OpenInputFile(path),
-                           MetricsRandomAccessFile);
+    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputFile(path), MetricsRandomAccessFile);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override {
-    TRACK_METRICS_AND_WRAP(IncrementReadCount, arrow::fs::LocalFileSystem::OpenInputFile(info.path()),
-                           MetricsRandomAccessFile);
+    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputFile(info.path()), MetricsRandomAccessFile);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
@@ -150,6 +157,7 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
 
 #undef TRACK_METRICS
 #undef TRACK_METRICS_AND_WRAP
+#undef WRAP_WITH_METRICS
 };
 
 arrow::Result<ArrowFileSystemPtr> LocalFileSystemProducer::Make() {

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -669,13 +669,19 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     }
 
     DCHECK_LE(position + bytes_read, *content_length);
-    SetCachedContentLength(*content_length);
+    SetCachedContentLengthIfAbsent(*content_length);
   }
 
   int64_t GetCachedContentLength() const { return content_length_.load(std::memory_order_acquire); }
 
   void SetCachedContentLength(int64_t content_length) {
     content_length_.store(content_length, std::memory_order_release);
+  }
+
+  void SetCachedContentLengthIfAbsent(int64_t content_length) {
+    int64_t expected = kNoSize;
+    content_length_.compare_exchange_strong(expected, content_length, std::memory_order_acq_rel,
+                                            std::memory_order_acquire);
   }
 
   bool HasCachedMetadata() const {

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -17,6 +17,8 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cinttypes>
+#include <cstdio>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -391,6 +393,38 @@ std::string FormatRange(int64_t start, int64_t length) {
   return ss.str();
 }
 
+std::optional<int64_t> ParseContentRangeSize(const Aws::String& content_range) {
+  int64_t first = 0;
+  int64_t last = 0;
+  int64_t size = 0;
+  int parsed = 0;
+
+  // Expected format: "bytes {first}-{last}/{size}".
+  if (std::sscanf(content_range.c_str(), "bytes %" SCNd64 "-%" SCNd64 "/%" SCNd64 "%n", &first, &last, &size,
+                  &parsed) == 3 &&
+      parsed == static_cast<int>(content_range.size()) && first >= 0 && last >= first && size >= 0) {
+    return size;
+  }
+
+  // Expected format: "bytes */{size}".
+  parsed = 0;
+  if (std::sscanf(content_range.c_str(), "bytes */%" SCNd64 "%n", &size, &parsed) == 1 &&
+      parsed == static_cast<int>(content_range.size()) && size >= 0) {
+    return size;
+  }
+
+  return std::nullopt;
+}
+
+template <typename ObjectResult>
+std::optional<int64_t> GetObjectSizeFromReadResult(const ObjectResult& result, int64_t position) {
+  auto content_length = ParseContentRangeSize(result.GetContentRange());
+  if (!content_length && position == 0 && result.GetContentRange().empty()) {
+    content_length = result.GetContentLength();
+  }
+  return content_length;
+}
+
 Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
   return [=]() { return Aws::New<StringViewStream>("", data, nbytes); };
 }
@@ -451,31 +485,10 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
       : holder_(std::move(holder)), io_context_(io_context), path_(path), content_length_(size) {}
 
   arrow::Status Init() {
-    // Issue a HEAD Object to get the content-length and ensure any
-    // errors (e.g. file not found) don't wait until the first Read() call.
-    if (content_length_ != kNoSize) {
-      DCHECK_GE(content_length_, 0);
-      return arrow::Status::OK();
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize) {
+      DCHECK_GE(content_length, 0);
     }
-
-    S3Model::HeadObjectRequest req;
-    req.SetBucket(ToAwsString(path_.bucket));
-    req.SetKey(ToAwsString(path_.key));
-
-    ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
-    auto outcome = client_lock.Move()->HeadObject(req);
-    if (!outcome.IsSuccess()) {
-      if (IsNotFound(outcome.GetError())) {
-        return PathNotFound(path_);
-      } else {
-        return ErrorToStatus(std::forward_as_tuple("When reading information for key '", path_.key, "' in bucket '",
-                                                   path_.bucket, "': "),
-                             "HeadObject", outcome.GetError());
-      }
-    }
-    content_length_ = outcome.GetResult().GetContentLength();
-    DCHECK_GE(content_length_, 0);
-    metadata_ = GetObjectMetadata(outcome.GetResult());
     return arrow::Status::OK();
   }
 
@@ -490,7 +503,8 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     if (position < 0) {
       return arrow::Status::Invalid("Cannot ", action, " from negative position");
     }
-    if (position > content_length_) {
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize && position > content_length) {
       return arrow::Status::IOError("Cannot ", action, " past end of file");
     }
     return arrow::Status::OK();
@@ -498,11 +512,16 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
 
   // RandomAccessFile APIs
 
-  arrow::Result<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadata() override { return metadata_; }
+  arrow::Result<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadata() override {
+    ARROW_RETURN_NOT_OK(CheckClosed());
+    ARROW_RETURN_NOT_OK(EnsureHeadObject(/*need_metadata=*/true));
+    std::lock_guard<std::mutex> lock(metadata_mutex_);
+    return metadata_;
+  }
 
   Future<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadataAsync(
       const arrow::io::IOContext& io_context) override {
-    return metadata_;
+    return Future<std::shared_ptr<const arrow::KeyValueMetadata>>::MakeFinished(ReadMetadata());
   }
 
   arrow::Status Close() override {
@@ -520,7 +539,8 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
 
   arrow::Result<int64_t> GetSize() override {
     ARROW_RETURN_NOT_OK(CheckClosed());
-    return content_length_;
+    ARROW_RETURN_NOT_OK(EnsureHeadObject(/*need_metadata=*/false));
+    return GetCachedContentLength();
   }
 
   arrow::Status Seek(int64_t position) override {
@@ -535,9 +555,7 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     FIU_RETURN_ON(FIUKEY_S3FS_READAT_FAIL,
                   arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_S3FS_READAT_FAIL)));
     ARROW_RETURN_NOT_OK(CheckClosed());
-    ARROW_RETURN_NOT_OK(CheckPosition(position, "read"));
-
-    nbytes = std::min(nbytes, content_length_ - position);
+    ARROW_ASSIGN_OR_RAISE(nbytes, GetReadSize(position, nbytes));
     if (nbytes == 0) {
       return 0;
     }
@@ -547,21 +565,27 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     ARROW_ASSIGN_OR_RAISE(S3Model::GetObjectResult result,
                           GetObjectRange(client_lock.get(), path_, position, nbytes, out));
 
-    auto& stream = result.GetBody();
-    stream.ignore(nbytes);
-    // NOTE: the stream is a stringstream by default, there is no actual error
-    // to check for.  However, stream.fail() may return true if EOF is reached.
-    return stream.gcount();
+    // The response body has already been written into the caller-provided
+    // PreallocatedStreamBuf. If the requested range extends past EOF, the
+    // buffer capacity is still `nbytes`, but the server returns a shorter 206
+    // body. Use the response Content-Length as the actual bytes read instead
+    // of consuming the stream and trusting gcount().
+    const auto response_content_length = result.GetContentLength();
+    if (response_content_length < 0 || response_content_length > nbytes) {
+      return arrow::Status::IOError("Unexpected GetObject Content-Length ", response_content_length,
+                                    " for range read of ", nbytes, " bytes");
+    }
+
+    const int64_t bytes_read = response_content_length;
+    CacheContentLengthFromRead(result, position, bytes_read);
+    return bytes_read;
   }
 
   arrow::Result<std::shared_ptr<Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
     FIU_RETURN_ON(FIUKEY_S3FS_READAT_FAIL,
                   arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_S3FS_READAT_FAIL)));
     ARROW_RETURN_NOT_OK(CheckClosed());
-    ARROW_RETURN_NOT_OK(CheckPosition(position, "read"));
-
-    // No need to allocate more than the remaining number of bytes
-    nbytes = std::min(nbytes, content_length_ - position);
+    ARROW_ASSIGN_OR_RAISE(nbytes, GetReadSize(position, nbytes));
 
     ARROW_ASSIGN_OR_RAISE(auto buf, AllocateResizableBuffer(nbytes, io_context_.pool()));
     if (nbytes > 0) {
@@ -589,6 +613,76 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     return buffer;
   }
 
+  arrow::Result<int64_t> GetReadSize(int64_t position, int64_t nbytes) const {
+    if (position < 0) {
+      return arrow::Status::Invalid("Cannot read from negative position");
+    }
+    if (nbytes < 0) {
+      return arrow::Status::Invalid("Cannot read negative number of bytes");
+    }
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize) {
+      if (position > content_length) {
+        return arrow::Status::IOError("Cannot read past end of file");
+      }
+      nbytes = std::min(nbytes, content_length - position);
+    }
+    return nbytes;
+  }
+
+  arrow::Status EnsureHeadObject(bool need_metadata) {
+    if (GetCachedContentLength() != kNoSize && (!need_metadata || HasCachedMetadata())) {
+      return arrow::Status::OK();
+    }
+
+    S3Model::HeadObjectRequest req;
+    req.SetBucket(ToAwsString(path_.bucket));
+    req.SetKey(ToAwsString(path_.key));
+
+    ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
+    auto outcome = client_lock.Move()->HeadObject(req);
+    if (!outcome.IsSuccess()) {
+      if (IsNotFound(outcome.GetError())) {
+        return PathNotFound(path_);
+      }
+      return ErrorToStatus(
+          std::forward_as_tuple("When reading information for key '", path_.key, "' in bucket '", path_.bucket, "': "),
+          "HeadObject", outcome.GetError());
+    }
+
+    auto content_length = outcome.GetResult().GetContentLength();
+    DCHECK_GE(content_length, 0);
+    auto metadata = GetObjectMetadata(outcome.GetResult());
+    {
+      std::lock_guard<std::mutex> lock(metadata_mutex_);
+      metadata_ = std::move(metadata);
+    }
+    SetCachedContentLength(content_length);
+    return arrow::Status::OK();
+  }
+
+  template <typename ObjectResult>
+  void CacheContentLengthFromRead(const ObjectResult& result, int64_t position, int64_t bytes_read) {
+    auto content_length = GetObjectSizeFromReadResult(result, position);
+    if (!content_length) {
+      return;
+    }
+
+    DCHECK_LE(position + bytes_read, *content_length);
+    SetCachedContentLength(*content_length);
+  }
+
+  int64_t GetCachedContentLength() const { return content_length_.load(std::memory_order_acquire); }
+
+  void SetCachedContentLength(int64_t content_length) {
+    content_length_.store(content_length, std::memory_order_release);
+  }
+
+  bool HasCachedMetadata() const {
+    std::lock_guard<std::mutex> lock(metadata_mutex_);
+    return metadata_ != nullptr;
+  }
+
   protected:
   std::shared_ptr<S3ClientHolder> holder_;
   const arrow::io::IOContext io_context_;
@@ -596,7 +690,8 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
 
   bool closed_ = false;
   int64_t pos_ = 0;
-  int64_t content_length_ = kNoSize;
+  mutable std::mutex metadata_mutex_;
+  std::atomic<int64_t> content_length_{kNoSize};
   std::shared_ptr<const arrow::KeyValueMetadata> metadata_;
 };
 

--- a/cpp/test/filesystem/cloud_file_system_test.cpp
+++ b/cpp/test/filesystem/cloud_file_system_test.cpp
@@ -501,8 +501,17 @@ TEST_F(CloudFsTest, DeleteFile) {
 }
 
 TEST_F(CloudFsTest, OpenInputStreamNotFound) {
-  auto result = fs_->OpenInputStream("/nonexistent_file_12345.txt");
-  ASSERT_FALSE(result.ok());
+  std::string path = "/nonexistent_file_12345.txt";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(path));
+  ASSERT_EQ(info.type(), arrow::fs::FileType::NotFound);
+
+  auto result = fs_->OpenInputStream(path);
+  if (result.ok()) {
+    // Lazy-open filesystems may defer not-found errors until the first read.
+    ASSERT_FALSE(result.ValueOrDie()->Read(1).ok());
+  }
 }
 
 TEST_F(CloudFsTest, OpenInputFileRandomRead) {
@@ -543,6 +552,158 @@ TEST_F(CloudFsTest, OpenInputFileRandomRead) {
   EXPECT_EQ(pos, 36);
 
   (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, OpenInputFileRangeReadPastEnd) {
+  std::string path = "/test_object_input_file_range_read_past_end.txt";
+  std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto write_buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(write_buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
+  const int64_t position = 10;
+  const std::string expected = content.substr(position);
+  ASSERT_AND_ASSIGN(auto read_buf, file->ReadAt(position, content.size()));
+  EXPECT_EQ(read_buf->size(), static_cast<int64_t>(expected.size()));
+  EXPECT_EQ(read_buf->ToString(), expected);
+
+  auto read_past_eof = file->ReadAt(static_cast<int64_t>(content.size()) + 1, 1);
+  EXPECT_FALSE(read_past_eof.ok());
+
+  (void)fs_->DeleteFile(path);
+}
+
+TEST_F(CloudFsTest, OpenInputFileCachesObjectSizeFromRead) {
+  std::string path = "/test_object_input_file_cache_from_read.txt";
+  std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto write_buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(write_buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
+  ASSERT_AND_ASSIGN(auto read_buf, file->ReadAt(0, content.size() + 1024));
+  ASSERT_EQ(read_buf->ToString(), content);
+
+  ASSERT_STATUS_OK(fs_->DeleteFile(path));
+
+  ASSERT_AND_ASSIGN(auto size, file->GetSize());
+  EXPECT_EQ(size, static_cast<int64_t>(content.size()));
+
+  ASSERT_AND_ASSIGN(auto eof_buf, file->ReadAt(content.size(), 1024));
+  EXPECT_EQ(eof_buf->size(), 0);
+}
+
+TEST_F(CloudFsTest, OpenInputFileCachesObjectInfoFromGetSize) {
+  std::string path = "/test_object_input_file_cache_from_get_size.txt";
+  std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto write_buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(write_buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
+  ASSERT_AND_ASSIGN(auto size, file->GetSize());
+  EXPECT_EQ(size, static_cast<int64_t>(content.size()));
+
+  ASSERT_STATUS_OK(fs_->DeleteFile(path));
+
+  ASSERT_AND_ASSIGN(auto cached_size, file->GetSize());
+  EXPECT_EQ(cached_size, static_cast<int64_t>(content.size()));
+
+  ASSERT_AND_ASSIGN(auto metadata, file->ReadMetadata());
+  ASSERT_NE(metadata, nullptr);
+  ASSERT_AND_ASSIGN(auto content_length, metadata->Get("Content-Length"));
+  EXPECT_EQ(content_length, std::to_string(content.size()));
+
+  ASSERT_AND_ASSIGN(auto eof_buf, file->ReadAt(content.size(), 1024));
+  EXPECT_EQ(eof_buf->size(), 0);
+}
+
+TEST_F(CloudFsTest, OpenInputFileWithFileInfoUsesKnownSize) {
+  std::string path = "/test_object_input_file_known_size.txt";
+  std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto write_buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(write_buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(path));
+  ASSERT_EQ(info.type(), arrow::fs::FileType::File);
+  ASSERT_EQ(info.size(), static_cast<int64_t>(content.size()));
+
+  std::shared_ptr<FilesystemMetrics> metrics;
+  auto observable_fs = std::dynamic_pointer_cast<Observable>(fs_);
+  if (observable_fs != nullptr) {
+    metrics = observable_fs->GetMetrics();
+    if (metrics != nullptr) {
+      metrics->Reset();
+    }
+  }
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(info));
+  ASSERT_STATUS_OK(fs_->DeleteFile(path));
+
+  ASSERT_AND_ASSIGN(auto size, file->GetSize());
+  EXPECT_EQ(size, static_cast<int64_t>(content.size()));
+  ASSERT_AND_ASSIGN(auto eof_buf, file->ReadAt(content.size(), 1024));
+  EXPECT_EQ(eof_buf->size(), 0);
+
+  if (metrics != nullptr) {
+    auto after_get_size = metrics->GetSnapshot();
+    EXPECT_EQ(after_get_size.read_count, 0);
+    EXPECT_EQ(after_get_size.read_bytes, 0);
+  }
+}
+
+TEST_F(CloudFsTest, OpenInputFileMetricsStayLazyAfterCachedRead) {
+  auto observable_fs = std::dynamic_pointer_cast<Observable>(fs_);
+  if (observable_fs == nullptr) {
+    GTEST_SKIP() << "Current filesystem does not support metrics";
+  }
+  auto metrics = observable_fs->GetMetrics();
+  if (metrics == nullptr) {
+    GTEST_SKIP() << "Current filesystem does not provide metrics";
+  }
+
+  std::string path = "/test_object_input_file_metrics_lazy.txt";
+  std::string content = "0123456789abcdefghijklmnopqrstuvwxyz";
+  (void)fs_->DeleteFile(path);
+
+  ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
+  auto write_buf = std::make_shared<arrow::Buffer>(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+  ASSERT_STATUS_OK(out->Write(write_buf));
+  ASSERT_STATUS_OK(out->Close());
+
+  metrics->Reset();
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
+  auto after_open = metrics->GetSnapshot();
+  EXPECT_EQ(after_open.read_count, 0);
+  EXPECT_EQ(after_open.read_bytes, 0);
+
+  ASSERT_AND_ASSIGN(auto read_buf, file->ReadAt(0, content.size() + 1024));
+  EXPECT_EQ(read_buf->ToString(), content);
+  auto after_read = metrics->GetSnapshot();
+  EXPECT_GT(after_read.read_count, after_open.read_count);
+  EXPECT_GT(after_read.read_bytes, after_open.read_bytes);
+
+  ASSERT_STATUS_OK(fs_->DeleteFile(path));
+
+  ASSERT_AND_ASSIGN(auto size, file->GetSize());
+  EXPECT_EQ(size, static_cast<int64_t>(content.size()));
+  auto after_get_size = metrics->GetSnapshot();
+  EXPECT_EQ(after_get_size.read_count, after_read.read_count);
+  EXPECT_EQ(after_get_size.read_bytes, after_read.read_bytes);
 }
 
 TEST_F(CloudFsTest, OverwriteExistingFile) {
@@ -788,13 +949,13 @@ TEST_F(CloudFsTest, WriteEmptyFile) {
   ASSERT_AND_ASSIGN(auto out, fs_->OpenOutputStream(path, nullptr));
   ASSERT_STATUS_OK(out->Close());
 
-  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(path));
-  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
-  EXPECT_EQ(read_buf->size(), 0);
-
   ASSERT_AND_ASSIGN(auto info, fs_->GetFileInfo(path));
   EXPECT_EQ(info.type(), arrow::fs::FileType::File);
   EXPECT_EQ(info.size(), 0);
+
+  ASSERT_AND_ASSIGN(auto in, fs_->OpenInputStream(info));
+  ASSERT_AND_ASSIGN(auto read_buf, in->Read(1024));
+  EXPECT_EQ(read_buf->size(), 0);
 
   (void)fs_->DeleteFile(path);
 }

--- a/cpp/test/filesystem/cloud_fs_metrics_test.cpp
+++ b/cpp/test/filesystem/cloud_fs_metrics_test.cpp
@@ -207,4 +207,149 @@ TEST_F(CloudFsMetricsTest, TestReadMetrics) {
   EXPECT_EQ(static_cast<int64_t>(test_data.size()), metrics->GetReadBytes());
 }
 
+TEST_F(CloudFsMetricsTest, TestOpenInputDoesNotIncrementReadMetrics) {
+  auto observable = std::dynamic_pointer_cast<Observable>(arrowfs_);
+  ASSERT_NE(observable, nullptr);
+  auto metrics = observable->GetMetrics();
+  ASSERT_NE(metrics, nullptr);
+
+  std::string test_file_name = GenerateTestFileName();
+  std::string test_data = "open should not count as read";
+  ASSERT_OK_AND_ASSIGN(auto output_stream, arrowfs_->OpenOutputStream(base_path_ + test_file_name, nullptr));
+  ASSERT_STATUS_OK(output_stream->Write(test_data.data(), test_data.size()));
+  ASSERT_STATUS_OK(output_stream->Close());
+
+  metrics->Reset();
+  ASSERT_OK_AND_ASSIGN(auto input_stream, arrowfs_->OpenInputStream(base_path_ + test_file_name));
+  EXPECT_EQ(0, metrics->GetReadCount());
+  EXPECT_EQ(0, metrics->GetReadBytes());
+  ASSERT_STATUS_OK(input_stream->Close());
+
+  ASSERT_OK_AND_ASSIGN(auto input_file, arrowfs_->OpenInputFile(base_path_ + test_file_name));
+  EXPECT_EQ(0, metrics->GetReadCount());
+  EXPECT_EQ(0, metrics->GetReadBytes());
+  ASSERT_STATUS_OK(input_file->Close());
+}
+
+TEST_F(CloudFsMetricsTest, TestReadMetricsCountSuccessfulReads) {
+  auto observable = std::dynamic_pointer_cast<Observable>(arrowfs_);
+  ASSERT_NE(observable, nullptr);
+  auto metrics = observable->GetMetrics();
+  ASSERT_NE(metrics, nullptr);
+
+  std::string test_file_name = GenerateTestFileName();
+  std::string test_data = "0123456789abcdefghijklmnopqrstuvwxyz";
+  ASSERT_OK_AND_ASSIGN(auto output_stream, arrowfs_->OpenOutputStream(base_path_ + test_file_name, nullptr));
+  ASSERT_STATUS_OK(output_stream->Write(test_data.data(), test_data.size()));
+  ASSERT_STATUS_OK(output_stream->Close());
+
+  metrics->Reset();
+  ASSERT_OK_AND_ASSIGN(auto input_stream, arrowfs_->OpenInputStream(base_path_ + test_file_name));
+  ASSERT_OK_AND_ASSIGN(auto first, input_stream->Read(5));
+  EXPECT_EQ(first->ToString(), "01234");
+  EXPECT_EQ(1, metrics->GetReadCount());
+  EXPECT_EQ(5, metrics->GetReadBytes());
+
+  ASSERT_OK_AND_ASSIGN(auto second, input_stream->Read(7));
+  EXPECT_EQ(second->ToString(), "56789ab");
+  EXPECT_EQ(2, metrics->GetReadCount());
+  EXPECT_EQ(12, metrics->GetReadBytes());
+  ASSERT_STATUS_OK(input_stream->Close());
+
+  metrics->Reset();
+  ASSERT_OK_AND_ASSIGN(auto input_file, arrowfs_->OpenInputFile(base_path_ + test_file_name));
+  EXPECT_EQ(0, metrics->GetReadCount());
+  EXPECT_EQ(0, metrics->GetReadBytes());
+
+  ASSERT_OK_AND_ASSIGN(auto range_a, input_file->ReadAt(0, 4));
+  EXPECT_EQ(range_a->ToString(), "0123");
+  EXPECT_EQ(1, metrics->GetReadCount());
+  EXPECT_EQ(4, metrics->GetReadBytes());
+
+  ASSERT_OK_AND_ASSIGN(auto range_b, input_file->ReadAt(10, 6));
+  EXPECT_EQ(range_b->ToString(), "abcdef");
+  EXPECT_EQ(2, metrics->GetReadCount());
+  EXPECT_EQ(10, metrics->GetReadBytes());
+
+  ASSERT_OK_AND_ASSIGN(auto eof, input_file->ReadAt(test_data.size(), 1024));
+  EXPECT_EQ(eof->size(), 0);
+  EXPECT_EQ(2, metrics->GetReadCount());
+  EXPECT_EQ(10, metrics->GetReadBytes());
+  ASSERT_STATUS_OK(input_file->Close());
+}
+
+TEST_F(CloudFsMetricsTest, TestReadMetricsCountSuccessfulAsyncReads) {
+  auto observable = std::dynamic_pointer_cast<Observable>(arrowfs_);
+  ASSERT_NE(observable, nullptr);
+  auto metrics = observable->GetMetrics();
+  ASSERT_NE(metrics, nullptr);
+
+  std::string test_file_name = GenerateTestFileName();
+  std::string test_data = "0123456789abcdefghijklmnopqrstuvwxyz";
+  auto test_data_size = static_cast<int64_t>(test_data.size());
+  ASSERT_OK_AND_ASSIGN(auto output_stream, arrowfs_->OpenOutputStream(base_path_ + test_file_name, nullptr));
+  ASSERT_STATUS_OK(output_stream->Write(test_data.data(), test_data.size()));
+  ASSERT_STATUS_OK(output_stream->Close());
+
+  ASSERT_OK_AND_ASSIGN(auto input_file, arrowfs_->OpenInputFile(base_path_ + test_file_name));
+  metrics->Reset();
+
+  auto read_result = input_file->ReadAsync({}, 5, 7).result();
+  ASSERT_STATUS_OK(read_result.status());
+  ASSERT_EQ(read_result.ValueOrDie()->size(), 7);
+  EXPECT_EQ(metrics->GetReadCount(), 1);
+  EXPECT_EQ(metrics->GetReadBytes(), 7);
+
+  auto eof_result = input_file->ReadAsync({}, test_data_size, 1024).result();
+  ASSERT_STATUS_OK(eof_result.status());
+  ASSERT_EQ(eof_result.ValueOrDie()->size(), 0);
+  EXPECT_EQ(metrics->GetReadCount(), 1);
+  EXPECT_EQ(metrics->GetReadBytes(), 7);
+
+  auto failed_result = input_file->ReadAsync({}, -1, 1).result();
+  ASSERT_STATUS_NOT_OK(failed_result.status());
+  EXPECT_EQ(metrics->GetReadCount(), 1);
+  EXPECT_EQ(metrics->GetReadBytes(), 7);
+
+  metrics->Reset();
+  std::vector<arrow::io::ReadRange> ranges = {
+      {0, 4},
+      {4, 0},
+      {test_data_size, 1024},
+      {10, 6},
+  };
+  auto futures = input_file->ReadManyAsync({}, ranges);
+  ASSERT_EQ(futures.size(), ranges.size());
+
+  auto range_0 = futures[0].result();
+  ASSERT_STATUS_OK(range_0.status());
+  EXPECT_EQ(range_0.ValueOrDie()->size(), 4);
+
+  auto range_1 = futures[1].result();
+  ASSERT_STATUS_OK(range_1.status());
+  EXPECT_EQ(range_1.ValueOrDie()->size(), 0);
+
+  auto range_2 = futures[2].result();
+  ASSERT_STATUS_OK(range_2.status());
+  EXPECT_EQ(range_2.ValueOrDie()->size(), 0);
+
+  auto range_3 = futures[3].result();
+  ASSERT_STATUS_OK(range_3.status());
+  EXPECT_EQ(range_3.ValueOrDie()->size(), 6);
+
+  EXPECT_EQ(metrics->GetReadCount(), 2);
+  EXPECT_EQ(metrics->GetReadBytes(), 10);
+
+  metrics->Reset();
+  std::vector<arrow::io::ReadRange> invalid_ranges = {{-1, 1}};
+  auto failed_futures = input_file->ReadManyAsync({}, invalid_ranges);
+  ASSERT_EQ(failed_futures.size(), 1);
+  auto failed_range = failed_futures[0].result();
+  ASSERT_STATUS_NOT_OK(failed_range.status());
+  EXPECT_EQ(metrics->GetReadCount(), 0);
+  EXPECT_EQ(metrics->GetReadBytes(), 0);
+
+  ASSERT_STATUS_OK(input_file->Close());
+}
+
 }  // namespace milvus_storage::test

--- a/cpp/test/filesystem/local_file_system_test.cpp
+++ b/cpp/test/filesystem/local_file_system_test.cpp
@@ -381,7 +381,7 @@ TEST_F(LocalFsTest, TestMetricsForRandomAccessFile) {
   ASSERT_AND_ASSIGN(auto buffer2, file->ReadAt(10, 10));
   ASSERT_STATUS_OK(file->Close());
 
-  EXPECT_EQ(metrics->GetReadCount(), 1);   // One OpenInputFile call
+  EXPECT_EQ(metrics->GetReadCount(), 2);   // Two successful ReadAt calls
   EXPECT_EQ(metrics->GetReadBytes(), 20);  // 10 + 10 bytes read
 }
 


### PR DESCRIPTION
This change makes input file opens lazy. Before this, opening an input file on S3 or Azure could immediately trigger remote metadata calls like HEAD or GetProperties just to build the file handle. Now those calls are deferred until the caller actually needs size or metadata, and normal range reads can cache the object size from the read response when the provider returns enough information. This keeps simple opens cheap while still preserving the same behavior once size, metadata, or actual data is requested.

It also aligns the read metrics behavior across S3, Azure, and local filesystems. Opening an input stream or file no longer counts as a read; read_count and read_bytes are updated only after bytes are successfully returned to the caller. That makes the metrics reflect real read IO instead of handle creation, and avoids inflating counts for lazy opens or EOF reads.

The tests cover lazy opens, size caching, real read counting, EOF handling, and the updated provider expectations.