### PR TITLE
enhance: add optional AWS S3 CRT build support

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,7 +12,12 @@ option(WITH_BENCHMARK "Build with micro benchmark." ON)
 option(WITH_JNI "Build with JNI library." OFF)
 option(WITH_PYTHON_BINDING "Build for Python bindings with hidden symbols." OFF)
 option(WITH_FIU "Build with fault injection support (libfiu)." OFF)
+option(WITH_CRT "Build with AWS S3 CRT support." OFF)
 option(ARROW_WITH_JEMALLOC "Build with jemalloc." OFF)
+
+if (WITH_CRT)
+  add_compile_definitions(WITH_CRT)
+endif()
 
 include(GNUInstallDirs)
 
@@ -37,6 +42,7 @@ find_package(nlohmann_json REQUIRED CONFIG)
 find_package(opentelemetry-cpp REQUIRED)
 find_package(google-cloud-cpp REQUIRED)
 find_package(CURL REQUIRED)
+find_package(AWSSDK REQUIRED CONFIG)
 find_package(milvus-common REQUIRED)
 find_package(libavrocpp QUIET)
 if(NOT libavrocpp_FOUND)
@@ -93,6 +99,10 @@ list(APPEND LINK_LIBS
   prometheus-cpp::core
   opentelemetry-cpp::opentelemetry_proto
 )
+
+if (WITH_CRT)
+  list(APPEND LINK_LIBS AWS::aws-sdk-cpp-s3-crt)
+endif()
 
 # folly depends on libaio for Linux AIO; Conan 2.x CMakeDeps doesn't
 # propagate this system library automatically.

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -12,6 +12,7 @@ endif
 use_asan := $(or $(USE_ASAN),True)
 with_ut := $(or $(WITH_UT),True)
 with_fiu := $(or $(WITH_FIU),True)
+with_crt := $(or $(WITH_CRT),False)
 with_benchmark := $(or $(WITH_BENCHMARK),True)
 build_type := $(or $(BUILD_TYPE),Release)
 use_jni := $(or $(USE_JNI),False)
@@ -40,14 +41,17 @@ build:
 	@echo "use_jni: ${use_jni}"
 	@echo "use_python_binding: ${use_python_binding}"
 	@echo "with_fiu: ${with_fiu}"
+	@echo "with_crt: ${with_crt}"
 
 	mkdir -p build && cd build && \
 	${CONAN_BASE} \
 	-o "&:with_ut=${with_ut}" -o "&:with_benchmark=${with_benchmark}" -o "&:with_asan=${use_asan}" \
-	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" && \
+	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" \
+	-o "&:with_crt=${with_crt}" && \
 	conan build .. ${CONAN_SETTINGS} \
 	-o "&:with_ut=${with_ut}" -o "&:with_benchmark=${with_benchmark}" -o "&:with_asan=${use_asan}" \
-	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}"
+	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" \
+	-o "&:with_crt=${with_crt}"
 
 package: build
 	mkdir -p build && cd build && \

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -31,6 +31,7 @@ class StorageConan(ConanFile):
         "with_jni": [True, False],
         "with_python_binding": [True, False],
         "with_fiu": [True, False],
+        "with_crt": [True, False],
     }
     default_options = {
         "shared": True,
@@ -43,6 +44,7 @@ class StorageConan(ConanFile):
         "with_jni": False,
         "with_python_binding": False,
         "with_fiu": False,
+        "with_crt": False,
         "folly/*:shared": True,
         "glog/*:with_gflags": True,
         "glog/*:shared": True,
@@ -52,6 +54,7 @@ class StorageConan(ConanFile):
         "grpc/*:shared": True,
         "grpc/*:secure": True,
         "aws-sdk-cpp/*:config": True,
+        "aws-sdk-cpp/*:s3-crt": False,
         "aws-sdk-cpp/*:text-to-speech": False,
         "aws-sdk-cpp/*:transfer": False,
         # Force aws-c-* / s2n to be shared so all aws-cpp-sdk subdir .so files
@@ -128,6 +131,10 @@ class StorageConan(ConanFile):
         # macOS cannot build opentelemetry-cpp with shared=True.
         if self.settings.os == "Linux":
             self.options["opentelemetry-cpp"].shared = True
+        if self.options.with_crt:
+            # aws-sdk-cpp uses a hyphenated option name; package-pattern syntax
+            # sets the real option, while .s3_crt does not.
+            self.options.update(options_values={"aws-sdk-cpp/*:s3-crt": "True"})
         self.options["arrow"].with_azure = True
         if self.options.with_jni and self.settings.os != "Macos":
             self.options["arrow"].shared = True
@@ -235,6 +242,7 @@ class StorageConan(ConanFile):
         tc.variables["WITH_JNI"] = self.options.with_jni
         tc.variables["WITH_PYTHON_BINDING"] = self.options.with_python_binding
         tc.variables["WITH_FIU"] = self.options.with_fiu
+        tc.variables["WITH_CRT"] = self.options.with_crt
 
         # Set JAVA_HOME for JNI compilation
         if self.options.with_jni:

--- a/cpp/test/filesystem/s3_crt_build_test.cpp
+++ b/cpp/test/filesystem/s3_crt_build_test.cpp
@@ -33,9 +33,6 @@ TEST(S3CrtBuildSupportTest, HeadersAndStaticClientSymbolsAreAvailable) {
 
   ASSERT_STATUS_OK(EnsureS3Initialized());
 
-  Aws::S3Crt::S3CrtClientConfiguration config;
-  EXPECT_FALSE(config.region.empty());
-
   const char* service_name = Aws::S3Crt::S3CrtClient::GetServiceName();
   ASSERT_NE(service_name, nullptr);
   EXPECT_FALSE(std::string(service_name).empty());

--- a/cpp/test/filesystem/s3_crt_build_test.cpp
+++ b/cpp/test/filesystem/s3_crt_build_test.cpp
@@ -1,0 +1,46 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef WITH_CRT
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <type_traits>
+
+#include <aws/s3-crt/S3CrtClient.h>
+#include <aws/s3-crt/S3CrtClientConfiguration.h>
+
+#include "milvus-storage/filesystem/s3/s3_global.h"
+#include "test_env.h"
+
+namespace milvus_storage::test {
+
+TEST(S3CrtBuildSupportTest, HeadersAndStaticClientSymbolsAreAvailable) {
+  static_assert(std::is_class_v<Aws::S3Crt::S3CrtClient>);
+  static_assert(std::is_default_constructible_v<Aws::S3Crt::S3CrtClientConfiguration>);
+
+  ASSERT_STATUS_OK(EnsureS3Initialized());
+
+  Aws::S3Crt::S3CrtClientConfiguration config;
+  EXPECT_FALSE(config.region.empty());
+
+  const char* service_name = Aws::S3Crt::S3CrtClient::GetServiceName();
+  ASSERT_NE(service_name, nullptr);
+  EXPECT_FALSE(std::string(service_name).empty());
+}
+
+}  // namespace milvus_storage::test
+
+#endif  // WITH_CRT


### PR DESCRIPTION
We need a way to build milvus-storage with AWS S3 CRT support without changing the default build path. The reason this is guarded by WITH_CRT is that bringing in AWS CRT still feels more like an experimental feature at this stage, so it should be easy to opt into without making it part of every normal build yet.

This change adds a with_crt Conan option and threads it through the Makefile and CMake as `WITH_CRT`. When it is enabled, Conan turns on `aws-sdk-cpp/*:s3-crt`, CMake defines `WITH_CRT`, and the build links against `AWS::aws-sdk-cpp-s3-crt` so the CRT headers and symbols are available to the storage library build.