### PR TITLE
enhance: default zstd-3 and uncompress vector columns

### DIFF
--- a/cpp/benchmark/CMakeLists.txt
+++ b/cpp/benchmark/CMakeLists.txt
@@ -5,6 +5,7 @@ set(BENCHMARK_SOURCES
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_main.cpp
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_wr.cpp
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_footer_size.cpp
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_compression_levels.cpp
 )
 
 # Format Layer benchmarks (format availability checked at runtime)

--- a/cpp/benchmark/benchmark_compression_levels.cpp
+++ b/cpp/benchmark/benchmark_compression_levels.cpp
@@ -1,0 +1,212 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <arrow/api.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/io/file.h>
+#include <arrow/record_batch.h>
+#include <parquet/properties.h>
+
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/format/parquet/parquet_writer.h"
+
+// Compression-level benchmark.
+//
+// All runs go through milvus_storage::parquet::ParquetFileWriter::Make,
+// which hardcodes UNCOMPRESSED for vector columns (FIXED_SIZE_BINARY /
+// BINARY). The only thing varied across configs is the file-level ZSTD
+// compression level applied to non-vector columns.
+//
+// Schema:
+//   pk:     int64               (sequential)
+//   text:   utf8                (random 100-500 byte printable ASCII)
+//   vector: fixed_size_binary   (truly random uint8 bytes, 768 * 4 = 3 KiB)
+//
+// Run:
+//   ./benchmark --benchmark_filter=CompressionBench
+namespace milvus_storage::benchmark_compression {
+
+namespace {
+
+constexpr int kVectorDim = 768;
+constexpr int kRowsPerBatch = 1000;
+constexpr int kBatches = 100;  // 100k rows total ≈ 294 MiB raw vector + scalars
+
+struct WriterConfig {
+  std::string label;
+  int level;
+};
+
+const std::vector<WriterConfig>& Configs() {
+  static const std::vector<WriterConfig> kConfigs = {
+      {"zstd3", 3},
+      {"zstd5", 5},
+  };
+  return kConfigs;
+}
+
+std::shared_ptr<arrow::Schema> MakeSchema() {
+  return arrow::schema({
+      arrow::field("pk", arrow::int64(), /*nullable=*/false),
+      arrow::field("text", arrow::utf8(), /*nullable=*/false),
+      arrow::field("vector", arrow::fixed_size_binary(kVectorDim * 4), /*nullable=*/false),
+  });
+}
+
+// Generate deterministic batches so every config sees identical bytes.
+std::vector<std::shared_ptr<arrow::RecordBatch>> MakeBatches(const std::shared_ptr<arrow::Schema>& schema) {
+  std::vector<std::shared_ptr<arrow::RecordBatch>> out;
+  out.reserve(kBatches);
+
+  std::mt19937 rng(0xC0DEC0DE);
+  std::uniform_int_distribution<int> byte_dist(0, 255);
+  std::uniform_int_distribution<int> printable_dist(0x20, 0x7E);
+  std::uniform_int_distribution<int> text_len_dist(100, 500);
+
+  for (int b = 0; b < kBatches; ++b) {
+    arrow::Int64Builder pk_builder;
+    arrow::StringBuilder text_builder;
+    arrow::FixedSizeBinaryBuilder vec_builder(arrow::fixed_size_binary(kVectorDim * 4));
+    pk_builder.Resize(kRowsPerBatch).ok();
+    vec_builder.Resize(kRowsPerBatch).ok();
+
+    std::vector<uint8_t> vec_bytes(kVectorDim * 4);
+    std::string text_buf;
+    text_buf.reserve(500);
+    for (int r = 0; r < kRowsPerBatch; ++r) {
+      pk_builder.UnsafeAppend(static_cast<int64_t>(b * kRowsPerBatch + r));
+
+      int text_len = text_len_dist(rng);
+      text_buf.resize(text_len);
+      for (int i = 0; i < text_len; ++i) {
+        text_buf[i] = static_cast<char>(printable_dist(rng));
+      }
+      text_builder.Append(text_buf).ok();
+
+      for (size_t i = 0; i < vec_bytes.size(); ++i) {
+        vec_bytes[i] = static_cast<uint8_t>(byte_dist(rng));
+      }
+      vec_builder.UnsafeAppend(vec_bytes.data());
+    }
+
+    auto pk_arr = pk_builder.Finish().ValueOrDie();
+    auto text_arr = text_builder.Finish().ValueOrDie();
+    auto vec_arr = vec_builder.Finish().ValueOrDie();
+    out.push_back(arrow::RecordBatch::Make(schema, kRowsPerBatch, {pk_arr, text_arr, vec_arr}));
+  }
+  return out;
+}
+
+std::shared_ptr<::parquet::WriterProperties> BuildWriterProps(const WriterConfig& cfg) {
+  return ::parquet::WriterProperties::Builder()
+      .compression(::parquet::Compression::ZSTD)
+      ->compression_level(cfg.level)
+      ->build();
+}
+
+class CompressionBench : public ::benchmark::Fixture {
+  public:
+  void SetUp(::benchmark::State& st) override {
+    schema_ = MakeSchema();
+    if (batches_.empty()) {
+      batches_ = MakeBatches(schema_);
+    }
+    fs_ = std::make_shared<arrow::fs::LocalFileSystem>();
+    base_path_ = "/tmp/milvus_storage_compression_bench";
+    auto _ = fs_->CreateDir(base_path_, /*recursive=*/true);
+    (void)_;
+  }
+
+  void TearDown(::benchmark::State&) override {}
+
+  protected:
+  std::shared_ptr<arrow::Schema> schema_;
+  static std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+  std::shared_ptr<arrow::fs::LocalFileSystem> fs_;
+  std::string base_path_;
+};
+
+std::vector<std::shared_ptr<arrow::RecordBatch>> CompressionBench::batches_;
+
+}  // namespace
+
+BENCHMARK_DEFINE_F(CompressionBench, Write)(::benchmark::State& st) {
+  const auto& cfg = Configs()[static_cast<size_t>(st.range(0))];
+  st.SetLabel(cfg.label);
+  auto writer_props = BuildWriterProps(cfg);
+
+  int64_t last_file_size = 0;
+  int64_t iter_idx = 0;
+
+  milvus_storage::StorageConfig storage_config;
+  for (auto _ : st) {
+    auto file_path = base_path_ + "/" + cfg.label + "_" + std::to_string(iter_idx++) + ".parquet";
+
+    auto writer_res =
+        milvus_storage::parquet::ParquetFileWriter::Make(schema_, fs_, file_path, storage_config, writer_props);
+    if (!writer_res.ok()) {
+      st.SkipWithError(writer_res.status().ToString().c_str());
+      return;
+    }
+    auto writer = std::move(writer_res).ValueOrDie();
+
+    for (const auto& batch : batches_) {
+      auto status = writer->Write(batch);
+      if (!status.ok()) {
+        st.SkipWithError(status.ToString().c_str());
+        return;
+      }
+    }
+
+    auto close_res = writer->Close();
+    if (!close_res.ok()) {
+      st.SkipWithError(close_res.status().ToString().c_str());
+      return;
+    }
+
+    auto info = fs_->GetFileInfo(file_path);
+    if (info.ok()) {
+      last_file_size = info.ValueOrDie().size();
+    }
+    auto del = fs_->DeleteFile(file_path);
+    (void)del;
+  }
+
+  int64_t total_rows = static_cast<int64_t>(kBatches) * kRowsPerBatch;
+  // text mean length ≈ 300 bytes (uniform 100..500). pk is int64 (8 B);
+  // vector is fixed_size_binary(kVectorDim*4).
+  int64_t raw_bytes = total_rows * (8 + 300 + kVectorDim * 4);
+  st.counters["file_MiB"] = ::benchmark::Counter(static_cast<double>(last_file_size) / 1048576.0);
+  st.counters["raw_MiB_approx"] = ::benchmark::Counter(static_cast<double>(raw_bytes) / 1048576.0);
+  st.counters["rows"] = ::benchmark::Counter(static_cast<double>(total_rows));
+}
+
+BENCHMARK_REGISTER_F(CompressionBench, Write)
+    ->Arg(0)  // zstd3
+    ->Arg(1)  // zstd5
+    ->Unit(::benchmark::kMillisecond)
+    ->Iterations(3);
+
+}  // namespace milvus_storage::benchmark_compression

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -18,6 +18,7 @@
 
 #include <arrow/io/buffered.h>
 #include <arrow/io/memory.h>
+#include <arrow/util/compression.h>
 #include <parquet/properties.h>
 #include <parquet/metadata.h>
 #include <boost/variant.hpp>
@@ -129,6 +130,12 @@ ParquetFileWriter::ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
     auto deep_copied_decryption = writer_props->file_encryption_properties()->DeepClone();
     builder.encryption(std::move(deep_copied_decryption));
   }
+  // Legacy callers (e.g. PackedRecordBatchWriter) often construct an empty
+  // parquet::WriterProperties whose file-level compression defaults to
+  // UNCOMPRESSED. Apply ZSTD level 3 in that case so the legacy path
+  // matches the property-registry default used by the new properties-based
+  // ParquetFileWriter::Make. Explicit non-UNCOMPRESSED settings from the
+  // caller are preserved.
   if (writer_props->default_column_properties().compression() == ::parquet::Compression::UNCOMPRESSED) {
     builder.compression(::parquet::Compression::ZSTD);
     builder.compression_level(3);
@@ -138,8 +145,19 @@ ParquetFileWriter::ParquetFileWriter(std::shared_ptr<arrow::Schema> schema,
     auto field = schema_->field(i);
     switch (field->type()->id()) {
       case arrow::Type::FIXED_SIZE_BINARY:
+        // Dense vector columns are effectively random bytes; ZSTD wastes
+        // CPU on them without shrinking the output. Always emit them
+        // UNCOMPRESSED and skip statistics. The per-column level is reset
+        // to the codec-default sentinel because parquet rejects
+        // "UNCOMPRESSED + explicit level" at build time.
+        builder.compression(field->name(), ::parquet::Compression::UNCOMPRESSED);
+        builder.compression_level(field->name(), ::arrow::util::kUseDefaultCompressionLevel);
+        builder.disable_statistics(field->name());
+        break;
       case arrow::Type::BINARY:
-        // Disable statistics for vector columns
+        // Variable-length binary may carry LOB payloads or sparse vectors;
+        // leave the caller's compression choice alone. Statistics on long
+        // binary blobs are not useful, so skip those.
         builder.disable_statistics(field->name());
         break;
       default:

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -506,7 +506,7 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
     REGISTER_PROPERTY(PROPERTY_WRITER_COMPRESSION_LEVEL,
                       PropertyType::INT32,
                       "The compression level used in the writer.",
-                      5,
+                      3,
                       ValidatePropertyType()),
     REGISTER_PROPERTY(PROPERTY_WRITER_ENABLE_DICTIONARY,
                       PropertyType::BOOL,

--- a/cpp/test/api_properties_test.cpp
+++ b/cpp/test/api_properties_test.cpp
@@ -22,7 +22,7 @@ TEST_F(APIPropertiesTest, basic) {
   // Test get default value
   EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_WRITER_COMPRESSION), "zstd");
   EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_WRITER_FORMAT), LOON_FORMAT_PARQUET);
-  EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_COMPRESSION_LEVEL), 5);
+  EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_COMPRESSION_LEVEL), 3);
   EXPECT_EQ(GetValueNoError<int32_t>(pp, PROPERTY_WRITER_BUFFER_SIZE), 32 * 1024 * 1024);
   EXPECT_TRUE(GetValueNoError<bool>(pp, PROPERTY_WRITER_ENABLE_DICTIONARY));
 

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -23,6 +23,8 @@
 #include <arrow/filesystem/filesystem.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
+#include <parquet/file_reader.h>
+#include <parquet/metadata.h>
 #include <parquet/properties.h>
 
 #include "test_env.h"
@@ -534,6 +536,132 @@ TEST_F(ParquetFileWriterTest, FooterSizeMatchesActualFile) {
 
   // Also verify file_size
   EXPECT_EQ(close_result.Get<uint64_t>(api::kPropertyFileSize), static_cast<uint64_t>(file_size));
+}
+
+// Helper: write a small record batch through ParquetFileWriter::Make and
+// return the parquet column-chunk compression codecs (one entry per column,
+// in schema order) for the first row group.
+namespace {
+arrow::Result<std::vector<::parquet::Compression::type>> WriteAndReadColumnCompression(
+    const std::shared_ptr<arrow::fs::FileSystem>& fs,
+    const std::shared_ptr<arrow::Schema>& schema,
+    const std::shared_ptr<arrow::RecordBatch>& batch,
+    const std::string& file_path,
+    bool use_properties_make,
+    const milvus_storage::api::Properties& properties) {
+  if (use_properties_make) {
+    ARROW_ASSIGN_OR_RAISE(auto writer,
+                          milvus_storage::parquet::ParquetFileWriter::Make(fs, schema, file_path, properties));
+    ARROW_RETURN_NOT_OK(writer->Write(batch));
+    ARROW_ASSIGN_OR_RAISE(auto _close, writer->Close());
+    (void)_close;
+  } else {
+    milvus_storage::StorageConfig config;
+    ARROW_ASSIGN_OR_RAISE(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(schema, fs, file_path, config));
+    ARROW_RETURN_NOT_OK(writer->Write(batch));
+    ARROW_ASSIGN_OR_RAISE(auto _close, writer->Close());
+    (void)_close;
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto file, fs->OpenInputFile(file_path));
+  auto reader = ::parquet::ParquetFileReader::Open(file);
+  auto metadata = reader->metadata();
+  std::vector<::parquet::Compression::type> codecs;
+  codecs.reserve(schema->num_fields());
+  auto rg = metadata->RowGroup(0);
+  for (int i = 0; i < rg->num_columns(); ++i) {
+    codecs.push_back(rg->ColumnChunk(i)->compression());
+  }
+  return codecs;
+}
+}  // namespace
+
+// Dense vector columns (FIXED_SIZE_BINARY) should land UNCOMPRESSED in the
+// file. BINARY columns may carry LOB / sparse-vector payloads where
+// compression can still help, so they inherit the file-level codec. Other
+// columns also follow the file-level codec. Verified through both
+// ParquetFileWriter::Make overloads.
+TEST_F(ParquetFileWriterTest, FixedSizeBinaryColumnsAreUncompressed) {
+  const int64_t num_rows = 16;
+  auto schema = arrow::schema({
+      arrow::field("id", arrow::int64(), false /*nullable*/, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("dense_vec", arrow::fixed_size_binary(128), false,
+                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"})),
+      arrow::field("blob", arrow::binary(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"102"})),
+  });
+
+  arrow::Int64Builder id_builder;
+  arrow::FixedSizeBinaryBuilder dense_builder(arrow::fixed_size_binary(128));
+  arrow::BinaryBuilder blob_builder;
+  for (int64_t i = 0; i < num_rows; ++i) {
+    ASSERT_TRUE(id_builder.Append(i).ok());
+    std::vector<uint8_t> v(128, static_cast<uint8_t>(i));
+    ASSERT_TRUE(dense_builder.Append(v.data()).ok());
+    std::string s(32, static_cast<char>('a' + (i % 26)));
+    ASSERT_TRUE(blob_builder.Append(s).ok());
+  }
+  ASSERT_AND_ASSIGN(auto id_array, id_builder.Finish());
+  ASSERT_AND_ASSIGN(auto dense_array, dense_builder.Finish());
+  ASSERT_AND_ASSIGN(auto blob_array, blob_builder.Finish());
+  auto batch = arrow::RecordBatch::Make(schema, num_rows, {id_array, dense_array, blob_array});
+
+  // Legacy Make (parquet::WriterProperties default => UNCOMPRESSED at file
+  // level): constructor falls back to ZSTD-3 default. FIXED_SIZE_BINARY is
+  // forced UNCOMPRESSED per-column; BINARY follows the file default (ZSTD).
+  {
+    auto file_path = base_path_ + "/data/vector_uncompressed_legacy.parquet";
+    ASSERT_AND_ASSIGN(auto codecs, WriteAndReadColumnCompression(fs_, schema, batch, file_path,
+                                                                 /*use_properties_make=*/false, properties_));
+    ASSERT_EQ(codecs.size(), 3u);
+    EXPECT_EQ(codecs[0], ::parquet::Compression::ZSTD) << "id should be ZSTD";
+    EXPECT_EQ(codecs[1], ::parquet::Compression::UNCOMPRESSED) << "dense_vec should be UNCOMPRESSED";
+    EXPECT_EQ(codecs[2], ::parquet::Compression::ZSTD) << "blob (BINARY) should follow file-level ZSTD";
+  }
+
+  // Properties-based Make (registry default zstd / level 3): same expectation.
+  {
+    auto file_path = base_path_ + "/data/vector_uncompressed_props.parquet";
+    ASSERT_AND_ASSIGN(auto codecs, WriteAndReadColumnCompression(fs_, schema, batch, file_path,
+                                                                 /*use_properties_make=*/true, properties_));
+    ASSERT_EQ(codecs.size(), 3u);
+    EXPECT_EQ(codecs[0], ::parquet::Compression::ZSTD) << "id should be ZSTD";
+    EXPECT_EQ(codecs[1], ::parquet::Compression::UNCOMPRESSED) << "dense_vec should be UNCOMPRESSED";
+    EXPECT_EQ(codecs[2], ::parquet::Compression::ZSTD) << "blob (BINARY) should follow file-level ZSTD";
+  }
+}
+
+// File-level ZSTD setting does not leak into vector columns — they are
+// always emitted UNCOMPRESSED regardless of the caller's WriterProperties.
+TEST_F(ParquetFileWriterTest, FileLevelCompressionDoesNotPreventVectorUncompressed) {
+  const int64_t num_rows = 8;
+  auto schema = arrow::schema({
+      arrow::field("dense_vec", arrow::fixed_size_binary(64), false,
+                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"})),
+  });
+
+  arrow::FixedSizeBinaryBuilder b(arrow::fixed_size_binary(64));
+  for (int64_t i = 0; i < num_rows; ++i) {
+    std::vector<uint8_t> v(64, static_cast<uint8_t>(i));
+    ASSERT_TRUE(b.Append(v.data()).ok());
+  }
+  ASSERT_AND_ASSIGN(auto arr, b.Finish());
+  auto batch = arrow::RecordBatch::Make(schema, num_rows, {arr});
+
+  // File-level ZSTD-7 — vector column still emitted UNCOMPRESSED.
+  auto props =
+      ::parquet::WriterProperties::Builder().compression(::parquet::Compression::ZSTD)->compression_level(7)->build();
+  auto file_path = base_path_ + "/data/vector_filelevel_only.parquet";
+  milvus_storage::StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer,
+                    milvus_storage::parquet::ParquetFileWriter::Make(schema, fs_, file_path, config, props));
+  ASSERT_TRUE(writer->Write(batch).ok());
+  ASSERT_AND_ASSIGN(auto _close, writer->Close());
+  (void)_close;
+
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(file_path));
+  auto reader = ::parquet::ParquetFileReader::Open(file);
+  auto metadata = reader->metadata();
+  EXPECT_EQ(metadata->RowGroup(0)->ColumnChunk(0)->compression(), ::parquet::Compression::UNCOMPRESSED);
 }
 
 TEST_F(ParquetFileWriterTest, FooterSizeNotMatch) {


### PR DESCRIPTION
See milvus-io/milvus#50452.

Two changes that together cut parquet write CPU on vector
workloads without hurting file size:

1. PROPERTY_WRITER_COMPRESSION_LEVEL registry default lowered
   from 5 to 3. At level 5 ZSTD switches from the dfast strategy
   to greedy with row matchfinder; on random float embeddings
   that costs ~8% more CPU for near-zero size benefit. The Milvus
   import benchmark observed +10% wall time on V3 (which used the
   level-5 default) over V2 (which forces level 3 via the legacy
   ParquetFileWriter coercion).

2. ParquetFileWriter emits FIXED_SIZE_BINARY and BINARY columns
   as UNCOMPRESSED with statistics disabled. Vector payloads
   behave like incompressible bytes; ZSTD spends CPU on them
   without shrinking the output.

A new benchmark in cpp/benchmark/benchmark_compression_levels.cpp
exercises the two configurations (zstd-3 vs zstd-5) through
ParquetFileWriter::Make on a pk + text + vector schema.

Tests:
- APIPropertiesTest.basic updated for the new default
- ParquetFileWriterTest.VectorColumnsAreUncompressed
- ParquetFileWriterTest.FileLevelCompressionDoesNotPreventVectorUncompressed