### PR TITLE
fix: limit parquet dict pagesize to 1/16 row group size

### DIFF
--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -99,6 +99,12 @@ static std::shared_ptr<::parquet::WriterProperties> convert_write_properties(
     builder.disable_dictionary();
   }
 
+  // Fall back to PLAIN once the per-column dictionary reaches 1/16 of the
+  // row group size. With parquet's default 1 MB limit and our ~1 MB row
+  // groups, high-cardinality columns end up with a dictionary page that
+  // mirrors the column data instead of falling back, inflating the file.
+  builder.dictionary_pagesize_limit(DEFAULT_MAX_ROW_GROUP_SIZE / 16);
+
   return builder.build();
 }
 


### PR DESCRIPTION
See #543

The parquet writer was not setting dictionary_pagesize_limit, leaving
it at parquet's 1 MB default. With our 1 MB byte-bounded row groups,
a column's dictionary can grow to fill the row group before falling
back to PLAIN, leaving a dictionary page that mirrors the column data
for high-cardinality columns.

Setting the limit to row_group_size / 16 triggers fallback early on
high-cardinality columns while preserving dictionary encoding where
it helps.