### PR TITLE
enhance: support FixedSizeBinary in nested types for Vortex

### DIFF
--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -12,7 +12,7 @@ use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_array::ffi_stream::FFI_ArrowArrayStream;
 use arrow_array::{
     Array, ArrayRef as ArrowArrayRef, FixedSizeBinaryArray, FixedSizeListArray, RecordBatch,
-    RecordBatchReader, UInt8Array,
+    RecordBatchReader, UInt8Array, make_array,
 };
 use arrow_data::ArrayData;
 use arrow_data::ffi::FFI_ArrowArray;
@@ -307,50 +307,67 @@ pub(crate) fn select(fields: Vec<String>, child: Box<Expr>) -> Box<Expr> {
  * Both types have identical memory layout, enabling zero-copy conversion.
  */
 
-/// Check if a DataType is FixedSizeBinary
-fn is_fixed_size_binary(dt: &DataType) -> bool {
-    matches!(dt, DataType::FixedSizeBinary(_))
+fn to_vortex_field(field: &Field) -> Option<Arc<Field>> {
+    to_vortex_data_type(field.data_type())
+        .map(|data_type| Arc::new(field.clone().with_data_type(data_type)))
 }
 
-/// Check if schema contains any FixedSizeBinary fields
-fn schema_has_fixed_size_binary(schema: &Schema) -> bool {
-    schema
-        .fields()
-        .iter()
-        .any(|f| is_fixed_size_binary(f.data_type()))
-}
-
-/// Convert FixedSizeBinary type to FixedSizeList<u8>
-fn fixed_size_binary_to_list_type(byte_width: i32) -> DataType {
-    DataType::FixedSizeList(
-        Arc::new(Field::new("item", DataType::UInt8, false)),
-        byte_width,
-    )
+fn to_vortex_data_type(dt: &DataType) -> Option<DataType> {
+    match dt {
+        DataType::FixedSizeBinary(byte_width) => Some(DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::UInt8, false)),
+            *byte_width,
+        )),
+        DataType::List(field) => to_vortex_field(field).map(DataType::List),
+        DataType::LargeList(field) => to_vortex_field(field).map(DataType::LargeList),
+        DataType::ListView(field) => to_vortex_field(field).map(DataType::ListView),
+        DataType::LargeListView(field) => to_vortex_field(field).map(DataType::LargeListView),
+        DataType::FixedSizeList(field, list_size) => to_vortex_field(field)
+            .map(|field| DataType::FixedSizeList(field, *list_size)),
+        DataType::Struct(fields) => {
+            let mut changed = false;
+            let converted_fields: Vec<_> = fields
+                .iter()
+                .map(|field| match to_vortex_field(field) {
+                    Some(converted_field) => {
+                        changed = true;
+                        converted_field
+                    }
+                    None => field.clone(),
+                })
+                .collect();
+            if changed {
+                Some(DataType::Struct(converted_fields.into()))
+            } else {
+                None
+            }
+        }
+        DataType::Dictionary(key_type, value_type) => to_vortex_data_type(value_type)
+            .map(|value_type| DataType::Dictionary(key_type.clone(), Box::new(value_type))),
+        _ => None,
+    }
 }
 
 /// Convert schema: replace FixedSizeBinary with FixedSizeList<u8>
-fn convert_schema_for_vortex(schema: &Schema) -> Schema {
-    if !schema_has_fixed_size_binary(schema) {
-        return schema.clone();
-    }
-
+fn convert_schema_for_vortex(schema: &Schema) -> Option<Schema> {
+    let mut changed = false;
     let new_fields: Vec<_> = schema
         .fields()
         .iter()
-        .map(|field| {
-            if let DataType::FixedSizeBinary(byte_width) = field.data_type() {
-                Arc::new(Field::new(
-                    field.name(),
-                    fixed_size_binary_to_list_type(*byte_width),
-                    field.is_nullable(),
-                ))
-            } else {
-                field.clone()
+        .map(|field| match to_vortex_field(field) {
+            Some(converted_field) => {
+                changed = true;
+                converted_field
             }
+            None => field.clone(),
         })
         .collect();
 
-    Schema::new_with_metadata(new_fields, schema.metadata().clone())
+    if changed {
+        Some(Schema::new_with_metadata(new_fields, schema.metadata().clone()))
+    } else {
+        None
+    }
 }
 
 /// Convert FixedSizeBinary array to FixedSizeList<u8> array (zero-copy)
@@ -360,10 +377,12 @@ fn convert_fixed_size_binary_to_list(array: &FixedSizeBinaryArray) -> ArrowArray
     // Get the underlying data buffer directly (zero-copy via Arc)
     let data = array.to_data();
     let values_buffer = data.buffers()[0].clone();
+    let values_offset = data.offset() * byte_width as usize;
 
     // Create UInt8Array from the buffer directly (zero-copy)
     let child_data = ArrayData::builder(DataType::UInt8)
         .len(array.len() * byte_width as usize)
+        .offset(values_offset)
         .add_buffer(values_buffer)
         .build()
         .expect("Failed to build UInt8 ArrayData");
@@ -382,7 +401,10 @@ fn convert_fixed_size_binary_to_list(array: &FixedSizeBinaryArray) -> ArrowArray
 }
 
 /// Convert FixedSizeList<u8> array to FixedSizeBinary array (zero-copy)
-fn convert_list_to_fixed_size_binary(array: &FixedSizeListArray, byte_width: i32) -> ArrowArrayRef {
+fn convert_list_to_fixed_size_binary(
+    array: &FixedSizeListArray,
+    byte_width: i32,
+) -> ArrowArrayRef {
     let values = array.values();
 
     // Get the u8 child array
@@ -394,101 +416,233 @@ fn convert_list_to_fixed_size_binary(array: &FixedSizeListArray, byte_width: i32
     // Get the underlying buffer directly (zero-copy via Arc)
     let u8_data = u8_array.to_data();
     let values_buffer = u8_data.buffers()[0].clone();
+    let byte_width_usize = byte_width as usize;
+    assert_eq!(
+        u8_data.offset() % byte_width_usize,
+        0,
+        "FixedSizeList<u8> child offset must align to FixedSizeBinary width"
+    );
+    let values_offset = array.offset() + u8_data.offset() / byte_width_usize;
 
     // Build FixedSizeBinaryArray from the buffer directly (zero-copy)
-    let mut builder = ArrayData::builder(DataType::FixedSizeBinary(byte_width))
+    let fsb_data = ArrayData::builder(DataType::FixedSizeBinary(byte_width))
         .len(array.len())
-        .add_buffer(values_buffer);
-
-    if let Some(nulls) = array.nulls() {
-        builder = builder.null_bit_buffer(Some(nulls.buffer().clone()));
-    }
-
-    let fsb_data = builder
+        .offset(values_offset)
+        .add_buffer(values_buffer)
+        .nulls(array.nulls().cloned())
         .build()
         .expect("Failed to build FixedSizeBinary ArrayData");
     Arc::new(FixedSizeBinaryArray::from(fsb_data))
 }
 
+fn rebuild_array_with_children(
+    array: &ArrowArrayRef,
+    data_type: DataType,
+    child_data: Vec<ArrayData>,
+    context: &str,
+) -> ArrowArrayRef {
+    let data = array.to_data();
+    let converted_data = data
+        .into_builder()
+        .data_type(data_type)
+        .child_data(child_data)
+        .build()
+        .expect(context);
+    make_array(converted_data)
+}
+
+fn to_vortex_arrow_array(array: &ArrowArrayRef) -> Option<ArrowArrayRef> {
+    match array.data_type() {
+        DataType::FixedSizeBinary(_) => {
+            let fsb_array = array
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .expect("Expected FixedSizeBinaryArray");
+            Some(convert_fixed_size_binary_to_list(fsb_array))
+        }
+        DataType::List(_)
+        | DataType::LargeList(_)
+        | DataType::ListView(_)
+        | DataType::LargeListView(_)
+        | DataType::FixedSizeList(_, _) => {
+            let data = array.to_data();
+            let child_data = data.child_data();
+            assert_eq!(child_data.len(), 1, "Expected one child array");
+            let child_array = make_array(child_data[0].clone());
+            let converted_child = to_vortex_arrow_array(&child_array)?;
+            let converted_type = to_vortex_data_type(array.data_type())
+                .expect("Expected converted Arrow data type for Vortex");
+            Some(rebuild_array_with_children(
+                array,
+                converted_type,
+                vec![converted_child.to_data()],
+                "Failed to build Arrow nested array converted for Vortex",
+            ))
+        }
+        DataType::Struct(_) => {
+            let mut changed = false;
+            let converted_children: Vec<_> = array
+                .to_data()
+                .child_data()
+                .iter()
+                .map(|child| {
+                    let child_array = make_array(child.clone());
+                    match to_vortex_arrow_array(&child_array) {
+                        Some(converted_child) => {
+                            changed = true;
+                            converted_child.to_data()
+                        }
+                        None => child.clone(),
+                    }
+                })
+                .collect();
+            if changed {
+                let converted_type = to_vortex_data_type(array.data_type())
+                    .expect("Expected converted Arrow struct type for Vortex");
+                Some(rebuild_array_with_children(
+                    array,
+                    converted_type,
+                    converted_children,
+                    "Failed to build Arrow struct array converted for Vortex",
+                ))
+            } else {
+                None
+            }
+        }
+        DataType::Dictionary(_, _) => {
+            let data = array.to_data();
+            let child_data = data.child_data();
+            if child_data.is_empty() {
+                return None;
+            }
+            let child_array = make_array(child_data[0].clone());
+            let converted_child = to_vortex_arrow_array(&child_array)?;
+            let converted_type = to_vortex_data_type(array.data_type())
+                .expect("Expected converted Arrow dictionary type for Vortex");
+            Some(rebuild_array_with_children(
+                array,
+                converted_type,
+                vec![converted_child.to_data()],
+                "Failed to build Arrow dictionary array converted for Vortex",
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn to_arrow_array(array: &ArrowArrayRef, target_type: &DataType) -> Option<ArrowArrayRef> {
+    match target_type {
+        DataType::FixedSizeBinary(byte_width) => {
+            let fsl_array = array
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .expect("Expected FixedSizeListArray");
+            Some(convert_list_to_fixed_size_binary(fsl_array, *byte_width))
+        }
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::FixedSizeList(field, _) => {
+            let data = array.to_data();
+            let child_data = data.child_data();
+            assert_eq!(child_data.len(), 1, "Expected one child array");
+            let child_array = make_array(child_data[0].clone());
+            let converted_child = to_arrow_array(&child_array, field.data_type())?;
+            Some(rebuild_array_with_children(
+                array,
+                target_type.clone(),
+                vec![converted_child.to_data()],
+                "Failed to build Arrow nested array converted from Vortex",
+            ))
+        }
+        DataType::Struct(fields) => {
+            let mut changed = false;
+            let converted_children: Vec<_> = array
+                .to_data()
+                .child_data()
+                .iter()
+                .zip(fields.iter())
+                .map(|(child, field)| {
+                    let child_array = make_array(child.clone());
+                    match to_arrow_array(&child_array, field.data_type()) {
+                        Some(converted_child) => {
+                            changed = true;
+                            converted_child.to_data()
+                        }
+                        None => child.clone(),
+                    }
+                })
+                .collect();
+            if changed {
+                Some(rebuild_array_with_children(
+                    array,
+                    target_type.clone(),
+                    converted_children,
+                    "Failed to build Arrow struct array converted from Vortex",
+                ))
+            } else {
+                None
+            }
+        }
+        DataType::Dictionary(_, value_type) => {
+            let data = array.to_data();
+            let child_data = data.child_data();
+            if child_data.is_empty() {
+                return None;
+            }
+            let child_array = make_array(child_data[0].clone());
+            let converted_child = to_arrow_array(&child_array, value_type)?;
+            Some(rebuild_array_with_children(
+                array,
+                target_type.clone(),
+                vec![converted_child.to_data()],
+                "Failed to build Arrow dictionary array converted from Vortex",
+            ))
+        }
+        _ => None,
+    }
+}
+
 /// Convert RecordBatch: replace FixedSizeList<u8> columns with FixedSizeBinary
 /// based on the original schema that specifies FixedSizeBinary
-fn convert_record_batch_from_vortex(batch: &RecordBatch, original_schema: &Schema) -> RecordBatch {
-    if !schema_has_fixed_size_binary(original_schema) {
-        return batch.clone();
-    }
-
+fn convert_record_batch_from_vortex(
+    batch: &RecordBatch,
+    original_schema: &Schema,
+) -> Option<RecordBatch> {
+    let mut changed = false;
     let new_columns: Vec<ArrowArrayRef> = batch
         .columns()
         .iter()
         .zip(original_schema.fields().iter())
-        .map(|(col, orig_field)| {
-            if let DataType::FixedSizeBinary(byte_width) = orig_field.data_type() {
-                if let DataType::FixedSizeList(_, _) = col.data_type() {
-                    let fsl_array = col
-                        .as_any()
-                        .downcast_ref::<FixedSizeListArray>()
-                        .expect("Expected FixedSizeListArray");
-                    convert_list_to_fixed_size_binary(fsl_array, *byte_width)
-                } else {
-                    col.clone()
-                }
-            } else {
-                col.clone()
+        .map(|(col, orig_field)| match to_arrow_array(col, orig_field.data_type()) {
+            Some(converted_col) => {
+                changed = true;
+                converted_col
             }
+            None => col.clone(),
         })
         .collect();
 
-    RecordBatch::try_new(Arc::new(original_schema.clone()), new_columns)
-        .expect("Failed to create converted RecordBatch")
+    if changed {
+        Some(
+            RecordBatch::try_new(Arc::new(original_schema.clone()), new_columns)
+                .expect("Failed to create converted RecordBatch"),
+        )
+    } else {
+        None
+    }
 }
 
 /// Convert StructArray: replace FixedSizeBinary columns with FixedSizeList<u8>
 fn convert_struct_array_for_vortex(
     struct_array: &arrow_array::StructArray,
 ) -> arrow_array::StructArray {
-    let schema = Schema::new(struct_array.fields().clone());
-    if !schema_has_fixed_size_binary(&schema) {
-        return struct_array.clone();
+    let array = Arc::new(struct_array.clone()) as ArrowArrayRef;
+    match to_vortex_arrow_array(&array) {
+        Some(converted) => converted.as_struct().clone(),
+        None => struct_array.clone(),
     }
-
-    let new_fields: Vec<_> = struct_array
-        .fields()
-        .iter()
-        .map(|field| {
-            if let DataType::FixedSizeBinary(byte_width) = field.data_type() {
-                Arc::new(Field::new(
-                    field.name(),
-                    fixed_size_binary_to_list_type(*byte_width),
-                    field.is_nullable(),
-                ))
-            } else {
-                field.clone()
-            }
-        })
-        .collect();
-
-    let new_columns: Vec<ArrowArrayRef> = struct_array
-        .columns()
-        .iter()
-        .map(|col| {
-            if let DataType::FixedSizeBinary(_) = col.data_type() {
-                let fsb_array = col
-                    .as_any()
-                    .downcast_ref::<FixedSizeBinaryArray>()
-                    .expect("Expected FixedSizeBinaryArray");
-                convert_fixed_size_binary_to_list(fsb_array)
-            } else {
-                col.clone()
-            }
-        })
-        .collect();
-
-    arrow_array::StructArray::try_new(
-        new_fields.into(),
-        new_columns,
-        struct_array.nulls().cloned(),
-    )
-    .expect("Failed to create converted StructArray")
 }
 
 /*
@@ -550,9 +704,16 @@ impl VortexWriter {
                 .map_err(|e| VortexError::from(e))?,
         );
 
-        // Convert FixedSizeBinary columns to FixedSizeList<u8> for Vortex compatibility
-        let converted_array = convert_struct_array_for_vortex(&arrow_array_data);
-        let converted_schema = convert_schema_for_vortex(&arrow_schema);
+        let (converted_schema, converted_array) = if let Some(converted_schema) =
+            convert_schema_for_vortex(&arrow_schema)
+        {
+            (
+                converted_schema,
+                convert_struct_array_for_vortex(&arrow_array_data),
+            )
+        } else {
+            (arrow_schema, arrow_array_data)
+        };
         let vortex_schema = RustDType::from_arrow(&converted_schema);
 
         // lazy init the inner_writer
@@ -653,8 +814,9 @@ impl VortexFile {
         let ffi_schema = unsafe { FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema) };
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
-        // Convert schema for Vortex (FixedSizeBinary -> FixedSizeList<u8>)
-        let converted_schema = Arc::new(convert_schema_for_vortex(&original_schema));
+        let converted_schema = convert_schema_for_vortex(original_schema.as_ref())
+            .map(Arc::new)
+            .unwrap_or_else(|| original_schema.clone());
 
         Ok(Box::new(VortexScanBuilder {
             inner: self.inner.scan()?.with_split_row_indices(false),
@@ -860,8 +1022,9 @@ impl VortexScanBuilder {
             unsafe { FFI_ArrowSchema::from_raw(output_schema as *mut FFI_ArrowSchema) };
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
-        // Convert schema for Vortex (FixedSizeBinary -> FixedSizeList<u8>)
-        let converted_schema = Arc::new(convert_schema_for_vortex(&original_schema));
+        let converted_schema = convert_schema_for_vortex(original_schema.as_ref())
+            .map(Arc::new)
+            .unwrap_or_else(|| original_schema.clone());
 
         self.output_schema = Some(converted_schema);
         self.original_schema = Some(original_schema);
@@ -914,7 +1077,8 @@ impl std::iter::Iterator for ConvertingRecordBatchReader {
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.next() {
             Some(Ok(batch)) => {
-                let converted = convert_record_batch_from_vortex(&batch, &self.original_schema);
+                let converted =
+                    convert_record_batch_from_vortex(&batch, &self.original_schema).unwrap_or(batch);
                 Some(Ok(converted))
             }
             Some(Err(e)) => Some(Err(e)),
@@ -956,22 +1120,21 @@ pub(crate) unsafe fn scan_builder_into_stream(
     let scan = inner.prepare()?;
     let iter = scan.execute_array_iter(row_range, &*VORTEX_RT)?;
     let data_type = DataType::Struct(vortex_schema.fields().clone());
+    let needs_conversion = vortex_schema.as_ref() != original_schema.as_ref();
     let reader = VortexRecordBatchReader {
         iter,
         schema: vortex_schema,
         data_type,
     };
 
-    // Wrap with converting reader if schema has FixedSizeBinary
-    let final_reader: Box<dyn RecordBatchReader + Send> =
-        if schema_has_fixed_size_binary(&original_schema) {
-            Box::new(ConvertingRecordBatchReader {
-                inner: Box::new(reader),
-                original_schema,
-            })
-        } else {
-            Box::new(reader)
-        };
+    let final_reader: Box<dyn RecordBatchReader + Send> = if needs_conversion {
+        Box::new(ConvertingRecordBatchReader {
+            inner: Box::new(reader),
+            original_schema,
+        })
+    } else {
+        Box::new(reader)
+    };
 
     let stream = FFI_ArrowArrayStream::new(final_reader);
     let out_stream = out_stream as *mut FFI_ArrowArrayStream;

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -12,7 +12,7 @@ use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_array::ffi_stream::FFI_ArrowArrayStream;
 use arrow_array::{
     Array, ArrayRef as ArrowArrayRef, FixedSizeBinaryArray, FixedSizeListArray, RecordBatch,
-    RecordBatchReader, UInt8Array, make_array,
+    RecordBatchReader, StructArray, UInt8Array, make_array,
 };
 use arrow_data::ArrayData;
 use arrow_data::ffi::FFI_ArrowArray;
@@ -307,76 +307,235 @@ pub(crate) fn select(fields: Vec<String>, child: Box<Expr>) -> Box<Expr> {
  * Both types have identical memory layout, enabling zero-copy conversion.
  */
 
-fn to_vortex_field(field: &Field) -> Option<Arc<Field>> {
-    to_vortex_data_type(field.data_type())
-        .map(|data_type| Arc::new(field.clone().with_data_type(data_type)))
+#[derive(Clone)]
+enum VortexArrayConversion {
+    FixedSizeBinary {
+        converted_type: DataType,
+    },
+    List {
+        converted_type: DataType,
+        child: Box<VortexArrayConversion>,
+    },
+    Struct {
+        converted_type: DataType,
+        children: Vec<Option<VortexArrayConversion>>,
+    },
 }
 
-fn to_vortex_data_type(dt: &DataType) -> Option<DataType> {
+impl VortexArrayConversion {
+    fn converted_type(&self) -> &DataType {
+        match self {
+            Self::FixedSizeBinary { converted_type }
+            | Self::List { converted_type, .. }
+            | Self::Struct { converted_type, .. } => converted_type,
+        }
+    }
+}
+
+struct VortexSchemaConversion {
+    schema: Schema,
+    fields: Vec<Option<VortexArrayConversion>>,
+}
+
+fn convert_field_for_vortex(
+    field: &Field,
+) -> Result<Option<(Arc<Field>, VortexArrayConversion)>, ArrowError> {
+    let Some(conversion) = build_vortex_array_conversion(field.data_type())? else {
+        return Ok(None);
+    };
+    Ok(Some((
+        Arc::new(
+            field
+                .clone()
+                .with_data_type(conversion.converted_type().clone()),
+        ),
+        conversion,
+    )))
+}
+
+fn build_vortex_array_conversion(
+    dt: &DataType,
+) -> Result<Option<VortexArrayConversion>, ArrowError> {
     match dt {
-        DataType::FixedSizeBinary(byte_width) => Some(DataType::FixedSizeList(
-            Arc::new(Field::new("item", DataType::UInt8, false)),
-            *byte_width,
+        DataType::FixedSizeBinary(byte_width) => Ok(Some(VortexArrayConversion::FixedSizeBinary {
+            converted_type: DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::UInt8, false)),
+                *byte_width,
+            ),
+        })),
+        DataType::List(field) => {
+            Ok(
+                convert_field_for_vortex(field)?.map(|(field, child)| {
+                    VortexArrayConversion::List {
+                        converted_type: DataType::List(field),
+                        child: Box::new(child),
+                    }
+                }),
+            )
+        }
+        DataType::LargeList(field) => {
+            Ok(
+                convert_field_for_vortex(field)?.map(|(field, child)| {
+                    VortexArrayConversion::List {
+                        converted_type: DataType::LargeList(field),
+                        child: Box::new(child),
+                    }
+                }),
+            )
+        }
+        DataType::ListView(field) => {
+            Ok(
+                convert_field_for_vortex(field)?.map(|(field, child)| {
+                    VortexArrayConversion::List {
+                        converted_type: DataType::ListView(field),
+                        child: Box::new(child),
+                    }
+                }),
+            )
+        }
+        DataType::LargeListView(field) => Ok(convert_field_for_vortex(field)?.map(
+            |(field, child)| VortexArrayConversion::List {
+                converted_type: DataType::LargeListView(field),
+                child: Box::new(child),
+            },
         )),
-        DataType::List(field) => to_vortex_field(field).map(DataType::List),
-        DataType::LargeList(field) => to_vortex_field(field).map(DataType::LargeList),
-        DataType::ListView(field) => to_vortex_field(field).map(DataType::ListView),
-        DataType::LargeListView(field) => to_vortex_field(field).map(DataType::LargeListView),
-        DataType::FixedSizeList(field, list_size) => to_vortex_field(field)
-            .map(|field| DataType::FixedSizeList(field, *list_size)),
+        DataType::FixedSizeList(field, list_size) => Ok(convert_field_for_vortex(field)?.map(
+            |(field, child)| VortexArrayConversion::List {
+                converted_type: DataType::FixedSizeList(field, *list_size),
+                child: Box::new(child),
+            },
+        )),
         DataType::Struct(fields) => {
             let mut changed = false;
-            let converted_fields: Vec<_> = fields
-                .iter()
-                .map(|field| match to_vortex_field(field) {
-                    Some(converted_field) => {
+            let mut child_conversions = Vec::with_capacity(fields.len());
+            let mut converted_fields = Vec::with_capacity(fields.len());
+            for field in fields {
+                match convert_field_for_vortex(field)? {
+                    Some((converted_field, conversion)) => {
                         changed = true;
-                        converted_field
+                        child_conversions.push(Some(conversion));
+                        converted_fields.push(converted_field);
                     }
-                    None => field.clone(),
-                })
-                .collect();
+                    None => {
+                        child_conversions.push(None);
+                        converted_fields.push(field.clone());
+                    }
+                }
+            }
             if changed {
-                Some(DataType::Struct(converted_fields.into()))
+                Ok(Some(VortexArrayConversion::Struct {
+                    converted_type: DataType::Struct(converted_fields.into()),
+                    children: child_conversions,
+                }))
             } else {
-                None
+                Ok(None)
             }
         }
-        DataType::Dictionary(key_type, value_type) => to_vortex_data_type(value_type)
-            .map(|value_type| DataType::Dictionary(key_type.clone(), Box::new(value_type))),
-        _ => None,
+        DataType::Dictionary(_, _) if contains_fixed_size_binary(dt) => {
+            Err(unsupported_container_error(
+                "Dictionary",
+                "FixedSizeBinary nested inside Dictionary is not supported by the Vortex bridge conversion",
+            ))
+        }
+        DataType::Map(_, _) if contains_fixed_size_binary(dt) => Err(unsupported_container_error(
+            "Map",
+            "FixedSizeBinary nested inside Map is not supported by the Vortex bridge conversion",
+        )),
+        DataType::Union(_, _) if contains_fixed_size_binary(dt) => {
+            Err(unsupported_container_error(
+                "Union",
+                "FixedSizeBinary nested inside Union is not supported by the Vortex bridge conversion",
+            ))
+        }
+        DataType::RunEndEncoded(_, _) if contains_fixed_size_binary(dt) => {
+            Err(unsupported_container_error(
+                "RunEndEncoded",
+                "FixedSizeBinary nested inside RunEndEncoded is not supported by the Vortex bridge conversion",
+            ))
+        }
+        _ => Ok(None),
     }
+}
+
+fn contains_fixed_size_binary(dt: &DataType) -> bool {
+    match dt {
+        DataType::FixedSizeBinary(_) => true,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::FixedSizeList(field, _) => contains_fixed_size_binary(field.data_type()),
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| contains_fixed_size_binary(field.data_type())),
+        DataType::Dictionary(_, value_type) => contains_fixed_size_binary(value_type),
+        DataType::Map(field, _) => contains_fixed_size_binary(field.data_type()),
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, field)| contains_fixed_size_binary(field.data_type())),
+        DataType::RunEndEncoded(run_ends, values) => {
+            contains_fixed_size_binary(run_ends.data_type())
+                || contains_fixed_size_binary(values.data_type())
+        }
+        _ => false,
+    }
+}
+
+fn unsupported_container_error(container: &str, message: &str) -> ArrowError {
+    arrow_conversion_error(format!("{container} conversion is unsupported: {message}"))
 }
 
 /// Convert schema: replace FixedSizeBinary with FixedSizeList<u8>
-fn convert_schema_for_vortex(schema: &Schema) -> Option<Schema> {
+fn convert_schema_for_vortex(
+    schema: &Schema,
+) -> Result<Option<VortexSchemaConversion>, ArrowError> {
     let mut changed = false;
-    let new_fields: Vec<_> = schema
-        .fields()
-        .iter()
-        .map(|field| match to_vortex_field(field) {
-            Some(converted_field) => {
+    let mut field_conversions = Vec::with_capacity(schema.fields().len());
+    let mut new_fields = Vec::with_capacity(schema.fields().len());
+    for field in schema.fields() {
+        match convert_field_for_vortex(field)? {
+            Some((converted_field, conversion)) => {
                 changed = true;
-                converted_field
+                field_conversions.push(Some(conversion));
+                new_fields.push(converted_field);
             }
-            None => field.clone(),
-        })
-        .collect();
+            None => {
+                field_conversions.push(None);
+                new_fields.push(field.clone());
+            }
+        }
+    }
 
     if changed {
-        Some(Schema::new_with_metadata(new_fields, schema.metadata().clone()))
+        Ok(Some(VortexSchemaConversion {
+            schema: Schema::new_with_metadata(new_fields, schema.metadata().clone()),
+            fields: field_conversions,
+        }))
     } else {
-        None
+        Ok(None)
     }
 }
 
+fn arrow_conversion_error(message: impl Into<String>) -> ArrowError {
+    ArrowError::InvalidArgumentError(message.into())
+}
+
 /// Convert FixedSizeBinary array to FixedSizeList<u8> array (zero-copy)
-fn convert_fixed_size_binary_to_list(array: &FixedSizeBinaryArray) -> ArrowArrayRef {
+fn convert_fixed_size_binary_to_list(
+    array: &FixedSizeBinaryArray,
+) -> Result<ArrowArrayRef, ArrowError> {
     let byte_width = array.value_length();
+    if byte_width <= 0 {
+        return Err(arrow_conversion_error(format!(
+            "FixedSizeBinary byte width must be positive, got {byte_width}"
+        )));
+    }
 
     // Get the underlying data buffer directly (zero-copy via Arc)
     let data = array.to_data();
-    let values_buffer = data.buffers()[0].clone();
+    let values_buffer = data.buffers().first().cloned().ok_or_else(|| {
+        arrow_conversion_error("FixedSizeBinary array is missing its values buffer")
+    })?;
     let values_offset = data.offset() * byte_width as usize;
 
     // Create UInt8Array from the buffer directly (zero-copy)
@@ -384,44 +543,61 @@ fn convert_fixed_size_binary_to_list(array: &FixedSizeBinaryArray) -> ArrowArray
         .len(array.len() * byte_width as usize)
         .offset(values_offset)
         .add_buffer(values_buffer)
-        .build()
-        .expect("Failed to build UInt8 ArrayData");
+        .build()?;
     let child_array = UInt8Array::from(child_data);
 
     // Create FixedSizeList array
     let list_field = Arc::new(Field::new("item", DataType::UInt8, false));
     let nulls = array.nulls().cloned();
 
-    Arc::new(FixedSizeListArray::new(
+    Ok(Arc::new(FixedSizeListArray::try_new(
         list_field,
         byte_width,
         Arc::new(child_array),
         nulls,
-    ))
+    )?))
 }
 
 /// Convert FixedSizeList<u8> array to FixedSizeBinary array (zero-copy)
 fn convert_list_to_fixed_size_binary(
     array: &FixedSizeListArray,
     byte_width: i32,
-) -> ArrowArrayRef {
+) -> Result<ArrowArrayRef, ArrowError> {
+    if byte_width <= 0 {
+        return Err(arrow_conversion_error(format!(
+            "FixedSizeBinary byte width must be positive, got {byte_width}"
+        )));
+    }
+    if array.value_length() != byte_width {
+        return Err(arrow_conversion_error(format!(
+            "FixedSizeList<u8> value width {} does not match target FixedSizeBinary width {}",
+            array.value_length(),
+            byte_width
+        )));
+    }
+
     let values = array.values();
 
     // Get the u8 child array
     let u8_array = values
         .as_any()
         .downcast_ref::<UInt8Array>()
-        .expect("Expected UInt8 child array");
+        .ok_or_else(|| arrow_conversion_error("Expected UInt8 child array"))?;
 
     // Get the underlying buffer directly (zero-copy via Arc)
     let u8_data = u8_array.to_data();
-    let values_buffer = u8_data.buffers()[0].clone();
+    let values_buffer =
+        u8_data.buffers().first().cloned().ok_or_else(|| {
+            arrow_conversion_error("UInt8 child array is missing its values buffer")
+        })?;
     let byte_width_usize = byte_width as usize;
-    assert_eq!(
-        u8_data.offset() % byte_width_usize,
-        0,
-        "FixedSizeList<u8> child offset must align to FixedSizeBinary width"
-    );
+    if u8_data.offset() % byte_width_usize != 0 {
+        return Err(arrow_conversion_error(format!(
+            "FixedSizeList<u8> child offset {} must align to FixedSizeBinary width {}",
+            u8_data.offset(),
+            byte_width
+        )));
+    }
     let values_offset = array.offset() + u8_data.offset() / byte_width_usize;
 
     // Build FixedSizeBinaryArray from the buffer directly (zero-copy)
@@ -430,9 +606,8 @@ fn convert_list_to_fixed_size_binary(
         .offset(values_offset)
         .add_buffer(values_buffer)
         .nulls(array.nulls().cloned())
-        .build()
-        .expect("Failed to build FixedSizeBinary ArrayData");
-    Arc::new(FixedSizeBinaryArray::from(fsb_data))
+        .build()?;
+    Ok(Arc::new(FixedSizeBinaryArray::from(fsb_data)))
 }
 
 fn rebuild_array_with_children(
@@ -440,104 +615,105 @@ fn rebuild_array_with_children(
     data_type: DataType,
     child_data: Vec<ArrayData>,
     context: &str,
-) -> ArrowArrayRef {
+) -> Result<ArrowArrayRef, ArrowError> {
     let data = array.to_data();
     let converted_data = data
         .into_builder()
         .data_type(data_type)
         .child_data(child_data)
         .build()
-        .expect(context);
-    make_array(converted_data)
+        .map_err(|e| arrow_conversion_error(format!("{context}: {e}")))?;
+    Ok(make_array(converted_data))
 }
 
-fn to_vortex_arrow_array(array: &ArrowArrayRef) -> Option<ArrowArrayRef> {
-    match array.data_type() {
-        DataType::FixedSizeBinary(_) => {
+fn apply_vortex_array_conversion(
+    array: &ArrowArrayRef,
+    conversion: &VortexArrayConversion,
+) -> Result<ArrowArrayRef, ArrowError> {
+    match conversion {
+        VortexArrayConversion::FixedSizeBinary { .. } => {
             let fsb_array = array
                 .as_any()
                 .downcast_ref::<FixedSizeBinaryArray>()
-                .expect("Expected FixedSizeBinaryArray");
-            Some(convert_fixed_size_binary_to_list(fsb_array))
+                .ok_or_else(|| arrow_conversion_error("Expected FixedSizeBinaryArray"))?;
+            convert_fixed_size_binary_to_list(fsb_array)
         }
-        DataType::List(_)
-        | DataType::LargeList(_)
-        | DataType::ListView(_)
-        | DataType::LargeListView(_)
-        | DataType::FixedSizeList(_, _) => {
+        VortexArrayConversion::List {
+            converted_type,
+            child,
+        } => {
             let data = array.to_data();
             let child_data = data.child_data();
-            assert_eq!(child_data.len(), 1, "Expected one child array");
+            if child_data.len() != 1 {
+                return Err(arrow_conversion_error(format!(
+                    "Expected one child array for {}, got {}",
+                    array.data_type(),
+                    child_data.len()
+                )));
+            }
             let child_array = make_array(child_data[0].clone());
-            let converted_child = to_vortex_arrow_array(&child_array)?;
-            let converted_type = to_vortex_data_type(array.data_type())
-                .expect("Expected converted Arrow data type for Vortex");
-            Some(rebuild_array_with_children(
+            let converted_child = apply_vortex_array_conversion(&child_array, child)?;
+            rebuild_array_with_children(
                 array,
-                converted_type,
+                converted_type.clone(),
                 vec![converted_child.to_data()],
                 "Failed to build Arrow nested array converted for Vortex",
-            ))
+            )
         }
-        DataType::Struct(_) => {
-            let mut changed = false;
-            let converted_children: Vec<_> = array
-                .to_data()
-                .child_data()
-                .iter()
-                .map(|child| {
-                    let child_array = make_array(child.clone());
-                    match to_vortex_arrow_array(&child_array) {
-                        Some(converted_child) => {
-                            changed = true;
-                            converted_child.to_data()
-                        }
-                        None => child.clone(),
-                    }
-                })
-                .collect();
-            if changed {
-                let converted_type = to_vortex_data_type(array.data_type())
-                    .expect("Expected converted Arrow struct type for Vortex");
-                Some(rebuild_array_with_children(
-                    array,
-                    converted_type,
-                    converted_children,
-                    "Failed to build Arrow struct array converted for Vortex",
-                ))
-            } else {
-                None
-            }
-        }
-        DataType::Dictionary(_, _) => {
+        VortexArrayConversion::Struct {
+            converted_type,
+            children,
+        } => {
             let data = array.to_data();
             let child_data = data.child_data();
-            if child_data.is_empty() {
-                return None;
+            if child_data.len() != children.len() {
+                return Err(arrow_conversion_error(format!(
+                    "Struct child count mismatch for {}: array has {}, conversion expects {}",
+                    array.data_type(),
+                    child_data.len(),
+                    children.len()
+                )));
             }
-            let child_array = make_array(child_data[0].clone());
-            let converted_child = to_vortex_arrow_array(&child_array)?;
-            let converted_type = to_vortex_data_type(array.data_type())
-                .expect("Expected converted Arrow dictionary type for Vortex");
-            Some(rebuild_array_with_children(
+
+            let mut converted_children = Vec::with_capacity(child_data.len());
+            for (child, child_conversion) in child_data.iter().zip(children.iter()) {
+                match child_conversion {
+                    Some(child_conversion) => {
+                        let child_array = make_array(child.clone());
+                        converted_children.push(
+                            apply_vortex_array_conversion(&child_array, child_conversion)?
+                                .to_data(),
+                        );
+                    }
+                    None => {
+                        converted_children.push(child.clone());
+                    }
+                }
+            }
+            rebuild_array_with_children(
                 array,
-                converted_type,
-                vec![converted_child.to_data()],
-                "Failed to build Arrow dictionary array converted for Vortex",
-            ))
+                converted_type.clone(),
+                converted_children,
+                "Failed to build Arrow struct array converted for Vortex",
+            )
         }
-        _ => None,
     }
 }
 
-fn to_arrow_array(array: &ArrowArrayRef, target_type: &DataType) -> Option<ArrowArrayRef> {
+fn to_arrow_array(
+    array: &ArrowArrayRef,
+    target_type: &DataType,
+) -> Result<Option<ArrowArrayRef>, ArrowError> {
     match target_type {
         DataType::FixedSizeBinary(byte_width) => {
             let fsl_array = array
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
-                .expect("Expected FixedSizeListArray");
-            Some(convert_list_to_fixed_size_binary(fsl_array, *byte_width))
+                .ok_or_else(|| arrow_conversion_error("Expected FixedSizeListArray"))?;
+            Ok(Some(convert_list_to_fixed_size_binary(
+                fsl_array,
+                *byte_width,
+            )?))
         }
         DataType::List(field)
         | DataType::LargeList(field)
@@ -546,61 +722,81 @@ fn to_arrow_array(array: &ArrowArrayRef, target_type: &DataType) -> Option<Arrow
         | DataType::FixedSizeList(field, _) => {
             let data = array.to_data();
             let child_data = data.child_data();
-            assert_eq!(child_data.len(), 1, "Expected one child array");
+            if child_data.len() != 1 {
+                return Err(arrow_conversion_error(format!(
+                    "Expected one child array for {}, got {}",
+                    target_type,
+                    child_data.len()
+                )));
+            }
             let child_array = make_array(child_data[0].clone());
-            let converted_child = to_arrow_array(&child_array, field.data_type())?;
-            Some(rebuild_array_with_children(
+            let Some(converted_child) = to_arrow_array(&child_array, field.data_type())? else {
+                return Ok(None);
+            };
+            Ok(Some(rebuild_array_with_children(
                 array,
                 target_type.clone(),
                 vec![converted_child.to_data()],
                 "Failed to build Arrow nested array converted from Vortex",
-            ))
+            )?))
         }
         DataType::Struct(fields) => {
             let mut changed = false;
-            let converted_children: Vec<_> = array
-                .to_data()
-                .child_data()
-                .iter()
-                .zip(fields.iter())
-                .map(|(child, field)| {
-                    let child_array = make_array(child.clone());
-                    match to_arrow_array(&child_array, field.data_type()) {
-                        Some(converted_child) => {
-                            changed = true;
-                            converted_child.to_data()
-                        }
-                        None => child.clone(),
+            let data = array.to_data();
+            let child_data = data.child_data();
+            if child_data.len() != fields.len() {
+                return Err(arrow_conversion_error(format!(
+                    "Struct child count mismatch for read-back conversion: array has {}, target schema expects {} ({})",
+                    child_data.len(),
+                    fields.len(),
+                    target_type
+                )));
+            }
+
+            let mut converted_children = Vec::with_capacity(child_data.len());
+            for (child, field) in child_data.iter().zip(fields.iter()) {
+                let child_array = make_array(child.clone());
+                match to_arrow_array(&child_array, field.data_type())? {
+                    Some(converted_child) => {
+                        changed = true;
+                        converted_children.push(converted_child.to_data());
                     }
-                })
-                .collect();
+                    None => converted_children.push(child.clone()),
+                }
+            }
             if changed {
-                Some(rebuild_array_with_children(
+                Ok(Some(rebuild_array_with_children(
                     array,
                     target_type.clone(),
                     converted_children,
                     "Failed to build Arrow struct array converted from Vortex",
-                ))
+                )?))
             } else {
-                None
+                Ok(None)
             }
         }
         DataType::Dictionary(_, value_type) => {
             let data = array.to_data();
             let child_data = data.child_data();
-            if child_data.is_empty() {
-                return None;
+            if child_data.len() != 1 {
+                return Err(arrow_conversion_error(format!(
+                    "Dictionary read-back conversion expects one values child for {}, got {}",
+                    target_type,
+                    child_data.len()
+                )));
             }
             let child_array = make_array(child_data[0].clone());
-            let converted_child = to_arrow_array(&child_array, value_type)?;
-            Some(rebuild_array_with_children(
+            let Some(converted_child) = to_arrow_array(&child_array, value_type)? else {
+                return Ok(None);
+            };
+            Ok(Some(rebuild_array_with_children(
                 array,
                 target_type.clone(),
                 vec![converted_child.to_data()],
                 "Failed to build Arrow dictionary array converted from Vortex",
-            ))
+            )?))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -609,40 +805,52 @@ fn to_arrow_array(array: &ArrowArrayRef, target_type: &DataType) -> Option<Arrow
 fn convert_record_batch_from_vortex(
     batch: &RecordBatch,
     original_schema: &Schema,
-) -> Option<RecordBatch> {
+) -> Result<Option<RecordBatch>, ArrowError> {
+    if batch.num_columns() != original_schema.fields().len() {
+        return Err(arrow_conversion_error(format!(
+            "RecordBatch column count mismatch for read-back conversion: batch has {}, original schema expects {}",
+            batch.num_columns(),
+            original_schema.fields().len()
+        )));
+    }
+
     let mut changed = false;
-    let new_columns: Vec<ArrowArrayRef> = batch
-        .columns()
-        .iter()
-        .zip(original_schema.fields().iter())
-        .map(|(col, orig_field)| match to_arrow_array(col, orig_field.data_type()) {
+    let mut new_columns = Vec::with_capacity(batch.num_columns());
+    for (col, orig_field) in batch.columns().iter().zip(original_schema.fields().iter()) {
+        match to_arrow_array(col, orig_field.data_type())? {
             Some(converted_col) => {
                 changed = true;
-                converted_col
+                new_columns.push(converted_col);
             }
-            None => col.clone(),
-        })
-        .collect();
+            None => new_columns.push(col.clone()),
+        }
+    }
 
     if changed {
-        Some(
-            RecordBatch::try_new(Arc::new(original_schema.clone()), new_columns)
-                .expect("Failed to create converted RecordBatch"),
-        )
+        Ok(Some(RecordBatch::try_new(
+            Arc::new(original_schema.clone()),
+            new_columns,
+        )?))
     } else {
-        None
+        Ok(None)
     }
 }
 
 /// Convert StructArray: replace FixedSizeBinary columns with FixedSizeList<u8>
 fn convert_struct_array_for_vortex(
-    struct_array: &arrow_array::StructArray,
-) -> arrow_array::StructArray {
+    struct_array: &StructArray,
+    conversion: &VortexSchemaConversion,
+) -> Result<StructArray, ArrowError> {
     let array = Arc::new(struct_array.clone()) as ArrowArrayRef;
-    match to_vortex_arrow_array(&array) {
-        Some(converted) => converted.as_struct().clone(),
-        None => struct_array.clone(),
-    }
+    let root_conversion = VortexArrayConversion::Struct {
+        converted_type: DataType::Struct(conversion.schema.fields().clone()),
+        children: conversion.fields.clone(),
+    };
+    Ok(apply_vortex_array_conversion(&array, &root_conversion)?
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| arrow_conversion_error("Expected converted StructArray"))?
+        .clone())
 }
 
 /*
@@ -704,13 +912,11 @@ impl VortexWriter {
                 .map_err(|e| VortexError::from(e))?,
         );
 
-        let (converted_schema, converted_array) = if let Some(converted_schema) =
-            convert_schema_for_vortex(&arrow_schema)
+        let (converted_schema, converted_array) = if let Some(conversion) =
+            convert_schema_for_vortex(&arrow_schema)?
         {
-            (
-                converted_schema,
-                convert_struct_array_for_vortex(&arrow_array_data),
-            )
+            let converted_array = convert_struct_array_for_vortex(&arrow_array_data, &conversion)?;
+            (conversion.schema, converted_array)
         } else {
             (arrow_schema, arrow_array_data)
         };
@@ -803,6 +1009,7 @@ impl VortexFile {
             inner: self.inner.scan()?.with_split_row_indices(false),
             output_schema: None,
             original_schema: None,
+            needs_conversion: false,
             row_range: None,
         }))
     }
@@ -814,14 +1021,17 @@ impl VortexFile {
         let ffi_schema = unsafe { FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema) };
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
-        let converted_schema = convert_schema_for_vortex(original_schema.as_ref())
-            .map(Arc::new)
+        let schema_conversion = convert_schema_for_vortex(original_schema.as_ref())?;
+        let needs_conversion = schema_conversion.is_some();
+        let converted_schema = schema_conversion
+            .map(|conversion| Arc::new(conversion.schema))
             .unwrap_or_else(|| original_schema.clone());
 
         Ok(Box::new(VortexScanBuilder {
             inner: self.inner.scan()?.with_split_row_indices(false),
             output_schema: Some(converted_schema),
             original_schema: Some(original_schema),
+            needs_conversion,
             row_range: None,
         }))
     }
@@ -969,6 +1179,7 @@ pub(crate) struct VortexScanBuilder {
     inner: ScanBuilder<ArrayRef>,
     output_schema: Option<SchemaRef>, // Converted schema for Vortex (FixedSizeList<u8>)
     original_schema: Option<SchemaRef>, // Original schema from user (may contain FixedSizeBinary)
+    needs_conversion: bool,
     row_range: Option<Range<u64>>,
 }
 
@@ -1022,12 +1233,15 @@ impl VortexScanBuilder {
             unsafe { FFI_ArrowSchema::from_raw(output_schema as *mut FFI_ArrowSchema) };
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
-        let converted_schema = convert_schema_for_vortex(original_schema.as_ref())
-            .map(Arc::new)
+        let schema_conversion = convert_schema_for_vortex(original_schema.as_ref())?;
+        let needs_conversion = schema_conversion.is_some();
+        let converted_schema = schema_conversion
+            .map(|conversion| Arc::new(conversion.schema))
             .unwrap_or_else(|| original_schema.clone());
 
         self.output_schema = Some(converted_schema);
         self.original_schema = Some(original_schema);
+        self.needs_conversion = needs_conversion;
         Ok(())
     }
 }
@@ -1077,9 +1291,11 @@ impl std::iter::Iterator for ConvertingRecordBatchReader {
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.next() {
             Some(Ok(batch)) => {
-                let converted =
-                    convert_record_batch_from_vortex(&batch, &self.original_schema).unwrap_or(batch);
-                Some(Ok(converted))
+                match convert_record_batch_from_vortex(&batch, &self.original_schema) {
+                    Ok(Some(converted)) => Some(Ok(converted)),
+                    Ok(None) => Some(Ok(batch)),
+                    Err(e) => Some(Err(e)),
+                }
             }
             Some(Err(e)) => Some(Err(e)),
             None => None,
@@ -1104,23 +1320,24 @@ pub(crate) unsafe fn scan_builder_into_stream(
         inner,
         output_schema,
         original_schema,
+        needs_conversion,
         row_range,
     } = *builder;
 
-    let (vortex_schema, original_schema) = match (output_schema, original_schema) {
-        (Some(vs), Some(os)) => (vs, os),
-        (Some(vs), None) => (vs.clone(), vs),
-        (None, _) => {
-            let dtype = inner.dtype()?;
-            let arrow_schema = Arc::new(dtype.to_arrow_schema()?);
-            (arrow_schema.clone(), arrow_schema)
-        }
-    };
+    let (vortex_schema, original_schema, needs_conversion) =
+        match (output_schema, original_schema) {
+            (Some(vs), Some(os)) => (vs, os, needs_conversion),
+            (Some(vs), None) => (vs.clone(), vs, false),
+            (None, _) => {
+                let dtype = inner.dtype()?;
+                let arrow_schema = Arc::new(dtype.to_arrow_schema()?);
+                (arrow_schema.clone(), arrow_schema, false)
+            }
+        };
 
     let scan = inner.prepare()?;
     let iter = scan.execute_array_iter(row_range, &*VORTEX_RT)?;
     let data_type = DataType::Struct(vortex_schema.fields().clone());
-    let needs_conversion = vortex_schema.as_ref() != original_schema.as_ref();
     let reader = VortexRecordBatchReader {
         iter,
         schema: vortex_schema,

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -584,6 +584,16 @@ fn convert_list_to_fixed_size_binary(
         .downcast_ref::<UInt8Array>()
         .ok_or_else(|| arrow_conversion_error("Expected UInt8 child array"))?;
 
+    // Milvus only creates this FixedSizeList<u8> as a bridge representation for
+    // FixedSizeBinary, whose nullability is row-level. Byte-level child nulls
+    // cannot be represented when converting back to FixedSizeBinary.
+    if u8_array.nulls().is_some() {
+        return Err(arrow_conversion_error(format!(
+            "FixedSizeList<u8> child UInt8 array must not contain byte-level nulls when converting to FixedSizeBinary; null_count={}",
+            u8_array.null_count()
+        )));
+    }
+
     // Get the underlying buffer directly (zero-copy via Arc)
     let u8_data = u8_array.to_data();
     let values_buffer =
@@ -700,26 +710,25 @@ fn apply_vortex_array_conversion(
     }
 }
 
-fn to_arrow_array(
+fn apply_arrow_array_conversion(
     array: &ArrowArrayRef,
     target_type: &DataType,
-) -> Result<Option<ArrowArrayRef>, ArrowError> {
-    match target_type {
-        DataType::FixedSizeBinary(byte_width) => {
+    conversion: &VortexArrayConversion,
+) -> Result<ArrowArrayRef, ArrowError> {
+    match conversion {
+        VortexArrayConversion::FixedSizeBinary { .. } => {
+            let DataType::FixedSizeBinary(byte_width) = target_type else {
+                return Err(arrow_conversion_error(format!(
+                    "Expected FixedSizeBinary target type for read-back conversion, got {target_type}"
+                )));
+            };
             let fsl_array = array
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
                 .ok_or_else(|| arrow_conversion_error("Expected FixedSizeListArray"))?;
-            Ok(Some(convert_list_to_fixed_size_binary(
-                fsl_array,
-                *byte_width,
-            )?))
+            convert_list_to_fixed_size_binary(fsl_array, *byte_width)
         }
-        DataType::List(field)
-        | DataType::LargeList(field)
-        | DataType::ListView(field)
-        | DataType::LargeListView(field)
-        | DataType::FixedSizeList(field, _) => {
+        VortexArrayConversion::List { child, .. } => {
             let data = array.to_data();
             let child_data = data.child_data();
             if child_data.len() != 1 {
@@ -730,18 +739,33 @@ fn to_arrow_array(
                 )));
             }
             let child_array = make_array(child_data[0].clone());
-            let Some(converted_child) = to_arrow_array(&child_array, field.data_type())? else {
-                return Ok(None);
+            let target_child_type = match target_type {
+                DataType::List(field)
+                | DataType::LargeList(field)
+                | DataType::ListView(field)
+                | DataType::LargeListView(field)
+                | DataType::FixedSizeList(field, _) => field.data_type(),
+                _ => {
+                    return Err(arrow_conversion_error(format!(
+                        "Expected list target type for read-back conversion, got {target_type}"
+                    )));
+                }
             };
-            Ok(Some(rebuild_array_with_children(
+            let converted_child =
+                apply_arrow_array_conversion(&child_array, target_child_type, child)?;
+            rebuild_array_with_children(
                 array,
                 target_type.clone(),
                 vec![converted_child.to_data()],
                 "Failed to build Arrow nested array converted from Vortex",
-            )?))
+            )
         }
-        DataType::Struct(fields) => {
-            let mut changed = false;
+        VortexArrayConversion::Struct { children, .. } => {
+            let DataType::Struct(fields) = target_type else {
+                return Err(arrow_conversion_error(format!(
+                    "Expected struct target type for read-back conversion, got {target_type}"
+                )));
+            };
             let data = array.to_data();
             let child_data = data.child_data();
             if child_data.len() != fields.len() {
@@ -752,51 +776,40 @@ fn to_arrow_array(
                     target_type
                 )));
             }
+            if child_data.len() != children.len() {
+                return Err(arrow_conversion_error(format!(
+                    "Struct child count mismatch for read-back conversion plan: array has {}, conversion expects {}",
+                    child_data.len(),
+                    children.len()
+                )));
+            }
 
             let mut converted_children = Vec::with_capacity(child_data.len());
-            for (child, field) in child_data.iter().zip(fields.iter()) {
-                let child_array = make_array(child.clone());
-                match to_arrow_array(&child_array, field.data_type())? {
-                    Some(converted_child) => {
-                        changed = true;
-                        converted_children.push(converted_child.to_data());
+            for ((child, field), child_conversion) in
+                child_data.iter().zip(fields.iter()).zip(children.iter())
+            {
+                match child_conversion {
+                    Some(child_conversion) => {
+                        let child_array = make_array(child.clone());
+                        converted_children.push(
+                            apply_arrow_array_conversion(
+                                &child_array,
+                                field.data_type(),
+                                child_conversion,
+                            )?
+                            .to_data(),
+                        );
                     }
                     None => converted_children.push(child.clone()),
                 }
             }
-            if changed {
-                Ok(Some(rebuild_array_with_children(
-                    array,
-                    target_type.clone(),
-                    converted_children,
-                    "Failed to build Arrow struct array converted from Vortex",
-                )?))
-            } else {
-                Ok(None)
-            }
-        }
-        DataType::Dictionary(_, value_type) => {
-            let data = array.to_data();
-            let child_data = data.child_data();
-            if child_data.len() != 1 {
-                return Err(arrow_conversion_error(format!(
-                    "Dictionary read-back conversion expects one values child for {}, got {}",
-                    target_type,
-                    child_data.len()
-                )));
-            }
-            let child_array = make_array(child_data[0].clone());
-            let Some(converted_child) = to_arrow_array(&child_array, value_type)? else {
-                return Ok(None);
-            };
-            Ok(Some(rebuild_array_with_children(
+            rebuild_array_with_children(
                 array,
                 target_type.clone(),
-                vec![converted_child.to_data()],
-                "Failed to build Arrow dictionary array converted from Vortex",
-            )?))
+                converted_children,
+                "Failed to build Arrow struct array converted from Vortex",
+            )
         }
-        _ => Ok(None),
     }
 }
 
@@ -805,7 +818,8 @@ fn to_arrow_array(
 fn convert_record_batch_from_vortex(
     batch: &RecordBatch,
     original_schema: &Schema,
-) -> Result<Option<RecordBatch>, ArrowError> {
+    conversion: &VortexSchemaConversion,
+) -> Result<RecordBatch, ArrowError> {
     if batch.num_columns() != original_schema.fields().len() {
         return Err(arrow_conversion_error(format!(
             "RecordBatch column count mismatch for read-back conversion: batch has {}, original schema expects {}",
@@ -813,27 +827,37 @@ fn convert_record_batch_from_vortex(
             original_schema.fields().len()
         )));
     }
+    if batch.num_columns() != conversion.fields.len() {
+        return Err(arrow_conversion_error(format!(
+            "RecordBatch column count mismatch for read-back conversion plan: batch has {}, conversion expects {}",
+            batch.num_columns(),
+            conversion.fields.len()
+        )));
+    }
 
-    let mut changed = false;
     let mut new_columns = Vec::with_capacity(batch.num_columns());
-    for (col, orig_field) in batch.columns().iter().zip(original_schema.fields().iter()) {
-        match to_arrow_array(col, orig_field.data_type())? {
-            Some(converted_col) => {
-                changed = true;
-                new_columns.push(converted_col);
+    for ((col, orig_field), field_conversion) in batch
+        .columns()
+        .iter()
+        .zip(original_schema.fields().iter())
+        .zip(conversion.fields.iter())
+    {
+        match field_conversion {
+            Some(field_conversion) => {
+                new_columns.push(apply_arrow_array_conversion(
+                    col,
+                    orig_field.data_type(),
+                    field_conversion,
+                )?);
             }
             None => new_columns.push(col.clone()),
         }
     }
 
-    if changed {
-        Ok(Some(RecordBatch::try_new(
-            Arc::new(original_schema.clone()),
-            new_columns,
-        )?))
-    } else {
-        Ok(None)
-    }
+    Ok(RecordBatch::try_new(
+        Arc::new(original_schema.clone()),
+        new_columns,
+    )?)
 }
 
 /// Convert StructArray: replace FixedSizeBinary columns with FixedSizeList<u8>
@@ -1009,7 +1033,7 @@ impl VortexFile {
             inner: self.inner.scan()?.with_split_row_indices(false),
             output_schema: None,
             original_schema: None,
-            needs_conversion: false,
+            conversion_plan: None,
             row_range: None,
         }))
     }
@@ -1022,16 +1046,16 @@ impl VortexFile {
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
         let schema_conversion = convert_schema_for_vortex(original_schema.as_ref())?;
-        let needs_conversion = schema_conversion.is_some();
         let converted_schema = schema_conversion
-            .map(|conversion| Arc::new(conversion.schema))
+            .as_ref()
+            .map(|conversion| Arc::new(conversion.schema.clone()))
             .unwrap_or_else(|| original_schema.clone());
 
         Ok(Box::new(VortexScanBuilder {
             inner: self.inner.scan()?.with_split_row_indices(false),
             output_schema: Some(converted_schema),
             original_schema: Some(original_schema),
-            needs_conversion,
+            conversion_plan: schema_conversion,
             row_range: None,
         }))
     }
@@ -1179,7 +1203,7 @@ pub(crate) struct VortexScanBuilder {
     inner: ScanBuilder<ArrayRef>,
     output_schema: Option<SchemaRef>, // Converted schema for Vortex (FixedSizeList<u8>)
     original_schema: Option<SchemaRef>, // Original schema from user (may contain FixedSizeBinary)
-    needs_conversion: bool,
+    conversion_plan: Option<VortexSchemaConversion>,
     row_range: Option<Range<u64>>,
 }
 
@@ -1234,14 +1258,14 @@ impl VortexScanBuilder {
         let original_schema = Arc::new(Schema::try_from(&ffi_schema)?);
 
         let schema_conversion = convert_schema_for_vortex(original_schema.as_ref())?;
-        let needs_conversion = schema_conversion.is_some();
         let converted_schema = schema_conversion
-            .map(|conversion| Arc::new(conversion.schema))
+            .as_ref()
+            .map(|conversion| Arc::new(conversion.schema.clone()))
             .unwrap_or_else(|| original_schema.clone());
 
         self.output_schema = Some(converted_schema);
         self.original_schema = Some(original_schema);
-        self.needs_conversion = needs_conversion;
+        self.conversion_plan = schema_conversion;
         Ok(())
     }
 }
@@ -1283,6 +1307,7 @@ where
 struct ConvertingRecordBatchReader {
     inner: Box<dyn RecordBatchReader + Send>,
     original_schema: SchemaRef,
+    plan: Option<VortexSchemaConversion>,
 }
 
 impl std::iter::Iterator for ConvertingRecordBatchReader {
@@ -1290,13 +1315,14 @@ impl std::iter::Iterator for ConvertingRecordBatchReader {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.next() {
-            Some(Ok(batch)) => {
-                match convert_record_batch_from_vortex(&batch, &self.original_schema) {
-                    Ok(Some(converted)) => Some(Ok(converted)),
-                    Ok(None) => Some(Ok(batch)),
-                    Err(e) => Some(Err(e)),
-                }
-            }
+            Some(Ok(batch)) => match self.plan.as_ref() {
+                Some(plan) => Some(convert_record_batch_from_vortex(
+                    &batch,
+                    &self.original_schema,
+                    plan,
+                )),
+                None => Some(Ok(batch)),
+            },
             Some(Err(e)) => Some(Err(e)),
             None => None,
         }
@@ -1320,18 +1346,18 @@ pub(crate) unsafe fn scan_builder_into_stream(
         inner,
         output_schema,
         original_schema,
-        needs_conversion,
+        conversion_plan,
         row_range,
     } = *builder;
 
-    let (vortex_schema, original_schema, needs_conversion) =
-        match (output_schema, original_schema) {
-            (Some(vs), Some(os)) => (vs, os, needs_conversion),
-            (Some(vs), None) => (vs.clone(), vs, false),
-            (None, _) => {
+    let (vortex_schema, original_schema, plan) =
+        match (output_schema, original_schema, conversion_plan) {
+            (Some(vs), Some(os), plan) => (vs, os, plan),
+            (Some(vs), None, _) => (vs.clone(), vs, None),
+            (None, _, _) => {
                 let dtype = inner.dtype()?;
                 let arrow_schema = Arc::new(dtype.to_arrow_schema()?);
-                (arrow_schema.clone(), arrow_schema, false)
+                (arrow_schema.clone(), arrow_schema, None)
             }
         };
 
@@ -1344,10 +1370,11 @@ pub(crate) unsafe fn scan_builder_into_stream(
         data_type,
     };
 
-    let final_reader: Box<dyn RecordBatchReader + Send> = if needs_conversion {
+    let final_reader: Box<dyn RecordBatchReader + Send> = if plan.is_some() {
         Box::new(ConvertingRecordBatchReader {
             inner: Box::new(reader),
             original_schema,
+            plan,
         })
     } else {
         Box::new(reader)

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -18,10 +18,12 @@
 #include <cstring>
 #include <memory>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #include <arrow/api.h>
 #include <arrow/array.h>
+#include <arrow/array/array_dict.h>
 #include <arrow/array/concatenate.h>
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/record_batch.h>
@@ -112,6 +114,173 @@ INSTANTIATE_TEST_SUITE_P(V1V2,
                            return "V" + std::to_string(info.param);
                          });
 
+namespace {
+
+constexpr int kDictionaryValueGroup = 3;
+
+std::string MakeFixedSizeBinaryValue(int64_t row, int64_t group, int64_t index, int byte_width) {
+  std::string value(byte_width, '\0');
+  for (int byte_index = 0; byte_index < byte_width; ++byte_index) {
+    value[byte_index] = static_cast<char>((row * 31 + group * 17 + index * 7 + byte_index) & 0xff);
+  }
+  return value;
+}
+
+arrow::Status AppendFixedSizeBinaryValue(
+    arrow::FixedSizeBinaryBuilder* builder, int64_t row, int64_t group, int64_t index, int byte_width) {
+  return builder->Append(MakeFixedSizeBinaryValue(row, group, index, byte_width));
+}
+
+void AssertFixedSizeBinaryValue(const std::shared_ptr<arrow::FixedSizeBinaryArray>& array,
+                                int64_t index,
+                                const std::string& expected) {
+  ASSERT_NE(array, nullptr);
+  ASSERT_FALSE(array->IsNull(index));
+  ASSERT_EQ(static_cast<int32_t>(expected.size()), array->byte_width());
+  ASSERT_EQ(0, std::memcmp(array->GetValue(index), expected.data(), expected.size()));
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeListOfFixedSizeBinaryArray(int64_t num_rows,
+                                                                            int vectors_per_row,
+                                                                            int vector_width) {
+  auto value_builder = std::make_shared<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_width));
+  arrow::ListBuilder list_builder(arrow::default_memory_pool(), value_builder);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(list_builder.Append());
+    for (int vector_index = 0; vector_index < vectors_per_row; ++vector_index) {
+      ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(value_builder.get(), row, 0, vector_index, vector_width));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(list_builder.Finish(&array));
+  return array;
+}
+
+void AssertListOfFixedSizeBinaryArray(const std::shared_ptr<arrow::ListArray>& list_array,
+                                      int64_t source_row_offset,
+                                      int64_t num_rows,
+                                      int vectors_per_row,
+                                      int vector_width) {
+  ASSERT_NE(list_array, nullptr);
+  ASSERT_EQ(num_rows, list_array->length());
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ASSERT_FALSE(list_array->IsNull(row));
+    auto values = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(list_array->value_slice(row));
+    ASSERT_NE(values, nullptr);
+    ASSERT_EQ(vectors_per_row, values->length());
+    for (int vector_index = 0; vector_index < vectors_per_row; ++vector_index) {
+      AssertFixedSizeBinaryValue(values, vector_index,
+                                 MakeFixedSizeBinaryValue(source_row_offset + row, 0, vector_index, vector_width));
+    }
+  }
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeStructOfFixedSizeBinaryArray(int64_t num_rows, int vector_width) {
+  arrow::FixedSizeBinaryBuilder fsb_builder(arrow::fixed_size_binary(vector_width));
+  arrow::Int32Builder int_builder;
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(&fsb_builder, row, 1, 0, vector_width));
+    ARROW_RETURN_NOT_OK(int_builder.Append(static_cast<int32_t>(row * 13)));
+  }
+
+  std::shared_ptr<arrow::Array> fsb_array;
+  std::shared_ptr<arrow::Array> int_array;
+  ARROW_RETURN_NOT_OK(fsb_builder.Finish(&fsb_array));
+  ARROW_RETURN_NOT_OK(int_builder.Finish(&int_array));
+
+  return arrow::StructArray::Make({fsb_array, int_array},
+                                  {arrow::field("fsb", arrow::fixed_size_binary(vector_width), false),
+                                   arrow::field("other", arrow::int32(), false)});
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeNullableFixedSizeBinaryArray(int64_t num_rows, int vector_width) {
+  arrow::FixedSizeBinaryBuilder fsb_builder(arrow::fixed_size_binary(vector_width));
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    if (row == 1 || row == 4) {
+      ARROW_RETURN_NOT_OK(fsb_builder.AppendNull());
+    } else {
+      ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(&fsb_builder, row, 2, 0, vector_width));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(fsb_builder.Finish(&array));
+  return array;
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeNestedListOfFixedSizeBinaryArray(int64_t num_rows,
+                                                                                  int groups_per_row,
+                                                                                  int vectors_per_group,
+                                                                                  int vector_width) {
+  auto value_builder = std::make_shared<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_width));
+  auto inner_list_builder = std::make_shared<arrow::ListBuilder>(arrow::default_memory_pool(), value_builder);
+  arrow::ListBuilder outer_list_builder(arrow::default_memory_pool(), inner_list_builder);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(outer_list_builder.Append());
+    for (int group = 0; group < groups_per_row; ++group) {
+      ARROW_RETURN_NOT_OK(inner_list_builder->Append());
+      for (int vector_index = 0; vector_index < vectors_per_group; ++vector_index) {
+        ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(value_builder.get(), row, group, vector_index, vector_width));
+      }
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(outer_list_builder.Finish(&array));
+  return array;
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeDictionaryOfFixedSizeBinaryArray(const std::vector<int32_t>& indices,
+                                                                                  int dictionary_size,
+                                                                                  int vector_width) {
+  arrow::FixedSizeBinaryBuilder dictionary_builder(arrow::fixed_size_binary(vector_width));
+  for (int dict_index = 0; dict_index < dictionary_size; ++dict_index) {
+    ARROW_RETURN_NOT_OK(
+        AppendFixedSizeBinaryValue(&dictionary_builder, dict_index, kDictionaryValueGroup, 0, vector_width));
+  }
+
+  arrow::Int32Builder indices_builder;
+  for (auto index : indices) {
+    if (index < 0) {
+      ARROW_RETURN_NOT_OK(indices_builder.AppendNull());
+    } else {
+      ARROW_RETURN_NOT_OK(indices_builder.Append(index));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> dictionary_values;
+  std::shared_ptr<arrow::Array> index_array;
+  ARROW_RETURN_NOT_OK(dictionary_builder.Finish(&dictionary_values));
+  ARROW_RETURN_NOT_OK(indices_builder.Finish(&index_array));
+
+  return arrow::DictionaryArray::FromArrays(arrow::dictionary(arrow::int32(), arrow::fixed_size_binary(vector_width)),
+                                            index_array, dictionary_values);
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeFixedSizeListUInt8Array(int64_t num_rows, int value_width) {
+  auto value_builder = std::make_shared<arrow::UInt8Builder>();
+  arrow::FixedSizeListBuilder list_builder(arrow::default_memory_pool(), value_builder, value_width);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(list_builder.Append());
+    for (int byte_index = 0; byte_index < value_width; ++byte_index) {
+      ARROW_RETURN_NOT_OK(value_builder->Append(static_cast<uint8_t>((row * 17 + byte_index) & 0xff)));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(list_builder.Finish(&array));
+  return array;
+}
+
+}  // namespace
+
 TEST_P(VortexBasicTest, TestBasicWrite) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
@@ -183,6 +352,181 @@ TEST_P(VortexBasicTest, TestListOfFixedSizeBinary512WriteRead) {
       ASSERT_EQ(0, std::memcmp(read_values->GetValue(value_index), expected.data(), vector_width));
     }
   }
+}
+
+TEST_P(VortexBasicTest, TestSlicedListOfFixedSizeBinaryWriteRead) {
+  const int64_t total_rows = 7;
+  const int64_t slice_offset = 2;
+  const int64_t slice_length = 4;
+  const int vectors_per_row = 3;
+  const int vector_width = 32;
+
+  ASSERT_AND_ASSIGN(auto full_vector_array, MakeListOfFixedSizeBinaryArray(total_rows, vectors_per_row, vector_width));
+  auto sliced_vector_array = full_vector_array->Slice(slice_offset, slice_length);
+  ASSERT_GT(sliced_vector_array->offset(), 0);
+
+  auto vector_array_schema = arrow::schema({arrow::field("vector_array", sliced_vector_array->type(), false,
+                                                         arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(vector_array_schema, slice_length, {sliced_vector_array});
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, vector_array_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(slice_length, cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, vector_array_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"vector_array"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  {
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, slice_length));
+    ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(slice_length, read_rb->num_rows());
+    auto read_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(0));
+    AssertListOfFixedSizeBinaryArray(read_list, slice_offset, slice_length, vectors_per_row, vector_width);
+  }
+
+  {
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(1, slice_length));
+    ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(slice_length - 1, read_rb->num_rows());
+    auto read_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(0));
+    AssertListOfFixedSizeBinaryArray(read_list, slice_offset + 1, slice_length - 1, vectors_per_row, vector_width);
+  }
+}
+
+TEST_P(VortexBasicTest, TestNestedFixedSizeBinaryWriteRead) {
+  const int64_t num_rows = 6;
+  const int vector_width = 16;
+  const int groups_per_row = 2;
+  const int vectors_per_group = 2;
+
+  ASSERT_AND_ASSIGN(auto struct_array, MakeStructOfFixedSizeBinaryArray(num_rows, vector_width));
+  ASSERT_AND_ASSIGN(auto nullable_array, MakeNullableFixedSizeBinaryArray(num_rows, vector_width));
+  ASSERT_AND_ASSIGN(auto nested_list_array,
+                    MakeNestedListOfFixedSizeBinaryArray(num_rows, groups_per_row, vectors_per_group, vector_width));
+
+  auto nested_schema = arrow::schema({
+      arrow::field("entity", struct_array->type(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("nullable_embedding", nullable_array->type(), true,
+                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"})),
+      arrow::field("nested_vectors", nested_list_array->type(), false,
+                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"102"})),
+  });
+
+  auto rb = arrow::RecordBatch::Make(nested_schema, num_rows, {struct_array, nullable_array, nested_list_array});
+  auto vx_writer = vortex::VortexFileWriter(file_system_, nested_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(num_rows, cgfile.end_index);
+
+  auto vx_reader =
+      vortex::VortexFormatReader(file_system_, nested_schema, test_file_name_, properties_,
+                                 std::vector<std::string>{"entity", "nullable_embedding", "nested_vectors"});
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(num_rows, read_rb->num_rows());
+  ASSERT_EQ(3, read_rb->num_columns());
+
+  auto read_struct = std::dynamic_pointer_cast<arrow::StructArray>(read_rb->column(0));
+  ASSERT_NE(read_struct, nullptr);
+  auto read_struct_fsb = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_struct->field(0));
+  ASSERT_NE(read_struct_fsb, nullptr);
+  auto read_struct_other = std::dynamic_pointer_cast<arrow::Int32Array>(read_struct->field(1));
+  ASSERT_NE(read_struct_other, nullptr);
+  for (int64_t row = 0; row < num_rows; ++row) {
+    AssertFixedSizeBinaryValue(read_struct_fsb, row, MakeFixedSizeBinaryValue(row, 1, 0, vector_width));
+    ASSERT_EQ(static_cast<int32_t>(row * 13), read_struct_other->Value(row));
+  }
+
+  auto read_nullable = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_rb->column(1));
+  ASSERT_NE(read_nullable, nullptr);
+  ASSERT_EQ(2, read_nullable->null_count());
+  for (int64_t row = 0; row < num_rows; ++row) {
+    if (row == 1 || row == 4) {
+      ASSERT_TRUE(read_nullable->IsNull(row));
+    } else {
+      AssertFixedSizeBinaryValue(read_nullable, row, MakeFixedSizeBinaryValue(row, 2, 0, vector_width));
+    }
+  }
+
+  auto read_outer_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(2));
+  ASSERT_NE(read_outer_list, nullptr);
+  ASSERT_EQ(num_rows, read_outer_list->length());
+  for (int64_t row = 0; row < num_rows; ++row) {
+    auto read_inner_list = std::dynamic_pointer_cast<arrow::ListArray>(read_outer_list->value_slice(row));
+    ASSERT_NE(read_inner_list, nullptr);
+    ASSERT_EQ(groups_per_row, read_inner_list->length());
+    for (int group = 0; group < groups_per_row; ++group) {
+      auto read_vectors = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_inner_list->value_slice(group));
+      ASSERT_NE(read_vectors, nullptr);
+      ASSERT_EQ(vectors_per_group, read_vectors->length());
+      for (int vector_index = 0; vector_index < vectors_per_group; ++vector_index) {
+        AssertFixedSizeBinaryValue(read_vectors, vector_index,
+                                   MakeFixedSizeBinaryValue(row, group, vector_index, vector_width));
+      }
+    }
+  }
+}
+
+TEST_P(VortexBasicTest, TestDictionaryOfFixedSizeBinaryWriteFails) {
+  const std::vector<int32_t> indices = {0, 2, 1, -1, 2, 0, 1};
+  const int64_t num_rows = static_cast<int64_t>(indices.size());
+  const int dictionary_size = 3;
+  const int vector_width = 24;
+
+  ASSERT_AND_ASSIGN(auto dictionary_array,
+                    MakeDictionaryOfFixedSizeBinaryArray(indices, dictionary_size, vector_width));
+
+  auto dictionary_schema = arrow::schema({arrow::field("dictionary_embedding", dictionary_array->type(), true,
+                                                       arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(dictionary_schema, num_rows, {dictionary_array});
+  auto vx_writer = vortex::VortexFileWriter(file_system_, dictionary_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+
+  try {
+    auto status = vx_writer.Flush();
+    FAIL() << "Expected Dictionary<FixedSizeBinary> to be rejected, got status: " << status.ToString();
+  } catch (const vortex::VortexException& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("Dictionary"), std::string::npos) << message;
+    EXPECT_NE(message.find("FixedSizeBinary"), std::string::npos) << message;
+    EXPECT_NE(message.find("not supported"), std::string::npos) << message;
+  }
+}
+
+TEST_P(VortexBasicTest, TestFixedSizeListWidthMismatchReadFails) {
+  const int64_t num_rows = 4;
+  const int written_width = 4;
+  const int read_width = 3;
+
+  ASSERT_AND_ASSIGN(auto vector_array, MakeFixedSizeListUInt8Array(num_rows, written_width));
+
+  auto write_schema = arrow::schema({arrow::field("embedding", vector_array->type(), false,
+                                                  arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(write_schema, num_rows, {vector_array});
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, write_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(num_rows, cgfile.end_index);
+
+  auto read_schema = arrow::schema({arrow::field("embedding", arrow::fixed_size_binary(read_width), false,
+                                                 arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto vx_reader = vortex::VortexFormatReader(file_system_, read_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"embedding"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  auto read_result = vx_reader.blocking_read(0, num_rows);
+  ASSERT_FALSE(read_result.ok());
+  const auto status_message = read_result.status().ToString();
+  EXPECT_NE(status_message.find("FixedSizeListArray"), std::string::npos) << status_message;
+  EXPECT_NE(status_message.find("list size 4"), std::string::npos) << status_message;
+  EXPECT_NE(status_message.find("list size 3"), std::string::npos) << status_message;
 }
 
 TEST_P(VortexBasicTest, TestBasicRead) {

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -124,6 +124,67 @@ TEST_P(VortexBasicTest, TestBasicWrite) {
   ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 }
 
+TEST_P(VortexBasicTest, TestListOfFixedSizeBinary512WriteRead) {
+  const int64_t num_rows = 8;
+  const int vectors_per_row = 2;
+  const int vector_width = 512;
+
+  auto vector_array_field =
+      arrow::field("vector_array", arrow::list(arrow::field("item", arrow::fixed_size_binary(vector_width), false)),
+                   false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}));
+  auto vector_array_schema = arrow::schema({vector_array_field});
+
+  auto value_builder = std::make_shared<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_width));
+  arrow::ListBuilder list_builder(arrow::default_memory_pool(), value_builder);
+  std::vector<std::string> expected_values;
+  expected_values.reserve(num_rows * vectors_per_row);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ASSERT_STATUS_OK(list_builder.Append());
+    for (int vector_index = 0; vector_index < vectors_per_row; ++vector_index) {
+      std::string vector(vector_width, '\0');
+      for (int byte_index = 0; byte_index < vector_width; ++byte_index) {
+        vector[byte_index] = static_cast<char>((row * vectors_per_row + vector_index + byte_index) & 0xff);
+      }
+      ASSERT_STATUS_OK(value_builder->Append(vector));
+      expected_values.push_back(vector);
+    }
+  }
+
+  std::shared_ptr<arrow::Array> vector_array;
+  ASSERT_STATUS_OK(list_builder.Finish(&vector_array));
+
+  auto rb = arrow::RecordBatch::Make(vector_array_schema, num_rows, {vector_array});
+  auto vx_writer = vortex::VortexFileWriter(file_system_, vector_array_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(num_rows, cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, vector_array_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"vector_array"});
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(num_rows, read_rb->num_rows());
+  ASSERT_EQ(1, read_rb->num_columns());
+
+  auto read_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(0));
+  ASSERT_NE(read_list, nullptr);
+  auto read_values = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_list->values());
+  ASSERT_NE(read_values, nullptr);
+  ASSERT_EQ(vector_width, read_values->byte_width());
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ASSERT_EQ(vectors_per_row, read_list->value_length(row));
+    for (int vector_index = 0; vector_index < vectors_per_row; ++vector_index) {
+      auto value_index = read_list->value_offset(row) + vector_index;
+      const auto& expected = expected_values[static_cast<size_t>(value_index)];
+      ASSERT_EQ(0, std::memcmp(read_values->GetValue(value_index), expected.data(), vector_width));
+    }
+  }
+}
+
 TEST_P(VortexBasicTest, TestBasicRead) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -131,6 +131,18 @@ arrow::Status AppendFixedSizeBinaryValue(
   return builder->Append(MakeFixedSizeBinaryValue(row, group, index, byte_width));
 }
 
+arrow::Result<std::shared_ptr<arrow::Array>> MakeFixedSizeBinaryArray(int64_t num_rows, int vector_width) {
+  arrow::FixedSizeBinaryBuilder fsb_builder(arrow::fixed_size_binary(vector_width));
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(&fsb_builder, row, 0, 0, vector_width));
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(fsb_builder.Finish(&array));
+  return array;
+}
+
 void AssertFixedSizeBinaryValue(const std::shared_ptr<arrow::FixedSizeBinaryArray>& array,
                                 int64_t index,
                                 const std::string& expected) {
@@ -138,6 +150,19 @@ void AssertFixedSizeBinaryValue(const std::shared_ptr<arrow::FixedSizeBinaryArra
   ASSERT_FALSE(array->IsNull(index));
   ASSERT_EQ(static_cast<int32_t>(expected.size()), array->byte_width());
   ASSERT_EQ(0, std::memcmp(array->GetValue(index), expected.data(), expected.size()));
+}
+
+void AssertFixedSizeBinaryArray(const std::shared_ptr<arrow::FixedSizeBinaryArray>& array,
+                                int64_t source_row_offset,
+                                int64_t num_rows,
+                                int vector_width) {
+  ASSERT_NE(array, nullptr);
+  ASSERT_EQ(num_rows, array->length());
+  ASSERT_EQ(vector_width, array->byte_width());
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    AssertFixedSizeBinaryValue(array, row, MakeFixedSizeBinaryValue(source_row_offset + row, 0, 0, vector_width));
+  }
 }
 
 arrow::Result<std::shared_ptr<arrow::Array>> MakeListOfFixedSizeBinaryArray(int64_t num_rows,
@@ -158,11 +183,48 @@ arrow::Result<std::shared_ptr<arrow::Array>> MakeListOfFixedSizeBinaryArray(int6
   return array;
 }
 
-void AssertListOfFixedSizeBinaryArray(const std::shared_ptr<arrow::ListArray>& list_array,
-                                      int64_t source_row_offset,
-                                      int64_t num_rows,
-                                      int vectors_per_row,
-                                      int vector_width) {
+arrow::Result<std::shared_ptr<arrow::Array>> MakeLargeListOfFixedSizeBinaryArray(int64_t num_rows,
+                                                                                 int vectors_per_row,
+                                                                                 int vector_width) {
+  auto value_builder = std::make_shared<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_width));
+  arrow::LargeListBuilder list_builder(arrow::default_memory_pool(), value_builder);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(list_builder.Append());
+    for (int vector_index = 0; vector_index < vectors_per_row; ++vector_index) {
+      ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(value_builder.get(), row, 0, vector_index, vector_width));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(list_builder.Finish(&array));
+  return array;
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeFixedSizeListOfFixedSizeBinaryArray(int64_t num_rows,
+                                                                                     int vectors_per_row,
+                                                                                     int vector_width) {
+  auto value_builder = std::make_shared<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_width));
+  arrow::FixedSizeListBuilder list_builder(arrow::default_memory_pool(), value_builder, vectors_per_row);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(list_builder.Append());
+    for (int vector_index = 0; vector_index < vectors_per_row; ++vector_index) {
+      ARROW_RETURN_NOT_OK(AppendFixedSizeBinaryValue(value_builder.get(), row, 0, vector_index, vector_width));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(list_builder.Finish(&array));
+  return array;
+}
+
+template <typename ListArrayType>
+void AssertFixedSizeBinaryListValues(const std::shared_ptr<ListArrayType>& list_array,
+                                     int64_t source_row_offset,
+                                     int64_t num_rows,
+                                     int vectors_per_row,
+                                     int vector_width) {
   ASSERT_NE(list_array, nullptr);
   ASSERT_EQ(num_rows, list_array->length());
 
@@ -176,6 +238,30 @@ void AssertListOfFixedSizeBinaryArray(const std::shared_ptr<arrow::ListArray>& l
                                  MakeFixedSizeBinaryValue(source_row_offset + row, 0, vector_index, vector_width));
     }
   }
+}
+
+void AssertListOfFixedSizeBinaryArray(const std::shared_ptr<arrow::ListArray>& list_array,
+                                      int64_t source_row_offset,
+                                      int64_t num_rows,
+                                      int vectors_per_row,
+                                      int vector_width) {
+  AssertFixedSizeBinaryListValues(list_array, source_row_offset, num_rows, vectors_per_row, vector_width);
+}
+
+void AssertLargeListOfFixedSizeBinaryArray(const std::shared_ptr<arrow::LargeListArray>& list_array,
+                                           int64_t source_row_offset,
+                                           int64_t num_rows,
+                                           int vectors_per_row,
+                                           int vector_width) {
+  AssertFixedSizeBinaryListValues(list_array, source_row_offset, num_rows, vectors_per_row, vector_width);
+}
+
+void AssertFixedSizeListOfFixedSizeBinaryArray(const std::shared_ptr<arrow::FixedSizeListArray>& list_array,
+                                               int64_t source_row_offset,
+                                               int64_t num_rows,
+                                               int vectors_per_row,
+                                               int vector_width) {
+  AssertFixedSizeBinaryListValues(list_array, source_row_offset, num_rows, vectors_per_row, vector_width);
 }
 
 arrow::Result<std::shared_ptr<arrow::Array>> MakeStructOfFixedSizeBinaryArray(int64_t num_rows, int vector_width) {
@@ -271,6 +357,28 @@ arrow::Result<std::shared_ptr<arrow::Array>> MakeFixedSizeListUInt8Array(int64_t
     ARROW_RETURN_NOT_OK(list_builder.Append());
     for (int byte_index = 0; byte_index < value_width; ++byte_index) {
       ARROW_RETURN_NOT_OK(value_builder->Append(static_cast<uint8_t>((row * 17 + byte_index) & 0xff)));
+    }
+  }
+
+  std::shared_ptr<arrow::Array> array;
+  ARROW_RETURN_NOT_OK(list_builder.Finish(&array));
+  return array;
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>> MakeFixedSizeListUInt8ArrayWithChildNull(int64_t num_rows,
+                                                                                      int value_width) {
+  auto value_builder = std::make_shared<arrow::UInt8Builder>();
+  auto list_type = arrow::fixed_size_list(arrow::field("item", arrow::uint8(), true), value_width);
+  arrow::FixedSizeListBuilder list_builder(arrow::default_memory_pool(), value_builder, list_type);
+
+  for (int64_t row = 0; row < num_rows; ++row) {
+    ARROW_RETURN_NOT_OK(list_builder.Append());
+    for (int byte_index = 0; byte_index < value_width; ++byte_index) {
+      if (row == 1 && byte_index == 2) {
+        ARROW_RETURN_NOT_OK(value_builder->AppendNull());
+      } else {
+        ARROW_RETURN_NOT_OK(value_builder->Append(static_cast<uint8_t>((row * 17 + byte_index) & 0xff)));
+      }
     }
   }
 
@@ -393,6 +501,100 @@ TEST_P(VortexBasicTest, TestSlicedListOfFixedSizeBinaryWriteRead) {
     ASSERT_EQ(slice_length - 1, read_rb->num_rows());
     auto read_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(0));
     AssertListOfFixedSizeBinaryArray(read_list, slice_offset + 1, slice_length - 1, vectors_per_row, vector_width);
+  }
+}
+
+TEST_P(VortexBasicTest, TestLargeListOfFixedSizeBinaryWriteRead) {
+  const int64_t num_rows = 6;
+  const int vectors_per_row = 3;
+  const int vector_width = 32;
+
+  ASSERT_AND_ASSIGN(auto vector_array, MakeLargeListOfFixedSizeBinaryArray(num_rows, vectors_per_row, vector_width));
+  auto vector_schema = arrow::schema({arrow::field("large_vector_array", vector_array->type(), false,
+                                                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(vector_schema, num_rows, {vector_array});
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, vector_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(num_rows, cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, vector_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"large_vector_array"});
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(num_rows, read_rb->num_rows());
+  auto read_list = std::dynamic_pointer_cast<arrow::LargeListArray>(read_rb->column(0));
+  AssertLargeListOfFixedSizeBinaryArray(read_list, 0, num_rows, vectors_per_row, vector_width);
+}
+
+TEST_P(VortexBasicTest, TestFixedSizeListOfFixedSizeBinaryWriteRead) {
+  const int64_t num_rows = 6;
+  const int vectors_per_row = 3;
+  const int vector_width = 32;
+
+  ASSERT_AND_ASSIGN(auto vector_array,
+                    MakeFixedSizeListOfFixedSizeBinaryArray(num_rows, vectors_per_row, vector_width));
+  auto vector_schema = arrow::schema({arrow::field("fixed_vector_array", vector_array->type(), false,
+                                                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(vector_schema, num_rows, {vector_array});
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, vector_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(num_rows, cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, vector_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"fixed_vector_array"});
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(num_rows, read_rb->num_rows());
+  auto read_list = std::dynamic_pointer_cast<arrow::FixedSizeListArray>(read_rb->column(0));
+  AssertFixedSizeListOfFixedSizeBinaryArray(read_list, 0, num_rows, vectors_per_row, vector_width);
+}
+
+TEST_P(VortexBasicTest, TestSlicedFixedSizeBinaryWriteRead) {
+  const int64_t total_rows = 7;
+  const int64_t slice_offset = 2;
+  const int64_t slice_length = 4;
+  const int vector_width = 32;
+
+  ASSERT_AND_ASSIGN(auto full_vector_array, MakeFixedSizeBinaryArray(total_rows, vector_width));
+  auto sliced_vector_array = full_vector_array->Slice(slice_offset, slice_length);
+  ASSERT_GT(sliced_vector_array->offset(), 0);
+
+  auto vector_schema = arrow::schema({arrow::field("embedding", sliced_vector_array->type(), false,
+                                                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(vector_schema, slice_length, {sliced_vector_array});
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, vector_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(slice_length, cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, vector_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"embedding"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  {
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, slice_length));
+    ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(slice_length, read_rb->num_rows());
+    auto read_array = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_rb->column(0));
+    AssertFixedSizeBinaryArray(read_array, slice_offset, slice_length, vector_width);
+  }
+
+  {
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(1, slice_length));
+    ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
+    ASSERT_EQ(slice_length - 1, read_rb->num_rows());
+    auto read_array = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_rb->column(0));
+    AssertFixedSizeBinaryArray(read_array, slice_offset + 1, slice_length - 1, vector_width);
   }
 }
 
@@ -523,10 +725,36 @@ TEST_P(VortexBasicTest, TestFixedSizeListWidthMismatchReadFails) {
 
   auto read_result = vx_reader.blocking_read(0, num_rows);
   ASSERT_FALSE(read_result.ok());
-  const auto status_message = read_result.status().ToString();
-  EXPECT_NE(status_message.find("FixedSizeListArray"), std::string::npos) << status_message;
-  EXPECT_NE(status_message.find("list size 4"), std::string::npos) << status_message;
-  EXPECT_NE(status_message.find("list size 3"), std::string::npos) << status_message;
+}
+
+TEST_P(VortexBasicTest, TestFixedSizeListChildNullReadFails) {
+  const int64_t num_rows = 4;
+  const int vector_width = 4;
+
+  ASSERT_AND_ASSIGN(auto vector_array, MakeFixedSizeListUInt8ArrayWithChildNull(num_rows, vector_width));
+  ASSERT_EQ(vector_array->type()->id(), arrow::Type::FIXED_SIZE_LIST);
+  ASSERT_TRUE(vector_array->type()->field(0)->nullable());
+
+  auto write_schema = arrow::schema({arrow::field("embedding", vector_array->type(), false,
+                                                  arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto rb = arrow::RecordBatch::Make(write_schema, num_rows, {vector_array});
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, write_schema, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(rb));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(num_rows, cgfile.end_index);
+
+  auto read_schema = arrow::schema({arrow::field("embedding", arrow::fixed_size_binary(vector_width), false,
+                                                 arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
+  auto vx_reader = vortex::VortexFormatReader(file_system_, read_schema, test_file_name_, properties_,
+                                              std::vector<std::string>{"embedding"});
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  auto read_result = vx_reader.blocking_read(0, num_rows);
+  // FixedSizeBinary can only represent row-level nullability, so a FixedSizeList<UInt8>
+  // with byte-level child nulls must fail instead of silently dropping those nulls.
+  ASSERT_FALSE(read_result.ok());
 }
 
 TEST_P(VortexBasicTest, TestBasicRead) {


### PR DESCRIPTION
Vortex does not currently accept Arrow FixedSizeBinary directly, but callers can still pass schemas that contain it, including nested shapes like List<FixedSizeBinary(512)>. We should handle that at the milvus-storage bridge boundary instead of asking callers to rewrite their schemas or patching the vendored Vortex code.

This change teaches the Vortex bridge to translate FixedSizeBinary into FixedSizeList<UInt8> before data enters Vortex, and to translate it back when data is read with the original caller schema. The schema conversion now follows the same recursive shape as Vortex's Arrow dtype handling for list, large list, list view, fixed-size list, struct, and dictionary types, while only overriding the unsupported FixedSizeBinary leaf. When no conversion is needed, the bridge keeps using the original schema and array path.

The array conversion mirrors the schema conversion so nested data stays consistent with the converted Vortex dtype. FixedSizeBinary and FixedSizeList<UInt8> share the same physical byte layout, so the conversion rebuilds Arrow metadata and child arrays while reusing the underlying buffers instead of copying vector payloads.