### PR TITLE
fix:[3.0] lock FilesystemCache get-or-create path (#550)

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -392,6 +392,7 @@ class FilesystemCache {
   ~FilesystemCache() = default;
 
   // Filesystem instance cache (LRU)
+  mutable std::mutex mutex_;
   LRUCache<std::string, ArrowFileSystemPtr> cache_;
 };
 

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -225,7 +225,10 @@ arrow::Result<ArrowFileSystemPtr> FilesystemCache::get(const api::Properties& pr
 
   std::string cache_key = config.GetCacheKey();
 
-  // Check cache first
+  // Keep the miss/create/put sequence under one FilesystemCache lock. LRUCache
+  // protects each individual operation, but separate get() and put() calls would
+  // still allow concurrent same-key misses to create multiple filesystems.
+  std::lock_guard<std::mutex> lock(mutex_);
   auto cached_fs = cache_.get(cache_key);
   if (cached_fs.has_value()) {
     return cached_fs.value();

--- a/cpp/test/format/fs_cache_test.cpp
+++ b/cpp/test/format/fs_cache_test.cpp
@@ -14,7 +14,9 @@
 
 #include <gtest/gtest.h>
 #include <atomic>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/common/lrucache.h"
@@ -377,6 +379,57 @@ TEST_F(FileSystemCacheTest, ConcurrentGetsSingleCreate) {
 
   cache.clean();
   EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST_F(FileSystemCacheTest, ConcurrentSameKeyGetsReturnSingleCachedInstance) {
+  auto& cache = FilesystemCache::getInstance();
+  cache.set_capacity(10);
+
+  auto props = MakeProperties("SINGLE_CREATE");
+  std::string path = "s3://localhost_SINGLE_CREATE/bucket_SINGLE_CREATE/file.parquet";
+
+  const int thread_count = 256;
+  std::vector<std::thread> threads;
+  std::vector<ArrowFileSystemPtr> results(thread_count);
+  std::vector<std::string> errors(thread_count);
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+
+  threads.reserve(thread_count);
+  for (int i = 0; i < thread_count; ++i) {
+    threads.emplace_back([&cache, &props, &path, &results, &errors, &ready, &start, i]() {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+
+      auto result = cache.get(props, path);
+      if (!result.ok()) {
+        errors[i] = result.status().ToString();
+        return;
+      }
+      results[i] = result.ValueOrDie();
+    });
+  }
+
+  while (ready.load(std::memory_order_acquire) != thread_count) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  for (const auto& error : errors) {
+    EXPECT_TRUE(error.empty()) << error;
+  }
+
+  ASSERT_NE(results[0], nullptr);
+  for (const auto& fs : results) {
+    EXPECT_EQ(results[0], fs);
+  }
+  EXPECT_EQ(cache.size(), 1u);
 }
 
 TEST_F(FileSystemCacheTest, ConcurrentGetsAndCreate) {


### PR DESCRIPTION
pr: #550
Root cause: FilesystemCache::get checked the cache, created the filesystem, and inserted it without one lock around the sequence. With 256 threads entering at the same time, they could all observe a miss and create filesystem instances concurrently.