### PR TITLE
fix: disable AWS IMDS lookup for non-AWS S3 clients

### DIFF
--- a/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
@@ -117,7 +117,7 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_sessionName);
   }
 
-  Aws::Client::ClientConfiguration config;
+  Aws::Client::ClientConfiguration config(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   config.scheme = Aws::Http::Scheme::HTTPS;
   // not need in [aliyun]
   // config.region = tmpRegion;

--- a/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
@@ -45,7 +45,7 @@ AliyunOIDCAssumeRoleChainProvider::AliyunOIDCAssumeRoleChainProvider(const Aws::
   // do not re-validate here.
   m_innerOidc = Aws::MakeUnique<AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(kLogTag);
 
-  Aws::Client::ClientConfiguration cfg;
+  Aws::Client::ClientConfiguration cfg(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   cfg.scheme = Aws::Http::Scheme::HTTPS;
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 

--- a/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
@@ -53,7 +53,7 @@ static const int kImdsV2TtlSecs = 21600;
 namespace {
 
 std::shared_ptr<Aws::Http::HttpClient> MakeImdsHttpClient() {
-  Aws::Client::ClientConfiguration cfg;
+  Aws::Client::ClientConfiguration cfg(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   cfg.scheme = Aws::Http::Scheme::HTTP;
   // IMDS answers in milliseconds on a healthy VM; a multi-second stall means
   // the service is unreachable (e.g. not an ECS). Short caps keep a broken
@@ -161,7 +161,7 @@ AliyunRAMCredentialsProvider::AliyunRAMCredentialsProvider(const Aws::String& ro
     m_roleSessionName = Aws::Utils::UUID::RandomUUID();
   }
 
-  Aws::Client::ClientConfiguration cfg;
+  Aws::Client::ClientConfiguration cfg(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   cfg.scheme = Aws::Http::Scheme::HTTPS;
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -72,7 +72,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_sessionName);
   }
 
-  Aws::Client::ClientConfiguration config;
+  Aws::Client::ClientConfiguration config(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   config.scheme = Aws::Http::Scheme::HTTPS;
   config.region = m_region;
 

--- a/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
@@ -87,7 +87,7 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_sessionName);
   }
 
-  Aws::Client::ClientConfiguration config;
+  Aws::Client::ClientConfiguration config(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   config.scheme = Aws::Http::Scheme::HTTPS;
   config.region = m_region;
 

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -463,8 +463,17 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> GetClientHolder(std::shared_ptr<S
   return GetClientFinalizer()->AddClient(std::move(client));
 }
 
+static Aws::Client::ClientConfiguration MakeClientConfiguration(const S3Options& options) {
+  if (options.cloud_provider == kCloudProviderGCP || options.cloud_provider == kCloudProviderAliyun ||
+      options.cloud_provider == kCloudProviderTencent || options.cloud_provider == kCloudProviderHuawei) {
+    return Aws::Client::ClientConfiguration(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
+  }
+  return Aws::Client::ClientConfiguration();
+}
+
 // ------------ Implementation of ClientBuilder ------------
-ClientBuilder::ClientBuilder(S3Options options) : options_(std::move(options)) {}
+ClientBuilder::ClientBuilder(S3Options options)
+    : options_(std::move(options)), client_config_(MakeClientConfiguration(options_)) {}
 
 const Aws::Client::ClientConfiguration& ClientBuilder::config() const { return client_config_; }
 

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -781,6 +781,39 @@ TEST_F(S3UnitTest, TestS3GlobalOptions) {
 }
 
 TEST_F(S3UnitTest, TestClientBuilder) {
+  // Non-AWS S3-compatible backends must not probe AWS EC2 IMDS while
+  // constructing their AWS SDK client configuration.
+  {
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderAWS;
+    ClientBuilder builder(options);
+    EXPECT_FALSE(builder.config().disableIMDS);
+  }
+  {
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderAliyun;
+    ClientBuilder builder(options);
+    EXPECT_TRUE(builder.config().disableIMDS);
+  }
+  {
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderGCP;
+    ClientBuilder builder(options);
+    EXPECT_TRUE(builder.config().disableIMDS);
+  }
+  {
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderTencent;
+    ClientBuilder builder(options);
+    EXPECT_TRUE(builder.config().disableIMDS);
+  }
+  {
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderHuawei;
+    ClientBuilder builder(options);
+    EXPECT_TRUE(builder.config().disableIMDS);
+  }
+
   // Construct and access options/config
   {
     auto options = S3Options::FromAccessKey("ak", "sk");

--- a/cpp/test/filesystem/s3_provider_test.cpp
+++ b/cpp/test/filesystem/s3_provider_test.cpp
@@ -51,6 +51,10 @@ namespace milvus_storage {
 // RAII environment variable helper
 // ============================================================================
 
+Aws::Client::ClientConfiguration MakeNoImdsClientConfiguration() {
+  return Aws::Client::ClientConfiguration(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
+}
+
 class ScopedEnvVar {
   public:
   ScopedEnvVar(const std::string& name, const std::string& value) : name_(name) {
@@ -273,7 +277,7 @@ class S3ProviderTest : public ::testing::Test {
 
 TEST_F(S3ProviderTest, TestMockInfrastructure) {
   // Verify the factory is installed: CreateHttpClient should return our mock
-  Aws::Client::ClientConfiguration config;
+  auto config = MakeNoImdsClientConfiguration();
   auto client = Aws::Http::CreateHttpClient(config);
   ASSERT_EQ(client.get(), mock_client_.get()) << "CreateHttpClient did not return the mock client";
 
@@ -1197,7 +1201,7 @@ constexpr const char* kSTSSuccessXml = R"(<?xml version='1.0' encoding='UTF-8'?>
 TEST_F(S3ProviderTest, TestAliyunRAMSTSClientSuccess) {
   mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kSTSSuccessXml);
 
-  Aws::Client::ClientConfiguration cfg;
+  auto cfg = MakeNoImdsClientConfiguration();
   AliyunRAMSTSClient client(cfg);
 
   AliyunRAMSTSClient::AssumeRoleRequest req;
@@ -1237,7 +1241,7 @@ TEST_F(S3ProviderTest, TestAliyunRAMSTSClientSuccess) {
 TEST_F(S3ProviderTest, TestAliyunRAMSTSClientOmitsSecurityTokenForLongTermCaller) {
   mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, kSTSSuccessXml);
 
-  Aws::Client::ClientConfiguration cfg;
+  auto cfg = MakeNoImdsClientConfiguration();
   AliyunRAMSTSClient client(cfg);
 
   AliyunRAMSTSClient::AssumeRoleRequest req;
@@ -1260,7 +1264,7 @@ TEST_F(S3ProviderTest, TestAliyunRAMSTSClientOmitsSecurityTokenForLongTermCaller
 TEST_F(S3ProviderTest, TestAliyunRAMSTSClientEmptyResponse) {
   mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, "");
 
-  Aws::Client::ClientConfiguration cfg;
+  auto cfg = MakeNoImdsClientConfiguration();
   AliyunRAMSTSClient client(cfg);
 
   AliyunRAMSTSClient::AssumeRoleRequest req;
@@ -1281,7 +1285,7 @@ TEST_F(S3ProviderTest, TestAliyunRAMSTSClientMissingCredentialsElement) {
 <AssumeRoleResponse><RequestId>rid</RequestId></AssumeRoleResponse>)";
   mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, xml);
 
-  Aws::Client::ClientConfiguration cfg;
+  auto cfg = MakeNoImdsClientConfiguration();
   AliyunRAMSTSClient client(cfg);
 
   AliyunRAMSTSClient::AssumeRoleRequest req;
@@ -1302,7 +1306,7 @@ TEST_F(S3ProviderTest, TestAliyunRAMSTSClientUnexpectedRoot) {
 <ErrorResponse><Code>AccessDenied</Code></ErrorResponse>)";
   mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK, xml);
 
-  Aws::Client::ClientConfiguration cfg;
+  auto cfg = MakeNoImdsClientConfiguration();
   AliyunRAMSTSClient client(cfg);
 
   AliyunRAMSTSClient::AssumeRoleRequest req;


### PR DESCRIPTION
Non-AWS S3-compatible storage should not pay the cost of AWS EC2 metadata discovery. The AWS SDK default client configuration may try IMDS when region discovery is not already settled, and on Aliyun, GCP, Tencent, or Huawei that can turn a cold filesystem or credential client setup into a multi-second wait against an endpoint that is not useful for that cloud.

This change keeps AWS on the existing default behavior, but makes the non-AWS path explicit. The shared S3 client builder now creates its client configuration with IMDS disabled for GCP, Aliyun OSS, Tencent COS, and Huawei OBS, so normal object-store clients do not accidentally probe AWS metadata during construction.

The provider-specific credential paths get the same treatment. Aliyun web identity, Aliyun OIDC chained AssumeRole, Aliyun RAM mode, Tencent STS web identity, and Huawei STS web identity all build their AWS SDK client configuration with IMDS disabled up front. That still preserves the Aliyun ECS metadata flow where we intentionally call Aliyun’s own metadata endpoint; it only removes the unrelated AWS EC2 metadata fallback from the SDK configuration path.