### PR TITLE
Fix:[3.0] parquet projection for nested Arrow fields (#569)

### DIFF
--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -111,7 +111,8 @@ class ParquetFormatReader final : public FormatReader {
   uint64_t footer_size_ = 0;  ///< Pre-known footer size for single-IO footer read
 
   // init after open()
-  std::vector<int> needed_column_indices_;
+  // Parquet ReadRowGroup expects leaf-column indices, not top-level Arrow field indices.
+  std::vector<int> projected_leaf_column_indices_;
   std::vector<RowGroupInfo> row_group_infos_;
   std::shared_ptr<::parquet::arrow::FileReader> file_reader_;
 };  // ParquetFormatReader

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -24,6 +25,7 @@
 #include <fmt/format.h>
 
 #include <arrow/array/util.h>
+#include <arrow/extension_type.h>
 #include <arrow/io/caching.h>
 #include <arrow/record_batch.h>
 #include <arrow/table.h>
@@ -398,35 +400,101 @@ arrow::Status ParquetFormatReader::open() {
 arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::get_row_group_infos() { return row_group_infos_; }
 
 // Parquet uses a single schema_ (always derived from the file footer) rather than
-// separate read_schema_/file_schema_ like Lance/Vortex. Projection is handled via
-// needed_column_indices_.
+// separate read_schema_/file_schema_ like Lance/Vortex. Projection needs both
+// Arrow field indices and Parquet leaf column indices.
 std::shared_ptr<arrow::Schema> ParquetFormatReader::get_schema() const { return schema_; }
+
+static int get_leaf_column_count(const std::shared_ptr<arrow::DataType>& type) {
+  if (type->id() == arrow::Type::EXTENSION) {
+    const auto& extension_type = static_cast<const arrow::ExtensionType&>(*type);
+    return get_leaf_column_count(extension_type.storage_type());
+  }
+
+  if (type->num_fields() == 0) {
+    return 1;
+  }
+
+  int count = 0;
+  for (int i = 0; i < type->num_fields(); ++i) {
+    count += get_leaf_column_count(type->field(i)->type());
+  }
+  return count;
+}
+
+static arrow::Result<std::vector<int>> get_leaf_column_indices(const arrow::Schema& file_schema,
+                                                               const std::vector<std::string>& needed_columns,
+                                                               const std::string& path) {
+  // Build the start offset of each top-level Arrow field in the Parquet leaf-column list.
+  // ReadRowGroup expects Parquet leaf-column indices, but needed_columns contains
+  // top-level Arrow field names. Nested fields therefore need to expand to all
+  // leaf columns under that top-level field, while preserving needed_columns order.
+  // ex.
+  //   schema fields: [id, user struct<age: int32, name: string>, score]
+  //   Parquet leaf columns: [id, user.age, user.name, score]
+  //   leaf_column_offsets_by_field: [0, 1, 3, 4]
+  //   needed columns: [score, user]
+  //   leaf column indices: [3, 1, 2]
+  std::vector<int> leaf_column_offsets_by_field;
+  leaf_column_offsets_by_field.reserve(file_schema.num_fields() + 1);
+  leaf_column_offsets_by_field.emplace_back(0);
+  for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
+    leaf_column_offsets_by_field.emplace_back(leaf_column_offsets_by_field.back() +
+                                              get_leaf_column_count(file_schema.field(field_index)->type()));
+  }
+
+  const int leaf_column_count = leaf_column_offsets_by_field.back();
+  if (needed_columns.empty()) {
+    // No projection: read every Parquet leaf column.
+    std::vector<int> leaf_column_indices(leaf_column_count);
+    std::iota(leaf_column_indices.begin(), leaf_column_indices.end(), 0);
+    return leaf_column_indices;
+  }
+
+  // Resolve requested top-level fields in projection order and pre-compute output size.
+  // Continue the example above:
+  //   needed columns: [score, user]
+  //   top-level field indices: [2, 1]
+  //   projected leaf column count: 1 + 2 = 3
+  std::vector<int> top_level_field_indices;
+  top_level_field_indices.reserve(needed_columns.size());
+  int projected_leaf_column_count = 0;
+  for (const auto& column_name : needed_columns) {
+    const int top_level_field_index = file_schema.GetFieldIndex(column_name);
+    if (top_level_field_index < 0) {
+      return arrow::Status::Invalid(fmt::format("Column '{}' not found in schema. [path={}]", column_name, path));
+    }
+    top_level_field_indices.emplace_back(top_level_field_index);
+    projected_leaf_column_count +=
+        leaf_column_offsets_by_field[top_level_field_index + 1] - leaf_column_offsets_by_field[top_level_field_index];
+  }
+
+  // Expand each top-level field to the leaf columns that Parquet ReadRowGroup expects.
+  // The final order follows needed_columns, not file schema order.
+  // ex.
+  //   score -> leaf range [3, 4) -> [3]
+  //   user  -> leaf range [1, 3) -> [1, 2]
+  //   leaf column indices: [3, 1, 2]
+  std::vector<int> leaf_column_indices;
+  leaf_column_indices.reserve(projected_leaf_column_count);
+  for (const int top_level_field_index : top_level_field_indices) {
+    for (int column_index = leaf_column_offsets_by_field[top_level_field_index];
+         column_index < leaf_column_offsets_by_field[top_level_field_index + 1]; ++column_index) {
+      leaf_column_indices.emplace_back(column_index);
+    }
+  }
+
+  return leaf_column_indices;
+}
 
 arrow::Status ParquetFormatReader::set_needed_columns(const std::vector<std::string>& needed_columns) {
   if (!schema_) {
     return arrow::Status::Invalid(fmt::format("Parquet file schema is not initialized. [path={}]", path_));
   }
 
+  ARROW_ASSIGN_OR_RAISE(auto leaf_column_indices, get_leaf_column_indices(*schema_, needed_columns, path_));
+
   needed_columns_ = needed_columns;
-  needed_column_indices_.clear();
-
-  // Convert needed column names to column indices
-  if (needed_columns_.empty()) {
-    needed_column_indices_.reserve(schema_->num_fields());
-    for (int i = 0; i < schema_->num_fields(); ++i) {
-      needed_column_indices_.emplace_back(i);
-    }
-    return arrow::Status::OK();
-  }
-
-  needed_column_indices_.reserve(needed_columns_.size());
-  for (const auto& col_name : needed_columns_) {
-    int col_index = schema_->GetFieldIndex(col_name);
-    if (col_index < 0) {
-      return arrow::Status::Invalid(fmt::format("Column '{}' not found in schema. [path={}]", col_name, path_));
-    }
-    needed_column_indices_.emplace_back(col_index);
-  }
+  projected_leaf_column_indices_ = std::move(leaf_column_indices);
 
   return arrow::Status::OK();
 }
@@ -441,7 +509,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> ParquetFormatReader::get_chun
                     row_group_index, row_group_infos_.size()));
   }
 
-  ARROW_RETURN_NOT_OK(file_reader_->ReadRowGroup(row_group_index, needed_column_indices_, &table));
+  ARROW_RETURN_NOT_OK(file_reader_->ReadRowGroup(row_group_index, projected_leaf_column_indices_, &table));
 
   if (!table) {
     return arrow::Status::Invalid(
@@ -456,7 +524,7 @@ arrow::Result<std::shared_ptr<arrow::Table>> ParquetFormatReader::get_chunks_int
   std::shared_ptr<arrow::Table> table;
   assert(file_reader_);
 
-  ARROW_RETURN_NOT_OK(file_reader_->ReadRowGroups(rg_indices_in_file, needed_column_indices_, &table));
+  ARROW_RETURN_NOT_OK(file_reader_->ReadRowGroups(rg_indices_in_file, projected_leaf_column_indices_, &table));
 
   if (!table) {
     return arrow::Status::Invalid(fmt::format("Failed to read row groups. [path={}]", path_));
@@ -556,13 +624,13 @@ class RangeRecordBatchReader : public arrow::RecordBatchReader {
   RangeRecordBatchReader(std::shared_ptr<::parquet::arrow::FileReader> file_reader,
                          std::shared_ptr<arrow::Schema> schema,
                          std::vector<int> rg_indices,
-                         std::vector<int> column_indices,
+                         std::vector<int> leaf_column_indices,
                          uint64_t first_rg_slice_offset,
                          uint64_t total_rows)
       : file_reader_(std::move(file_reader)),
         schema_(std::move(schema)),
         rg_indices_(std::move(rg_indices)),
-        column_indices_(std::move(column_indices)),
+        leaf_column_indices_(std::move(leaf_column_indices)),
         first_rg_slice_offset_(first_rg_slice_offset),
         total_rows_(total_rows) {}
 
@@ -589,7 +657,7 @@ class RangeRecordBatchReader : public arrow::RecordBatchReader {
   arrow::Status LoadData() {
     // Read all row groups at once using ReadRowGroups (benefits from pre_buffer)
     std::shared_ptr<arrow::Table> table;
-    ARROW_RETURN_NOT_OK(file_reader_->ReadRowGroups(rg_indices_, column_indices_, &table));
+    ARROW_RETURN_NOT_OK(file_reader_->ReadRowGroups(rg_indices_, leaf_column_indices_, &table));
 
     if (!table) {
       return arrow::Status::Invalid("Failed to read row groups");
@@ -610,7 +678,7 @@ class RangeRecordBatchReader : public arrow::RecordBatchReader {
   std::shared_ptr<::parquet::arrow::FileReader> file_reader_;
   std::shared_ptr<arrow::Schema> schema_;
   std::vector<int> rg_indices_;
-  std::vector<int> column_indices_;
+  std::vector<int> leaf_column_indices_;
   uint64_t first_rg_slice_offset_;
   uint64_t total_rows_;
 
@@ -654,17 +722,23 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> ParquetFormatReader::re
   uint64_t first_rg_slice_offset = start_offset - first_rg_start_offset;
   uint64_t total_rows = end_offset - start_offset;
 
-  // Build projected schema for the reader
-  std::vector<std::shared_ptr<arrow::Field>> projected_fields;
-  projected_fields.reserve(needed_column_indices_.size());
-  for (int col_idx : needed_column_indices_) {
-    projected_fields.push_back(schema_->field(col_idx));
+  auto projected_schema = schema_;
+  if (!needed_columns_.empty()) {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    fields.reserve(needed_columns_.size());
+    for (const auto& column_name : needed_columns_) {
+      const int top_level_field_index = schema_->GetFieldIndex(column_name);
+      if (top_level_field_index < 0) {
+        return arrow::Status::Invalid(fmt::format("Column '{}' not found in schema. [path={}]", column_name, path_));
+      }
+      fields.emplace_back(schema_->field(top_level_field_index));
+    }
+    projected_schema = arrow::schema(std::move(fields));
   }
-  auto projected_schema = arrow::schema(projected_fields);
 
   // Use RangeRecordBatchReader which internally uses ReadRowGroups for batch I/O
   return std::make_shared<RangeRecordBatchReader>(file_reader_, projected_schema, std::move(rg_indices),
-                                                  needed_column_indices_, first_rg_slice_offset, total_rows);
+                                                  projected_leaf_column_indices_, first_rg_slice_offset, total_rows);
 }
 
 arrow::Result<std::shared_ptr<FormatReader>> ParquetFormatReader::clone_reader() {
@@ -686,7 +760,7 @@ ParquetFormatReader::ParquetFormatReader(const ParquetFormatReader& other,
       key_retriever_(other.key_retriever_),
       file_size_(other.file_size_),
       footer_size_(other.footer_size_),
-      needed_column_indices_(other.needed_column_indices_),
+      projected_leaf_column_indices_(other.projected_leaf_column_indices_),
       row_group_infos_(other.row_group_infos_),
       file_reader_(std::move(cloned_file_reader)) {}
 

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -17,6 +17,7 @@
 #include <random>
 
 #include <arrow/api.h>
+#include <arrow/extension_type.h>
 #include <arrow/io/api.h>
 #include <arrow/testing/gtest_util.h>
 #include <parquet/arrow/schema.h>
@@ -32,6 +33,48 @@
 namespace milvus_storage::test {
 
 using namespace milvus_storage::api;
+
+namespace {
+
+class NestedStructExtensionType : public arrow::ExtensionType {
+  public:
+  explicit NestedStructExtensionType(std::shared_ptr<arrow::DataType> storage_type)
+      : arrow::ExtensionType(std::move(storage_type)) {}
+
+  std::string extension_name() const override { return "milvus_storage.test.nested_struct"; }
+
+  bool ExtensionEquals(const arrow::ExtensionType& other) const override {
+    return extension_name() == other.extension_name() && storage_type()->Equals(*other.storage_type());
+  }
+
+  std::shared_ptr<arrow::Array> MakeArray(std::shared_ptr<arrow::ArrayData> data) const override {
+    return std::make_shared<arrow::ExtensionArray>(std::move(data));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::DataType>> Deserialize(std::shared_ptr<arrow::DataType> storage_type,
+                                                              const std::string&) const override {
+    return std::make_shared<NestedStructExtensionType>(std::move(storage_type));
+  }
+
+  std::string Serialize() const override { return ""; }
+};
+
+class ExtensionTypeRegistrationGuard {
+  public:
+  explicit ExtensionTypeRegistrationGuard(std::string extension_name) : extension_name_(std::move(extension_name)) {}
+
+  ~ExtensionTypeRegistrationGuard() {
+    auto status = arrow::UnregisterExtensionType(extension_name_);
+    if (!status.ok() && !status.IsKeyError()) {
+      ADD_FAILURE() << status.ToString();
+    }
+  }
+
+  private:
+  std::string extension_name_;
+};
+
+}  // namespace
 
 class FormatReaderTest : public ::testing::TestWithParam<std::string> {
   protected:
@@ -280,6 +323,173 @@ TEST_P(FormatReaderTest, ParquetCreateFromMetadataReappliesProjection) {
   for (int64_t i = 0; i < value_batch->num_rows(); ++i) {
     ASSERT_DOUBLE_EQ(value_array->Value(i), i * 1.5);
   }
+}
+
+TEST_P(FormatReaderTest, NestedProjectionPreservesTopLevelColumns) {
+  std::string format = GetParam();
+  auto field_metadata = [](const std::string& field_id) {
+    return arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {field_id});
+  };
+
+  auto profile_type =
+      arrow::struct_({arrow::field("score", arrow::int32(), false), arrow::field("label", arrow::utf8(), false)});
+  auto event_type =
+      arrow::struct_({arrow::field("code", arrow::int32(), false), arrow::field("message", arrow::utf8(), false)});
+  auto events_type = arrow::list(arrow::field("item", event_type, false));
+  auto nested_schema = arrow::schema({
+      arrow::field("id", arrow::int64(), false, field_metadata("0")),
+      arrow::field("profile", profile_type, false, field_metadata("1")),
+      arrow::field("events", events_type, false, field_metadata("2")),
+      arrow::field("note", arrow::utf8(), false, field_metadata("3")),
+  });
+
+  arrow::Int64Builder id_builder;
+  ASSERT_STATUS_OK(id_builder.AppendValues({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto ids, id_builder.Finish());
+
+  arrow::Int32Builder score_builder;
+  ASSERT_STATUS_OK(score_builder.AppendValues({10, 20, 30, 40}));
+  ASSERT_AND_ASSIGN(auto scores, score_builder.Finish());
+  arrow::StringBuilder label_builder;
+  ASSERT_STATUS_OK(label_builder.AppendValues({"cold", "warm", "hot", "peak"}));
+  ASSERT_AND_ASSIGN(auto labels, label_builder.Finish());
+  auto profiles =
+      std::make_shared<arrow::StructArray>(profile_type, 4, std::vector<std::shared_ptr<arrow::Array>>{scores, labels});
+
+  arrow::Int32Builder event_code_builder;
+  ASSERT_STATUS_OK(event_code_builder.AppendValues({1, 2, 3, 4, 5}));
+  ASSERT_AND_ASSIGN(auto event_codes, event_code_builder.Finish());
+  arrow::StringBuilder event_message_builder;
+  ASSERT_STATUS_OK(event_message_builder.AppendValues({"created", "queued", "running", "done", "archived"}));
+  ASSERT_AND_ASSIGN(auto event_messages, event_message_builder.Finish());
+  auto event_values = std::make_shared<arrow::StructArray>(
+      event_type, 5, std::vector<std::shared_ptr<arrow::Array>>{event_codes, event_messages});
+  arrow::Int32Builder event_offsets_builder;
+  ASSERT_STATUS_OK(event_offsets_builder.AppendValues({0, 2, 3, 3, 5}));
+  ASSERT_AND_ASSIGN(auto event_offsets, event_offsets_builder.Finish());
+  ASSERT_AND_ASSIGN(auto events, arrow::ListArray::FromArrays(events_type, *event_offsets, *event_values));
+
+  arrow::StringBuilder note_builder;
+  ASSERT_STATUS_OK(note_builder.AppendValues({"n0", "n1", "n2", "n3"}));
+  ASSERT_AND_ASSIGN(auto notes, note_builder.Finish());
+
+  auto record_batch = arrow::RecordBatch::Make(nested_schema, 4, {ids, profiles, events, notes});
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, nested_schema));
+  auto writer = Writer::create(base_path_, nested_schema, std::move(policy), properties_);
+  ASSERT_OK(writer->write(record_batch));
+  ASSERT_AND_ASSIGN(auto column_groups, writer->close());
+  ASSERT_EQ(column_groups->size(), 1);
+  ASSERT_EQ(column_groups->front()->files.size(), 1);
+
+  auto assert_batch_equal = [](const std::shared_ptr<arrow::RecordBatch>& actual,
+                               const std::shared_ptr<arrow::RecordBatch>& expected) {
+    ASSERT_TRUE(actual->Equals(*expected)) << "expected:\n"
+                                           << expected->ToString() << "\nactual:\n"
+                                           << actual->ToString() << "\nexpected schema:\n"
+                                           << expected->schema()->ToString(true) << "\nactual schema:\n"
+                                           << actual->schema()->ToString(true);
+  };
+
+  const std::vector<std::vector<int>> projection_cases = {
+      {0, 1, 2, 3}, {1}, {2}, {3, 2, 1}, {1, 3}, {0, 2},
+  };
+  for (size_t case_index = 0; case_index < projection_cases.size(); ++case_index) {
+    SCOPED_TRACE(::testing::Message() << "projection case " << case_index);
+
+    const auto& projected_field_indices = projection_cases[case_index];
+    std::vector<std::string> needed_columns;
+    needed_columns.reserve(projected_field_indices.size());
+    for (const int field_index : projected_field_indices) {
+      needed_columns.emplace_back(nested_schema->field(field_index)->name());
+    }
+
+    ASSERT_AND_ASSIGN(auto expected_batch, record_batch->SelectColumns(projected_field_indices));
+    ASSERT_AND_ASSIGN(auto format_reader,
+                      FormatReader::create(expected_batch->schema(), format, column_groups->front()->files.front(),
+                                           properties_, needed_columns, nullptr));
+
+    ASSERT_AND_ASSIGN(auto chunk, format_reader->get_chunk(0));
+    assert_batch_equal(chunk, expected_batch);
+
+    ASSERT_AND_ASSIGN(auto chunks, format_reader->get_chunks({0}));
+    ASSERT_AND_ASSIGN(auto chunks_batch, arrow::ConcatenateRecordBatches(chunks));
+    assert_batch_equal(chunks_batch, expected_batch);
+
+    ASSERT_AND_ASSIGN(auto range_reader, format_reader->read_with_range(1, 3));
+    ASSERT_TRUE(range_reader->schema()->Equals(*expected_batch->schema(), false))
+        << "expected schema:\n"
+        << expected_batch->schema()->ToString(true) << "\nactual schema:\n"
+        << range_reader->schema()->ToString(true);
+    ASSERT_AND_ASSIGN(auto range_batches, range_reader->ToRecordBatches());
+    ASSERT_AND_ASSIGN(auto range_batch, arrow::ConcatenateRecordBatches(range_batches));
+    assert_batch_equal(range_batch, expected_batch->Slice(1, 2));
+  }
+
+  if (format != LOON_FORMAT_PARQUET) {
+    return;
+  }
+
+  auto extension_storage_type =
+      arrow::struct_({arrow::field("real", arrow::float64(), false), arrow::field("imag", arrow::float64(), false)});
+  auto extension_type = std::make_shared<NestedStructExtensionType>(extension_storage_type);
+  auto unregister_status = arrow::UnregisterExtensionType(extension_type->extension_name());
+  ASSERT_TRUE(unregister_status.ok() || unregister_status.IsKeyError()) << unregister_status.ToString();
+  ASSERT_STATUS_OK(arrow::RegisterExtensionType(extension_type));
+  ExtensionTypeRegistrationGuard extension_guard(extension_type->extension_name());
+
+  auto extension_schema = arrow::schema({
+      arrow::field("id", arrow::int64(), false, field_metadata("0")),
+      arrow::field("extension_profile", extension_type, false, field_metadata("1")),
+      arrow::field("note", arrow::utf8(), false, field_metadata("2")),
+  });
+  auto extension_storage_schema = arrow::schema({
+      extension_schema->field(0),
+      arrow::field("extension_profile", extension_storage_type, false, field_metadata("1")),
+      extension_schema->field(2),
+  });
+
+  arrow::DoubleBuilder extension_real_builder;
+  ASSERT_STATUS_OK(extension_real_builder.AppendValues({1.5, 2.5, 3.5, 4.5}));
+  ASSERT_AND_ASSIGN(auto extension_reals, extension_real_builder.Finish());
+  arrow::DoubleBuilder extension_imag_builder;
+  ASSERT_STATUS_OK(extension_imag_builder.AppendValues({10.5, 20.5, 30.5, 40.5}));
+  ASSERT_AND_ASSIGN(auto extension_imags, extension_imag_builder.Finish());
+  auto extension_storage = std::make_shared<arrow::StructArray>(
+      extension_storage_type, 4, std::vector<std::shared_ptr<arrow::Array>>{extension_reals, extension_imags});
+  auto extension_profiles = arrow::ExtensionType::WrapArray(extension_type, extension_storage);
+
+  auto extension_batch = arrow::RecordBatch::Make(extension_schema, 4, {ids, extension_profiles, notes});
+  auto extension_storage_batch = arrow::RecordBatch::Make(extension_storage_schema, 4, {ids, extension_storage, notes});
+
+  ASSERT_AND_ASSIGN(auto extension_policy, CreateSinglePolicy(format, extension_schema));
+  auto extension_writer =
+      Writer::create(base_path_ + "/extension", extension_schema, std::move(extension_policy), properties_);
+  ASSERT_OK(extension_writer->write(extension_batch));
+  ASSERT_AND_ASSIGN(auto extension_column_groups, extension_writer->close());
+  ASSERT_EQ(extension_column_groups->size(), 1);
+  ASSERT_EQ(extension_column_groups->front()->files.size(), 1);
+
+  const auto& extension_file = extension_column_groups->front()->files.front();
+  ASSERT_AND_ASSIGN(auto loaded_metadata,
+                    parquet::ParquetFormatReader::MetaTrait::load_metadata(extension_file, properties_, nullptr));
+  auto metadata = std::make_shared<parquet::ParquetFormatReader::MetaTrait::Metadata>(*loaded_metadata);
+
+  // The file reader can return the extension column as its storage struct, which is allowed here.
+  // This regression is only about projection planning: metadata->file_schema may still contain
+  // the logical extension type, so leaf-column expansion must count leaves from storage_type().
+  metadata->file_schema = extension_schema;
+
+  const std::vector<int> extension_projected_field_indices = {2, 1};
+  const std::vector<std::string> extension_needed_columns = {"note", "extension_profile"};
+  ASSERT_AND_ASSIGN(auto extension_expected_batch,
+                    extension_storage_batch->SelectColumns(extension_projected_field_indices));
+  ASSERT_AND_ASSIGN(auto extension_reader,
+                    parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
+                        metadata, extension_file, extension_expected_batch->schema(), extension_needed_columns, ""));
+
+  ASSERT_AND_ASSIGN(auto extension_chunk, extension_reader->get_chunk(0));
+  assert_batch_equal(extension_chunk, extension_expected_batch);
 }
 
 INSTANTIATE_TEST_SUITE_P(FormatReaderTestP,

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -578,4 +578,91 @@ TEST_F(ParquetFileWriterTest, FooterSizeNotMatch) {
   verify_read(cached_file_size);
 }
 
+TEST_F(ParquetFileWriterTest, StructRoundTripThroughParquetFormatReader) {
+  constexpr int64_t kNumRows = 2;
+
+  arrow::Int32Builder id_builder;
+  ASSERT_STATUS_OK(id_builder.Append(10));
+  ASSERT_STATUS_OK(id_builder.Append(20));
+  ASSERT_AND_ASSIGN(auto ids, id_builder.Finish());
+
+  arrow::StringBuilder label_builder;
+  ASSERT_STATUS_OK(label_builder.Append("left"));
+  ASSERT_STATUS_OK(label_builder.Append("right"));
+  ASSERT_AND_ASSIGN(auto labels, label_builder.Finish());
+
+  arrow::FieldVector struct_fields = {arrow::field("id", arrow::int32(), false),
+                                      arrow::field("label", arrow::utf8(), false)};
+  auto struct_type = arrow::struct_(struct_fields);
+  auto struct_values = std::make_shared<arrow::StructArray>(struct_type, kNumRows,
+                                                            std::vector<std::shared_ptr<arrow::Array>>{ids, labels});
+  auto struct_field =
+      arrow::field("payload", struct_type, false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"0"}));
+  auto schema = arrow::schema({struct_field});
+  auto record_batch = arrow::RecordBatch::Make(schema, kNumRows, {struct_values});
+
+  std::string temp_file = base_path_ + "/data/test_struct.parquet";
+
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(schema, fs_, temp_file, config));
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+  ASSERT_AND_ASSIGN(auto close_result, writer->Close());
+
+  auto file_size = close_result.Get<uint64_t>(api::kPropertyFileSize);
+  auto footer_size = close_result.Get<uint64_t>(api::kPropertyFooterSize);
+  auto reader = milvus_storage::parquet::ParquetFormatReader(fs_, temp_file, properties_, /*needed_columns=*/{},
+                                                             /*key_retriever=*/nullptr, file_size, footer_size);
+  ASSERT_STATUS_OK(reader.open());
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
+  ASSERT_EQ(row_group_infos.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto read_batch, reader.get_chunk(0));
+  ASSERT_TRUE(read_batch->Equals(*record_batch)) << "expected:\n"
+                                                 << record_batch->ToString() << "\nactual:\n"
+                                                 << read_batch->ToString() << "\nexpected schema:\n"
+                                                 << record_batch->schema()->ToString(true) << "\nactual schema:\n"
+                                                 << read_batch->schema()->ToString(true);
+}
+
+TEST_F(ParquetFileWriterTest, DISABLED_FixedSizeListRoundTripThroughParquetFormatReader) {
+  constexpr int64_t kNumRows = 2;
+  constexpr int32_t kListSize = 4;
+
+  arrow::FloatBuilder values_builder;
+  for (int64_t row = 0; row < kNumRows; ++row) {
+    for (int32_t value = 0; value < kListSize; ++value) {
+      ASSERT_STATUS_OK(values_builder.Append(static_cast<float>(row * kListSize + value)));
+    }
+  }
+  ASSERT_AND_ASSIGN(auto values, values_builder.Finish());
+
+  auto list_type = arrow::fixed_size_list(arrow::field("item", arrow::float32(), false), kListSize);
+  ASSERT_AND_ASSIGN(auto vectors, arrow::FixedSizeListArray::FromArrays(values, list_type));
+  auto list_field = arrow::field("embedding", list_type, false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"0"}));
+  auto schema = arrow::schema({list_field});
+  auto record_batch = arrow::RecordBatch::Make(schema, kNumRows, {vectors});
+
+  std::string temp_file = base_path_ + "/data/test_fixed_size_list.parquet";
+
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(schema, fs_, temp_file, config));
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+  ASSERT_AND_ASSIGN(auto close_result, writer->Close());
+
+  auto file_size = close_result.Get<uint64_t>(api::kPropertyFileSize);
+  auto footer_size = close_result.Get<uint64_t>(api::kPropertyFooterSize);
+  auto reader = milvus_storage::parquet::ParquetFormatReader(fs_, temp_file, properties_, /*needed_columns=*/{},
+                                                             /*key_retriever=*/nullptr, file_size, footer_size);
+  ASSERT_STATUS_OK(reader.open());
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
+  ASSERT_EQ(row_group_infos.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto read_batch, reader.get_chunk(0));
+  ASSERT_TRUE(read_batch->Equals(*record_batch)) << "expected:\n"
+                                                 << record_batch->ToString() << "\nactual:\n"
+                                                 << read_batch->ToString() << "\nexpected schema:\n"
+                                                 << record_batch->schema()->ToString(true) << "\nactual schema:\n"
+                                                 << read_batch->schema()->ToString(true);
+}
+
 }  // namespace milvus_storage::test


### PR DESCRIPTION
Parquet reads were still treating projected columns as top-level Arrow field indexes, but ReadRowGroup actually expects Parquet leaf-column indexes. That worked for flat schemas, but nested fields like structs expand into multiple Parquet leaf columns, so projecting a nested top-level field could read the wrong physical columns or return an incomplete batch.

This change makes the projection path explicit: resolve requested top-level Arrow fields by name, compute each field's leaf-column range from the file schema, and pass the expanded leaf-column indexes into Parquet row group reads. Range reads use the same leaf-column projection and rebuild the returned schema from the requested top-level fields, so normal chunk reads and range reads now follow the same projection semantics.

The naming was also cleaned up around this path so the code says leaf column where it really means Parquet leaf columns, instead of mixing that up with Arrow field indexes. Fixed-size-list roundtrip is left disabled for now because that behavior is still separate from the nested projection fix.

---------