### PR TITLE
fix: Vortex FSST aborting on text payloads larger than 16MiB

### DIFF
--- a/cpp/src/format/bridge/rust/patches/2-cherry-pick-6676.patch
+++ b/cpp/src/format/bridge/rust/patches/2-cherry-pick-6676.patch
@@ -1,0 +1,53 @@
+From 8304ea80da2d89bc058acc5045b711bf50cb238a Mon Sep 17 00:00:00 2001
+From: Andrew Duffy <andrew@a10y.dev>
+Date: Wed, 25 Feb 2026 11:37:50 -0500
+Subject: [PATCH] resize FSST compressor buffer to be large enough for largest string
+
+Backport the production code change from vortex-data/vortex#6676.
+
+Signed-off-by: Andrew Duffy <andrew@a10y.dev>
+---
+ encodings/fsst/src/compress.rs | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/encodings/fsst/src/compress.rs b/encodings/fsst/src/compress.rs
+index 54b54b1..9f5ad75 100644
+--- a/encodings/fsst/src/compress.rs
++++ b/encodings/fsst/src/compress.rs
+@@ -49,6 +49,10 @@ where
+     Compressor::train(&lines)
+ }
+ 
++/// Most strings are small in practice. If we encounter a larger string, we reallocate
++/// the buffer to hold enough capacity for the worst-case compressed value.
++const DEFAULT_BUFFER_LEN: usize = 1024 * 1024;
++
+ /// Compress from an iterator of bytestrings using FSST.
+ pub fn fsst_compress_iter<'a, I>(
+     iter: I,
+@@ -59,8 +63,7 @@ pub fn fsst_compress_iter<'a, I>(
+ where
+     I: Iterator<Item = Option<&'a [u8]>>,
+ {
+-    // TODO(aduffy): this might be too small.
+-    let mut buffer = Vec::with_capacity(16 * 1024 * 1024);
++    let mut buffer = Vec::with_capacity(DEFAULT_BUFFER_LEN);
+     let mut builder = VarBinBuilder::<i32>::with_capacity(len);
+     let mut uncompressed_lengths: BufferMut<i32> = BufferMut::with_capacity(len);
+     for string in iter {
+@@ -72,7 +75,14 @@ where
+             Some(s) => {
+                 uncompressed_lengths.push(s.len().try_into().vortex_unwrap());
+ 
+-                // SAFETY: buffer is large enough
++                // make sure the buffer is 2x+7 larger than the input
++                let target_size = 2 * s.len() + 7;
++                if target_size > buffer.len() {
++                    let additional_capacity = target_size - buffer.len();
++                    buffer.reserve(additional_capacity);
++                }
++
++                // SAFETY: buffer is always sized to be large enough
+                 unsafe { compressor.compress_into(s, &mut buffer) };
+ 
+                 builder.append_value(&buffer);

--- a/cpp/test/lob_column/lob_column_writer_edge_test.cpp
+++ b/cpp/test/lob_column/lob_column_writer_edge_test.cpp
@@ -460,6 +460,36 @@ TEST_F(LobColumnWriterEdgeTest, VeryLargeText) {
   ASSERT_STATUS_OK(reader->Close());
 }
 
+TEST_F(LobColumnWriterEdgeTest, CloseDoesNotAbortForOversizedFsstTextPayload) {
+  auto child_config = config_;
+  child_config.max_lob_file_bytes = 64 * 1024 * 1024;
+  child_config.flush_threshold_bytes = 64 * 1024 * 1024;
+
+  auto manager_result = LobColumnManager::Create(fs_, child_config);
+  ASSERT_TRUE(manager_result.ok()) << manager_result.status().message();
+  auto manager = std::move(manager_result).ValueOrDie();
+
+  auto writer_result = manager->CreateWriter();
+  ASSERT_TRUE(writer_result.ok()) << writer_result.status().message();
+  auto writer = std::move(writer_result).ValueOrDie();
+
+  constexpr size_t kTextSize = 20 * 1024 * 1024;
+  std::string large_text;
+  large_text.resize(kTextSize);
+  uint64_t state = 0x9E3779B97F4A7C15ULL;
+  for (auto& ch : large_text) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    ch = static_cast<char>('!' + ((state >> 32) % 94));
+  }
+
+  auto ref = writer->WriteText(large_text);
+  ASSERT_TRUE(ref.ok()) << ref.status().message();
+  ASSERT_TRUE(IsLOBReference(ref.ValueOrDie().data()));
+
+  auto close_result = writer->Close();
+  ASSERT_TRUE(close_result.ok()) << close_result.status().message();
+}
+
 // ==================== Stats Tests ====================
 
 // test stats accuracy


### PR DESCRIPTION
cherry-pick : resize FSST compressor buffer to be large enough for largest string #6676(https://github.com/vortex-data/vortex/pull/6676)