### PR TITLE
enhance: support configurable Vortex coalescing window

### DIFF
--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -31,7 +31,10 @@ namespace milvus_storage::vortex {
 
 class VortexFile;
 struct VortexReadPlan;
-class ScanBuilder;
+namespace ffi {
+struct CoalescingWindow;
+}  // namespace ffi
+extern const ffi::CoalescingWindow kSmallCoalescingWindow;
 namespace expr {
 class Expr;
 }  // namespace expr
@@ -107,10 +110,11 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   // get the total memory usage(uncompressed memory) of the file
   uint64_t total_mem_usage();
 
-  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> streaming_read(uint64_t row_start,
-                                                                                        uint64_t row_end);
+  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> streaming_read(
+      uint64_t row_start, uint64_t row_end, const ffi::CoalescingWindow& coalescing_window);
 
-  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::ChunkedArray>> blocking_read(uint64_t row_start, uint64_t row_end);
+  [[nodiscard]] arrow::Result<std::shared_ptr<arrow::ChunkedArray>> blocking_read(
+      uint64_t row_start, uint64_t row_end, const ffi::CoalescingWindow& coalescing_window);
 
   // Vortex-specific extension: execute a planner-generated scan plan while keeping
   // the existing FormatReader interfaces unchanged.
@@ -131,7 +135,9 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
                      const std::shared_ptr<arrow::Schema>& read_schema,
                      const std::vector<std::string>& needed_columns);
 
-  [[nodiscard]] arrow::Result<ArrowArrayStream> read(uint64_t row_start, uint64_t row_end);
+  [[nodiscard]] arrow::Result<ArrowArrayStream> read(uint64_t row_start,
+                                                     uint64_t row_end,
+                                                     const ffi::CoalescingWindow& coalescing_window);
 
   private:
   std::shared_ptr<FileSystemWrapper> fs_holder_;

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -221,7 +221,7 @@ class VortexFile {
 
   /// Create a scan builder for the file.
   /// The scan builder can be used to scan the file.
-  ScanBuilder CreateScanBuilder() const;
+  ScanBuilder CreateScanBuilder(ffi::CoalescingWindow coalescing_window) const;
 
   /// Create a scan builder with arrow schema for the file.
   ScanBuilder CreateScanBuilderWithSchema(ArrowSchema& in_schema) const;

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -242,7 +242,7 @@ fn check_loon_ffi_result(result: &mut LoonFFIResult, context: &str) -> Result<()
     Ok(())
 }
 
-struct ThreadSafePtr<T> {
+pub(crate) struct ThreadSafePtr<T> {
     ptr: *mut c_void,
     _marker: PhantomData<T>,
 }
@@ -251,7 +251,7 @@ unsafe impl<T> Send for ThreadSafePtr<T> {}
 unsafe impl<T> Sync for ThreadSafePtr<T> {}
 
 impl<T> ThreadSafePtr<T> {
-    fn new(ptr: *mut c_void) -> Self {
+    pub(crate) fn new(ptr: *mut c_void) -> Self {
         Self {
             ptr,
             _marker: PhantomData,
@@ -261,7 +261,7 @@ impl<T> ThreadSafePtr<T> {
     // Add methods to safely access the pointer
     // every time we call as_ptr, we clone it ensure
     // the pointer is not moved
-    fn as_ptr(&self) -> *mut c_void {
+    pub(crate) fn as_ptr(&self) -> *mut c_void {
         self.ptr
     }
 
@@ -350,7 +350,7 @@ impl Write for ObjectStoreWriterCpp {
     }
 }
 
-const COALESCING_WINDOW: CoalesceWindow = CoalesceWindow {
+pub(crate) const DEFAULT_COALESCING_WINDOW: CoalesceWindow = CoalesceWindow {
     distance: 1024 * 1024,     // 1 MB
     max_size: 1 * 1024 * 1024, // 1 MB
 };
@@ -404,7 +404,12 @@ pub struct ObjectStoreReadSourceCpp {
 }
 
 impl ObjectStoreReadSourceCpp {
-    pub fn new(fs_rawptr: *mut std::ffi::c_void, path: &str, file_size: u64) -> VortexResult<Self> {
+    pub fn new(
+        fs_rawptr: *mut std::ffi::c_void,
+        path: &str,
+        file_size: u64,
+        coalesce_window: CoalesceWindow,
+    ) -> VortexResult<Self> {
         let mut reader_raw: *mut c_void = std::ptr::null_mut();
         let path_bytes = path.as_bytes();
         unsafe {
@@ -425,7 +430,7 @@ impl ObjectStoreReadSourceCpp {
             reader: Arc::new(ReaderHandle { ptr: reader_raw }),
             path: path.to_string(),
             uri: vortex_read_source_uri(path),
-            coalesce_window: Some(COALESCING_WINDOW),
+            coalesce_window: Some(coalesce_window),
         })
     }
 }

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -185,6 +185,11 @@ pub mod vortex_ffi {
         footer_size: u64,
     }
 
+    struct CoalescingWindow {
+        distance: u64,
+        max_size: u64,
+    }
+
     struct RowGroupZoneMapPruningStats {
         prune_eval_count: u64,
         pruned_row_group_count: u64,
@@ -267,7 +272,10 @@ pub mod vortex_ffi {
         type VortexFile;
         fn row_count(self: &VortexFile) -> u64;
         unsafe fn get_schema(self: &VortexFile, out_schema: *mut u8) -> Result<()>;
-        fn scan_builder(self: &VortexFile) -> Result<Box<VortexScanBuilder>>;
+        fn scan_builder(
+            self: &VortexFile,
+            window: CoalescingWindow,
+        ) -> Result<Box<VortexScanBuilder>>;
         unsafe fn scan_builder_with_schema(
             self: &VortexFile,
             in_schema: *mut u8,

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -218,7 +218,9 @@ void VortexFile::GetFileSchema(ArrowSchema& out_schema) const {
   }
 }
 
-ScanBuilder VortexFile::CreateScanBuilder() const { return ScanBuilder(impl_->scan_builder()); }
+ScanBuilder VortexFile::CreateScanBuilder(ffi::CoalescingWindow coalescing_window) const {
+  return ScanBuilder(impl_->scan_builder(coalescing_window));
+}
 
 ScanBuilder VortexFile::CreateScanBuilderWithSchema(ArrowSchema& in_schema) const {
   return ScanBuilder(impl_->scan_builder_with_schema(reinterpret_cast<uint8_t*>(&in_schema)));

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -2,10 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use anyhow::Result;
+use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arrow_array::cast::AsArray;
 use arrow_array::ffi::FFI_ArrowSchema;
@@ -1027,6 +1028,42 @@ impl VortexWriter {
 
 pub(crate) struct VortexFile {
     inner: vortex::file::VortexFile,
+    fswrapper: crate::filesystem_c::ThreadSafePtr<c_void>,
+    path: String,
+    file_size: u64,
+    default_window: CoalescingWindowKey,
+    views_by_window: Mutex<HashMap<CoalescingWindowKey, vortex::file::VortexFile>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CoalescingWindowKey {
+    distance: u64,
+    max_size: u64,
+}
+
+impl CoalescingWindowKey {
+    fn from_ffi(window: &crate::vortex_ffi::CoalescingWindow) -> Self {
+        Self {
+            distance: window.distance,
+            max_size: window.max_size,
+        }
+    }
+}
+
+fn to_vortex_coalesce_window(
+    window: &crate::vortex_ffi::CoalescingWindow,
+) -> vortex::io::file::CoalesceWindow {
+    vortex::io::file::CoalesceWindow {
+        distance: window.distance,
+        max_size: window.max_size,
+    }
+}
+
+fn default_ffi_coalescing_window() -> crate::vortex_ffi::CoalescingWindow {
+    crate::vortex_ffi::CoalescingWindow {
+        distance: crate::filesystem_c::DEFAULT_COALESCING_WINDOW.distance,
+        max_size: crate::filesystem_c::DEFAULT_COALESCING_WINDOW.max_size,
+    }
 }
 
 pub(crate) fn vortex_eof_size() -> u64 {
@@ -1034,14 +1071,62 @@ pub(crate) fn vortex_eof_size() -> u64 {
 }
 
 impl VortexFile {
+    fn open(
+        &self,
+        window: &crate::vortex_ffi::CoalescingWindow,
+    ) -> Result<vortex::file::VortexFile> {
+        let read_source = ObjectStoreReadSourceCpp::new(
+            self.fswrapper.as_ptr(),
+            &self.path,
+            self.file_size,
+            to_vortex_coalesce_window(window),
+        )
+        .map_err(VortexError::from)?;
+
+        let footer = self.inner.footer().clone();
+        let file = VORTEX_RT.block_on(async move {
+            VORTEX_SESSION
+                .open_options()
+                .with_footer(footer)
+                .open(read_source)
+                .await
+                .map_err(VortexError::from)
+        })?;
+
+        Ok(file)
+    }
+
+    fn open_with_coalescing_window(
+        &self,
+        window: crate::vortex_ffi::CoalescingWindow,
+    ) -> Result<vortex::file::VortexFile> {
+        let key = CoalescingWindowKey::from_ffi(&window);
+        if key == self.default_window {
+            return Ok(self.inner.clone());
+        }
+
+        if let Some(file) = self.views_by_window.lock().unwrap().get(&key).cloned() {
+            return Ok(file);
+        }
+
+        let opened = self.open(&window)?;
+        let mut guard = self.views_by_window.lock().unwrap();
+        let file = guard.entry(key).or_insert_with(|| opened.clone()).clone();
+        Ok(file)
+    }
+
     pub(crate) fn row_count(&self) -> u64 {
         self.inner.row_count()
     }
 
-    pub(crate) fn scan_builder(&self) -> Result<Box<VortexScanBuilder>> {
-        let num_natural_splits = self.inner.splits().map_err(VortexError::from)?.len();
+    pub(crate) fn scan_builder(
+        &self,
+        window: crate::vortex_ffi::CoalescingWindow,
+    ) -> Result<Box<VortexScanBuilder>> {
+        let file = self.open_with_coalescing_window(window)?;
+        let num_natural_splits = file.splits().map_err(VortexError::from)?.len();
         Ok(Box::new(VortexScanBuilder {
-            inner: self.inner.scan()?,
+            inner: file.scan()?,
             filter: None,
             output_schema: None,
             original_schema: None,
@@ -1422,8 +1507,14 @@ pub(crate) unsafe fn open_file(
     file_size: u64,
     footer_size: u64,
 ) -> Result<Box<VortexFile>> {
-    let read_source = ObjectStoreReadSourceCpp::new(fswrapper_ptr as *mut c_void, path, file_size)
-        .map_err(VortexError::from)?;
+    let default_window = default_ffi_coalescing_window();
+    let read_source = ObjectStoreReadSourceCpp::new(
+        fswrapper_ptr as *mut c_void,
+        path,
+        file_size,
+        to_vortex_coalesce_window(&default_window),
+    )
+    .map_err(VortexError::from)?;
     let mut open_options = VORTEX_SESSION.open_options();
     if file_size > 0 {
         // Use pre-known file size to skip the S3 HEAD request that size() would trigger.
@@ -1442,7 +1533,14 @@ pub(crate) unsafe fn open_file(
             .map_err(VortexError::from)
     })?;
 
-    Ok(Box::new(VortexFile { inner: file }))
+    Ok(Box::new(VortexFile {
+        inner: file,
+        fswrapper: crate::filesystem_c::ThreadSafePtr::new(fswrapper_ptr as *mut c_void),
+        path: path.to_string(),
+        file_size,
+        default_window: CoalescingWindowKey::from_ffi(&default_window),
+        views_by_window: Mutex::new(HashMap::new()),
+    }))
 }
 
 pub(crate) struct VortexScanBuilder {

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -35,7 +35,11 @@
 
 namespace milvus_storage::vortex {
 
+extern const ffi::CoalescingWindow kSmallCoalescingWindow{1024 * 1024, 1024 * 1024};
+
 namespace {
+const ffi::CoalescingWindow kLargeCoalescingWindow{1024 * 1024, 8 * 1024 * 1024};
+
 static uint8_t arrow_type_to_tag(const arrow::DataType& dt) {
   switch (dt.id()) {
     case arrow::Type::INT8:
@@ -503,8 +507,9 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::get_chunk
     return arrow::Status::Invalid(
         fmt::format("Vortex row group index {} out of range {}", row_group_index, row_group_infos_.size()));
   }
-  ARROW_ASSIGN_OR_RAISE(auto chunkedarray, blocking_read(row_group_infos_[row_group_index].start_offset,
-                                                         row_group_infos_[row_group_index].end_offset));
+  ARROW_ASSIGN_OR_RAISE(auto chunkedarray,
+                        blocking_read(row_group_infos_[row_group_index].start_offset,
+                                      row_group_infos_[row_group_index].end_offset, kLargeCoalescingWindow));
   assert(chunkedarray != nullptr);
 
   if (chunkedarray->num_chunks() == 0) {
@@ -560,7 +565,8 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> VortexFormatRead
     const auto& start_rg_info = row_group_infos_[rg_range.first];
     const auto& end_rg_info = row_group_infos_[rg_range.second];
 
-    ARROW_ASSIGN_OR_RAISE(auto chunked_array, blocking_read(start_rg_info.start_offset, end_rg_info.end_offset));
+    ARROW_ASSIGN_OR_RAISE(auto chunked_array,
+                          blocking_read(start_rg_info.start_offset, end_rg_info.end_offset, kLargeCoalescingWindow));
     // assign to rbs
     for (size_t j = 0; j < chunked_array->num_chunks(); ++j) {
       ARROW_ASSIGN_OR_RAISE(auto rb, arrow::RecordBatch::FromStructArray(chunked_array->chunk(j)));
@@ -581,7 +587,7 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read_with_plan(const VortexR
     return arrow::Status::Invalid("VortexFormatReader is not opened");
   }
 
-  auto scan_builder = vxfile_->CreateScanBuilder();
+  auto scan_builder = vxfile_->CreateScanBuilder(kSmallCoalescingWindow);
   if (split_row_indices_.has_value()) {
     scan_builder.WithSplitRowIndices(*split_row_indices_);
   }
@@ -611,7 +617,7 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read_row_ids_with_plan(const
     return arrow::Status::Invalid("VortexFormatReader is not opened");
   }
 
-  auto scan_builder = vxfile_->CreateScanBuilder();
+  auto scan_builder = vxfile_->CreateScanBuilder(kSmallCoalescingWindow);
   if (split_row_indices_.has_value()) {
     scan_builder.WithSplitRowIndices(*split_row_indices_);
   }
@@ -628,8 +634,10 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read_row_ids_with_plan(const
   return std::move(scan_builder).IntoStream();
 }
 
-arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start, uint64_t row_end) {
-  auto scan_builder = vxfile_->CreateScanBuilder();
+arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start,
+                                                         uint64_t row_end,
+                                                         const ffi::CoalescingWindow& coalescing_window) {
+  auto scan_builder = vxfile_->CreateScanBuilder(coalescing_window);
   if (!proj_cols_.empty()) {
     scan_builder.WithProjection(build_projection(proj_cols_));
   }
@@ -647,21 +655,21 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start, uin
   return std::move(scan_builder).IntoStream();
 }
 
-arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> VortexFormatReader::streaming_read(uint64_t row_start,
-                                                                                            uint64_t row_end) {
-  ARROW_ASSIGN_OR_RAISE(auto array_stream, read(row_start, row_end));
+arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> VortexFormatReader::streaming_read(
+    uint64_t row_start, uint64_t row_end, const ffi::CoalescingWindow& coalescing_window) {
+  ARROW_ASSIGN_OR_RAISE(auto array_stream, read(row_start, row_end, coalescing_window));
   return arrow::ImportRecordBatchReader(&array_stream);
 }
 
-arrow::Result<std::shared_ptr<arrow::ChunkedArray>> VortexFormatReader::blocking_read(uint64_t row_start,
-                                                                                      uint64_t row_end) {
-  ARROW_ASSIGN_OR_RAISE(auto array_stream, read(row_start, row_end));
+arrow::Result<std::shared_ptr<arrow::ChunkedArray>> VortexFormatReader::blocking_read(
+    uint64_t row_start, uint64_t row_end, const ffi::CoalescingWindow& coalescing_window) {
+  ARROW_ASSIGN_OR_RAISE(auto array_stream, read(row_start, row_end, coalescing_window));
   return arrow::ImportChunkedArray(&array_stream);
 }
 
 arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std::vector<int64_t>& row_indices) {
   assert(vxfile_);
-  auto scan_builder = vxfile_->CreateScanBuilder();
+  auto scan_builder = vxfile_->CreateScanBuilder(kSmallCoalescingWindow);
   if (!proj_cols_.empty()) {
     scan_builder.WithProjection(build_projection(proj_cols_));
   }
@@ -693,7 +701,7 @@ arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std:
 arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> VortexFormatReader::read_with_range(
     const uint64_t& start_offset, const uint64_t& end_offset) {
   assert(vxfile_);
-  return streaming_read(start_offset, end_offset);
+  return streaming_read(start_offset, end_offset, kLargeCoalescingWindow);
 }
 
 uint64_t VortexFormatReader::total_mem_usage() { return compute_total_mem_usage(*vxfile_); }

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -441,7 +441,7 @@ TEST_P(VortexBasicTest, TestListOfFixedSizeBinary512WriteRead) {
   auto vx_reader = vortex::VortexFormatReader(file_system_, vector_array_schema, test_file_name_, properties_,
                                               std::vector<std::string>{"vector_array"});
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(num_rows, read_rb->num_rows());
   ASSERT_EQ(1, read_rb->num_columns());
@@ -488,7 +488,7 @@ TEST_P(VortexBasicTest, TestSlicedListOfFixedSizeBinaryWriteRead) {
   ASSERT_STATUS_OK(vx_reader.open());
 
   {
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, slice_length));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, slice_length, kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(slice_length, read_rb->num_rows());
     auto read_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(0));
@@ -496,7 +496,7 @@ TEST_P(VortexBasicTest, TestSlicedListOfFixedSizeBinaryWriteRead) {
   }
 
   {
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(1, slice_length));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(1, slice_length, kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(slice_length - 1, read_rb->num_rows());
     auto read_list = std::dynamic_pointer_cast<arrow::ListArray>(read_rb->column(0));
@@ -523,7 +523,7 @@ TEST_P(VortexBasicTest, TestLargeListOfFixedSizeBinaryWriteRead) {
   auto vx_reader = vortex::VortexFormatReader(file_system_, vector_schema, test_file_name_, properties_,
                                               std::vector<std::string>{"large_vector_array"});
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(num_rows, read_rb->num_rows());
   auto read_list = std::dynamic_pointer_cast<arrow::LargeListArray>(read_rb->column(0));
@@ -550,7 +550,7 @@ TEST_P(VortexBasicTest, TestFixedSizeListOfFixedSizeBinaryWriteRead) {
   auto vx_reader = vortex::VortexFormatReader(file_system_, vector_schema, test_file_name_, properties_,
                                               std::vector<std::string>{"fixed_vector_array"});
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(num_rows, read_rb->num_rows());
   auto read_list = std::dynamic_pointer_cast<arrow::FixedSizeListArray>(read_rb->column(0));
@@ -582,7 +582,7 @@ TEST_P(VortexBasicTest, TestSlicedFixedSizeBinaryWriteRead) {
   ASSERT_STATUS_OK(vx_reader.open());
 
   {
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, slice_length));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, slice_length, kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(slice_length, read_rb->num_rows());
     auto read_array = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_rb->column(0));
@@ -590,7 +590,7 @@ TEST_P(VortexBasicTest, TestSlicedFixedSizeBinaryWriteRead) {
   }
 
   {
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(1, slice_length));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(1, slice_length, kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(slice_length - 1, read_rb->num_rows());
     auto read_array = std::dynamic_pointer_cast<arrow::FixedSizeBinaryArray>(read_rb->column(0));
@@ -628,7 +628,7 @@ TEST_P(VortexBasicTest, TestNestedFixedSizeBinaryWriteRead) {
       vortex::VortexFormatReader(file_system_, nested_schema, test_file_name_, properties_,
                                  std::vector<std::string>{"entity", "nullable_embedding", "nested_vectors"});
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, num_rows, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto read_rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(num_rows, read_rb->num_rows());
   ASSERT_EQ(3, read_rb->num_columns());
@@ -723,7 +723,7 @@ TEST_P(VortexBasicTest, TestFixedSizeListWidthMismatchReadFails) {
                                               std::vector<std::string>{"embedding"});
   ASSERT_STATUS_OK(vx_reader.open());
 
-  auto read_result = vx_reader.blocking_read(0, num_rows);
+  auto read_result = vx_reader.blocking_read(0, num_rows, kSmallCoalescingWindow);
   ASSERT_FALSE(read_result.ok());
 }
 
@@ -751,7 +751,7 @@ TEST_P(VortexBasicTest, TestFixedSizeListChildNullReadFails) {
                                               std::vector<std::string>{"embedding"});
   ASSERT_STATUS_OK(vx_reader.open());
 
-  auto read_result = vx_reader.blocking_read(0, num_rows);
+  auto read_result = vx_reader.blocking_read(0, num_rows, kSmallCoalescingWindow);
   // FixedSizeBinary can only represent row-level nullability, so a FixedSizeList<UInt8>
   // with byte-level child nulls must fail instead of silently dropping those nulls.
   ASSERT_FALSE(read_result.ok());
@@ -770,7 +770,7 @@ TEST_P(VortexBasicTest, TestBasicRead) {
 
   auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
 
   ASSERT_EQ(recordBatchsRows(), rb->num_rows());
@@ -802,7 +802,7 @@ TEST_P(VortexBasicTest, TestEmptyWriteRead) {
   ASSERT_STATUS_OK(vx_reader.open());
   ASSERT_EQ(0, vx_reader.rows());
 
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, vx_reader.rows()));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, vx_reader.rows(), kSmallCoalescingWindow));
   ASSERT_EQ(0, chunked_array->num_chunks());
 }
 
@@ -823,7 +823,7 @@ TEST_P(VortexBasicTest, TestReaderProjection) {
     ASSERT_STATUS_OK(vx_reader.open());
     ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
 
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(recordBatchsRows(), rb->num_rows());
     ASSERT_EQ(3, rb->num_columns());
@@ -845,7 +845,7 @@ TEST_P(VortexBasicTest, TestReaderProjection) {
     ASSERT_STATUS_OK(vx_reader.open());
     ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
 
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(recordBatchsRows(), rb->num_rows());
     ASSERT_EQ(3, rb->num_columns());
@@ -864,7 +864,7 @@ TEST_P(VortexBasicTest, TestReaderProjection) {
     ASSERT_STATUS_OK(vx_reader.open());
     ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
 
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(recordBatchsRows(), rb->num_rows());
     ASSERT_EQ(1, rb->num_columns());
@@ -880,7 +880,7 @@ TEST_P(VortexBasicTest, TestReaderProjection) {
     ASSERT_STATUS_OK(vx_reader.open());
     ASSERT_EQ(recordBatchsRows(), vx_reader.rows());
 
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(recordBatchsRows(), rb->num_rows());
     ASSERT_EQ(3, rb->num_columns());
@@ -1039,7 +1039,7 @@ TEST_P(VortexBasicTest, FooterSizeNotMatch) {
     auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
                                                 vx_file_size2, footer_size);
     ASSERT_STATUS_OK(vx_reader.open());
-    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+    ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
     ASSERT_EQ(recordBatchsRows(), rb->num_rows());
     ASSERT_EQ(3, rb->num_columns());

--- a/cpp/test/format/vortex/vortex_v2_test.cpp
+++ b/cpp/test/format/vortex/vortex_v2_test.cpp
@@ -135,7 +135,7 @@ TEST_F(VortexV2Test, TestV2StatsEnabledUsesRowGroupZoneMapLayout) {
   auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
                                               vx_file_size, vx_footer_size);
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(recordBatchsRows(), rb->num_rows());
   auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(rb->column(0));
@@ -171,7 +171,7 @@ TEST_F(VortexV2Test, TestV2StatsDisabledUsesPlainRowGroupLayout) {
   auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
                                               vx_file_size, vx_footer_size);
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(recordBatchsRows(), rb->num_rows());
 }
@@ -215,7 +215,7 @@ TEST_F(VortexV2Test, TestV2RowGroupZoneMapFilterScan) {
       VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size, vx_footer_size);
   ASSERT_EQ(vxfile.RootLayoutEncoding(), "milvus.v2_zoned_row_group");
 
-  auto scan_builder = vxfile.CreateScanBuilder();
+  auto scan_builder = vxfile.CreateScanBuilder(kSmallCoalescingWindow);
   scan_builder.WithFilter(expr::and_(expr::gt_eq(expr::column("id"), expr::literal(scalar::int64(1200))),
                                      expr::lt(expr::column("id"), expr::literal(scalar::int64(1300)))));
   scan_builder.WithProjection(expr::select(std::vector<std::string_view>{"id"}, expr::root()));
@@ -249,7 +249,7 @@ TEST_F(VortexV2Test, TestV2RowGroupWrite) {
   // --- blocking_read: full scan ---
   auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
   ASSERT_STATUS_OK(vx_reader.open());
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, total_rows));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, total_rows, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
 
   ASSERT_EQ(total_rows, rb->num_rows());
@@ -456,7 +456,7 @@ TEST_F(VortexV2Test, TestV2RowGroupSplitsBySize) {
   ASSERT_EQ(total_rows, static_cast<uint64_t>(rows_per_batch * 2));
 
   // --- blocking_read: full scan and verify string lengths ---
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, rows_per_batch * 2));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, rows_per_batch * 2, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(rb->num_rows(), rows_per_batch * 2);
   auto str_array = std::dynamic_pointer_cast<arrow::StringArray>(rb->column(0));
@@ -558,7 +558,7 @@ TEST_F(VortexV2Test, TestV2RowGroupMultiColumnSplitsBySize) {
   ASSERT_EQ(total_rows, static_cast<uint64_t>(rows_per_batch * 4));
 
   // --- blocking_read: full scan and verify data ---
-  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, rows_per_batch * 4));
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, rows_per_batch * 4, kSmallCoalescingWindow));
   ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
   ASSERT_EQ(rb->num_rows(), rows_per_batch * 4);
   ASSERT_EQ(rb->num_columns(), 3);


### PR DESCRIPTION
Vortex reads were using one fixed coalescing window everywhere, which made row-group and range reads too conservative for object-store IO. This change makes the read path choose the coalescing behavior based on how the data is being accessed, so larger sequential reads can merge more nearby requests while smaller point-style scans keep the tighter default window.

The C++ reader now passes an explicit coalescing window through the Vortex bridge when building scans. Normal plan scans, row-id reads, and take-style access keep the small 1MB window, while chunk, multi-chunk, and range reads use a larger 8MB max window to reduce fragmented IO on continuous reads.

On the Rust side, the Vortex file wrapper can reopen and cache file views by coalescing window. That lets different scan builders reuse the same footer metadata while still getting the right read-source settings for each access pattern, instead of forcing one global window for every reader operation.