### PR TITLE
fix: honor use_ssl for external table endpoints

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -147,8 +147,9 @@ struct StorageUri {
    */
   static arrow::Result<std::string> Make(const StorageUri& uri, bool include_address = true);
 
-  /// Ensure address has a URL scheme. Prepends "https://" if no "://" is present.
-  static std::string BuildEndpointUrl(const std::string& address);
+  /// Ensure address has a URL scheme. If no scheme is present, uses use_ssl
+  /// to choose "https://" or "http://".
+  static std::string BuildEndpointUrl(const std::string& address, bool use_ssl = true);
 
   /// Build Azure endpoint URL from authority and account name.
   /// '.' prefix → virtual-hosted: https://account.blob.core.windows.net

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -381,14 +381,14 @@ arrow::Result<std::string> StorageUri::Make(const StorageUri& uri, bool include_
   return uri.scheme + "://" + resolved_address + "/" + uri.bucket_name + "/" + uri.key;
 }
 
-std::string StorageUri::BuildEndpointUrl(const std::string& address) {
+std::string StorageUri::BuildEndpointUrl(const std::string& address, bool use_ssl) {
   if (address.empty()) {
     return {};
   }
   if (address.find("://") != std::string::npos) {
     return address;
   }
-  return "https://" + address;
+  return std::string(use_ssl ? "https://" : "http://") + address;
 }
 
 std::string StorageUri::BuildAzureEndpointAddress(const std::string& address,

--- a/cpp/src/format/iceberg/iceberg_common.cpp
+++ b/cpp/src/format/iceberg/iceberg_common.cpp
@@ -62,8 +62,9 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
   auto set_endpoint = [&](const std::string& key, const std::string& address) {
     if (address.empty())
       return;
-    options[key] = StorageUri::BuildEndpointUrl(address);
-    if (address.find("http://") == 0)
+    auto endpoint = StorageUri::BuildEndpointUrl(address, config.use_ssl);
+    options[key] = endpoint;
+    if (endpoint.find("http://") == 0)
       options["allow_http"] = "true";
   };
 

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -37,8 +37,9 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
   auto set_endpoint = [&](const std::string& key, const std::string& address) {
     if (address.empty())
       return;
-    options[key] = StorageUri::BuildEndpointUrl(address);
-    if (address.find("http://") == 0)
+    auto endpoint = StorageUri::BuildEndpointUrl(address, config.use_ssl);
+    options[key] = endpoint;
+    if (endpoint.find("http://") == 0)
       options["allow_http"] = "true";
   };
 

--- a/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
@@ -27,6 +27,7 @@ static ArrowFileSystemConfig MakeAwsConfig() {
   config.access_key_value = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
   config.region = "us-west-2";
   config.address = "s3.us-west-2.amazonaws.com";
+  config.use_ssl = true;
   return config;
 }
 
@@ -61,6 +62,7 @@ TEST_F(IcebergStorageOptionsTest, AliyunKeys) {
   config.access_key_id = "LTAI5tExample";
   config.access_key_value = "OSSSecretExample";
   config.address = "oss-cn-hangzhou.aliyuncs.com";
+  config.use_ssl = true;
 
   auto opts = ToStorageOptions(config);
 
@@ -86,6 +88,7 @@ TEST_F(IcebergStorageOptionsTest, AliyunArnRole) {
   config.external_id = "tenant-A-ext";
   config.region = "cn-hangzhou";
   config.address = "oss-cn-hangzhou.aliyuncs.com";
+  config.use_ssl = true;
   // Even if the caller populates AK/SK alongside role_arn, the iceberg
   // branch must drop them — a caller mistake here should not bypass OIDC.
   config.access_key_id = "LTAI-should-be-ignored";
@@ -124,6 +127,50 @@ TEST_F(IcebergStorageOptionsTest, GcpDefaultCredentials) {
   config.storage_type = "remote";
   config.cloud_provider = kCloudProviderGCP;
   EXPECT_TRUE(ToStorageOptions(config).empty());
+}
+
+TEST_F(IcebergStorageOptionsTest, BareEndpointUsesHttpWhenSslDisabled) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "localhost:9000";
+  config.use_ssl = false;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["s3.endpoint"], "http://localhost:9000");
+  EXPECT_EQ(opts["allow_http"], "true");
+}
+
+TEST_F(IcebergStorageOptionsTest, BareEndpointUsesHttpsWhenSslEnabled) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "s3.us-west-2.amazonaws.com";
+  config.use_ssl = true;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["s3.endpoint"], "https://s3.us-west-2.amazonaws.com");
+  EXPECT_EQ(opts.count("allow_http"), 0);
+}
+
+TEST_F(IcebergStorageOptionsTest, ExplicitHttpEndpointIsPreserved) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "http://localhost:9000";
+  config.use_ssl = true;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["s3.endpoint"], "http://localhost:9000");
+  EXPECT_EQ(opts["allow_http"], "true");
+}
+
+TEST_F(IcebergStorageOptionsTest, ExplicitHttpsEndpointIsPreservedWhenSslDisabled) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "https://s3.us-west-2.amazonaws.com";
+  config.use_ssl = false;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["s3.endpoint"], "https://s3.us-west-2.amazonaws.com");
+  EXPECT_EQ(opts.count("allow_http"), 0);
 }
 
 }  // namespace milvus_storage::iceberg::test

--- a/cpp/test/format/lance/lance_storage_options_test.cpp
+++ b/cpp/test/format/lance/lance_storage_options_test.cpp
@@ -51,6 +51,7 @@ static ArrowFileSystemConfig MakeAwsConfig() {
   config.access_key_value = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
   config.region = "us-west-2";
   config.address = "s3.us-west-2.amazonaws.com";
+  config.use_ssl = true;
   return config;
 }
 
@@ -90,6 +91,7 @@ TEST_F(LanceStorageOptionsTest, AliyunKeys) {
   config.access_key_value = "OSSSecretExample";
   config.region = "oss-cn-hangzhou";
   config.address = "oss-cn-hangzhou.aliyuncs.com";
+  config.use_ssl = true;
 
   auto opts = ToStorageOptions(config);
 
@@ -129,6 +131,50 @@ TEST_F(LanceStorageOptionsTest, LocalEmpty) {
   ArrowFileSystemConfig config;
   config.storage_type = "local";
   EXPECT_TRUE(ToStorageOptions(config).empty());
+}
+
+TEST_F(LanceStorageOptionsTest, BareEndpointUsesHttpWhenSslDisabled) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "localhost:9000";
+  config.use_ssl = false;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["aws_endpoint"], "http://localhost:9000");
+  EXPECT_EQ(opts["allow_http"], "true");
+}
+
+TEST_F(LanceStorageOptionsTest, BareEndpointUsesHttpsWhenSslEnabled) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "s3.us-west-2.amazonaws.com";
+  config.use_ssl = true;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["aws_endpoint"], "https://s3.us-west-2.amazonaws.com");
+  EXPECT_EQ(opts.count("allow_http"), 0);
+}
+
+TEST_F(LanceStorageOptionsTest, ExplicitHttpEndpointIsPreserved) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "http://localhost:9000";
+  config.use_ssl = true;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["aws_endpoint"], "http://localhost:9000");
+  EXPECT_EQ(opts["allow_http"], "true");
+}
+
+TEST_F(LanceStorageOptionsTest, ExplicitHttpsEndpointIsPreservedWhenSslDisabled) {
+  ArrowFileSystemConfig config = MakeAwsConfig();
+  config.address = "https://s3.us-west-2.amazonaws.com";
+  config.use_ssl = false;
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts["aws_endpoint"], "https://s3.us-west-2.amazonaws.com");
+  EXPECT_EQ(opts.count("allow_http"), 0);
 }
 
 }  // namespace milvus_storage::lance::test

--- a/docs/endpoint-use-ssl-design.md
+++ b/docs/endpoint-use-ssl-design.md
@@ -1,0 +1,94 @@
+# Endpoint Scheme from `use_ssl` for Lance and Iceberg
+
+## Context
+
+Lance and Iceberg convert `ArrowFileSystemConfig::address` into backend storage
+endpoint options through `StorageUri::BuildEndpointUrl`. Today that helper keeps
+an explicit URL scheme if present, but prepends `https://` to bare addresses.
+Because `lance_common.cpp` and `iceberg_common.cpp` do not pass
+`ArrowFileSystemConfig::use_ssl` into that helper, a config with
+`use_ssl=false` and `address=localhost:9000` still produces an HTTPS endpoint.
+
+This differs from the regular S3 and GCP filesystem producers, which derive the
+transport scheme from `use_ssl`.
+
+## Decision
+
+Extend `StorageUri::BuildEndpointUrl` so it accepts `use_ssl`:
+
+```cpp
+static std::string BuildEndpointUrl(const std::string& address, bool use_ssl = true);
+```
+
+The helper will keep explicit schemes authoritative:
+
+- `address=""` returns `""`.
+- `address="http://localhost:9000"` returns `http://localhost:9000`.
+- `address="https://example.com"` returns `https://example.com`.
+- Bare addresses use `use_ssl`: `true` becomes `https://...`, `false` becomes
+  `http://...`.
+
+The default argument preserves the old standalone helper behavior for any
+callers that do not opt into `use_ssl`.
+
+## Scope
+
+Update the shared endpoint helper and the two format option builders that depend
+on it:
+
+- `StorageUri::BuildEndpointUrl` declaration and implementation.
+- `lance::ToStorageOptions`, specifically the common endpoint setter used by
+  AWS, GCP, and OSS-style endpoints.
+- `iceberg::ToStorageOptions`, specifically the common endpoint setter used by
+  AWS S3 and Aliyun OSS endpoints.
+
+Do not change Azure endpoint handling. Lance Azure already uses
+`BuildAzureEndpointAddress(..., use_ssl)`, and Iceberg Azure passes an endpoint
+suffix rather than a full HTTP endpoint.
+
+Do not change regular S3, GCP, or Azure filesystem producers. Their direct
+`use_ssl` handling already matches this design.
+
+## Data Flow
+
+For Lance and Iceberg, endpoint construction becomes:
+
+1. The filesystem config is resolved from normal properties or `extfs.*`
+   properties.
+2. `ToStorageOptions(config)` passes `config.address` and `config.use_ssl` to
+   `BuildEndpointUrl`.
+3. If the resulting endpoint starts with `http://`, the format storage options
+   include `allow_http=true`.
+4. The Rust-backed Lance/Iceberg storage layer receives a final endpoint URL
+   whose scheme already reflects either the explicit address scheme or
+   `use_ssl`.
+
+This means callers that use a bare address and want HTTPS must set
+`use_ssl=true`. With the current `ArrowFileSystemConfig` default of
+`use_ssl=false`, a bare address intentionally resolves to HTTP after this
+change.
+
+## Error Handling
+
+No new validation is added. Existing behavior for malformed or unsupported
+endpoint strings remains unchanged: the helper only decides whether to preserve
+an explicit scheme or prepend one.
+
+Explicit URL schemes take precedence over `use_ssl`, so conflicting inputs such
+as `address=https://host` with `use_ssl=false` remain HTTPS rather than being
+rewritten.
+
+## Testing
+
+Add or update focused unit tests for both Lance and Iceberg storage options:
+
+- Bare address plus `use_ssl=false` produces an `http://` endpoint and sets
+  `allow_http=true`.
+- Bare address plus `use_ssl=true` produces an `https://` endpoint and does not
+  set `allow_http`.
+- Explicit `http://` is preserved and sets `allow_http=true`.
+- Explicit `https://` is preserved even if `use_ssl=false` and does not set
+  `allow_http`.
+
+Adjust existing tests that expect HTTPS from a bare address to set
+`use_ssl=true` explicitly.


### PR DESCRIPTION
Some external table setups pass a bare storage address together with use_ssl=false, expecting the format layer to connect to that endpoint over HTTP. Lance and Iceberg were not following that contract because the shared endpoint helper always filled in https:// when the address did not already include a scheme, so local or S3-compatible endpoints could still be reached through HTTPS even when SSL was explicitly disabled.

This change makes endpoint construction follow the filesystem config instead of assuming HTTPS for bare addresses. BuildEndpointUrl now accepts use_ssl while still preserving any explicit scheme already present in the address, and both Lance and Iceberg pass their ArrowFileSystemConfig value through when building backend storage options. allow_http is also derived from the final endpoint string, so explicit HTTP addresses and HTTP produced from use_ssl=false behave the same way.

The resulting rule is straightforward for callers: if the address includes a scheme, that scheme wins; if it is a bare address, use_ssl decides whether the endpoint becomes HTTP or HTTPS. This keeps explicit configurations backward-compatible while making the no-scheme case match the user's config intent.