### PR TITLE
fix: make writer close safe after partial column group initialization

### DIFF
--- a/cpp/include/milvus-storage/common/fiu_local.h
+++ b/cpp/include/milvus-storage/common/fiu_local.h
@@ -41,6 +41,7 @@
 #define FIUKEY_WRITER_WRITE_FAIL "writer.write.fail"
 #define FIUKEY_WRITER_FLUSH_FAIL "writer.flush.fail"
 #define FIUKEY_WRITER_CLOSE_FAIL "writer.close.fail"
+#define FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL "writer.init_column_group_writers.fail"
 
 // Reader fault points (low-level)
 #define FIUKEY_COLUMN_GROUP_READ_FAIL "column_group.read.fail"

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -371,7 +371,13 @@ FFI_EXPORT LoonFFIResult loon_writer_write(LoonWriterHandle handle, struct Arrow
 FFI_EXPORT LoonFFIResult loon_writer_flush(LoonWriterHandle handle);
 
 /**
- * @brief Closes the writer and returns the columngroups
+ * @brief Closes the writer and returns the column groups for a successfully written dataset.
+ *
+ * If a previous operation on this writer has already failed, close may still be called to
+ * release/finalize resources owned by the writer. In that case, even if close succeeds,
+ * the returned column groups are not a valid dataset manifest and must be discarded by
+ * the caller.
+ *
  * @param handle Writer handle
  * @param out_columngroups Output LoonColumnGroups structure (function allocates and returns pointer)
  *                         Caller must call `loon_column_groups_destroy` to free allocated memory

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -36,6 +36,7 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/common/layout.h"
+#include "milvus-storage/common/log.h"
 #include "milvus-storage/format/column_group_writer.h"
 
 namespace milvus_storage::api {
@@ -389,14 +390,33 @@ class WriterImpl : public Writer {
     }
     assert(config_keys.size() == config_values.size());
 
-    // Close all column group writers and collect statistics
-    assert(column_group_writers_.size() == column_groups_.size());
-    for (int i = 0; i < column_groups_.size(); i++) {
+    if (column_group_writers_.size() > column_groups_.size()) {
+      return arrow::Status::Invalid(
+          fmt::format("Internal error: More column group writers than column groups. [base_path={}, schema={}, "
+                      "writers={}, groups={}]",
+                      base_path_,  // NOLINT
+                      schema_->ToString(true), column_group_writers_.size(), column_groups_.size()));
+    }
+
+    // If any column group writer have not been created. just closed the exist one.
+    for (int i = 0; i < column_group_writers_.size(); i++) {
       ARROW_ASSIGN_OR_RAISE(auto column_group_files, column_group_writers_[i]->Close());
       std::swap(column_groups_[i]->files, column_group_files);
       cgs_->emplace_back(column_groups_[i]);
     }
+
     closed_ = true;
+
+    if (column_group_writers_.size() < column_groups_.size()) {
+      LOG_STORAGE_WARNING_ << fmt::format(
+          "Current writer have not been inited success. just return a emptu column groups."
+          "[base_path={}, schema={}, writers={}, groups={}]",
+          base_path_,  // NOLINT
+          schema_->ToString(true), column_group_writers_.size(), column_groups_.size());
+      cgs_->clear();
+      return cgs_;
+    }
+
     return cgs_;
   }
 
@@ -465,6 +485,9 @@ class WriterImpl : public Writer {
                             ColumnGroupWriter::create(base_path_, i, column_group, column_group_schema, properties_));
 
       column_group_writers_.emplace_back(std::move(writer));
+      FIU_RETURN_ON(
+          FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL,
+          arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL)));
     }
     assert(column_group_writers_.size() == column_groups_.size());
 

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <utility>
 #include <vector>
@@ -29,6 +30,7 @@
 
 #include "include/test_env.h"
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/writer.h"
@@ -52,6 +54,10 @@ constexpr int32_t kPrebufferFixedBinaryWidth = 2048;
 constexpr int64_t kPrebufferSmallHoleLimit = 1;
 constexpr int64_t kPrebufferLargeHoleLimit = 128LL * 1024;
 constexpr int64_t kPrebufferRangeSizeLimit = 64LL * 1024 * 1024;
+
+#ifdef BUILD_WITH_FIU
+std::once_flag api_writer_reader_fiu_init_flag;
+#endif
 
 std::shared_ptr<arrow::Schema> MakePrebufferFixedBinarySchema() {
   auto embedding = arrow::field("embedding", arrow::fixed_size_binary(kPrebufferFixedBinaryWidth), false,
@@ -157,6 +163,10 @@ class APIWriterReaderTest : public ::testing::TestWithParam<std::tuple<std::stri
   }
 
   void TearDown() override {
+#ifdef BUILD_WITH_FIU
+    FIU_DISABLE_FAULT(FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL);
+#endif
+
     // Clean up test directory
     ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
     ThreadPoolHolder::Release();
@@ -276,6 +286,30 @@ TEST_P(APIWriterReaderTest, SizeBasedColumnGroupPolicy) {
     EXPECT_LE(group->columns.size(), static_cast<size_t>(max_columns_in_group));
   }
 }
+
+#ifdef BUILD_WITH_FIU
+TEST_P(APIWriterReaderTest, WriterCloseAfterInitColumnGroupWritersFail) {
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "This cleanup path is covered with parquet format only";
+  }
+  std::call_once(api_writer_reader_fiu_init_flag, []() { FIU_INIT(); });
+
+  FIU_ENABLE_FAULT_ONETIME(FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy("id,name,value,vector", format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+
+  auto status = writer->write(test_batch_);
+  ASSERT_FALSE(status.ok());
+  EXPECT_TRUE(status.ToString().find(FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL) != std::string::npos);
+
+  auto close_result = writer->close();
+  ASSERT_TRUE(close_result.ok()) << close_result.status().ToString();
+  auto cgs = std::move(close_result).ValueOrDie();
+  ASSERT_NE(cgs, nullptr);
+  EXPECT_TRUE(cgs->empty());
+}
+#endif
 
 TEST_P(APIWriterReaderTest, TestWriteNotExistPath) {
   auto verify_writer = [&](const std::string& base_path, api::Properties& properties) {


### PR DESCRIPTION
Storage writes can fail after the writer has already planned multiple column groups but before every column group writer has been created. Milvus still calls close on that writer as a cleanup step, so close needs to handle this partially initialized state instead of assuming the metadata list and writer list always have the same size.

This change makes close work with the writers that actually exist, detects impossible internal state where there are more writers than groups, and returns an empty column group list when initialization did not finish. That keeps the cleanup path from producing invalid manifest data while still releasing the resources owned by the initialized column group writers.

The FFI close comment is also clarified to match this behavior: after a previous writer operation has failed, a successful close is only a cleanup result, and the returned column groups must not be treated as a valid dataset manifest.