### PR TITLE
fix: invalid static init issues in cloud provider validation

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -39,14 +39,14 @@
 
 namespace milvus_storage {
 
-inline const std::string kCloudProviderAWS = "aws";
-inline const std::string kCloudProviderGCP = "gcp";
-inline const std::string kCloudProviderAliyun = "aliyun";
-inline const std::string kCloudProviderTencent = "tencent";
-inline const std::string kCloudProviderHuawei = "huawei";
-inline const std::string kCloudProviderAzure = "azure";
+inline constexpr const char* kCloudProviderAWS = "aws";
+inline constexpr const char* kCloudProviderGCP = "gcp";
+inline constexpr const char* kCloudProviderAliyun = "aliyun";
+inline constexpr const char* kCloudProviderTencent = "tencent";
+inline constexpr const char* kCloudProviderHuawei = "huawei";
+inline constexpr const char* kCloudProviderAzure = "azure";
 
-inline const std::string kAzureFileSystemName = "abfs";
+inline constexpr const char* kAzureFileSystemName = "abfs";
 
 using ArrowFileSystemPtr = std::shared_ptr<arrow::fs::FileSystem>;
 

--- a/cpp/test/api_properties_test.cpp
+++ b/cpp/test/api_properties_test.cpp
@@ -5,6 +5,7 @@
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/properties.h"
+#include "milvus-storage/filesystem/fs.h"
 #include <string>
 #include <cstdint>
 #include <optional>
@@ -152,6 +153,24 @@ TEST_F(APIPropertiesTest, test_ffi_convert) {
 
     auto opt = ConvertFFIProperties(pp, &ffi_props);
     EXPECT_NE(opt, std::nullopt);
+  }
+}
+
+TEST_F(APIPropertiesTest, invalid_cloud_provider_error) {
+  const char* invalid_provider = "unknown-cloud-provider";
+  milvus_storage::api::Properties pp{};
+  milvus_storage::api::Properties converted{};
+  ::LoonProperty kvp[] = {{const_cast<char*>(loon_properties_fs_cloud_provider), const_cast<char*>(invalid_provider)}};
+  ::LoonProperties ffi_props{kvp, 1};
+
+  for (const auto& err :
+       {SetValue(pp, PROPERTY_FS_CLOUD_PROVIDER, invalid_provider), ConvertFFIProperties(converted, &ffi_props)}) {
+    ASSERT_NE(err, std::nullopt);
+    for (const auto* expected :
+         {"value 'unknown-cloud-provider'", "not in allowed set", kCloudProviderAWS, kCloudProviderGCP,
+          kCloudProviderAliyun, kCloudProviderAzure, kCloudProviderTencent, kCloudProviderHuawei}) {
+      EXPECT_NE(err->find(expected), std::string::npos) << *err;
+    }
   }
 }
 

--- a/cpp/test/format/external_table_arn_test.cpp
+++ b/cpp/test/format/external_table_arn_test.cpp
@@ -775,7 +775,7 @@ class ExternalTableAliyunArnTest : public ::testing::Test {
     // accepts static AK/SK directly via reqsign's load_via_static — no
     // indirection needed.
     api::SetValue(write_props_, PROPERTY_FS_STORAGE_TYPE, "remote");
-    api::SetValue(write_props_, PROPERTY_FS_CLOUD_PROVIDER, kCloudProviderAliyun.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_CLOUD_PROVIDER, kCloudProviderAliyun);
     api::SetValue(write_props_, PROPERTY_FS_ADDRESS, address_.c_str());
     api::SetValue(write_props_, PROPERTY_FS_BUCKET_NAME, arn_bucket_.c_str());
     api::SetValue(write_props_, PROPERTY_FS_REGION, region_.c_str());
@@ -788,7 +788,7 @@ class ExternalTableAliyunArnTest : public ::testing::Test {
     // role_arn would make reqsign's load_via_static win over
     // load_via_assume_role_with_oidc, silently bypassing the OIDC flow.
     api::SetValue(read_props_, "extfs.arn.storage_type", "remote");
-    api::SetValue(read_props_, "extfs.arn.cloud_provider", kCloudProviderAliyun.c_str());
+    api::SetValue(read_props_, "extfs.arn.cloud_provider", kCloudProviderAliyun);
     api::SetValue(read_props_, "extfs.arn.address", address_.c_str());
     api::SetValue(read_props_, "extfs.arn.bucket_name", arn_bucket_.c_str());
     api::SetValue(read_props_, "extfs.arn.region", region_.c_str());
@@ -1311,7 +1311,7 @@ class ExternalTableAliyunOIDCArnTest : public ::testing::Test {
     //    ExternalTableAliyunArnTest: the role_arn flow is exercised on the
     //    read leg only.
     api::SetValue(write_props_, PROPERTY_FS_STORAGE_TYPE, "remote");
-    api::SetValue(write_props_, PROPERTY_FS_CLOUD_PROVIDER, kCloudProviderAliyun.c_str());
+    api::SetValue(write_props_, PROPERTY_FS_CLOUD_PROVIDER, kCloudProviderAliyun);
     api::SetValue(write_props_, PROPERTY_FS_ADDRESS, address_.c_str());
     api::SetValue(write_props_, PROPERTY_FS_BUCKET_NAME, arn_bucket_.c_str());
     api::SetValue(write_props_, PROPERTY_FS_REGION, region_.c_str());
@@ -1322,7 +1322,7 @@ class ExternalTableAliyunOIDCArnTest : public ::testing::Test {
     // 5. read_props_ — extfs.arn.* with role_arn (and optional external_id)
     //    routed through the OIDC chain provider.
     api::SetValue(read_props_, "extfs.arn.storage_type", "remote");
-    api::SetValue(read_props_, "extfs.arn.cloud_provider", kCloudProviderAliyun.c_str());
+    api::SetValue(read_props_, "extfs.arn.cloud_provider", kCloudProviderAliyun);
     api::SetValue(read_props_, "extfs.arn.address", address_.c_str());
     api::SetValue(read_props_, "extfs.arn.bucket_name", arn_bucket_.c_str());
     api::SetValue(read_props_, "extfs.arn.region", region_.c_str());


### PR DESCRIPTION
The cloud provider validator builds its allowed-value list during static initialization, but those values were coming from inline std::string constants. That makes the code sensitive to initialization order: in the bad case, the validator can capture empty strings and later produce errors like `value 'aws' not in allowed set: [, , , , , ]`.

This change moves the cloud provider names to inline constexpr const char*, so the property registry always sees stable string literals instead of depending on std::string construction timing. I also applied the same treatment to the Azure filesystem name because it follows the same global-constant pattern and can be used from static initialization paths as well. With the constants now exposed as C strings, the affected call sites no longer need .c_str(). The API usage stays the same from a behavior perspective, but the initialization path is simpler and no longer relies on cross-translation-unit object construction order.