### PR TITLE
enhance: derive Vortex footer size from the written file layout

### DIFF
--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -278,7 +278,7 @@ pub mod vortex_ffi {
         fn row_group_zone_map_count(self: &VortexFile) -> Result<u64>;
         fn row_group_zone_map_data_before_zones(self: &VortexFile) -> Result<bool>;
         fn zone_map_segment_ids(self: &VortexFile) -> Result<Vec<u64>>;
-        fn footer_byte_range(self: &VortexFile, file_size: u64) -> Vec<u64>;
+        fn footer_byte_range(self: &VortexFile, file_size: u64) -> Result<Vec<u64>>;
         fn segment_bytes(self: &VortexFile, flat_segment_id: u64) -> Result<Vec<u64>>;
         fn field_layout_units(self: &VortexFile, field_name: &str) -> Result<Vec<u64>>;
         fn prune_row_groups(

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -25,7 +25,7 @@ use vortex::dtype::arrow::FromArrowType;
 use vortex::dtype::{DType as RustDType, DecimalDType, FieldName, Nullability, PType as RustPType};
 use vortex::error::VortexError;
 use vortex::expr::Expression;
-use vortex::file::{BlockingWriter, OpenOptionsSessionExt};
+use vortex::file::{BlockingWriter, OpenOptionsSessionExt, SegmentSpec};
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::tokio::TokioRuntime;
 use vortex::layout::layouts::row_idx::row_idx;
@@ -46,6 +46,42 @@ use crate::vortex_layout_strategy_v2::{LAYOUT_ID, build_row_group_strategy};
 // Upstream Vortex's built-in ZonedLayout is encoded as "vortex.stats".
 // It is the regular V1 zonemap layout, distinct from Milvus' V2 row-group zonemap.
 const VORTEX_ZONED_LAYOUT_ID: &str = "vortex.stats";
+const VORTEX_HEADER_SIZE: u64 = 4;
+
+fn footer_start_from_segments(segments: &[SegmentSpec]) -> Result<u64, VortexError> {
+    segments
+        .iter()
+        .try_fold(VORTEX_HEADER_SIZE, |footer_start, segment| {
+            let segment_end = segment
+                .offset
+                .checked_add(u64::from(segment.length))
+                .ok_or_else(|| {
+                    vortex::error::vortex_err!(
+                        "Vortex segment end overflows u64, offset={}, length={}",
+                        segment.offset,
+                        segment.length
+                    )
+                })?;
+            Ok(footer_start.max(segment_end))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vortex::buffer::Alignment;
+
+    #[test]
+    fn overflowing_segment_end_is_rejected() {
+        let segments = [SegmentSpec {
+            offset: u64::MAX,
+            length: 1,
+            alignment: Alignment::none(),
+        }];
+
+        assert!(footer_start_from_segments(&segments).is_err());
+    }
+}
 
 /*
  * Type
@@ -1002,16 +1038,28 @@ impl VortexWriter {
                 .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
             let file_size = summary.size();
 
-            // Re-serialize the footer to compute the exact footer region size on disk.
-            let footer_size: u64 = summary
-                .footer()
-                .clone()
-                .into_serializer()
-                .serialize()
-                .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?
-                .iter()
-                .map(|b| b.len() as u64)
-                .sum();
+            let footer = summary.footer();
+            let footer_start = footer_start_from_segments(footer.segment_map())
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+            if footer_start > file_size {
+                return Err(Box::new(vortex::error::vortex_err!(
+                    "Vortex footer start {} exceeds file size {}",
+                    footer_start,
+                    file_size
+                )));
+            }
+
+            let tail_size = file_size - footer_start;
+            let eof_size = vortex::file::EOF_SIZE as u64;
+            if tail_size < eof_size {
+                return Err(Box::new(vortex::error::vortex_err!(
+                    "Vortex footer tail size {} is smaller than EOF size {}",
+                    tail_size,
+                    eof_size
+                )));
+            }
+            let footer_size = tail_size - eof_size;
 
             return Ok(crate::vortex_ffi::VortexWriteSummary {
                 file_size,
@@ -1184,18 +1232,17 @@ impl VortexFile {
     }
 
     /// Returns [offset, length] for the full footer/tail region.
-    pub(crate) fn footer_byte_range(&self, file_size: u64) -> Vec<u64> {
+    pub(crate) fn footer_byte_range(&self, file_size: u64) -> Result<Vec<u64>> {
         let footer = self.inner.footer();
-        let footer_start = footer
-            .segment_map()
-            .iter()
-            .map(|segment| segment.offset + u64::from(segment.length))
-            .max()
-            .unwrap_or(0);
+        let footer_start = footer_start_from_segments(footer.segment_map())?;
         if footer_start > file_size {
-            vec![0, file_size]
+            anyhow::bail!(
+                "Vortex footer start {} exceeds file size {}",
+                footer_start,
+                file_size
+            );
         } else {
-            vec![footer_start, file_size - footer_start]
+            Ok(vec![footer_start, file_size - footer_start])
         }
     }
 

--- a/cpp/src/format/vortex/vortex_footer_reader.cpp
+++ b/cpp/src/format/vortex/vortex_footer_reader.cpp
@@ -109,10 +109,6 @@ std::vector<ByteRange> MergeByteRanges(std::vector<ByteRange> ranges) {
 
 namespace {
 
-// Small prefix reads cover Vortex open-time reads near the beginning of the
-// file without accidentally materializing the first data segment.
-constexpr uint64_t kDefaultHeaderReadSize = 4 * 1024;
-
 // Used only when the caller does not know the footer size. Vortex footer open
 // retries with a larger tail if this initial speculative read is insufficient.
 constexpr uint64_t kDefaultFooterReadSize = 2 * 1024 * 1024;
@@ -318,14 +314,56 @@ arrow::Status VortexFooterReader::Impl::OpenSparseVortexFile() {
 }
 
 arrow::Status VortexFooterReader::Impl::LoadFooter(const std::shared_ptr<arrow::io::RandomAccessFile>& input_file) {
-  const auto header_read_size = std::min<uint64_t>(file_size, kDefaultHeaderReadSize);
-  ARROW_RETURN_NOT_OK(FillVortexRangeFile(input_file, range_file, 0, header_read_size));
-
   const auto eof_size = VortexEofSize();
-  ARROW_ASSIGN_OR_RAISE(auto footer_body_size, ResolveInitialFooterBodySize(file_size, footer_size, eof_size));
-  const auto max_footer_body_size = file_size > eof_size ? file_size - eof_size : file_size;
+  auto finish_opened_footer = [&]() -> arrow::Status {
+    auto footer_range = vxfile->FooterByteRange(file_size);
+    if (footer_range.size() != 2 || footer_range[0] > file_size || footer_range[1] > file_size - footer_range[0]) {
+      return arrow::Status::Invalid(fmt::format("Invalid vortex footer byte range for {}", path));
+    }
+    footer_size = footer_range[1] > eof_size ? footer_range[1] - eof_size : 0;
+    rows = vxfile->RowCount();
+    return arrow::Status::OK();
+  };
+
+  uint64_t footer_body_size = 0;
   uint64_t loaded_tail_read_size = 0;
-  while (true) {
+
+  if (footer_size != 0) {
+    ARROW_ASSIGN_OR_RAISE(auto cached_footer_body_size, ResolveInitialFooterBodySize(file_size, footer_size, eof_size));
+    footer_body_size = cached_footer_body_size;
+    const auto tail_read_size = ResolveTailReadSize(file_size, footer_body_size, eof_size);
+    ARROW_RETURN_NOT_OK(FillVortexRangeFile(input_file, range_file, file_size - tail_read_size, tail_read_size));
+    try {
+      vxfile =
+          VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder.get()), sparse_path, file_size, footer_body_size);
+    } catch (const VortexException& e) {
+      LOG_STORAGE_WARNING_ << fmt::format(
+          "[VortexFooterReader] cached footer body size {} failed for {}, fallback to expanding retry: {}",
+          footer_body_size, path, e.what());
+      ARROW_ASSIGN_OR_RAISE(auto retry_footer_body_size, ResolveInitialFooterBodySize(file_size, 0, eof_size));
+      footer_body_size = std::max<uint64_t>(retry_footer_body_size, footer_body_size);
+      loaded_tail_read_size = tail_read_size;
+    }
+    if (vxfile) {
+      ARROW_RETURN_NOT_OK(finish_opened_footer());
+      if (footer_size <= footer_body_size) {
+        return arrow::Status::OK();
+      }
+      LOG_STORAGE_WARNING_ << fmt::format(
+          "[VortexFooterReader] cached footer body size {} is smaller than actual {} for {}, fallback to expanding "
+          "retry",
+          footer_body_size, footer_size, path);
+      footer_body_size = footer_size;
+      loaded_tail_read_size = tail_read_size;
+    }
+  } else {
+    ARROW_ASSIGN_OR_RAISE(auto initial_footer_body_size,
+                          ResolveInitialFooterBodySize(file_size, footer_size, eof_size));
+    footer_body_size = initial_footer_body_size;
+  }
+
+  const auto max_footer_body_size = file_size > eof_size ? file_size - eof_size : file_size;
+  while (footer_body_size <= max_footer_body_size) {
     const auto tail_read_size = ResolveTailReadSize(file_size, footer_body_size, eof_size);
     if (tail_read_size > loaded_tail_read_size) {
       const uint64_t new_bytes = tail_read_size - loaded_tail_read_size;
@@ -334,12 +372,13 @@ arrow::Status VortexFooterReader::Impl::LoadFooter(const std::shared_ptr<arrow::
       loaded_tail_read_size = tail_read_size;
     }
 
+    vxfile.reset();
     try {
       vxfile =
           VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder.get()), sparse_path, file_size, footer_body_size);
-      break;
+      return finish_opened_footer();
     } catch (const VortexException& e) {
-      if (footer_body_size >= max_footer_body_size) {
+      if (footer_body_size == max_footer_body_size) {
         return arrow::Status::IOError(fmt::format("Failed to open vortex file {}: {}", path, e.what()));
       }
       const auto doubled = footer_body_size > max_footer_body_size / 2 ? max_footer_body_size : footer_body_size * 2;
@@ -348,13 +387,9 @@ arrow::Status VortexFooterReader::Impl::LoadFooter(const std::shared_ptr<arrow::
     }
   }
 
-  auto footer_range = vxfile->FooterByteRange(file_size);
-  if (footer_range.size() != 2 || footer_range[0] > file_size || footer_range[1] > file_size - footer_range[0]) {
-    return arrow::Status::Invalid(fmt::format("Invalid vortex footer byte range for {}", path));
-  }
-  footer_size = footer_range[1] > eof_size ? footer_range[1] - eof_size : 0;
-  rows = vxfile->RowCount();
-  return arrow::Status::OK();
+  return arrow::Status::Invalid(fmt::format(
+      "Vortex initial footer body size exceeds file size, path={}, footer_body_size={}, max_footer_body_size={}", path,
+      footer_body_size, max_footer_body_size));
 }
 
 arrow::Status VortexFooterReader::Impl::LoadZoneMaps(const std::shared_ptr<arrow::io::RandomAccessFile>& input_file) {

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -972,9 +972,9 @@ TEST_P(VortexBasicTest, TestBasicTake) {
 TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
   auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
 
-  for (const auto& rb : record_batches_) {
-    ASSERT_TRUE(vx_writer.Write(rb).ok());
-  }
+  // Zero-row output intentionally covers footer-size computation with no data segments.
+  auto zero_row_batch = record_batches_.front()->Slice(0, 0);
+  ASSERT_TRUE(vx_writer.Write(zero_row_batch).ok());
 
   ASSERT_TRUE(vx_writer.Flush().ok());
   ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
@@ -996,25 +996,25 @@ TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
   // Verify magic
   ASSERT_EQ(std::string(reinterpret_cast<const char*>(eof + 4), 4), "VTXF");
 
-  // Get postscript_len from EOF
-  uint16_t postscript_len = 0;
-  std::memcpy(&postscript_len, eof + 2, 2);
+  constexpr uint64_t kVortexHeaderSize = 4;
+  const auto eof_size = VortexEofSize();
+  ASSERT_GE(static_cast<uint64_t>(actual_file_size), kVortexHeaderSize + eof_size);
+  EXPECT_EQ(vx_footer_size, static_cast<uint64_t>(actual_file_size) - kVortexHeaderSize - eof_size)
+      << "zero-row Vortex output should contain only the header before the footer body";
 
-  // Read postscript to get the earliest segment offset (= start of footer)
-  int64_t postscript_offset = actual_file_size - 8 - postscript_len;
-  ASSERT_GT(postscript_offset, 0);
+  auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+  auto vxfile =
+      VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_, vx_file_size, vx_footer_size);
+  auto footer_range = vxfile.FooterByteRange(vx_file_size);
+  ASSERT_EQ(footer_range.size(), 2u);
+  ASSERT_LE(footer_range[0], vx_file_size);
+  ASSERT_LE(footer_range[1], vx_file_size - footer_range[0]);
 
-  std::cout << "vx_footer_size: " << vx_footer_size << std::endl;
-  std::cout << "postscript_len: " << postscript_len << std::endl;
+  ASSERT_GT(footer_range[1], eof_size);
+  const auto actual_footer_body_size = footer_range[1] - eof_size;
 
-  // The footer spans from the earliest segment to the end of file.
-  // The postscript contains segment descriptors with absolute offsets.
-  // We can parse the postscript flatbuffer to find the earliest offset,
-  // but a simpler sanity check: footer_size must be > postscript_len + 8 (postscript + EOF)
-  // and footer_size must be < file_size - 4 (exclude file header magic).
-  EXPECT_GT(vx_footer_size, static_cast<uint64_t>(postscript_len) + 8)
-      << "footer_size should include postscript + EOF + segment data";
-  EXPECT_LT(vx_footer_size, vx_file_size - 4) << "footer_size should be less than file_size minus header magic";
+  EXPECT_EQ(vx_footer_size, actual_footer_body_size)
+      << "cached footer_size should match the actual Vortex footer body; normal open adds EOF_SIZE";
 }
 
 TEST_P(VortexBasicTest, FooterSizeNotMatch) {

--- a/cpp/test/format/vortex/vortex_local_format_test.cpp
+++ b/cpp/test/format/vortex/vortex_local_format_test.cpp
@@ -77,6 +77,7 @@ class InMemoryVortexRangeFile : public VortexRangeFile, public arrow::io::Random
       data_.resize(end);
     }
     std::memcpy(data_.data() + offset, data->data(), data->size());
+    write_ranges_.push_back(ByteRange{offset, static_cast<uint64_t>(data->size())});
     return arrow::Status::OK();
   }
 
@@ -151,9 +152,15 @@ class InMemoryVortexRangeFile : public VortexRangeFile, public arrow::io::Random
     std::memset(data_.data() + offset, 0, available);
   }
 
+  std::vector<ByteRange> WriteRanges() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return write_ranges_;
+  }
+
   private:
   mutable std::mutex mutex_;
   std::vector<uint8_t> data_;
+  std::vector<ByteRange> write_ranges_;
   int64_t position_ = 0;
   bool closed_ = false;
 };
@@ -291,10 +298,28 @@ TEST_F(VortexLocalFormatTest, TestFooterReaderOpensZeroRowVortexFile) {
   ASSERT_GT(cgfile.Get<uint64_t>(api::kPropertyFileSize), 0);
   ASSERT_GT(cgfile.Get<uint64_t>(api::kPropertyFooterSize), 0);
 
+  auto too_small_footer_file = cgfile;
+  too_small_footer_file.Set(api::kPropertyFooterSize, cgfile.Get<uint64_t>(api::kPropertyFooterSize) - 1);
+  auto too_small_footer_reader =
+      MakeFooterReader(too_small_footer_file, std::make_shared<InMemoryVortexRangeFileSystem>());
+  ASSERT_STATUS_OK(too_small_footer_reader->Open(file_system_));
+  ASSERT_TRUE(too_small_footer_reader->opened());
+  ASSERT_EQ(too_small_footer_reader->rows(), 0);
+  ASSERT_EQ(too_small_footer_reader->footer_size(), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
+
+  auto tiny_footer_file = cgfile;
+  tiny_footer_file.Set(api::kPropertyFooterSize, static_cast<uint64_t>(1));
+  auto tiny_footer_reader = MakeFooterReader(tiny_footer_file, std::make_shared<InMemoryVortexRangeFileSystem>());
+  ASSERT_STATUS_OK(tiny_footer_reader->Open(file_system_));
+  ASSERT_TRUE(tiny_footer_reader->opened());
+  ASSERT_EQ(tiny_footer_reader->rows(), 0);
+  ASSERT_EQ(tiny_footer_reader->footer_size(), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
+
   auto footer_reader = MakeFooterReader(cgfile, std::make_shared<InMemoryVortexRangeFileSystem>());
   ASSERT_STATUS_OK(footer_reader->Open(file_system_));
   ASSERT_TRUE(footer_reader->opened());
   ASSERT_EQ(footer_reader->rows(), 0);
+  ASSERT_EQ(footer_reader->footer_size(), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
   ASSERT_NE(footer_reader->file_schema(), nullptr);
 
   ASSERT_AND_ASSIGN(auto cell_metas, BuildVortexCellMetas(footer_reader, "id"));
@@ -322,6 +347,31 @@ TEST_F(VortexLocalFormatTest, TestFooterReaderOpenAfterWriterCloseWithoutWriteIf
   AssertLoadableEmptyCellMetas(cell_metas);
   ASSERT_AND_ASSIGN(auto group_cell_metas, BuildVortexGroupCellMetas(footer_reader, data_columns()));
   AssertLoadableEmptyCellMetas(group_cell_metas);
+}
+
+TEST_F(VortexLocalFormatTest, TestFooterReaderDoesNotPrefetchHeaderRangeWhenFooterSizeKnown) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+  const auto file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  const auto footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  const auto tail_read_size = footer_size + VortexEofSize();
+  ASSERT_LT(tail_read_size, file_size);
+
+  constexpr const char* kSparsePath = "test-file.vx.sparse";
+  auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+  auto footer_reader = MakeFooterReader(cgfile, sparse_fs);
+  ASSERT_STATUS_OK(footer_reader->Open(file_system_, false));
+
+  ASSERT_AND_ASSIGN(auto sparse_file, sparse_fs->GetInMemoryFile(kSparsePath));
+  const auto write_ranges = sparse_file->WriteRanges();
+  ASSERT_FALSE(write_ranges.empty());
+
+  const auto tail_offset = file_size - tail_read_size;
+  bool saw_footer_tail = false;
+  for (const auto& range : write_ranges) {
+    EXPECT_NE(range.offset, 0) << "known footer_size should not trigger a separate header prefetch";
+    saw_footer_tail = saw_footer_tail || (range.offset == tail_offset && range.length == tail_read_size);
+  }
+  ASSERT_TRUE(saw_footer_tail);
 }
 
 TEST_F(VortexLocalFormatTest, TestFooterReaderOptionalZoneMapLoadControlsPruning) {


### PR DESCRIPTION
Vortex footer size is stored in the manifest and later used by readers to fetch the footer tail in one shot, so it needs to describe the bytes Vortex actually wrote instead of a reserialized estimate. The old writer path rebuilt the footer and used that serialized length, which could drift from the real file layout and make the cached size smaller than the actual footer.

This changes the writer to calculate the footer start from the segment map returned by Vortex after writing. The cached footer_size is now the bytes after the last data segment, minus the fixed EOF marker. Empty segment maps are handled as a four-byte Vortex header, which keeps zero-row files consistent with the actual on-disk layout.

The footer reader now treats a non-zero cached footer size as the fast path: it reads footer_size + EOF once and opens the sparse file directly. If that open fails, or if the opened footer reports a larger real footer body, the reader falls back to the bounded expanding retry path instead of returning an eager error.

The reader also avoids the previous fixed 4KB prefix prefetch. Known footer sizes only materialize the footer tail into the sparse range file, removing an unnecessary extra read against object stores while preserving the existing retry path for unknown, legacy, or stale footer sizes.

This keeps the contract clear: footer_size means footer body size only, the read path adds EOF when fetching the tail, and unknown or legacy footer sizes can still use the speculative retry path.