### PR TITLE
enhance: Vortex writer flush semantics

### DIFF
--- a/cpp/benchmark/benchmark_format_write.cpp
+++ b/cpp/benchmark/benchmark_format_write.cpp
@@ -164,6 +164,136 @@ BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 
+static double DurationMillis(const std::chrono::steady_clock::time_point& start,
+                             const std::chrono::steady_clock::time_point& end) {
+  return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+static int64_t CountColumnGroupFiles(const std::shared_ptr<api::ColumnGroups>& cgs) {
+  int64_t files = 0;
+  for (const auto& cg : *cgs) {
+    files += static_cast<int64_t>(cg->files.size());
+  }
+  return files;
+}
+
+static double BytesToMiB(int64_t bytes) { return static_cast<double>(bytes) / 1024.0 / 1024.0; }
+
+// Split the same loaded data into many record batches and time writer->write()
+// separately from writer->close(). This mirrors Milvus sort compaction's
+// storage.Sort(...)->rw.Write(record) phase and the later srw.Close() phase.
+BENCHMARK_DEFINE_F(FormatWriteBenchmark, StageBreakdown)(::benchmark::State& st) {
+  auto format_idx = static_cast<size_t>(st.range(0));
+  auto writer_buffer_mib = static_cast<int64_t>(st.range(1));
+  auto rows_per_record = static_cast<int64_t>(st.range(2));
+  auto repeat_count = static_cast<int64_t>(st.range(3));
+
+  std::string format = GetFormatByIndex(format_idx);
+  if (!CheckFormatAvailable(st, format)) {
+    return;
+  }
+  if (rows_per_record <= 0) {
+    st.SkipWithError("rows_per_record must be positive");
+    return;
+  }
+  if (repeat_count <= 0) {
+    st.SkipWithError("repeat_count must be positive");
+    return;
+  }
+
+  const int64_t writer_buffer_bytes = writer_buffer_mib * 1024 * 1024;
+  api::SetValue(properties_, PROPERTY_WRITER_BUFFER_SIZE, std::to_string(writer_buffer_bytes).c_str());
+
+  int64_t input_rows = 0;
+  int64_t input_bytes = 0;
+  for (const auto& batch : batches_) {
+    input_rows += batch->num_rows();
+    input_bytes += CalculateRawDataSize(batch);
+  }
+
+  double total_write_ms = 0.0;
+  double total_close_ms = 0.0;
+  int64_t total_files = 0;
+  int64_t total_write_calls = 0;
+
+  for (auto _ : st) {
+    std::string path = GetUniquePath("stage_" + format);
+    BENCH_ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(GetSchemaBasePatterns(), format, schema_), st);
+
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    BENCH_ASSERT_NOT_NULL(writer, st);
+
+    int64_t write_calls = 0;
+    const auto write_start = std::chrono::steady_clock::now();
+    for (int64_t repeat = 0; repeat < repeat_count; ++repeat) {
+      for (const auto& batch : batches_) {
+        for (int64_t offset = 0; offset < batch->num_rows(); offset += rows_per_record) {
+          auto rows = std::min(rows_per_record, batch->num_rows() - offset);
+          BENCH_ASSERT_STATUS_OK(writer->write(batch->Slice(offset, rows)), st);
+          ++write_calls;
+        }
+      }
+    }
+    const auto write_end = std::chrono::steady_clock::now();
+
+    BENCH_ASSERT_AND_ASSIGN(auto cgs, writer->close(), st);
+    const auto close_end = std::chrono::steady_clock::now();
+
+    total_write_ms += DurationMillis(write_start, write_end);
+    total_close_ms += DurationMillis(write_end, close_end);
+    total_files += CountColumnGroupFiles(cgs);
+    total_write_calls += write_calls;
+    ::benchmark::DoNotOptimize(cgs);
+  }
+
+  const double iterations = static_cast<double>(st.iterations());
+  const int64_t logical_bytes_per_iteration = input_bytes * repeat_count;
+  const int64_t logical_rows_per_iteration = input_rows * repeat_count;
+  const double logical_mib_total = BytesToMiB(logical_bytes_per_iteration) * iterations;
+  const double total_ms = total_write_ms + total_close_ms;
+  const double write_calls_per_iteration = static_cast<double>(total_write_calls) / iterations;
+
+  st.counters["write_ms"] = ::benchmark::Counter(total_write_ms, ::benchmark::Counter::kAvgIterations);
+  st.counters["close_ms"] = ::benchmark::Counter(total_close_ms, ::benchmark::Counter::kAvgIterations);
+  st.counters["write_mib_per_s"] = ::benchmark::Counter(
+      total_write_ms > 0.0 ? logical_mib_total / (total_write_ms / 1000.0) : 0.0, ::benchmark::Counter::kDefaults);
+  st.counters["close_mib_per_s"] = ::benchmark::Counter(
+      total_close_ms > 0.0 ? logical_mib_total / (total_close_ms / 1000.0) : 0.0, ::benchmark::Counter::kDefaults);
+  st.counters["total_mib_per_s"] = ::benchmark::Counter(total_ms > 0.0 ? logical_mib_total / (total_ms / 1000.0) : 0.0,
+                                                        ::benchmark::Counter::kDefaults);
+  st.counters["close_over_write"] = ::benchmark::Counter(total_write_ms > 0.0 ? total_close_ms / total_write_ms : 0.0,
+                                                         ::benchmark::Counter::kDefaults);
+  st.counters["rows"] =
+      ::benchmark::Counter(static_cast<double>(logical_rows_per_iteration), ::benchmark::Counter::kDefaults);
+  st.counters["write_calls"] = ::benchmark::Counter(write_calls_per_iteration, ::benchmark::Counter::kDefaults);
+  st.counters["files"] =
+      ::benchmark::Counter(static_cast<double>(total_files) / iterations, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "raw_size", logical_bytes_per_iteration, ::benchmark::Counter::kDefaults);
+  if (write_calls_per_iteration > 0.0) {
+    ReportSize(st, "bytes_per_write", static_cast<int64_t>(logical_bytes_per_iteration / write_calls_per_iteration),
+               ::benchmark::Counter::kDefaults);
+  }
+
+  st.SetLabel(format + "/buffer=" + std::to_string(writer_buffer_mib) +
+              "MiB/record_rows=" + std::to_string(rows_per_record) + "/repeat=" + std::to_string(repeat_count));
+}
+
+constexpr int64_t kStageBreakdownWriterBufferMiB = 4;
+constexpr int64_t kStageBreakdownRowsPerWrite = 1024;
+constexpr int64_t kStageBreakdownRepeatCount = 50;
+
+BENCHMARK_REGISTER_F(FormatWriteBenchmark, StageBreakdown)
+    ->Name("WriterPipeline/StageBreakdown")
+    ->ArgsProduct({
+        {0, 1},                            // Format: parquet(0), vortex(1)
+        {kStageBreakdownWriterBufferMiB},  // Writer buffer MiB; small enough to force in-write flushes
+        {kStageBreakdownRowsPerWrite},     // Rows per writer->write call
+        {kStageBreakdownRepeatCount},      // About 1.1 GiB logical input with the default synthetic loader
+    })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime()
+    ->Iterations(3);
+
 //=============================================================================
 // File Size / Compression Analysis Benchmark
 //=============================================================================

--- a/cpp/include/milvus-storage/format/vortex/vortex_writer.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_writer.h
@@ -49,8 +49,6 @@ class VortexFileWriter final : public FormatWriter {
   std::shared_ptr<arrow::Schema> schema_;
   api::Properties properties_;
 
-  std::vector<std::shared_ptr<arrow::Array>> column_arrays_;
-
   int64_t written_rows_ = 0;
 };
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -183,6 +183,7 @@ class VortexWriter {
       uint8_t* fs_rawptr, const std::string& path, bool enable_stats, uint32_t format_version, uint64_t row_group_size);
 
   void Write(ArrowSchema& in_schema, ArrowArray& in_array);
+  void Flush();
   ffi::VortexWriteSummary Close();
 
   VortexWriter(VortexWriter&& other) noexcept = default;

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -313,11 +313,17 @@ impl ObjectStoreWriterHandle {
 
 impl Drop for ObjectStoreWriterHandle {
     fn drop(&mut self) {
-        // Normal close errors must be returned by explicit close().
-        // Drop only prevents leaking an opened C++ writer after early errors.
-        if let Err(e) = self.close() {
-            eprintln!("Warning: ObjectStoreWriterCpp close during Drop failed: {e}");
+        let mut writer = self.writer.lock().unwrap();
+        if writer.as_ptr().is_null() {
+            return;
         }
+
+        // Only explicit close may complete the object. Drop can run after writer
+        // errors, so calling close here would finalize partial data; release only
+        // the C++ wrapper.
+        let writer_raw = writer.as_raw_ptr();
+        unsafe { loon_filesystem_writer_destroy(writer_raw) };
+        *writer = ThreadSafePtr::new(std::ptr::null_mut());
     }
 }
 

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -285,6 +285,16 @@ pub struct ObjectStoreWriterHandle {
 }
 
 impl ObjectStoreWriterHandle {
+    pub fn flush(&self) -> Result<(), VortexError> {
+        let writer = self.writer.lock().unwrap();
+        if writer.as_ptr().is_null() {
+            return Ok(());
+        }
+
+        let mut result = unsafe { loon_filesystem_writer_flush(writer.as_ptr()) };
+        check_loon_ffi_result(&mut result, "Failed to flush data to ObjectStoreWriterCpp")
+    }
+
     pub fn close(&self) -> Result<(), VortexError> {
         let mut writer = self.writer.lock().unwrap();
         if writer.as_ptr().is_null() {
@@ -368,6 +378,10 @@ impl Write for ObjectStoreWriterCpp {
 
     fn flush(&mut self) -> std::io::Result<()> {
         let writer = self.writer.lock().unwrap();
+        if writer.as_ptr().is_null() {
+            return Ok(());
+        }
+
         let mut result = unsafe { loon_filesystem_writer_flush(writer.as_ptr()) };
         check_loon_ffi_result(&mut result, "Failed to flush data to ObjectStoreWriterCpp")
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -266,6 +266,7 @@ pub mod vortex_ffi {
             in_schema: *mut u8,
             in_array: *mut u8,
         ) -> Result<()>;
+        unsafe fn flush(self: &mut VortexWriter) -> Result<()>;
         unsafe fn close(self: &mut VortexWriter) -> Result<VortexWriteSummary>;
 
         // reader

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -180,6 +180,14 @@ void VortexWriter::Write(ArrowSchema& in_schema, ArrowArray& in_array) {
   }
 }
 
+void VortexWriter::Flush() {
+  try {
+    impl_->flush();
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw VortexException(e.what());
+  }
+}
+
 ffi::VortexWriteSummary VortexWriter::Close() {
   try {
     return impl_->close();

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -1033,6 +1033,15 @@ impl VortexWriter {
         Ok(())
     }
 
+    pub(crate) unsafe fn flush(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(writer_handle) = self.writer_handle.as_ref() {
+            writer_handle
+                .flush()
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        }
+        Ok(())
+    }
+
     pub(crate) unsafe fn close(
         &mut self,
     ) -> Result<crate::vortex_ffi::VortexWriteSummary, Box<dyn std::error::Error>> {

--- a/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
@@ -1481,12 +1481,26 @@ struct StatsBuildState {
     stats: Arc<[Stat]>,
 }
 
+fn row_group_zone_map_stats(stats: &[Stat]) -> Arc<[Stat]> {
+    stats
+        .iter()
+        .copied()
+        .filter(|stat| {
+            matches!(
+                stat,
+                Stat::Min | Stat::Max | Stat::Sum | Stat::NullCount | Stat::NaNCount
+            )
+        })
+        .collect()
+}
+
 impl StatsBuildState {
     fn new(
         dtype: &DType,
         stats: Arc<[Stat]>,
         max_variable_length_statistics_size: usize,
     ) -> VortexResult<Self> {
+        let stats = row_group_zone_map_stats(&stats);
         let struct_fields = dtype
             .as_struct_fields_opt()
             .ok_or_else(|| vortex_err!("{LAYOUT_ID} writer requires struct input"))?;
@@ -1726,13 +1740,58 @@ pub fn build_row_group_strategy(
     }
 }
 
+#[derive(Clone)]
+struct PredefinedFlatDataStrategy {
+    flat: FlatLayoutStrategy,
+    compressed: CompressingStrategy,
+}
+
+impl PredefinedFlatDataStrategy {
+    fn new(flat: FlatLayoutStrategy, compressed: CompressingStrategy) -> Self {
+        Self { flat, compressed }
+    }
+}
+
+fn is_predefined_flat_data_dtype(dtype: &DType) -> bool {
+    matches!(dtype, DType::FixedSizeList(..))
+}
+
+#[async_trait]
+impl LayoutStrategy for PredefinedFlatDataStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        stream: SendableSequentialStream,
+        eof: SequencePointer,
+        handle: Handle,
+    ) -> VortexResult<LayoutRef> {
+        if is_predefined_flat_data_dtype(stream.dtype()) {
+            self.flat
+                .write_stream(ctx, segment_sink, stream, eof, handle)
+                .await
+        } else {
+            self.compressed
+                .write_stream(ctx, segment_sink, stream, eof, handle)
+                .await
+        }
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.flat.buffered_bytes() + self.compressed.buffered_bytes()
+    }
+}
+
 fn build_data_strategy() -> Arc<dyn LayoutStrategy> {
     let flat = FlatLayoutStrategy {
         inline_array_node: true,
         ..Default::default()
     };
-    let compress_flat = CompressingStrategy::new_btrblocks(flat, false);
-    let chunked_inner = ChunkedLayoutStrategy::new(compress_flat.clone());
+    // Unlike the V1 strategy, V2 does not add a global dictionary layer before
+    // data compression, so keep integer dictionary encoding enabled here.
+    let compress_flat = CompressingStrategy::new_btrblocks(flat.clone(), false);
+    let data_child = PredefinedFlatDataStrategy::new(flat, compress_flat.clone());
+    let chunked_inner = ChunkedLayoutStrategy::new(data_child);
     let validity = CollectStrategy::new(compress_flat);
     let struct_inner = StructStrategy::new(chunked_inner, validity);
     Arc::new(ChunkedLayoutStrategy::new(struct_inner))
@@ -1751,10 +1810,11 @@ fn build_zones_strategy() -> Arc<dyn LayoutStrategy> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vortex::arrays::{ChunkedArray, ConstantArray};
+    use vortex::arrays::{ChunkedArray, ConstantArray, FixedSizeListArray};
     use vortex::buffer::{BitBufferMut, ByteBufferMut};
     use vortex::expr::{and, gt_eq, lit, lt};
     use vortex::file::{OpenOptionsSessionExt, VortexWriteOptions};
+    use vortex::stats::StatsProvider;
     use vortex::stream::ArrayStreamExt;
 
     #[test]
@@ -1806,6 +1866,42 @@ mod tests {
         .into_array())
     }
 
+    fn fixed_size_list_u8_struct_chunk(rows: usize, list_size: u32) -> VortexResult<ArrayRef> {
+        let values = (0..rows * list_size as usize)
+            .map(|idx| idx as u8)
+            .collect::<Vec<_>>();
+        let values =
+            PrimitiveArray::new(Buffer::copy_from(values.as_slice()), Validity::NonNullable)
+                .into_array();
+        let vector =
+            FixedSizeListArray::new(values, list_size, Validity::NonNullable, rows).into_array();
+        Ok(StructArray::try_new(
+            FieldNames::from(["vector"]),
+            vec![vector],
+            rows,
+            Validity::NonNullable,
+        )?
+        .into_array())
+    }
+
+    fn fixed_size_list_i32_struct_chunk(rows: usize, list_size: u32) -> VortexResult<ArrayRef> {
+        let values = (0..rows * list_size as usize)
+            .map(|idx| idx as i32)
+            .collect::<Vec<_>>();
+        let values =
+            PrimitiveArray::new(Buffer::copy_from(values.as_slice()), Validity::NonNullable)
+                .into_array();
+        let vector =
+            FixedSizeListArray::new(values, list_size, Validity::NonNullable, rows).into_array();
+        Ok(StructArray::try_new(
+            FieldNames::from(["vector"]),
+            vec![vector],
+            rows,
+            Validity::NonNullable,
+        )?
+        .into_array())
+    }
+
     #[test]
     fn logical_size_estimate_saturates_struct_overflow() -> VortexResult<()> {
         let len = usize::MAX / 8;
@@ -1835,6 +1931,46 @@ mod tests {
 
         let wrong_dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
         assert!(buffer.drain_one_group(&wrong_dtype).is_err());
+    }
+
+    #[test]
+    fn row_group_zone_map_does_not_compute_uncompressed_size_for_fixed_size_list()
+    -> VortexResult<()> {
+        let row_group = fixed_size_list_u8_struct_chunk(8, 128)?;
+        let stats = Arc::<[Stat]>::from([
+            Stat::Min,
+            Stat::Max,
+            Stat::Sum,
+            Stat::NullCount,
+            Stat::NaNCount,
+            Stat::UncompressedSizeInBytes,
+        ]);
+        let mut stats_state = StatsBuildState::new(row_group.dtype(), stats, 64)?;
+
+        stats_state.push_row_group(&row_group)?;
+
+        let struct_row_group = row_group.to_struct();
+        let vector = struct_row_group.field_by_name("vector")?;
+        assert!(
+            vector
+                .statistics()
+                .get(Stat::UncompressedSizeInBytes)
+                .is_none(),
+            "row-group zonemap stats should not force FixedSizeList uncompressed-size computation"
+        );
+        let Some((_zones, metadata)) = stats_state.finish()? else {
+            panic!("expected fixed-size-list null-count zonemap metadata");
+        };
+        let vector_metadata = metadata
+            .column(&"vector".into())
+            .expect("expected vector zonemap metadata");
+        assert!(
+            !vector_metadata
+                .present_stats
+                .contains(&Stat::UncompressedSizeInBytes),
+            "row-group zonemap metadata should not advertise uncompressed-size stats"
+        );
+        Ok(())
     }
 
     #[tokio::test]
@@ -1894,6 +2030,53 @@ mod tests {
         assert!(
             pruned_row_groups > 0,
             "expected row-group zonemap pruning to drop at least one row group"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn data_strategy_does_not_compute_all_stats_for_fixed_size_list_u8() -> VortexResult<()> {
+        let input = fixed_size_list_u8_struct_chunk(8, 128)?;
+        let mut buffer = ByteBufferMut::empty();
+
+        VortexWriteOptions::new(crate::VORTEX_SESSION.clone())
+            .with_file_statistics(vec![])
+            .with_strategy(build_data_strategy())
+            .write(&mut buffer, input.clone().to_array_stream())
+            .await?;
+
+        let input_struct = input.to_struct();
+        let vector = input_struct.field_by_name("vector")?;
+        assert!(
+            vector
+                .statistics()
+                .get(Stat::UncompressedSizeInBytes)
+                .is_none(),
+            "FixedSizeList<U8> data writes should avoid the compression path that computes all stats"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn data_strategy_does_not_compute_all_stats_for_fixed_size_list_i32() -> VortexResult<()>
+    {
+        let input = fixed_size_list_i32_struct_chunk(8, 16)?;
+        let mut buffer = ByteBufferMut::empty();
+
+        VortexWriteOptions::new(crate::VORTEX_SESSION.clone())
+            .with_file_statistics(vec![])
+            .with_strategy(build_data_strategy())
+            .write(&mut buffer, input.clone().to_array_stream())
+            .await?;
+
+        let input_struct = input.to_struct();
+        let vector = input_struct.field_by_name("vector")?;
+        assert!(
+            vector
+                .statistics()
+                .get(Stat::UncompressedSizeInBytes)
+                .is_none(),
+            "FixedSizeList<I32> data writes should avoid the compression path that computes all stats"
         );
         Ok(())
     }

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -44,6 +44,10 @@ VortexFileWriter::VortexFileWriter(const std::shared_ptr<arrow::fs::FileSystem>&
       properties_(properties) {}
 
 arrow::Status VortexFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> batch) {
+  if (closed_) {
+    return arrow::Status::Invalid("Vortex writer is closed. [file_path=", file_path_, "]");
+  }
+
   try {
     assert(!closed_);
     assert(batch->schema()->Equals(*schema_, false));
@@ -63,16 +67,25 @@ arrow::Status VortexFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> 
 }
 
 arrow::Status VortexFileWriter::Flush() {
+  if (closed_) {
+    return arrow::Status::Invalid("Vortex writer is closed. [file_path=", file_path_, "]");
+  }
+
   try {
     assert(!closed_);
     vx_writer_.Flush();
     return arrow::Status::OK();
   } catch (const VortexException& e) {
+    closed_ = true;
     return arrow::Status::IOError("Failed to flush Vortex file: ", e.what());
   }
 }
 
 arrow::Result<api::ColumnGroupFile> VortexFileWriter::Close() {
+  if (closed_) {
+    return arrow::Status::Invalid("Vortex writer is closed. [file_path=", file_path_, "]");
+  }
+
   try {
     assert(!closed_);
 

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -44,56 +44,52 @@ VortexFileWriter::VortexFileWriter(const std::shared_ptr<arrow::fs::FileSystem>&
       properties_(properties) {}
 
 arrow::Status VortexFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> batch) {
-  assert(!closed_);
-  assert(batch->schema()->Equals(*schema_, false));
-  written_rows_ += batch->num_rows();
+  try {
+    assert(!closed_);
+    assert(batch->schema()->Equals(*schema_, false));
 
-  ARROW_ASSIGN_OR_RAISE(auto arrow_struct_array, batch->ToStructArray());
-
-  column_arrays_.emplace_back(arrow_struct_array);
-  assert(arrow_struct_array->num_fields() != 0);
-  return arrow::Status::OK();
+    ARROW_ASSIGN_OR_RAISE(auto arrow_struct_array, batch->ToStructArray());
+    assert(arrow_struct_array->num_fields() != 0);
+    ArrowArray exported_array;
+    ArrowSchema exported_schema;
+    ARROW_RETURN_NOT_OK(arrow::ExportArray(*arrow_struct_array, &exported_array, &exported_schema));
+    vx_writer_.Write(exported_schema, exported_array);
+    written_rows_ += batch->num_rows();
+    return arrow::Status::OK();
+  } catch (const VortexException& e) {
+    closed_ = true;
+    return arrow::Status::IOError("Failed to write Vortex file: ", e.what());
+  }
 }
 
 arrow::Status VortexFileWriter::Flush() {
-  ArrowArray exported_array;
-  ArrowSchema exported_schema;
-  assert(!closed_);
-
-  for (const auto& struct_array : column_arrays_) {
-    ARROW_RETURN_NOT_OK(arrow::ExportArray(*struct_array, &exported_array, &exported_schema));
-    try {
-      vx_writer_.Write(exported_schema, exported_array);
-    } catch (const VortexException& e) {
-      return arrow::Status::IOError(e.what());
-    }
+  try {
+    assert(!closed_);
+    vx_writer_.Flush();
+    return arrow::Status::OK();
+  } catch (const VortexException& e) {
+    return arrow::Status::IOError("Failed to flush Vortex file: ", e.what());
   }
-
-  column_arrays_.clear();
-  return arrow::Status::OK();
 }
 
 arrow::Result<api::ColumnGroupFile> VortexFileWriter::Close() {
-  assert(!closed_);
-
-  ARROW_RETURN_NOT_OK(Flush());
-  // Close returns the total file size and footer size from WriteSummary
-  ffi::VortexWriteSummary summary;
   try {
-    summary = vx_writer_.Close();
+    assert(!closed_);
+
+    // Close returns the total file size and footer size from WriteSummary
+    auto summary = vx_writer_.Close();
+    closed_ = true;
+    return api::ColumnGroupFile{
+        .path = file_path_,
+        .start_index = 0,
+        .end_index = written_rows_,
+        .properties = {{api::kPropertyFileSize, std::to_string(summary.file_size)},
+                       {api::kPropertyFooterSize, std::to_string(summary.footer_size)}},
+    };
   } catch (const VortexException& e) {
     closed_ = true;
-    return arrow::Status::IOError(e.what());
+    return arrow::Status::IOError("Failed to close Vortex file: ", e.what());
   }
-
-  closed_ = true;
-  return api::ColumnGroupFile{
-      .path = file_path_,
-      .start_index = 0,
-      .end_index = written_rows_,
-      .properties = {{api::kPropertyFileSize, std::to_string(summary.file_size)},
-                     {api::kPropertyFooterSize, std::to_string(summary.footer_size)}},
-  };
 }
 
 }  // namespace milvus_storage::vortex

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -401,6 +401,24 @@ TEST_P(VortexBasicTest, TestBasicWrite) {
   ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 }
 
+TEST_P(VortexBasicTest, FlushAllowsSubsequentWrites) {
+  ASSERT_AND_ASSIGN(auto first_batch, MakeTestData(0, 1));
+  ASSERT_AND_ASSIGN(auto second_batch, MakeTestData(1, 1));
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+  ASSERT_STATUS_OK(vx_writer.Write(first_batch));
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_STATUS_OK(vx_writer.Write(second_batch));
+
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+  ASSERT_EQ(first_batch->num_rows() + second_batch->num_rows(), cgfile.end_index);
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns());
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto chunked_array, vx_reader.blocking_read(0, cgfile.end_index, kSmallCoalescingWindow));
+  ASSERT_AND_ASSIGN(auto rb, ChunkedArrayToRecordBatch(chunked_array));
+  ASSERT_EQ(cgfile.end_index, rb->num_rows());
+}
+
 TEST_P(VortexBasicTest, TestListOfFixedSizeBinary512WriteRead) {
   const int64_t num_rows = 8;
   const int vectors_per_row = 2;
@@ -687,10 +705,13 @@ TEST_P(VortexBasicTest, TestDictionaryOfFixedSizeBinaryWriteFails) {
                                                        arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"}))});
   auto rb = arrow::RecordBatch::Make(dictionary_schema, num_rows, {dictionary_array});
   auto vx_writer = vortex::VortexFileWriter(file_system_, dictionary_schema, test_file_name_, properties_);
-  ASSERT_STATUS_OK(vx_writer.Write(rb));
 
-  auto status = vx_writer.Flush();
-  ASSERT_STATUS_NOT_OK(status);
+  auto status = vx_writer.Write(rb);
+  if (status.ok()) {
+    status = vx_writer.Flush();
+  }
+
+  ASSERT_FALSE(status.ok());
   const std::string message = status.ToString();
   EXPECT_NE(message.find("Dictionary"), std::string::npos) << message;
   EXPECT_NE(message.find("FixedSizeBinary"), std::string::npos) << message;

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -32,6 +32,7 @@
 
 #include <boost/filesystem/operations.hpp>
 
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 #include "milvus-storage/format/vortex/vortex_writer.h"
@@ -419,6 +420,54 @@ TEST_P(VortexBasicTest, FlushAllowsSubsequentWrites) {
   ASSERT_EQ(cgfile.end_index, rb->num_rows());
 }
 
+#ifdef BUILD_WITH_FIU
+TEST_P(VortexBasicTest, S3FlushFailureCloseReturnsErrorAndLeavesNoObject) {
+  ArrowFileSystemConfig fs_config;
+  ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
+  const auto is_s3_provider =
+      fs_config.cloud_provider == kCloudProviderAWS || fs_config.cloud_provider == kCloudProviderAliyun ||
+      fs_config.cloud_provider == kCloudProviderTencent || fs_config.cloud_provider == kCloudProviderHuawei;
+  if (fs_config.storage_type != "remote" || !is_s3_provider) {
+    GTEST_SKIP() << "Test requires S3-backed remote filesystem.";
+  }
+
+  ASSERT_EQ(0, InitFiuOnce());
+
+  const std::string test_path =
+      GetTestBasePath("vortex-s3-flush-fiu") + "/flush-fail-v" + std::to_string(GetParam()) + ".vx";
+  (void)file_system_->DeleteFile(test_path);
+
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_path, properties_);
+  const auto rows_per_batch = record_batches_.front()->num_rows();
+  for (int i = 0; i < 10; ++i) {
+    ASSERT_AND_ASSIGN(auto rb, MakeTestData(i * rows_per_batch, rows_per_batch));
+    ASSERT_STATUS_OK(vx_writer.Write(rb));
+  }
+
+  arrow::Status write_status = arrow::Status::OK();
+  {
+    ScopedFiuFault fault(FIUKEY_S3FS_WRITER_FLUSH_FAIL, /*one_time=*/false);
+    ASSERT_EQ(0, fault.enable_result());
+
+    for (int i = 10; i < 20; ++i) {
+      ASSERT_AND_ASSIGN(auto rb, MakeTestData(i * rows_per_batch, rows_per_batch));
+      write_status = vx_writer.Write(rb);
+      if (!write_status.ok()) {
+        EXPECT_NE(write_status.ToString().find(FIUKEY_S3FS_WRITER_FLUSH_FAIL), std::string::npos)
+            << write_status.ToString();
+        break;
+      }
+    }
+
+    auto close_result = vx_writer.Close();
+    ASSERT_FALSE(close_result.ok());
+  }
+
+  ASSERT_AND_ASSIGN(auto file_info, file_system_->GetFileInfo(test_path));
+  EXPECT_EQ(arrow::fs::FileType::NotFound, file_info.type()) << file_info.ToString();
+}
+#endif
+
 TEST_P(VortexBasicTest, TestListOfFixedSizeBinary512WriteRead) {
   const int64_t num_rows = 8;
   const int vectors_per_row = 2;
@@ -716,6 +765,10 @@ TEST_P(VortexBasicTest, TestDictionaryOfFixedSizeBinaryWriteFails) {
   EXPECT_NE(message.find("Dictionary"), std::string::npos) << message;
   EXPECT_NE(message.find("FixedSizeBinary"), std::string::npos) << message;
   EXPECT_NE(message.find("not supported"), std::string::npos) << message;
+
+  auto close_result = vx_writer.Close();
+  ASSERT_FALSE(close_result.ok());
+  EXPECT_TRUE(close_result.status().IsInvalid()) << close_result.status().ToString();
 }
 
 TEST_P(VortexBasicTest, TestFixedSizeListWidthMismatchReadFails) {


### PR DESCRIPTION
Vortex flush now matches the writer semantics we want: it is a lightweight request to push already-written data further down to the filesystem layer, not a request to finalize or reshape Vortex layout data. This keeps flush safe to call between writes without creating synthetic chunks or changing row group behavior just because the caller wanted to drain buffered data.

The C++ writer now forwards each record batch to the Vortex bridge during Write instead of holding batches in memory until Flush. Flush only reaches the shared object-store writer, and if that writer has not been opened yet it simply does nothing. Once data has reached the filesystem path, the existing filesystem and multipart upload logic remains responsible for deciding how much buffered data can be pushed to remote storage.

The Vortex writer boundary also converts bridge-side failures into Arrow statuses for writer creation, write, flush, and close, so the format writer reports errors through the same API shape as the rest of the storage write path.