### PR TITLE
enhance: route arrow Status to finer LOON FFI error codes

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -45,8 +45,14 @@ extern "C" {
 #define LOON_TXN_EXHAUSTED_RETRY 10
 #define LOON_TXN_RESOLUTION_FAILED 11
 #define LOON_FILE_NOT_FOUND 12
+// Transient IO failure (network/throttling/timeout on object storage); the
+// caller may retry or reroute to another replica.
+#define LOON_IO_ERROR 13
+// The data on disk is malformed/corrupt (parquet/arrow decode failure); this is
+// a permanent data error, retrying will not help.
+#define LOON_DATA_ERROR 14
 // Internal use only. Do not use LOON_ERRORCODE_MAX in caller code.
-#define LOON_ERRORCODE_MAX 13
+#define LOON_ERRORCODE_MAX 15
 
 // usage example(caller must free the message string):
 //

--- a/cpp/include/milvus-storage/ffi_internal/result.h
+++ b/cpp/include/milvus-storage/ffi_internal/result.h
@@ -16,6 +16,7 @@
 
 #include "milvus-storage/ffi_c.h"
 
+#include <arrow/status.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -60,4 +61,28 @@ LoonFFIResult CreateFFIResult(int code, Args&&... args) {
   result.message = strdup(ss.str().c_str());
 
   return result;
+}
+
+// Route an arrow::Status failure onto a finer LOON error code so the failure
+// category survives the FFI boundary instead of every arrow error collapsing to
+// LOON_ARROW_ERROR. The milvus consumer then maps the LOON code to a segcore
+// ErrorCode with the right retry policy:
+//   OutOfMemory                 -> LOON_MEMORY_ERROR (transient, retriable)
+//   IOError                     -> LOON_IO_ERROR     (transient object-storage
+//                                  failure: throttling/timeout/reset; retriable)
+//   Invalid/TypeError/KeyError  -> LOON_DATA_ERROR   (malformed/corrupt data on
+//                                  disk; permanent). Note: this is the data path,
+//                                  so a decode failure is a data error, not a
+//                                  caller-argument error.
+inline int ArrowStatusToLoonCode(const arrow::Status& status) {
+  if (status.IsOutOfMemory()) {
+    return LOON_MEMORY_ERROR;
+  }
+  if (status.IsIOError()) {
+    return LOON_IO_ERROR;
+  }
+  if (status.IsInvalid() || status.IsTypeError() || status.IsKeyError()) {
+    return LOON_DATA_ERROR;
+  }
+  return LOON_ARROW_ERROR;
 }

--- a/cpp/src/ffi/exttable_c.cpp
+++ b/cpp/src/ffi/exttable_c.cpp
@@ -67,7 +67,7 @@ LoonFFIResult loon_exttable_explore(const char** columns,
 
     auto files_result = fmt_res.ValueOrDie()->explore(explore_dir, properties_map);
     if (!files_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, files_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(files_result.status()), files_result.status().ToString());
     }
     auto files = files_result.ValueOrDie();
 
@@ -84,7 +84,7 @@ LoonFFIResult loon_exttable_explore(const char** columns,
     // commit the column groups
     auto fs_result = milvus_storage::FilesystemCache::getInstance().get(properties_map);
     if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_result.status()), fs_result.status().ToString());
     }
     auto transaction_result = Transaction::Open(fs_result.ValueOrDie(), base_path);
     if (!transaction_result.ok()) {
@@ -139,19 +139,20 @@ LoonFFIResult loon_exttable_get_file_info(const char* format,
     // Resolve filesystem and validate file existence before creating reader
     auto fs_res = milvus_storage::FilesystemCache::getInstance().get(properties_map, file_path);
     if (!fs_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_res.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_res.status()), fs_res.status().ToString());
     }
     auto fs = fs_res.ValueOrDie();
 
     auto uri_res = milvus_storage::StorageUri::Parse(file_path);
     if (!uri_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to parse file_path URI '", file_path, "': ", uri_res.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(uri_res.status()), "Failed to parse file_path URI '", file_path,
+                   "': ", uri_res.status().ToString());
     }
     std::string resolved_path = uri_res->scheme.empty() ? file_path : uri_res->key;
 
     auto file_info_res = fs->GetFileInfo(resolved_path);
     if (!file_info_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, file_info_res.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(file_info_res.status()), file_info_res.status().ToString());
     }
     auto file_info = file_info_res.ValueOrDie();
 
@@ -166,12 +167,12 @@ LoonFFIResult loon_exttable_get_file_info(const char* format,
     ColumnGroupFile cg_file{std::string(file_path), 0, 0, {}};
     auto reader_res = fmt_res.ValueOrDie()->create_reader(nullptr, cg_file, properties_map, {}, nullptr);
     if (!reader_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, reader_res.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(reader_res.status()), reader_res.status().ToString());
     }
 
     auto rg_infos_res = reader_res.ValueOrDie()->get_row_group_infos();
     if (!rg_infos_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, rg_infos_res.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(rg_infos_res.status()), rg_infos_res.status().ToString());
     }
     auto& rg_infos = rg_infos_res.ValueOrDie();
     *out_num_of_rows = rg_infos.empty() ? 0 : rg_infos.back().end_offset;
@@ -208,7 +209,7 @@ LoonFFIResult loon_exttable_read_manifest(const char* manifest_file_path,
   try {
     auto manifest_res = read_manifest(manifest_file_path, properties);
     if (!manifest_res.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, manifest_res.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(manifest_res.status()), manifest_res.status().ToString());
     }
     auto manifest = manifest_res.ValueOrDie();
 

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -59,7 +59,7 @@ LoonFFIResult loon_filesystem_get(const ::LoonProperties* properties,
     auto& cache = FilesystemCache::getInstance();
     auto fs_result = cache.get(properties_map, path_str);
     if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_result.status()), fs_result.status().ToString());
     }
 
     auto fs_wrapper = std::make_unique<FileSystemWrapper>(fs_result.ValueOrDie());
@@ -135,7 +135,7 @@ LoonFFIResult loon_filesystem_open_writer(FileSystemHandle handle,
     }
 
     if (!output_stream_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, output_stream_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(output_stream_result.status()), output_stream_result.status().ToString());
     }
 
     auto output_stream = output_stream_result.ValueOrDie();
@@ -159,7 +159,7 @@ LoonFFIResult loon_filesystem_writer_write(FileSystemWriterHandle handle, const 
     auto output_stream = reinterpret_cast<OutputStreamWrapper*>(handle)->get();
     auto write_status = output_stream->Write(data, size);
     if (!write_status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, write_status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(write_status), write_status.ToString());
     }
     RETURN_SUCCESS();
   } catch (const std::exception& e) {
@@ -178,7 +178,7 @@ LoonFFIResult loon_filesystem_writer_flush(FileSystemWriterHandle handle) {
     auto output_stream = reinterpret_cast<OutputStreamWrapper*>(handle)->get();
     auto flush_result = output_stream->Flush();
     if (!flush_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, flush_result.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(flush_result), flush_result.ToString());
     }
 
     RETURN_SUCCESS();
@@ -197,7 +197,7 @@ LoonFFIResult loon_filesystem_writer_close(FileSystemWriterHandle handle) {
     auto output_stream = reinterpret_cast<OutputStreamWrapper*>(handle)->get();
     auto close_result = output_stream->Close();
     if (!close_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, close_result.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(close_result), close_result.ToString());
     }
 
     RETURN_SUCCESS();
@@ -227,7 +227,7 @@ LoonFFIResult loon_filesystem_get_file_info(FileSystemHandle handle,
     std::string path(reinterpret_cast<const char*>(path_ptr), path_len);
     auto info_result = fs->GetFileInfo(path);
     if (!info_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Fail to get file info, [path=", path,
+      RETURN_ERROR(ArrowStatusToLoonCode(info_result.status()), "Fail to get file info, [path=", path,
                    "] details: ", info_result.status().ToString());
     }
 
@@ -270,7 +270,7 @@ LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
       if (::arrow::internal::ErrnoFromStatus(input_file_result.status()) == ENOENT) {
         RETURN_ERROR(LOON_FILE_NOT_FOUND, "File not found: ", input_file_result.status().ToString());
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, "Fail to open input stream, [path=", path,
+      RETURN_ERROR(ArrowStatusToLoonCode(input_file_result.status()), "Fail to open input stream, [path=", path,
                    "] details: ", input_file_result.status().ToString());
     }
 
@@ -280,8 +280,8 @@ LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
     if (!read_result.ok()) {
       // won't fail, no need check
       (void)input_file->Close();
-      RETURN_ERROR(LOON_ARROW_ERROR, "Fail to read object data, [path=", path, ", offset=", offset, ", size=", nbytes,
-                   "] details: ", read_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(read_result.status()), "Fail to read object data, [path=", path,
+                   ", offset=", offset, ", size=", nbytes, "] details: ", read_result.status().ToString());
     }
 
     read_size = read_result.ValueOrDie();
@@ -295,7 +295,8 @@ LoonFFIResult loon_filesystem_read_file(FileSystemHandle handle,
     // close the inputstream
     auto close_result = input_file->Close();
     if (!close_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Fail to close inputstream, details: ", close_result.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(close_result),
+                   "Fail to close inputstream, details: ", close_result.ToString());
     }
 
     RETURN_SUCCESS();
@@ -333,7 +334,7 @@ LoonFFIResult loon_filesystem_open_reader(FileSystemHandle handle,
       if (::arrow::internal::ErrnoFromStatus(input_file_result.status()) == ENOENT) {
         RETURN_ERROR(LOON_FILE_NOT_FOUND, "File not found: ", input_file_result.status().ToString());
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, input_file_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(input_file_result.status()), input_file_result.status().ToString());
     }
 
     auto input_file = input_file_result.ValueOrDie();
@@ -361,8 +362,8 @@ LoonFFIResult loon_filesystem_reader_readat(FileSystemReaderHandle handle,
     auto input_file = reinterpret_cast<RandomAccessFileWrapper*>(handle)->get();
     auto read_result = input_file->ReadAt(offset, nbytes, out_data);
     if (!read_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Fail to read object data, [offset=", offset, ", size=", nbytes,
-                   "] details: ", read_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(read_result.status()), "Fail to read object data, [offset=", offset,
+                   ", size=", nbytes, "] details: ", read_result.status().ToString());
     }
 
     auto read_size = read_result.ValueOrDie();
@@ -394,7 +395,8 @@ LoonFFIResult loon_filesystem_reader_close(FileSystemReaderHandle handle) {
     auto input_file = reinterpret_cast<RandomAccessFileWrapper*>(handle)->get();
     auto close_result = input_file->Close();
     if (!close_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Fail to close inputstream, details: ", close_result.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(close_result),
+                   "Fail to close inputstream, details: ", close_result.ToString());
     }
 
     RETURN_SUCCESS();
@@ -441,7 +443,8 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
       if (::arrow::internal::ErrnoFromStatus(input_result.status()) == ENOENT) {
         RETURN_ERROR(LOON_FILE_NOT_FOUND, "File not found: ", input_result.status().ToString());
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to open input file: ", input_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(input_result.status()),
+                   "Failed to open input file: ", input_result.status().ToString());
     }
     auto input_file = input_result.ValueOrDie();
 
@@ -449,7 +452,8 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
     auto size_result = input_file->GetSize();
     if (!size_result.ok()) {
       (void)input_file->Close();
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to get file size: ", size_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(size_result.status()),
+                   "Failed to get file size: ", size_result.status().ToString());
     }
     *out_size = static_cast<uint64_t>(size_result.ValueOrDie());
 
@@ -458,7 +462,8 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
       auto metadata_result = input_file->ReadMetadata();
       if (!metadata_result.ok()) {
         (void)input_file->Close();
-        RETURN_ERROR(LOON_ARROW_ERROR, "Failed to read metadata: ", metadata_result.status().ToString());
+        RETURN_ERROR(ArrowStatusToLoonCode(metadata_result.status()),
+                     "Failed to read metadata: ", metadata_result.status().ToString());
       }
       auto metadata = metadata_result.ValueOrDie();
       if (metadata && metadata->size() > 0) {
@@ -508,7 +513,7 @@ LoonFFIResult loon_filesystem_get_file_stats(FileSystemHandle handle,
 
     auto close_result = input_file->Close();
     if (!close_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to close input file: ", close_result.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(close_result), "Failed to close input file: ", close_result.ToString());
     }
 
     RETURN_SUCCESS();
@@ -577,7 +582,8 @@ LoonFFIResult loon_filesystem_read_file_all(
       if (::arrow::internal::ErrnoFromStatus(input_result.status()) == ENOENT) {
         RETURN_ERROR(LOON_FILE_NOT_FOUND, "File not found: ", input_result.status().ToString());
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to open input file: ", input_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(input_result.status()),
+                   "Failed to open input file: ", input_result.status().ToString());
     }
     auto input_file = input_result.ValueOrDie();
 
@@ -585,7 +591,8 @@ LoonFFIResult loon_filesystem_read_file_all(
     auto size_result = input_file->GetSize();
     if (!size_result.ok()) {
       (void)input_file->Close();
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to get file size: ", size_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(size_result.status()),
+                   "Failed to get file size: ", size_result.status().ToString());
     }
     auto file_size = size_result.ValueOrDie();
 
@@ -604,7 +611,8 @@ LoonFFIResult loon_filesystem_read_file_all(
       *out_data = nullptr;
       *out_size = 0;
       (void)input_file->Close();
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to read file: ", read_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(read_result.status()),
+                   "Failed to read file: ", read_result.status().ToString());
     }
     auto buffer = read_result.ValueOrDie();
 
@@ -616,7 +624,7 @@ LoonFFIResult loon_filesystem_read_file_all(
       free(*out_data);
       *out_data = nullptr;
       *out_size = 0;
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to close input file: ", close_result.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(close_result), "Failed to close input file: ", close_result.ToString());
     }
 
     RETURN_SUCCESS();
@@ -675,7 +683,8 @@ LoonFFIResult loon_filesystem_write_file(FileSystemHandle handle,
     // Open output stream
     auto stream_result = fs->OpenOutputStream(path, metadata);
     if (!stream_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to open output stream: ", stream_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(stream_result.status()),
+                   "Failed to open output stream: ", stream_result.status().ToString());
     }
     auto output_stream = stream_result.ValueOrDie();
 
@@ -684,14 +693,14 @@ LoonFFIResult loon_filesystem_write_file(FileSystemHandle handle,
       auto write_status = output_stream->Write(data, data_size);
       if (!write_status.ok()) {
         (void)output_stream->Close();  // Try to close, ignore errors
-        RETURN_ERROR(LOON_ARROW_ERROR, "Failed to write data: ", write_status.ToString());
+        RETURN_ERROR(ArrowStatusToLoonCode(write_status), "Failed to write data: ", write_status.ToString());
       }
     }
 
     // Close the stream
     auto close_status = output_stream->Close();
     if (!close_status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to close output stream: ", close_status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(close_status), "Failed to close output stream: ", close_status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -714,7 +723,8 @@ LoonFFIResult loon_filesystem_delete_file(FileSystemHandle handle, const char* p
     // Verify file exists before deletion
     auto file_info_result = fs->GetFileInfo(path);
     if (!file_info_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to get file info: ", file_info_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(file_info_result.status()),
+                   "Failed to get file info: ", file_info_result.status().ToString());
     }
     auto file_info = file_info_result.ValueOrDie();
 
@@ -729,7 +739,7 @@ LoonFFIResult loon_filesystem_delete_file(FileSystemHandle handle, const char* p
     // Delete the file
     auto delete_status = fs->DeleteFile(path);
     if (!delete_status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to delete file: ", delete_status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(delete_status), "Failed to delete file: ", delete_status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -766,7 +776,8 @@ LoonFFIResult loon_filesystem_get_path_info(FileSystemHandle handle,
     // Get file info
     auto file_info_result = fs->GetFileInfo(path);
     if (!file_info_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to get file info: ", file_info_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(file_info_result.status()),
+                   "Failed to get file info: ", file_info_result.status().ToString());
     }
 
     auto file_info = file_info_result.ValueOrDie();
@@ -825,7 +836,7 @@ LoonFFIResult loon_filesystem_create_dir(FileSystemHandle handle,
     // Create directory
     auto create_status = fs->CreateDir(path, recursive);
     if (!create_status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to create directory: ", create_status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(create_status), "Failed to create directory: ", create_status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -878,7 +889,8 @@ LoonFFIResult loon_filesystem_list_dir(
       if (::arrow::internal::ErrnoFromStatus(file_info_result.status()) == ENOENT) {
         RETURN_ERROR(LOON_FILE_NOT_FOUND, "Directory not found: ", file_info_result.status().ToString());
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to list directory: ", file_info_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(file_info_result.status()),
+                   "Failed to list directory: ", file_info_result.status().ToString());
     }
 
     auto file_infos = file_info_result.ValueOrDie();

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -63,12 +63,12 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
     // Open transaction
     auto fs_result = milvus_storage::FilesystemCache::getInstance().get(properties_map, base_path);
     if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_result.status()), fs_result.status().ToString());
     }
     auto transaction_result =
         Transaction::Open(fs_result.ValueOrDie(), base_path, read_version, *resolver, retry_limit);
     if (!transaction_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, transaction_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(transaction_result.status()), transaction_result.status().ToString());
     }
     auto transaction = std::move(transaction_result.ValueOrDie());
 
@@ -131,7 +131,7 @@ LoonFFIResult loon_transaction_get_manifest(LoonTransactionHandle handle, LoonMa
     auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
     auto manifest_result = cpp_transaction->GetManifest();
     if (!manifest_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, manifest_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(manifest_result.status()), manifest_result.status().ToString());
     }
     auto manifest = manifest_result.ValueOrDie();
     // Export manifest to LoonManifest structure

--- a/cpp/src/ffi/reader_c.cpp
+++ b/cpp/src/ffi/reader_c.cpp
@@ -66,7 +66,7 @@ LoonFFIResult loon_get_chunk_indices(LoonChunkReaderHandle reader,
 
     auto result = cpp_reader->get_chunk_indices(input_indices);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     const auto& output_indices = result.ValueOrDie();
@@ -125,12 +125,12 @@ LoonFFIResult loon_get_chunk(LoonChunkReaderHandle reader,
     auto* cpp_reader = reinterpret_cast<ChunkReader*>(reader);
     auto result = cpp_reader->get_chunk(chunk_index);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
     auto record_batch = result.ValueOrDie();
     arrow::Status status = arrow::ExportRecordBatch(*record_batch, out_array);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     if (out_schema) {
@@ -139,7 +139,7 @@ LoonFFIResult loon_get_chunk(LoonChunkReaderHandle reader,
         if (out_array->release) {
           out_array->release(out_array);
         }
-        RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+        RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
       }
     }
 
@@ -186,7 +186,7 @@ LoonFFIResult loon_get_chunk_metadatas(LoonChunkReaderHandle reader,
       if (!estimated_mem_result.ok()) {
         // must be 0 because calloc and `number_of_chunks` will be updated at last.
         loon_free_chunk_metadatas(out_chunk_metadata);
-        RETURN_ERROR(LOON_ARROW_ERROR, estimated_mem_result.status().ToString());
+        RETURN_ERROR(ArrowStatusToLoonCode(estimated_mem_result.status()), estimated_mem_result.status().ToString());
       }
       const auto& estimated_memsz = estimated_mem_result.ValueOrDie();
       assert(estimated_memsz.size() == cpp_reader->total_number_of_chunks());
@@ -213,7 +213,7 @@ LoonFFIResult loon_get_chunk_metadatas(LoonChunkReaderHandle reader,
       auto chunk_rows = cpp_reader->get_chunk_rows();
       if (!chunk_rows.ok()) {
         loon_free_chunk_metadatas(out_chunk_metadata);
-        RETURN_ERROR(LOON_ARROW_ERROR, chunk_rows.status().ToString());
+        RETURN_ERROR(ArrowStatusToLoonCode(chunk_rows.status()), chunk_rows.status().ToString());
       }
       const auto& rows_per_chunk = chunk_rows.ValueOrDie();
       assert(rows_per_chunk.size() == cpp_reader->total_number_of_chunks());
@@ -284,7 +284,7 @@ LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
 
     auto result = cpp_reader->get_chunks(indices, parallelism);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     const auto& record_batches = result.ValueOrDie();
@@ -303,7 +303,7 @@ LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
           loon_free_chunk_arrays(*arrays, i);
           *num_arrays = 0;
           *arrays = nullptr;
-          RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+          RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
         }
       }
     } else {
@@ -318,7 +318,7 @@ LoonFFIResult loon_get_chunks(LoonChunkReaderHandle reader,
         loon_free_chunk_arrays(*arrays, *num_arrays);
         *num_arrays = 0;
         *arrays = nullptr;
-        RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+        RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
       }
     }
 
@@ -397,7 +397,7 @@ LoonFFIResult loon_reader_new(const LoonColumnGroups* column_groups,
 
     auto result = arrow::ImportSchema(schema);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     auto cpp_schema = result.ValueOrDie();
@@ -449,13 +449,13 @@ LoonFFIResult loon_get_record_batch_reader(LoonReaderHandle reader,
 
     auto result = cpp_reader->get_record_batch_reader(predicate_str);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     auto array_stream = result.ValueOrDie();
     arrow::Status status = arrow::ExportRecordBatchReader(array_stream, out_array_stream);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -480,7 +480,7 @@ LoonFFIResult loon_get_chunk_reader(LoonReaderHandle reader,
     auto cpp_needed_columns = convert_needed_columns(needed_columns, num_columns);
     auto result = cpp_reader->get_chunk_reader(column_group_id, cpp_needed_columns);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     // Transfer ownership to a raw pointer for C interface
@@ -521,13 +521,13 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
 
     auto result = cpp_reader->take(indices, parallelism, cpp_needed_columns);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     auto table = result.ValueOrDie();
     auto rbs_result = ConvertTableToRecordBatchs(table);
     if (!rbs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, rbs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(rbs_result.status()), rbs_result.status().ToString());
     }
     auto record_batches = rbs_result.ValueOrDie();
 
@@ -542,7 +542,7 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
           loon_free_chunk_arrays(*arrays, i);
           *num_arrays = 0;
           *arrays = nullptr;
-          RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+          RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
         }
       }
 
@@ -553,7 +553,7 @@ LoonFFIResult loon_take(LoonReaderHandle reader,
           loon_free_chunk_arrays(*arrays, *num_arrays);
           *num_arrays = 0;
           *arrays = nullptr;
-          RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+          RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
         }
       }
     } else {

--- a/cpp/src/ffi/result_c.cpp
+++ b/cpp/src/ffi/result_c.cpp
@@ -32,7 +32,9 @@ std::string error_to_string(int code) {
                                         "Not supported",                  //
                                         "Transaction exhausted retry",    //
                                         "Transaction resolution failed",  //
-                                        "File not found"};
+                                        "File not found",                 //
+                                        "IO error",                       //
+                                        "Data error"};
   static_assert(sizeof(error_strings) / sizeof((error_strings)[0]) == LOON_ERRORCODE_MAX);
 
   if (code < LOON_SUCCESS || code >= LOON_ERRORCODE_MAX) {

--- a/cpp/src/ffi/segment_reader_c.cpp
+++ b/cpp/src/ffi/segment_reader_c.cpp
@@ -73,14 +73,14 @@ LoonFFIResult loon_segment_reader_open(const char* segment_path,
     // import arrow schema
     auto schema_result = arrow::ImportSchema(schema_raw);
     if (!schema_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(schema_result.status()), schema_result.status().ToString());
     }
     auto schema = schema_result.ValueOrDie();
 
     // convert config
     auto config_result = ConvertReaderConfig(config, props_map);
     if (!config_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, config_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(config_result.status()), config_result.status().ToString());
     }
     auto cpp_config = config_result.ValueOrDie();
 
@@ -95,27 +95,27 @@ LoonFFIResult loon_segment_reader_open(const char* segment_path,
     // resolve filesystem from properties via the fs cache
     auto fs_result = FilesystemCache::getInstance().get(props_map, segment_path);
     if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_result.status()), fs_result.status().ToString());
     }
     auto fs = std::move(fs_result).ValueOrDie();
 
     // open transaction to read manifest
     auto txn_result = api::transaction::Transaction::Open(fs, segment_path, version, api::transaction::FailResolver, 1);
     if (!txn_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, txn_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(txn_result.status()), txn_result.status().ToString());
     }
     auto txn = std::move(txn_result).ValueOrDie();
 
     auto manifest_result = txn->GetManifest();
     if (!manifest_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, manifest_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(manifest_result.status()), manifest_result.status().ToString());
     }
     auto manifest = std::move(manifest_result).ValueOrDie();
 
     // open reader from manifest
     auto reader_result = SegmentReader::Open(fs, manifest, schema, columns, cpp_config);
     if (!reader_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, reader_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(reader_result.status()), reader_result.status().ToString());
     }
 
     auto reader = std::move(reader_result).ValueOrDie();
@@ -142,7 +142,7 @@ LoonFFIResult loon_segment_reader_get_stream(LoonSegmentReaderHandle handle, Arr
     auto status = arrow::ExportRecordBatchReader(
         std::shared_ptr<arrow::RecordBatchReader>(reader, [](arrow::RecordBatchReader*) {}), out_stream);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -174,7 +174,7 @@ LoonFFIResult loon_segment_reader_take(LoonSegmentReaderHandle handle,
 
     auto result = reader->Take(indices, par);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
     auto table = std::move(result).ValueOrDie();
 
@@ -182,7 +182,7 @@ LoonFFIResult loon_segment_reader_take(LoonSegmentReaderHandle handle,
     auto batch_reader = std::make_shared<arrow::TableBatchReader>(std::move(table));
     auto status = arrow::ExportRecordBatchReader(batch_reader, out_stream);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -206,13 +206,13 @@ LoonFFIResult loon_segment_reader_get_filtered_stream(LoonSegmentReaderHandle ha
 
     auto result = reader->GetStream(pred);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
     auto batch_reader = std::move(result).ValueOrDie();
 
     auto status = arrow::ExportRecordBatchReader(batch_reader, out_stream);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -245,7 +245,7 @@ LoonFFIResult loon_segment_reader_get_chunk_reader(LoonSegmentReaderHandle handl
 
     auto result = reader->GetChunkReader(column_group_index, columns);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     auto chunk_reader = std::move(result).ValueOrDie();

--- a/cpp/src/ffi/segment_writer_c.cpp
+++ b/cpp/src/ffi/segment_writer_c.cpp
@@ -80,28 +80,28 @@ LoonFFIResult loon_segment_writer_new(ArrowSchema* schema_raw,
     // import arrow schema
     auto schema_result = arrow::ImportSchema(schema_raw);
     if (!schema_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(schema_result.status()), schema_result.status().ToString());
     }
     auto schema = schema_result.ValueOrDie();
 
     // convert config
     auto config_result = ConvertWriterConfig(config, props_map);
     if (!config_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, config_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(config_result.status()), config_result.status().ToString());
     }
     auto cpp_config = config_result.ValueOrDie();
 
     // resolve filesystem from properties via the fs cache
     auto fs_result = FilesystemCache::getInstance().get(props_map, cpp_config.segment_path);
     if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, fs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_result.status()), fs_result.status().ToString());
     }
     auto fs = std::move(fs_result).ValueOrDie();
 
     // create segment writer
     auto writer_result = SegmentWriter::Create(fs, schema, cpp_config);
     if (!writer_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, writer_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(writer_result.status()), writer_result.status().ToString());
     }
 
     auto writer = std::move(writer_result).ValueOrDie();
@@ -126,13 +126,13 @@ LoonFFIResult loon_segment_writer_write(LoonSegmentWriterHandle handle, ArrowArr
     auto rb_result = arrow::ImportRecordBatch(array, writer->GetOriginalSchema());
     if (!rb_result.ok()) {
       array->release(array);
-      RETURN_ERROR(LOON_ARROW_ERROR, rb_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(rb_result.status()), rb_result.status().ToString());
     }
     auto batch = rb_result.ValueOrDie();
 
     auto status = writer->Write(batch);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -152,7 +152,7 @@ LoonFFIResult loon_segment_writer_flush(LoonSegmentWriterHandle handle) {
     auto* writer = reinterpret_cast<SegmentWriter*>(handle);
     auto status = writer->Flush();
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -172,7 +172,7 @@ LoonFFIResult loon_segment_writer_close(LoonSegmentWriterHandle handle, LoonSegm
     auto* writer = reinterpret_cast<SegmentWriter*>(handle);
     auto result = writer->Close();
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
 
     auto output = std::move(result).ValueOrDie();

--- a/cpp/src/ffi/v2_packed_writer_c.cpp
+++ b/cpp/src/ffi/v2_packed_writer_c.cpp
@@ -78,7 +78,7 @@ LoonFFIResult loon_packed_writer_new(const char* const* paths,
 
     auto schema_result = arrow::ImportSchema(schema_raw);
     if (!schema_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(schema_result.status()), schema_result.status().ToString());
     }
     auto schema = schema_result.ValueOrDie();
 
@@ -122,7 +122,8 @@ LoonFFIResult loon_packed_writer_new(const char* const* paths,
     // exact path.
     auto fs_result = FilesystemCache::getInstance().get(properties_map, path_vec[0]);
     if (!fs_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to obtain filesystem: ", fs_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(fs_result.status()),
+                   "Failed to obtain filesystem: ", fs_result.status().ToString());
     }
     auto fs = fs_result.ValueOrDie();
 
@@ -139,7 +140,8 @@ LoonFFIResult loon_packed_writer_new(const char* const* paths,
     auto writer_result = PackedRecordBatchWriter::Make(fs, path_vec, schema, storage_config, column_groups,
                                                        effective_buffer, ::parquet::default_writer_properties());
     if (!writer_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, "Failed to create PackedRecordBatchWriter: ", writer_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(writer_result.status()),
+                   "Failed to create PackedRecordBatchWriter: ", writer_result.status().ToString());
     }
 
     auto* holder = new PackedWriterHolder{writer_result.ValueOrDie(), std::move(schema)};
@@ -163,14 +165,14 @@ LoonFFIResult loon_packed_writer_write(LoonPackedWriterHandle handle, ArrowArray
       if (array->release) {
         array->release(array);
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, rb_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(rb_result.status()), rb_result.status().ToString());
     }
     auto status = holder->writer->Write(rb_result.ValueOrDie());
     if (!status.ok()) {
       if (array->release) {
         array->release(array);
       }
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
     RETURN_SUCCESS();
   } catch (std::exception& e) {
@@ -190,7 +192,7 @@ LoonFFIResult loon_packed_writer_close(LoonPackedWriterHandle handle) {
     auto* holder = reinterpret_cast<PackedWriterHolder*>(handle);
     auto status = holder->writer->Close();
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
     RETURN_SUCCESS();
   } catch (std::exception& e) {

--- a/cpp/src/ffi/writer_c.cpp
+++ b/cpp/src/ffi/writer_c.cpp
@@ -41,14 +41,14 @@ LoonFFIResult loon_writer_new(const char* base_path,
 
     auto schema_result = arrow::ImportSchema(schema_raw);
     if (!schema_result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, schema_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(schema_result.status()), schema_result.status().ToString());
     }
     auto schema = schema_result.ValueOrDie();
     std::unique_ptr<ColumnGroupPolicy> policy;
 
     auto policy_status = ColumnGroupPolicy::create_column_group_policy(properties_map, schema).Value(&policy);
     if (!policy_status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, policy_status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(policy_status), policy_status.ToString());
     }
 
     auto cpp_writer = Writer::create(std::move(std::string(base_path)), schema, std::move(policy), properties_map);
@@ -75,13 +75,13 @@ LoonFFIResult loon_writer_write(LoonWriterHandle handle, struct ArrowArray* arra
     auto rb_result = arrow::ImportRecordBatch(array, cpp_writer->schema());
     if (!rb_result.ok()) {
       array->release(array);
-      RETURN_ERROR(LOON_ARROW_ERROR, rb_result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(rb_result.status()), rb_result.status().ToString());
     }
     auto record_batch = rb_result.ValueOrDie();
 
     auto status = cpp_writer->write(record_batch);
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -100,7 +100,7 @@ LoonFFIResult loon_writer_flush(LoonWriterHandle handle) {
     auto* cpp_writer = reinterpret_cast<Writer*>(handle);
     auto status = cpp_writer->flush();
     if (!status.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(status), status.ToString());
     }
 
     RETURN_SUCCESS();
@@ -143,7 +143,7 @@ LoonFFIResult loon_writer_close(LoonWriterHandle handle,
     auto* cpp_writer = reinterpret_cast<Writer*>(handle);
     auto result = cpp_writer->close(meta_keys_vec, meta_vals_vec);
     if (!result.ok()) {
-      RETURN_ERROR(LOON_ARROW_ERROR, result.status().ToString());
+      RETURN_ERROR(ArrowStatusToLoonCode(result.status()), result.status().ToString());
     }
     auto cgs = result.ValueOrDie();
 

--- a/cpp/test/ffi/result_test.cpp
+++ b/cpp/test/ffi/result_test.cpp
@@ -1,0 +1,43 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <arrow/status.h>
+
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_internal/result.h"
+
+namespace milvus_storage::test {
+
+// ArrowStatusToLoonCode routes an arrow failure onto a finer LOON code so the
+// consumer can tell a transient failure (retriable) from a permanent one.
+TEST(ArrowStatusToLoonCode, RoutesByCategory) {
+  EXPECT_EQ(ArrowStatusToLoonCode(arrow::Status::OutOfMemory("oom")), LOON_MEMORY_ERROR);
+  EXPECT_EQ(ArrowStatusToLoonCode(arrow::Status::IOError("io")), LOON_IO_ERROR);
+  EXPECT_EQ(ArrowStatusToLoonCode(arrow::Status::Invalid("invalid")), LOON_DATA_ERROR);
+  EXPECT_EQ(ArrowStatusToLoonCode(arrow::Status::TypeError("type")), LOON_DATA_ERROR);
+  EXPECT_EQ(ArrowStatusToLoonCode(arrow::Status::KeyError("key")), LOON_DATA_ERROR);
+  // Anything not specifically categorized stays the generic arrow error.
+  EXPECT_EQ(ArrowStatusToLoonCode(arrow::Status::UnknownError("other")), LOON_ARROW_ERROR);
+}
+
+// The new codes must have matching strings (the static_assert in result_c.cpp
+// also guards that error_strings stays in sync with LOON_ERRORCODE_MAX).
+TEST(ErrorToString, CoversNewCodes) {
+  EXPECT_EQ(error_to_string(LOON_IO_ERROR), "IO error");
+  EXPECT_EQ(error_to_string(LOON_DATA_ERROR), "Data error");
+}
+
+}  // namespace milvus_storage::test


### PR DESCRIPTION
## What

Every arrow failure crossing the loon FFI boundary collapsed to `LOON_ARROW_ERROR`, so a consumer (milvus segcore) could not tell a transient failure from a permanent one and had to treat them all as one opaque error.

This PR adds an `ArrowStatusToLoonCode` helper (`ffi_internal/result.h`) and routes the `RETURN_ERROR(LOON_ARROW_ERROR, ...)` sites through it so the failure category survives the FFI boundary:

| arrow::Status | LOON code | meaning |
|---|---|---|
| `IsOutOfMemory()` | `LOON_MEMORY_ERROR` | transient, retriable |
| `IsIOError()` | `LOON_IO_ERROR` (new) | transient object-storage failure (throttling / timeout / reset), retriable |
| `IsInvalid()` / `IsTypeError()` / `IsKeyError()` | `LOON_DATA_ERROR` (new) | malformed / corrupt data on disk, permanent |
| everything else | `LOON_ARROW_ERROR` | unclassified |

Two new codes (`LOON_IO_ERROR`, `LOON_DATA_ERROR`) are added to the FFI enum (`ffi_c.h`) with their `error_to_string` entries. Applied across all FFI entry points (reader / writer / segment / manifest / exttable / filesystem).

## Why

The codes are consumed on the milvus side, which maps each LOON code onto the matching segcore `ErrorCode` (`LOON_IO_ERROR -> FileReadFailed` retriable, `LOON_DATA_ERROR -> DataFormatBroken` permanent, ...). Without the finer LOON codes a transient S3 IO failure was indistinguishable from permanent data corruption and could not be retried / rerouted.

## Pairs with

The milvus-side consumer change (separate PR on milvus-io/milvus) that reads these LOON codes at segcore's loon FFI boundary. Context: milvus error-handling standardization, milvus-io/milvus#47420.

## Verified

- Builds cleanly (`make build`, produces `libmilvus-storage.so`).
- `clang-format-18` clean.
