### PR TITLE
enhance: add packed-specific V2 extend status codes 

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -167,7 +167,7 @@ class StorageConan(ConanFile):
         self.requires("libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d")
         self.requires("google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43")
         self.requires("opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720")
-        self.requires("milvus-common/1.0.0-9ca5ea6@milvus/dev#274d428d85f1d3d996e1092f0c9c7144")
+        self.requires("milvus-common/1.0.0-3a5f4d4@milvus/dev#27802abedaf4eb8199b2dc01d19c55a7")
         # azure-sdk-for-cpp is a transitive dep of Arrow, but must be declared
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.

--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -25,6 +25,14 @@
 namespace milvus_storage {
 enum class ExtendStatusCode : char {
   // arrow::StatusCode biggest is 45
+  // Packed-specific error codes.
+  PackedInvalidArgs = 50,
+  PackedStorageIO = 51,
+  PackedMetadataCorrupted = 52,
+  PackedFileCorrupted = 53,
+  PackedArrowError = 54,
+  PackedUnexpected = 55,
+
   AwsErrorNoSuchUpload = 101,
   AwsErrorConflict = 102,
   AwsErrorPreConditionFailed = 103,
@@ -67,6 +75,8 @@ class ExtendStatusDetail : public arrow::StatusDetail {
   std::string extra_info_;
 };
 
-arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info);
+arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info = "");
+
+arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause);
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -22,6 +22,9 @@
 #include <arrow/status.h>
 #include <arrow/result.h>
 
+// from milvus-common repo
+#include "common/EasyAssert.h"
+
 namespace milvus_storage {
 enum class ExtendStatusCode : char {
   // arrow::StatusCode biggest is 45
@@ -78,5 +81,9 @@ class ExtendStatusDetail : public arrow::StatusDetail {
 arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info = "");
 
 arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause);
+
+milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code);
+
+milvus::SegcoreError ToSegcoreError(const arrow::Status& status);
 
 }  // namespace milvus_storage

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -89,4 +89,24 @@ arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const 
   return MakeExtendError(wrapped_code, fmt::format("{}: {}", message, cause_message), cause_message);
 }
 
+milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
+  if (code == ExtendStatusCode::PackedInvalidArgs) {
+    return milvus::InvalidParameter;
+  }
+  return milvus::StorageError;
+}
+
+milvus::SegcoreError ToSegcoreError(const arrow::Status& status) {
+  if (status.ok()) {
+    return milvus::SegcoreError::success();
+  }
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  if (detail) {
+    return {ToSegcoreErrorCode(detail->code()), status.ToString()};
+  }
+  auto code = status.IsInvalid() ? ExtendStatusCode::PackedInvalidArgs : ExtendStatusCode::PackedArrowError;
+  return {ToSegcoreErrorCode(code), status.ToString()};
+}
+
 }  // namespace milvus_storage

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -20,6 +20,7 @@
 
 #include <arrow/status.h>
 #include <arrow/result.h>
+#include <fmt/format.h>
 
 namespace milvus_storage {
 
@@ -39,6 +40,18 @@ std::string ExtendStatusDetail::extra_info() const { return extra_info_; }
 
 std::string ExtendStatusDetail::CodeAsString() const {
   switch (code()) {
+    case ExtendStatusCode::PackedInvalidArgs:
+      return "PackedInvalidArgs";
+    case ExtendStatusCode::PackedStorageIO:
+      return "PackedStorageIO";
+    case ExtendStatusCode::PackedMetadataCorrupted:
+      return "PackedMetadataCorrupted";
+    case ExtendStatusCode::PackedFileCorrupted:
+      return "PackedFileCorrupted";
+    case ExtendStatusCode::PackedArrowError:
+      return "PackedArrowError";
+    case ExtendStatusCode::PackedUnexpected:
+      return "PackedUnexpected";
     case ExtendStatusCode::AwsErrorNoSuchUpload:
       return "AwsErrorNoSuchUpload";
     case ExtendStatusCode::AwsErrorConflict:
@@ -64,8 +77,16 @@ std::shared_ptr<ExtendStatusDetail> ExtendStatusDetail::UnwrapStatus(const arrow
 }
 
 arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info) {
-  arrow::StatusCode arrow_code = arrow::StatusCode::IOError;
+  auto arrow_code =
+      code == ExtendStatusCode::PackedInvalidArgs ? arrow::StatusCode::Invalid : arrow::StatusCode::IOError;
   return {arrow_code, std::move(message), std::make_shared<ExtendStatusDetail>(code, std::move(extra_info))};
+}
+
+arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause) {
+  auto detail = ExtendStatusDetail::UnwrapStatus(cause);
+  auto wrapped_code = detail ? detail->code() : code;
+  auto cause_message = cause.ToString();
+  return MakeExtendError(wrapped_code, fmt::format("{}: {}", message, cause_message), cause_message);
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -62,9 +62,8 @@ std::string ExtendStatusDetail::CodeAsString() const {
       return "TxnExhaustedRetry";
     case ExtendStatusCode::TxnResolutionFailed:
       return "TxnResolutionFailed";
-    default:
-      return "Unknown";
   }
+  return "Unknown";
 }
 
 void ExtendStatusDetail::set_extra_info(std::string extra_info) { extra_info_ = std::move(extra_info); }

--- a/cpp/src/packed/column_group.cpp
+++ b/cpp/src/packed/column_group.cpp
@@ -14,6 +14,7 @@
 
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/extend_status.h"
 #include <arrow/table.h>
 #include <arrow/status.h>
 
@@ -32,7 +33,7 @@ ColumnGroup::ColumnGroup(GroupId group_id,
 
 arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBatch>& batch) {
   if (!batch) {
-    return arrow::Status::IOError("ColumnGroup::AddRecordBatch: batch is null");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "ColumnGroup::AddRecordBatch: batch is null");
   }
   batches_.emplace_back(batch);
 
@@ -46,9 +47,11 @@ arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBat
 
 arrow::Status ColumnGroup::Merge(const ColumnGroup& other) {
   for (auto& batch : other.batches_) {
-    if (!AddRecordBatch(batch).ok()) {
-      return arrow::Status::IOError("ColumnGroup::Merge: failed to merge record batch");
-    };
+    auto status = AddRecordBatch(batch);
+    if (!status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedUnexpected, "ColumnGroup::Merge: failed to merge record batch",
+                             status);
+    }
   }
   return arrow::Status::OK();
 }

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -14,6 +14,8 @@
 
 #include <memory>
 #include <algorithm>
+#include <exception>
+#include <stdexcept>
 #include <utility>
 
 #include <arrow/array/data.h>
@@ -32,10 +34,42 @@
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/packed/chunk_manager.h"
 #include "milvus-storage/packed/reader.h"
 
 namespace milvus_storage {
+
+namespace {
+
+arrow::Result<std::shared_ptr<PackedFileMetadata>> MakePackedMetadata(
+    const std::shared_ptr<::parquet::FileMetaData>& metadata, const std::string& path) {
+  if (!metadata) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Packed parquet metadata is null. [path={}]", path));
+  }
+  if (!metadata->key_value_metadata()) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Packed parquet key-value metadata is missing. [path={}]", path));
+  }
+
+  try {
+    auto result = PackedFileMetadata::Make(metadata);
+    if (!result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                             fmt::format("Failed to parse packed file metadata. [path={}]", path), result.status());
+    }
+    return result;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Failed to parse packed file metadata. [path={}, error={}]", path, e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Failed to parse packed file metadata with unknown exception. [path={}]", path));
+  }
+}
+
+}  // namespace
 
 PackedRecordBatchReader::PackedRecordBatchReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                                  std::vector<std::string>& paths,
@@ -60,6 +94,16 @@ arrow::Status PackedRecordBatchReader::init(const std::shared_ptr<arrow::fs::Fil
                                             const std::shared_ptr<arrow::Schema>& schema,
                                             parquet::ReaderProperties& reader_props,
                                             const parquet::ArrowReaderProperties& arrow_reader_props) {
+  if (!fs) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader null file system provided");
+  }
+  if (paths.empty()) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader empty paths provided");
+  }
+  if (!schema) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader null schema provided");
+  }
+
   // read first file metadata to get field id mapping and do schema matching
   ARROW_RETURN_NOT_OK(schemaMatching(fs, schema, paths, reader_props, arrow_reader_props));
 
@@ -68,12 +112,12 @@ arrow::Status PackedRecordBatchReader::init(const std::shared_ptr<arrow::fs::Fil
   for (const auto& path : needed_paths_) {
     auto result = MakeArrowFileReader(*fs, path, reader_props, arrow_reader_props);
     if (!result.ok()) {
-      return arrow::Status::Invalid(
-          fmt::format("Error making file reader with path {}: {}", path, result.status().ToString()));
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             fmt::format("Error making file reader with path {}", path), result.status());
     }
     auto file_reader = std::move(result.ValueOrDie());
     auto metadata = file_reader->parquet_reader()->metadata();
-    ARROW_ASSIGN_OR_RAISE(auto file_metadata, PackedFileMetadata::Make(metadata));
+    ARROW_ASSIGN_OR_RAISE(auto file_metadata, MakePackedMetadata(metadata, path));
     metadata_list_.emplace_back(std::move(file_metadata));
     file_readers_.emplace_back(std::move(file_reader));
 
@@ -105,20 +149,23 @@ arrow::Status PackedRecordBatchReader::schemaMatching(const std::shared_ptr<arro
   // read first file metadata to get field id mapping
   auto result = MakeArrowFileReader(*fs, paths[0], reader_props, arrow_reader_props);
   if (!result.ok()) {
-    return arrow::Status::Invalid(
-        fmt::format("Error making file reader with path {}: {}", paths[0], result.status().ToString()));
+    return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                           fmt::format("Error making file reader with path {}", paths[0]), result.status());
   }
   auto parquet_metadata = result.ValueOrDie()->parquet_reader()->metadata();
-  ARROW_ASSIGN_OR_RAISE(auto metadata, PackedFileMetadata::Make(parquet_metadata));
+  ARROW_ASSIGN_OR_RAISE(auto metadata, MakePackedMetadata(parquet_metadata, paths[0]));
 
   // parse field id list from schema
   std::vector<std::shared_ptr<arrow::Field>> fields;
   std::vector<std::shared_ptr<arrow::Field>> needed_fields;
-  auto status = FieldIDList::Make(schema);
-  if (!status.ok()) {
-    return arrow::Status::Invalid(fmt::format("Error getting field id list from schema: {}", schema->ToString(true)));
+  auto field_id_list = FieldIDList::Make(schema);
+  if (!field_id_list.ok()) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           fmt::format("Error getting field id list from schema: {}. [schema={}]",
+                                       field_id_list.status().ToString(), schema->ToString(true)),
+                           field_id_list.status().ToString());
   }
-  field_id_list_ = status.ValueOrDie();
+  field_id_list_ = field_id_list.ValueOrDie();
 
   // schema matching
   field_id_mapping_ = metadata->GetFieldIDMapping();
@@ -126,6 +173,13 @@ arrow::Status PackedRecordBatchReader::schemaMatching(const std::shared_ptr<arro
     FieldID field_id = field_id_list_.Get(i);
     if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
       auto column_offset = field_id_mapping_[field_id];
+      if (column_offset.path_index < 0 || static_cast<size_t>(column_offset.path_index) >= paths.size()) {
+        return MakeExtendError(
+            ExtendStatusCode::PackedMetadataCorrupted,
+            fmt::format("Packed field id metadata references path index outside provided paths. [field_id={}, "
+                        "path_index={}, num_paths={}]",
+                        field_id, column_offset.path_index, paths.size()));
+      }
       needed_column_offsets_.emplace_back(column_offset);
       needed_paths_.emplace(paths[column_offset.path_index]);
       fields.emplace_back(schema->field(i));
@@ -200,13 +254,14 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
       return arrow::Status::OK();
     } else {
       // Otherwise, the rows are not match, there is something wrong with the files.
-      return arrow::Status::Invalid(fmt::format("File broken at index {}. [path={}, row_offset={}, row_limit={}]",
-                                                drained_index,  // NOLINT
-                                                needed_paths_.size() > static_cast<size_t>(drained_index)
-                                                    ? *std::next(needed_paths_.begin(), drained_index)
-                                                    : "unknown",                                 // NOLINT
-                                                column_group_states_[drained_index].row_offset,  // NOLINT
-                                                row_limit_));
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             fmt::format("File broken at index {}. [path={}, row_offset={}, row_limit={}]",
+                                         drained_index,  // NOLINT
+                                         needed_paths_.size() > static_cast<size_t>(drained_index)
+                                             ? *std::next(needed_paths_.begin(), drained_index)
+                                             : "unknown",                                 // NOLINT
+                                         column_group_states_[drained_index].row_offset,  // NOLINT
+                                         row_limit_));
     }
   }
 
@@ -236,7 +291,13 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
     read_count_++;
     column_group_states_[i].read_times++;
     std::shared_ptr<arrow::Table> read_table = nullptr;
-    ARROW_RETURN_NOT_OK(file_readers_[i]->ReadRowGroups(rgs_to_read[i], &read_table));
+    auto read_status = file_readers_[i]->ReadRowGroups(rgs_to_read[i], &read_table);
+    if (!read_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             fmt::format("Failed to read packed row groups. [path={}]",
+                                         needed_paths_.size() > i ? *std::next(needed_paths_.begin(), i) : "unknown"),
+                             read_status);
+    }
     int path_index = file_reader_to_path_index_[i];
     tables_[path_index].push(std::move(read_table));
   }
@@ -250,58 +311,93 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
 }
 
 arrow::Status PackedRecordBatchReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
-  if (absolute_row_position_ >= row_limit_) {
-    ARROW_RETURN_NOT_OK(advanceBuffer());
+  try {
+    if (!out) {
+      return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader ReadNext output pointer is null");
+    }
+
     if (absolute_row_position_ >= row_limit_) {
-      *out = nullptr;
-      return arrow::Status::OK();
+      ARROW_RETURN_NOT_OK(advanceBuffer());
+      if (absolute_row_position_ >= row_limit_) {
+        *out = nullptr;
+        return arrow::Status::OK();
+      }
     }
-  }
 
-  // Determine the maximum contiguous slice across all tables
-  auto batch_data = chunk_manager_->SliceChunksByMaxContiguousSlice(row_limit_ - absolute_row_position_, tables_);
-  int64_t chunk_size = chunk_manager_->GetChunkSize();
-  absolute_row_position_ += chunk_size;
-  std::shared_ptr<arrow::RecordBatch> batch =
-      arrow::RecordBatch::Make(needed_schema_, chunk_size, std::move(batch_data));
-
-  int batch_index = 0;
-  std::vector<std::shared_ptr<arrow::Array>> arrays;
-  for (size_t i = 0; i < field_id_list_.size(); ++i) {
-    FieldID field_id = field_id_list_.Get(i);
-    if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
-      // RVO here, no need std::move
-      arrays.emplace_back(batch->column(batch_index++));
-    } else {
-      auto null_array = arrow::MakeArrayOfNull(schema_->field(i)->type(), chunk_size).ValueOrDie();
-      arrays.emplace_back(std::move(null_array));
+    // Determine the maximum contiguous slice across all tables
+    std::vector<std::shared_ptr<arrow::ArrayData>> batch_data;
+    try {
+      batch_data = chunk_manager_->SliceChunksByMaxContiguousSlice(row_limit_ - absolute_row_position_, tables_);
+    } catch (const std::exception& e) {
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             fmt::format("Packed file chunk layout is corrupted: {}", e.what()));
+    } catch (...) {
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             "Packed file chunk layout is corrupted with unknown exception");
     }
+    int64_t chunk_size = chunk_manager_->GetChunkSize();
+    absolute_row_position_ += chunk_size;
+    std::shared_ptr<arrow::RecordBatch> batch =
+        arrow::RecordBatch::Make(needed_schema_, chunk_size, std::move(batch_data));
+
+    int batch_index = 0;
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    for (size_t i = 0; i < field_id_list_.size(); ++i) {
+      FieldID field_id = field_id_list_.Get(i);
+      if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
+        // RVO here, no need std::move
+        arrays.emplace_back(batch->column(batch_index++));
+      } else {
+        auto null_array_result = arrow::MakeArrayOfNull(schema_->field(i)->type(), chunk_size);
+        if (!null_array_result.ok()) {
+          return WrapExtendError(ExtendStatusCode::PackedArrowError,
+                                 fmt::format("Failed to create null array. [field_index={}]", i),
+                                 null_array_result.status());
+        }
+        auto null_array = null_array_result.ValueOrDie();
+        arrays.emplace_back(std::move(null_array));
+      }
+    }
+    *out = arrow::RecordBatch::Make(schema_, chunk_size, arrays);
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed reader read next failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed reader read next with unknown exception failed unexpectedly");
   }
-  *out = arrow::RecordBatch::Make(schema_, chunk_size, arrays);
-  return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchReader::Close() {
-  LOG_STORAGE_DEBUG_ << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
-  for (size_t i = 0; i < column_group_states_.size(); ++i) {
-    LOG_STORAGE_DEBUG_ << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
-  }
-
-  // Clean up remaining data in all tables
-  for (auto& table_queue : tables_) {
-    while (!table_queue.empty()) {
-      table_queue.front().reset();  // Explicitly release shared_ptr
-      table_queue.pop();
+  try {
+    LOG_STORAGE_DEBUG_ << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
+    for (size_t i = 0; i < column_group_states_.size(); ++i) {
+      LOG_STORAGE_DEBUG_ << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
     }
-  }
 
-  read_count_ = 0;
-  column_group_states_.clear();
-  tables_.clear();
-  file_readers_.clear();
-  metadata_list_.clear();
-  memory_used_ = 0;
-  return arrow::Status::OK();
+    // Clean up remaining data in all tables
+    for (auto& table_queue : tables_) {
+      while (!table_queue.empty()) {
+        table_queue.front().reset();  // Explicitly release shared_ptr
+        table_queue.pop();
+      }
+    }
+
+    read_count_ = 0;
+    column_group_states_.clear();
+    tables_.clear();
+    file_readers_.clear();
+    metadata_list_.clear();
+    memory_used_ = 0;
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed reader close failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed reader close with unknown exception failed unexpectedly");
+  }
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
 #include <utility>
 
@@ -28,6 +29,7 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/format/parquet/parquet_writer.h"
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
@@ -70,22 +72,25 @@ arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> PackedRecordBatchWriter:
 
 arrow::Status PackedRecordBatchWriter::init() {
   if (!schema_) {
-    return arrow::Status::Invalid("Packed writer null schema provided");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed writer null schema provided");
   }
 
   if (paths_.size() != group_indices_.size()) {
-    return arrow::Status::Invalid(fmt::format("Mismatch between paths number and column groups number: {} vs {}",
-                                              paths_.size(), group_indices_.size()));
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           fmt::format("Mismatch between paths number and column groups number: {} vs {}",
+                                       paths_.size(), group_indices_.size()));
   }
 
   if (!fs_) {
-    return arrow::Status::Invalid("Packed writer null file system provided");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed writer null file system provided");
   }
 
   auto field_id_list = FieldIDList::Make(schema_);
   if (!field_id_list.ok()) {
-    return arrow::Status::Invalid(fmt::format("Failed to get field id from schema: {}. [schema={}]",
-                                              field_id_list.status().ToString(), schema_->ToString(true)));
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           fmt::format("Failed to get field id from schema: {}. [schema={}]",
+                                       field_id_list.status().ToString(), schema_->ToString(true)),
+                           field_id_list.status().ToString());
   }
 
   // Validate column group indices are within bounds
@@ -93,8 +98,9 @@ arrow::Status PackedRecordBatchWriter::init() {
   for (const auto& group_indice : group_indices_) {
     for (int col_index : group_indice) {
       if (col_index < 0 || col_index >= num_fields) {
-        return arrow::Status::Invalid(fmt::format("Column index out of range: {} (schema has {} fields), [schema={}]",
-                                                  col_index, num_fields, schema_->ToString(true)));
+        return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                               fmt::format("Column index out of range: {} (schema has {} fields), [schema={}]",
+                                           col_index, num_fields, schema_->ToString(true)));
       }
     }
   }
@@ -104,79 +110,134 @@ arrow::Status PackedRecordBatchWriter::init() {
   splitter_ = IndicesBasedSplitter(group_indices_);
   for (size_t i = 0; i < paths_.size(); ++i) {
     auto column_group_schema = getColumnGroupSchema(schema_, group_indices_[i]);
-    ARROW_ASSIGN_OR_RAISE(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(
-                                           column_group_schema, fs_, paths_[i], storage_config_, writer_props_));
+    auto writer_result = milvus_storage::parquet::ParquetFileWriter::Make(column_group_schema, fs_, paths_[i],
+                                                                          storage_config_, writer_props_);
+    if (!writer_result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             fmt::format("Failed to create packed column group writer. [path={}]", paths_[i]),
+                             writer_result.status());
+    }
+    auto writer = std::move(writer_result).ValueOrDie();
     group_writers_.emplace_back(std::move(writer));
   }
   return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::RecordBatch>& record) {
-  // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
-                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
+  try {
+    // Fault injection point for testing
+    FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
+                  MakeExtendError(ExtendStatusCode::PackedStorageIO,
+                                  fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
 
-  if (!record) {
+    if (!record) {
+      return arrow::Status::OK();
+    }
+
+    for (const auto& group_indice : group_indices_) {
+      for (int col_index : group_indice) {
+        if (col_index < 0 || col_index >= record->num_columns()) {
+          return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                                 fmt::format("Record batch column index out of range: {} (record batch has {} columns)",
+                                             col_index, record->num_columns()));
+        }
+      }
+    }
+
+    size_t next_batch_size = GetRecordBatchMemorySize(record);
+
+    std::vector<ColumnGroup> column_groups = splitter_.Split(record);
+
+    // Flush column groups until there's enough room for the new column groups
+    // to ensure that memory usage stays strictly below the limit
+    while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
+      LOG_STORAGE_DEBUG_ << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
+                         << ", flushing column group: " << max_heap_.top().first;
+      auto max_group = max_heap_.top();
+      max_heap_.pop();
+
+      assert(current_memory_usage_ >= max_group.second);
+      current_memory_usage_ -= max_group.second;
+
+      milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
+      auto flush_status = writer->Flush();
+      if (!flush_status.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
+                               flush_status);
+      }
+    }
+
+    // After flushing, add the new column groups if memory usage allows
+    for (const ColumnGroup& group : column_groups) {
+      current_memory_usage_ += group.GetMemoryUsage();
+      max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
+
+      assert(group.GrpId() < group_writers_.size());
+      auto& grp_writer = group_writers_[group.GrpId()];
+      auto write_status = grp_writer->Write(group.GetRecordBatch(0));
+      if (!write_status.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to write packed column group", write_status);
+      }
+    }
+
+    ARROW_RETURN_NOT_OK(balanceMaxHeap());
     return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed writer write failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer write with unknown exception failed unexpectedly");
   }
-
-  size_t next_batch_size = GetRecordBatchMemorySize(record);
-
-  std::vector<ColumnGroup> column_groups = splitter_.Split(record);
-
-  // Flush column groups until there's enough room for the new column groups
-  // to ensure that memory usage stays strictly below the limit
-  while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
-    LOG_STORAGE_DEBUG_ << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
-                       << ", flushing column group: " << max_heap_.top().first;
-    auto max_group = max_heap_.top();
-    max_heap_.pop();
-
-    assert(current_memory_usage_ >= max_group.second);
-    current_memory_usage_ -= max_group.second;
-
-    milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
-    ARROW_RETURN_NOT_OK(writer->Flush());
-  }
-
-  // After flushing, add the new column groups if memory usage allows
-  for (const ColumnGroup& group : column_groups) {
-    current_memory_usage_ += group.GetMemoryUsage();
-    max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
-
-    assert(group.GrpId() < group_writers_.size());
-    auto& grp_writer = group_writers_[group.GrpId()];
-    ARROW_RETURN_NOT_OK(grp_writer->Write(group.GetRecordBatch(0)));
-  }
-
-  ARROW_RETURN_NOT_OK(balanceMaxHeap());
-  return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::Close() {
-  // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
-                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
+  try {
+    // Fault injection point for testing
+    FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
+                  MakeExtendError(ExtendStatusCode::PackedStorageIO,
+                                  fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
 
-  // Check if already closed
-  if (closed_) {
-    return arrow::Status::OK();
-  }
+    // Check if already closed
+    if (closed_) {
+      return arrow::Status::OK();
+    }
 
-  // flush all remaining column groups before closing
-  auto status = flushRemainingBuffer();
-  if (status.ok()) {
-    closed_ = true;
+    // flush all remaining column groups before closing
+    auto status = flushRemainingBuffer();
+    if (status.ok()) {
+      closed_ = true;
+    }
+    return status;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed writer close failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer close with unknown exception failed unexpectedly");
   }
-  return status;
 }
 
 arrow::Result<std::vector<size_t>> PackedRecordBatchWriter::Tell() const {
-  std::vector<size_t> positions(group_writers_.size());
-  for (size_t writer_idx = 0; writer_idx < group_writers_.size(); ++writer_idx) {
-    ARROW_ASSIGN_OR_RAISE(positions[writer_idx], group_writers_[writer_idx]->Tell());
+  try {
+    std::vector<size_t> positions(group_writers_.size());
+    for (size_t writer_idx = 0; writer_idx < group_writers_.size(); ++writer_idx) {
+      auto tell_result = group_writers_[writer_idx]->Tell();
+      if (!tell_result.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                               fmt::format("Failed to tell packed column group writer. [writer_index={}]", writer_idx),
+                               tell_result.status());
+      }
+      positions[writer_idx] = tell_result.ValueOrDie();
+    }
+    return positions;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed writer tell failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer tell with unknown exception failed unexpectedly");
   }
-  return positions;
 }
 
 arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, const std::string& value) {
@@ -186,8 +247,8 @@ arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, c
 
 arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
   // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL,
-                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
+  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, MakeExtendError(ExtendStatusCode::PackedStorageIO,
+                                                          fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
 
   if (closed_) {
     return arrow::Status::OK();
@@ -200,13 +261,30 @@ arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
 
     LOG_STORAGE_DEBUG_ << "Flushing remaining column group: " << max_group.first;
     current_memory_usage_ -= max_group.second;
-    ARROW_RETURN_NOT_OK(grp_writer->Flush());
+    auto flush_status = grp_writer->Flush();
+    if (!flush_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
+                             flush_status);
+    }
   }
 
   for (auto& grp_writer : group_writers_) {
-    ARROW_RETURN_NOT_OK(grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize()));
-    ARROW_RETURN_NOT_OK(grp_writer->AddUserMetadata(user_metadata_));
-    ARROW_RETURN_NOT_OK(grp_writer->Close());
+    auto append_status = grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize());
+    if (!append_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to append packed group field id metadata",
+                             append_status);
+    }
+
+    auto metadata_status = grp_writer->AddUserMetadata(user_metadata_);
+    if (!metadata_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to add packed user metadata", metadata_status);
+    }
+
+    auto close_result = grp_writer->Close();
+    if (!close_result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to close packed column group writer",
+                             close_result.status());
+    }
   }
 
   return arrow::Status::OK();

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -16,6 +16,7 @@
 
 #include <arrow/status.h>
 
+#include "common/EasyAssert.h"
 #include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::test {
@@ -153,6 +154,50 @@ TEST_F(ExtendStatusTest, WrapExtendErrorAddsDetailToPlainStatus) {
   EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
   EXPECT_NE(wrapped.ToString().find("open packed file"), std::string::npos);
   EXPECT_NE(detail->extra_info().find("disk unavailable"), std::string::npos);
+}
+
+TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
+  struct Case {
+    ExtendStatusCode code;
+    milvus::ErrorCode expected;
+  };
+
+  const Case cases[] = {
+      {ExtendStatusCode::PackedInvalidArgs, milvus::InvalidParameter},
+      {ExtendStatusCode::PackedStorageIO, milvus::StorageError},
+      {ExtendStatusCode::PackedMetadataCorrupted, milvus::StorageError},
+      {ExtendStatusCode::PackedFileCorrupted, milvus::StorageError},
+      {ExtendStatusCode::PackedArrowError, milvus::StorageError},
+      {ExtendStatusCode::PackedUnexpected, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorNoSuchUpload, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorConflict, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorPreConditionFailed, milvus::StorageError},
+      {ExtendStatusCode::TxnExhaustedRetry, milvus::StorageError},
+      {ExtendStatusCode::TxnResolutionFailed, milvus::StorageError},
+  };
+
+  for (const auto& test_case : cases) {
+    EXPECT_EQ(ToSegcoreErrorCode(test_case.code), test_case.expected);
+  }
+}
+
+TEST_F(ExtendStatusTest, PlainInvalidStatusConvertsToSegcoreError) {
+  auto status = arrow::Status::Invalid("bad packed args");
+
+  auto error = ToSegcoreError(status);
+
+  EXPECT_EQ(error.get_error_code(), milvus::InvalidParameter);
+  EXPECT_NE(std::string(error.what()).find("bad packed args"), std::string::npos);
+}
+
+TEST_F(ExtendStatusTest, ExtendStatusConvertsToSegcoreError) {
+  auto status = MakeExtendError(ExtendStatusCode::PackedFileCorrupted, "bad packed file", "footer mismatch");
+
+  auto error = ToSegcoreError(status);
+
+  EXPECT_EQ(error.get_error_code(), milvus::StorageError);
+  EXPECT_NE(std::string(error.what()).find("bad packed file"), std::string::npos);
+  EXPECT_NE(std::string(error.what()).find("PackedFileCorrupted"), std::string::npos);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -99,4 +99,60 @@ TEST_F(ExtendStatusTest, TestExtendStatusDetail) {
   }
 }
 
+TEST_F(ExtendStatusTest, PackedCodesUseExpectedArrowStatusCodeAndDetail) {
+  struct Case {
+    ExtendStatusCode code;
+    const char* name;
+    bool is_invalid;
+  };
+
+  const Case cases[] = {
+      {ExtendStatusCode::PackedInvalidArgs, "PackedInvalidArgs", true},
+      {ExtendStatusCode::PackedStorageIO, "PackedStorageIO", false},
+      {ExtendStatusCode::PackedMetadataCorrupted, "PackedMetadataCorrupted", false},
+      {ExtendStatusCode::PackedFileCorrupted, "PackedFileCorrupted", false},
+      {ExtendStatusCode::PackedArrowError, "PackedArrowError", false},
+      {ExtendStatusCode::PackedUnexpected, "PackedUnexpected", false},
+  };
+
+  for (const auto& test_case : cases) {
+    auto status = MakeExtendError(test_case.code, "message", "extra");
+    ASSERT_FALSE(status.ok()) << test_case.name;
+    EXPECT_EQ(status.IsInvalid(), test_case.is_invalid) << test_case.name;
+    EXPECT_EQ(status.IsIOError(), !test_case.is_invalid) << test_case.name;
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << test_case.name << ": " << status.ToString();
+    EXPECT_EQ(detail->code(), test_case.code);
+    EXPECT_EQ(detail->extra_info(), "extra");
+    EXPECT_EQ(detail->CodeAsString(), test_case.name);
+    EXPECT_NE(detail->ToString().find(test_case.name), std::string::npos);
+    EXPECT_NE(detail->ToString().find("extra"), std::string::npos);
+  }
+}
+
+TEST_F(ExtendStatusTest, WrapExtendErrorPreservesExistingDetail) {
+  auto original = MakeExtendError(ExtendStatusCode::PackedStorageIO, "storage failed", "cause");
+
+  auto wrapped = WrapExtendError(ExtendStatusCode::PackedUnexpected, "outer message", original);
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
+  EXPECT_NE(wrapped.ToString().find("outer message"), std::string::npos);
+  EXPECT_NE(wrapped.ToString().find("storage failed"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("storage failed"), std::string::npos);
+}
+
+TEST_F(ExtendStatusTest, WrapExtendErrorAddsDetailToPlainStatus) {
+  auto wrapped = WrapExtendError(ExtendStatusCode::PackedStorageIO, "open packed file",
+                                 arrow::Status::IOError("disk unavailable"));
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
+  EXPECT_NE(wrapped.ToString().find("open packed file"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("disk unavailable"), std::string::npos);
+}
+
 }  // namespace milvus_storage::test

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <parquet/arrow/writer.h>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/packed/column_group.h"
+#include "milvus-storage/packed/reader.h"
+#include "milvus-storage/packed/writer.h"
+
+#include "packed_test_base.h"
+
+namespace milvus_storage {
+
+namespace {
+
+void ExpectPackedCode(const arrow::Status& status, ExtendStatusCode code) {
+  ASSERT_FALSE(status.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), code);
+}
+
+void ExpectExceptionMessageContainsCode(const std::function<void()>& fn, const std::string& code_name) {
+  try {
+    fn();
+    FAIL() << "expected runtime_error";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find(code_name), std::string::npos) << e.what();
+  }
+}
+
+}  // namespace
+
+class PackedErrorStatusTest : public PackedTestBase {};
+
+TEST_F(PackedErrorStatusTest, WriterPathGroupMismatchIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0}, {1}};
+
+  auto result = PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, WriterColumnIndexOutOfRangeIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{schema_->num_fields()}};
+
+  auto result = PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, WriterRecordBatchColumnMismatchIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto short_batch, record_batch_->SelectColumns({0, 1}));
+
+  auto status = writer->Write(short_batch);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+  (void)writer->Close();
+}
+
+TEST_F(PackedErrorStatusTest, ColumnGroupNullBatchIsInvalidArgs) {
+  ColumnGroup group(0, {0});
+
+  auto status = group.AddRecordBatch(nullptr);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, ReaderMissingFileIsStorageIO) {
+  std::vector<std::string> paths = {path_ + "/missing.parquet"};
+
+  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
+                                     "PackedStorageIO");
+}
+
+TEST_F(PackedErrorStatusTest, ReaderNullOutputPointerIsInvalidArgs) {
+  SetupOneFile();
+  std::vector<std::string> paths = {one_file_path_};
+  PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_);
+
+  auto status = reader.ReadNext(nullptr);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+  ASSERT_STATUS_OK(reader.Close());
+}
+
+TEST_F(PackedErrorStatusTest, ReaderMissingPackedMetadataIsMetadataCorrupted) {
+  auto parquet_path = path_ + "/plain.parquet";
+  ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(parquet_path));
+  ASSERT_STATUS_OK(::parquet::arrow::WriteTable(*table_, arrow::default_memory_pool(), sink, 2));
+  ASSERT_STATUS_OK(sink->Close());
+  std::vector<std::string> paths = {parquet_path};
+
+  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
+                                     "PackedMetadataCorrupted");
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
This change adds a dedicated extend status detail for the packed layer, so packed failures can carry structured error codes instead of relying only on generic Arrow status text.

The packed codes split caller-side invalid input from storage-side and internal failures. Bad schemas, invalid column groups, null output pointers, and null batches now land in PackedInvalidArgs, while file open/read/write/flush/close failures are reported as storage I/O. Corrupted packed metadata, broken file layout, Arrow API failures, and unexpected exceptions each get their own bucket.

The implementation keeps the existing packed behavior intact on the normal path. Reader construction still throws when initialization fails, writer initialization still goes through the existing Result flow, and Write(nullptr) remains a successful no-op. The new catch blocks stay around packed APIs that already return Arrow status, so exceptions are converted only at the public packed boundary where callers can consume them.