### PR TITLE
enhance:[2.6] add packed-specific v2 extend status codes

### DIFF
--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -25,6 +25,14 @@
 namespace milvus_storage {
 enum class ExtendStatusCode : char {
   // arrow::StatusCode biggest is 45
+  // Packed-specific error codes.
+  PackedInvalidArgs = 50,
+  PackedStorageIO = 51,
+  PackedMetadataCorrupted = 52,
+  PackedFileCorrupted = 53,
+  PackedArrowError = 54,
+  PackedUnexpected = 55,
+
   NoSuchUpload = 101,
 };
 
@@ -61,6 +69,8 @@ class ExtendStatusDetail : public arrow::StatusDetail {
   std::string extra_info_;
 };
 
-arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info);
+arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info = "");
+
+arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause);
 
 }  // namespace milvus_storage

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <arrow/status.h>
 #include <arrow/result.h>
@@ -39,6 +40,18 @@ std::string ExtendStatusDetail::extra_info() const { return extra_info_; }
 
 std::string ExtendStatusDetail::CodeAsString() const {
   switch (code()) {
+    case ExtendStatusCode::PackedInvalidArgs:
+      return "PackedInvalidArgs";
+    case ExtendStatusCode::PackedStorageIO:
+      return "PackedStorageIO";
+    case ExtendStatusCode::PackedMetadataCorrupted:
+      return "PackedMetadataCorrupted";
+    case ExtendStatusCode::PackedFileCorrupted:
+      return "PackedFileCorrupted";
+    case ExtendStatusCode::PackedArrowError:
+      return "PackedArrowError";
+    case ExtendStatusCode::PackedUnexpected:
+      return "PackedUnexpected";
     case ExtendStatusCode::NoSuchUpload:
       return "NoSuchUpload";
     default:
@@ -56,9 +69,16 @@ std::shared_ptr<ExtendStatusDetail> ExtendStatusDetail::UnwrapStatus(const arrow
 }
 
 arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info) {
-  arrow::StatusCode arrow_code = arrow::StatusCode::IOError;
-  return arrow::Status(arrow_code, std::move(message),
-                       std::make_shared<ExtendStatusDetail>(code, std::move(extra_info)));
+  auto arrow_code =
+      code == ExtendStatusCode::PackedInvalidArgs ? arrow::StatusCode::Invalid : arrow::StatusCode::IOError;
+  return {arrow_code, std::move(message), std::make_shared<ExtendStatusDetail>(code, std::move(extra_info))};
+}
+
+arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause) {
+  auto detail = ExtendStatusDetail::UnwrapStatus(cause);
+  auto wrapped_code = detail ? detail->code() : code;
+  auto cause_message = cause.ToString();
+  return MakeExtendError(wrapped_code, std::move(message) + ": " + cause_message, cause_message);
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/packed/column_group.cpp
+++ b/cpp/src/packed/column_group.cpp
@@ -14,6 +14,7 @@
 
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/extend_status.h"
 #include <arrow/table.h>
 #include <arrow/status.h>
 
@@ -32,7 +33,7 @@ ColumnGroup::ColumnGroup(GroupId group_id,
 
 arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBatch>& batch) {
   if (!batch) {
-    return arrow::Status::IOError("ColumnGroup::AddRecordBatch: batch is null");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "ColumnGroup::AddRecordBatch: batch is null");
   }
   batches_.emplace_back(batch);
 
@@ -46,9 +47,11 @@ arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBat
 
 arrow::Status ColumnGroup::Merge(const ColumnGroup& other) {
   for (auto& batch : other.batches_) {
-    if (!AddRecordBatch(batch).ok()) {
-      return arrow::Status::IOError("ColumnGroup::Merge: failed to merge record batch");
-    };
+    auto status = AddRecordBatch(batch);
+    if (!status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedUnexpected, "ColumnGroup::Merge: failed to merge record batch",
+                             status);
+    }
   }
   return arrow::Status::OK();
 }

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -14,6 +14,11 @@
 
 #include <memory>
 #include <algorithm>
+#include <exception>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 #include <arrow/array/data.h>
 #include <arrow/array/util.h>
@@ -28,12 +33,44 @@
 #include <parquet/properties.h>
 
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/packed/chunk_manager.h"
 #include "milvus-storage/packed/reader.h"
 
 namespace milvus_storage {
+
+namespace {
+
+arrow::Result<std::shared_ptr<PackedFileMetadata>> MakePackedMetadata(
+    const std::shared_ptr<::parquet::FileMetaData>& metadata, const std::string& path) {
+  if (!metadata) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           "Packed parquet metadata is null. [path=" + path + "]");
+  }
+  if (!metadata->key_value_metadata()) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           "Packed parquet key-value metadata is missing. [path=" + path + "]");
+  }
+
+  try {
+    auto result = PackedFileMetadata::Make(metadata);
+    if (!result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                             "Failed to parse packed file metadata. [path=" + path + "]", result.status());
+    }
+    return result;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           "Failed to parse packed file metadata. [path=" + path + ", error=" + e.what() + "]");
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           "Failed to parse packed file metadata with unknown exception. [path=" + path + "]");
+  }
+}
+
+}  // namespace
 
 PackedRecordBatchReader::PackedRecordBatchReader(std::shared_ptr<arrow::fs::FileSystem> fs,
                                                  std::vector<std::string>& paths,
@@ -58,6 +95,16 @@ arrow::Status PackedRecordBatchReader::init(std::shared_ptr<arrow::fs::FileSyste
                                             std::shared_ptr<arrow::Schema> schema,
                                             parquet::ReaderProperties& reader_props,
                                             const parquet::ArrowReaderProperties& arrow_reader_props) {
+  if (!fs) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader null file system provided");
+  }
+  if (paths.empty()) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader empty paths provided");
+  }
+  if (!schema) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader null schema provided");
+  }
+
   // read first file metadata to get field id mapping and do schema matching
   ARROW_RETURN_NOT_OK(schemaMatching(fs, schema, paths, reader_props, arrow_reader_props));
 
@@ -66,11 +113,12 @@ arrow::Status PackedRecordBatchReader::init(std::shared_ptr<arrow::fs::FileSyste
   for (const auto& path : needed_paths_) {
     auto result = MakeArrowFileReader(*fs, path, reader_props, arrow_reader_props);
     if (!result.ok()) {
-      return arrow::Status::Invalid("Error making file reader with path " + path + ":" + result.status().ToString());
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Error making file reader with path " + path,
+                             result.status());
     }
     auto file_reader = std::move(result.ValueOrDie());
     auto metadata = file_reader->parquet_reader()->metadata();
-    ARROW_ASSIGN_OR_RAISE(auto file_metadata, PackedFileMetadata::Make(metadata));
+    ARROW_ASSIGN_OR_RAISE(auto file_metadata, MakePackedMetadata(metadata, path));
     metadata_list_.emplace_back(std::move(file_metadata));
     file_readers_.emplace_back(std::move(file_reader));
 
@@ -102,19 +150,23 @@ arrow::Status PackedRecordBatchReader::schemaMatching(std::shared_ptr<arrow::fs:
   // read first file metadata to get field id mapping
   auto result = MakeArrowFileReader(*fs, paths[0], reader_props, arrow_reader_props);
   if (!result.ok()) {
-    return arrow::Status::Invalid("Error making file reader with path " + paths[0] + ":" + result.status().ToString());
+    return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Error making file reader with path " + paths[0],
+                           result.status());
   }
   auto parquet_metadata = result.ValueOrDie()->parquet_reader()->metadata();
-  ARROW_ASSIGN_OR_RAISE(auto metadata, PackedFileMetadata::Make(parquet_metadata));
+  ARROW_ASSIGN_OR_RAISE(auto metadata, MakePackedMetadata(parquet_metadata, paths[0]));
 
   // parse field id list from schema
   std::vector<std::shared_ptr<arrow::Field>> fields;
   std::vector<std::shared_ptr<arrow::Field>> needed_fields;
-  auto status = FieldIDList::Make(schema);
-  if (!status.ok()) {
-    return arrow::Status::Invalid("Error getting field id list from schema: " + schema->ToString());
+  auto field_id_list = FieldIDList::Make(schema);
+  if (!field_id_list.ok()) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           "Error getting field id list from schema: " + field_id_list.status().ToString() +
+                               ". [schema=" + schema->ToString(true) + "]",
+                           field_id_list.status().ToString());
   }
-  field_id_list_ = status.ValueOrDie();
+  field_id_list_ = field_id_list.ValueOrDie();
 
   // schema matching
   field_id_mapping_ = metadata->GetFieldIDMapping();
@@ -122,6 +174,13 @@ arrow::Status PackedRecordBatchReader::schemaMatching(std::shared_ptr<arrow::fs:
     FieldID field_id = field_id_list_.Get(i);
     if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
       auto column_offset = field_id_mapping_[field_id];
+      if (column_offset.path_index < 0 || static_cast<size_t>(column_offset.path_index) >= paths.size()) {
+        return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                               "Packed field id metadata references path index outside provided paths. [field_id=" +
+                                   std::to_string(field_id) +
+                                   ", path_index=" + std::to_string(column_offset.path_index) +
+                                   ", num_paths=" + std::to_string(paths.size()) + "]");
+      }
       needed_column_offsets_.emplace_back(column_offset);
       needed_paths_.emplace(paths[column_offset.path_index]);
       fields.emplace_back(schema->field(i));
@@ -196,7 +255,13 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
       return arrow::Status::OK();
     } else {
       // Otherwise, the rows are not match, there is something wrong with the files.
-      return arrow::Status::Invalid("File broken at index " + std::to_string(drained_index));
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             "File broken at index " + std::to_string(drained_index) + ". [path=" +
+                                 (needed_paths_.size() > static_cast<size_t>(drained_index)
+                                      ? *std::next(needed_paths_.begin(), drained_index)
+                                      : std::string("unknown")) +
+                                 ", row_offset=" + std::to_string(column_group_states_[drained_index].row_offset) +
+                                 ", row_limit=" + std::to_string(row_limit_) + "]");
     }
   }
 
@@ -226,7 +291,14 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
     read_count_++;
     column_group_states_[i].read_times++;
     std::shared_ptr<arrow::Table> read_table = nullptr;
-    ARROW_RETURN_NOT_OK(file_readers_[i]->ReadRowGroups(rgs_to_read[i], &read_table));
+    auto read_status = file_readers_[i]->ReadRowGroups(rgs_to_read[i], &read_table);
+    if (!read_status.ok()) {
+      return WrapExtendError(
+          ExtendStatusCode::PackedStorageIO,
+          "Failed to read packed row groups. [path=" +
+              (needed_paths_.size() > i ? *std::next(needed_paths_.begin(), i) : std::string("unknown")) + "]",
+          read_status);
+    }
     int path_index = file_reader_to_path_index_[i];
     tables_[path_index].push(std::move(read_table));
   }
@@ -240,58 +312,93 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
 }
 
 arrow::Status PackedRecordBatchReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
-  if (absolute_row_position_ >= row_limit_) {
-    ARROW_RETURN_NOT_OK(advanceBuffer());
+  try {
+    if (!out) {
+      return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader ReadNext output pointer is null");
+    }
+
     if (absolute_row_position_ >= row_limit_) {
-      *out = nullptr;
-      return arrow::Status::OK();
+      ARROW_RETURN_NOT_OK(advanceBuffer());
+      if (absolute_row_position_ >= row_limit_) {
+        *out = nullptr;
+        return arrow::Status::OK();
+      }
     }
-  }
 
-  // Determine the maximum contiguous slice across all tables
-  auto batch_data = chunk_manager_->SliceChunksByMaxContiguousSlice(row_limit_ - absolute_row_position_, tables_);
-  int64_t chunk_size = chunk_manager_->GetChunkSize();
-  absolute_row_position_ += chunk_size;
-  std::shared_ptr<arrow::RecordBatch> batch =
-      arrow::RecordBatch::Make(needed_schema_, chunk_size, std::move(batch_data));
-
-  int batch_index = 0;
-  std::vector<std::shared_ptr<arrow::Array>> arrays;
-  for (size_t i = 0; i < field_id_list_.size(); ++i) {
-    FieldID field_id = field_id_list_.Get(i);
-    if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
-      // RVO here, no need std::move
-      arrays.emplace_back(batch->column(batch_index++));
-    } else {
-      auto null_array = arrow::MakeArrayOfNull(schema_->field(i)->type(), chunk_size).ValueOrDie();
-      arrays.emplace_back(std::move(null_array));
+    // Determine the maximum contiguous slice across all tables
+    std::vector<std::shared_ptr<arrow::ArrayData>> batch_data;
+    try {
+      batch_data = chunk_manager_->SliceChunksByMaxContiguousSlice(row_limit_ - absolute_row_position_, tables_);
+    } catch (const std::exception& e) {
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             std::string("Packed file chunk layout is corrupted: ") + e.what());
+    } catch (...) {
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             "Packed file chunk layout is corrupted with unknown exception");
     }
+    int64_t chunk_size = chunk_manager_->GetChunkSize();
+    absolute_row_position_ += chunk_size;
+    std::shared_ptr<arrow::RecordBatch> batch =
+        arrow::RecordBatch::Make(needed_schema_, chunk_size, std::move(batch_data));
+
+    int batch_index = 0;
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    for (size_t i = 0; i < field_id_list_.size(); ++i) {
+      FieldID field_id = field_id_list_.Get(i);
+      if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
+        // RVO here, no need std::move
+        arrays.emplace_back(batch->column(batch_index++));
+      } else {
+        auto null_array_result = arrow::MakeArrayOfNull(schema_->field(i)->type(), chunk_size);
+        if (!null_array_result.ok()) {
+          return WrapExtendError(ExtendStatusCode::PackedArrowError,
+                                 "Failed to create null array. [field_index=" + std::to_string(i) + "]",
+                                 null_array_result.status());
+        }
+        auto null_array = null_array_result.ValueOrDie();
+        arrays.emplace_back(std::move(null_array));
+      }
+    }
+    *out = arrow::RecordBatch::Make(schema_, chunk_size, arrays);
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           std::string("Packed reader read next failed unexpectedly: ") + e.what());
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed reader read next with unknown exception failed unexpectedly");
   }
-  *out = arrow::RecordBatch::Make(schema_, chunk_size, arrays);
-  return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchReader::Close() {
-  ARROW_LOG(DEBUG) << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
-  for (size_t i = 0; i < column_group_states_.size(); ++i) {
-    ARROW_LOG(DEBUG) << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
-  }
-
-  // Clean up remaining data in all tables
-  for (auto& table_queue : tables_) {
-    while (!table_queue.empty()) {
-      table_queue.front().reset();  // Explicitly release shared_ptr
-      table_queue.pop();
+  try {
+    ARROW_LOG(DEBUG) << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
+    for (size_t i = 0; i < column_group_states_.size(); ++i) {
+      ARROW_LOG(DEBUG) << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
     }
-  }
 
-  read_count_ = 0;
-  column_group_states_.clear();
-  tables_.clear();
-  file_readers_.clear();
-  metadata_list_.clear();
-  memory_used_ = 0;
-  return arrow::Status::OK();
+    // Clean up remaining data in all tables
+    for (auto& table_queue : tables_) {
+      while (!table_queue.empty()) {
+        table_queue.front().reset();  // Explicitly release shared_ptr
+        table_queue.pop();
+      }
+    }
+
+    read_count_ = 0;
+    column_group_states_.clear();
+    tables_.clear();
+    file_readers_.clear();
+    metadata_list_.clear();
+    memory_used_ = 0;
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           std::string("Packed reader close failed unexpectedly: ") + e.what());
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed reader close with unknown exception failed unexpectedly");
+  }
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -17,20 +17,24 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 #include <arrow/type.h>
 #include <arrow/util/logging.h>
 #include <arrow/status.h>
 
+#include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
-#include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/format/parquet/parquet_writer.h"
+#include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
-#include "milvus-storage/common/config.h"
-#include "milvus-storage/common/arrow_util.h"
 
 namespace milvus_storage {
 
@@ -59,38 +63,43 @@ arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> PackedRecordBatchWriter:
     std::vector<std::vector<int>>& column_groups,
     size_t buffer_size,
     std::shared_ptr<::parquet::WriterProperties> writer_props) {
-  auto writer = std::shared_ptr<PackedRecordBatchWriter>(
-      new PackedRecordBatchWriter(fs, paths, schema, storage_config, column_groups, buffer_size, writer_props));
+  auto writer = std::shared_ptr<PackedRecordBatchWriter>(new PackedRecordBatchWriter(
+      std::move(fs), paths, std::move(schema), storage_config, column_groups, buffer_size, std::move(writer_props)));
   ARROW_RETURN_NOT_OK(writer->init());
   return writer;
 }
 
 arrow::Status PackedRecordBatchWriter::init() {
   if (!schema_) {
-    return arrow::Status::Invalid("Packed writer null schema provided");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed writer null schema provided");
   }
 
   if (paths_.size() != group_indices_.size()) {
-    return arrow::Status::Invalid("Mismatch between paths number and column groups number: " +
-                                  std::to_string(paths_.size()) + " vs " + std::to_string(group_indices_.size()));
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           "Mismatch between paths number and column groups number: " + std::to_string(paths_.size()) +
+                               " vs " + std::to_string(group_indices_.size()));
   }
 
   if (!fs_) {
-    return arrow::Status::Invalid("Packed writer null file system provided");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed writer null file system provided");
   }
 
   auto field_id_list = FieldIDList::Make(schema_);
   if (!field_id_list.ok()) {
-    return arrow::Status::Invalid("Failed to get field id from schema");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           "Failed to get field id from schema: " + field_id_list.status().ToString() +
+                               ". [schema=" + schema_->ToString(true) + "]",
+                           field_id_list.status().ToString());
   }
 
   // Validate column group indices are within bounds
   int num_fields = schema_->num_fields();
-  for (size_t i = 0; i < group_indices_.size(); ++i) {
-    for (int col_index : group_indices_[i]) {
+  for (const auto& group_indice : group_indices_) {
+    for (int col_index : group_indice) {
       if (col_index < 0 || col_index >= num_fields) {
-        return arrow::Status::Invalid("Column index out of range: " + std::to_string(col_index) + " (schema has " +
-                                      std::to_string(num_fields) + " fields)");
+        return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                               "Column index out of range: " + std::to_string(col_index) + " (schema has " +
+                                   std::to_string(num_fields) + " fields), [schema=" + schema_->ToString(true) + "]");
       }
     }
   }
@@ -100,63 +109,102 @@ arrow::Status PackedRecordBatchWriter::init() {
   splitter_ = IndicesBasedSplitter(group_indices_);
   for (size_t i = 0; i < paths_.size(); ++i) {
     auto column_group_schema = getColumnGroupSchema(schema_, group_indices_[i]);
-    ARROW_ASSIGN_OR_RAISE(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(
-                                           column_group_schema, fs_, paths_[i], storage_config_, writer_props_));
+    auto writer_result = milvus_storage::parquet::ParquetFileWriter::Make(column_group_schema, fs_, paths_[i],
+                                                                          storage_config_, writer_props_);
+    if (!writer_result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             "Failed to create packed column group writer. [path=" + paths_[i] + "]",
+                             writer_result.status());
+    }
+    auto writer = std::move(writer_result).ValueOrDie();
     group_writers_.emplace_back(std::move(writer));
   }
   return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::RecordBatch>& record) {
-  if (!record) {
+  try {
+    if (!record) {
+      return arrow::Status::OK();
+    }
+
+    for (const auto& group_indice : group_indices_) {
+      for (int col_index : group_indice) {
+        if (col_index < 0 || col_index >= record->num_columns()) {
+          return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                                 "Record batch column index out of range: " + std::to_string(col_index) +
+                                     " (record batch has " + std::to_string(record->num_columns()) + " columns)");
+        }
+      }
+    }
+
+    size_t next_batch_size = GetRecordBatchMemorySize(record);
+
+    std::vector<ColumnGroup> column_groups = splitter_.Split(record);
+
+    // Flush column groups until there's enough room for the new column groups
+    // to ensure that memory usage stays strictly below the limit
+    while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
+      ARROW_LOG(DEBUG) << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
+                       << ", flushing column group: " << max_heap_.top().first;
+      auto max_group = max_heap_.top();
+      max_heap_.pop();
+
+      assert(current_memory_usage_ >= max_group.second);
+      current_memory_usage_ -= max_group.second;
+
+      milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
+      auto flush_status = writer->Flush();
+      if (!flush_status.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
+                               flush_status);
+      }
+    }
+
+    // After flushing, add the new column groups if memory usage allows
+    for (const ColumnGroup& group : column_groups) {
+      current_memory_usage_ += group.GetMemoryUsage();
+      max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
+
+      assert(group.GrpId() < group_writers_.size());
+      auto& grp_writer = group_writers_[group.GrpId()];
+      auto write_status = grp_writer->Write(group.GetRecordBatch(0));
+      if (!write_status.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to write packed column group", write_status);
+      }
+    }
+
+    ARROW_RETURN_NOT_OK(balanceMaxHeap());
     return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           std::string("Packed writer write failed unexpectedly: ") + e.what());
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer write with unknown exception failed unexpectedly");
   }
-
-  size_t next_batch_size = GetRecordBatchMemorySize(record);
-
-  std::vector<ColumnGroup> column_groups = splitter_.Split(record);
-
-  // Flush column groups until there's enough room for the new column groups
-  // to ensure that memory usage stays strictly below the limit
-  while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
-    ARROW_LOG(DEBUG) << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
-                     << ", flushing column group: " << max_heap_.top().first;
-    auto max_group = max_heap_.top();
-    max_heap_.pop();
-
-    assert(current_memory_usage_ >= max_group.second);
-    current_memory_usage_ -= max_group.second;
-
-    milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
-    ARROW_RETURN_NOT_OK(writer->Flush());
-  }
-
-  // After flushing, add the new column groups if memory usage allows
-  for (const ColumnGroup& group : column_groups) {
-    current_memory_usage_ += group.GetMemoryUsage();
-    max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
-
-    assert(group.GrpId() < group_writers_.size());
-    auto& grp_writer = group_writers_[group.GrpId()];
-    ARROW_RETURN_NOT_OK(grp_writer->Write(group.GetRecordBatch(0)));
-  }
-
-  ARROW_RETURN_NOT_OK(balanceMaxHeap());
-  return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::Close() {
-  // Check if already closed
-  if (closed_) {
-    return arrow::Status::OK();
-  }
+  try {
+    // Check if already closed
+    if (closed_) {
+      return arrow::Status::OK();
+    }
 
-  // flush all remaining column groups before closing
-  auto status = flushRemainingBuffer();
-  if (status.ok()) {
-    closed_ = true;
+    // flush all remaining column groups before closing
+    auto status = flushRemainingBuffer();
+    if (status.ok()) {
+      closed_ = true;
+    }
+    return status;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           std::string("Packed writer close failed unexpectedly: ") + e.what());
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer close with unknown exception failed unexpectedly");
   }
-  return status;
 }
 
 arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, const std::string& value) {
@@ -176,13 +224,30 @@ arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
 
     ARROW_LOG(DEBUG) << "Flushing remaining column group: " << max_group.first;
     current_memory_usage_ -= max_group.second;
-    ARROW_RETURN_NOT_OK(grp_writer->Flush());
+    auto flush_status = grp_writer->Flush();
+    if (!flush_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
+                             flush_status);
+    }
   }
 
   for (auto& grp_writer : group_writers_) {
-    ARROW_RETURN_NOT_OK(grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize()));
-    ARROW_RETURN_NOT_OK(grp_writer->AddUserMetadata(user_metadata_));
-    ARROW_RETURN_NOT_OK(grp_writer->Close());
+    auto append_status = grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize());
+    if (!append_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to append packed group field id metadata",
+                             append_status);
+    }
+
+    auto metadata_status = grp_writer->AddUserMetadata(user_metadata_);
+    if (!metadata_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to add packed user metadata", metadata_status);
+    }
+
+    auto close_result = grp_writer->Close();
+    if (!close_result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to close packed column group writer",
+                             close_result);
+    }
   }
 
   return arrow::Status::OK();

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -1,0 +1,137 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <arrow/status.h>
+
+#include "milvus-storage/common/extend_status.h"
+
+namespace milvus_storage::test {
+
+class ExtendStatusTest : public ::testing::Test {};
+
+TEST_F(ExtendStatusTest, TestMakeExtendError) {
+  // NoSuchUpload
+  {
+    auto status = MakeExtendError(ExtendStatusCode::NoSuchUpload, "upload gone", "extra info");
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsIOError());
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::NoSuchUpload);
+    EXPECT_EQ(detail->extra_info(), "extra info");
+  }
+}
+
+TEST_F(ExtendStatusTest, TestUnwrapStatus) {
+  // Plain IOError -> nullptr
+  {
+    auto detail = ExtendStatusDetail::UnwrapStatus(arrow::Status::IOError("plain error"));
+    EXPECT_EQ(detail, nullptr);
+  }
+
+  // OK status -> nullptr
+  {
+    auto detail = ExtendStatusDetail::UnwrapStatus(arrow::Status::OK());
+    EXPECT_EQ(detail, nullptr);
+  }
+}
+
+TEST_F(ExtendStatusTest, TestExtendStatusDetail) {
+  // CodeAsString
+  { EXPECT_EQ(ExtendStatusDetail(ExtendStatusCode::NoSuchUpload).CodeAsString(), "NoSuchUpload"); }
+
+  // ToString
+  {
+    ExtendStatusDetail detail(ExtendStatusCode::NoSuchUpload, "my extra");
+    auto str = detail.ToString();
+    EXPECT_NE(str.find("NoSuchUpload"), std::string::npos);
+    EXPECT_NE(str.find("my extra"), std::string::npos);
+  }
+
+  // SetExtraInfo
+  {
+    ExtendStatusDetail detail(ExtendStatusCode::NoSuchUpload);
+    EXPECT_EQ(detail.extra_info(), "");
+    detail.set_extra_info("new info");
+    EXPECT_EQ(detail.extra_info(), "new info");
+  }
+
+  // TypeId
+  {
+    ExtendStatusDetail detail(ExtendStatusCode::NoSuchUpload);
+    EXPECT_NE(detail.type_id(), nullptr);
+    EXPECT_EQ(std::string(detail.type_id()), "milvus_storage::ExtendStatusDetail");
+  }
+}
+
+TEST_F(ExtendStatusTest, PackedCodesUseExpectedArrowStatusCodeAndDetail) {
+  struct Case {
+    ExtendStatusCode code;
+    const char* name;
+    bool is_invalid;
+  };
+
+  const Case cases[] = {
+      {ExtendStatusCode::PackedInvalidArgs, "PackedInvalidArgs", true},
+      {ExtendStatusCode::PackedStorageIO, "PackedStorageIO", false},
+      {ExtendStatusCode::PackedMetadataCorrupted, "PackedMetadataCorrupted", false},
+      {ExtendStatusCode::PackedFileCorrupted, "PackedFileCorrupted", false},
+      {ExtendStatusCode::PackedArrowError, "PackedArrowError", false},
+      {ExtendStatusCode::PackedUnexpected, "PackedUnexpected", false},
+  };
+
+  for (const auto& test_case : cases) {
+    auto status = MakeExtendError(test_case.code, "message", "extra");
+    ASSERT_FALSE(status.ok()) << test_case.name;
+    EXPECT_EQ(status.IsInvalid(), test_case.is_invalid) << test_case.name;
+    EXPECT_EQ(status.IsIOError(), !test_case.is_invalid) << test_case.name;
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << test_case.name << ": " << status.ToString();
+    EXPECT_EQ(detail->code(), test_case.code);
+    EXPECT_EQ(detail->extra_info(), "extra");
+    EXPECT_EQ(detail->CodeAsString(), test_case.name);
+    EXPECT_NE(detail->ToString().find(test_case.name), std::string::npos);
+    EXPECT_NE(detail->ToString().find("extra"), std::string::npos);
+  }
+}
+
+TEST_F(ExtendStatusTest, WrapExtendErrorPreservesExistingDetail) {
+  auto original = MakeExtendError(ExtendStatusCode::PackedStorageIO, "storage failed", "cause");
+
+  auto wrapped = WrapExtendError(ExtendStatusCode::PackedUnexpected, "outer message", original);
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
+  EXPECT_NE(wrapped.ToString().find("outer message"), std::string::npos);
+  EXPECT_NE(wrapped.ToString().find("storage failed"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("storage failed"), std::string::npos);
+}
+
+TEST_F(ExtendStatusTest, WrapExtendErrorAddsDetailToPlainStatus) {
+  auto wrapped = WrapExtendError(ExtendStatusCode::PackedStorageIO, "open packed file",
+                                 arrow::Status::IOError("disk unavailable"));
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
+  EXPECT_NE(wrapped.ToString().find("open packed file"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("disk unavailable"), std::string::npos);
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <parquet/arrow/writer.h>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/packed/column_group.h"
+#include "milvus-storage/packed/reader.h"
+#include "milvus-storage/packed/writer.h"
+
+#include "packed_test_base.h"
+
+namespace milvus_storage {
+
+namespace {
+
+void ExpectPackedCode(const arrow::Status& status, ExtendStatusCode code) {
+  ASSERT_FALSE(status.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), code);
+}
+
+void ExpectExceptionMessageContainsCode(const std::function<void()>& fn, const std::string& code_name) {
+  try {
+    fn();
+    FAIL() << "expected runtime_error";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find(code_name), std::string::npos) << e.what();
+  }
+}
+
+}  // namespace
+
+class PackedErrorStatusTest : public PackedTestBase {};
+
+TEST_F(PackedErrorStatusTest, WriterPathGroupMismatchIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0}, {1}};
+
+  auto result = PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, WriterColumnIndexOutOfRangeIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{schema_->num_fields()}};
+
+  auto result = PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, WriterRecordBatchColumnMismatchIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto short_batch, record_batch_->SelectColumns({0, 1}));
+
+  auto status = writer->Write(short_batch);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+  (void)writer->Close();
+}
+
+TEST_F(PackedErrorStatusTest, ColumnGroupNullBatchIsInvalidArgs) {
+  ColumnGroup group(0, {0});
+
+  auto status = group.AddRecordBatch(nullptr);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, ReaderMissingFileIsStorageIO) {
+  std::vector<std::string> paths = {path_ + "/missing.parquet"};
+
+  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
+                                     "PackedStorageIO");
+}
+
+TEST_F(PackedErrorStatusTest, ReaderNullOutputPointerIsInvalidArgs) {
+  SetupOneFile();
+  std::vector<std::string> paths = {one_file_path_};
+  PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_);
+
+  auto status = reader.ReadNext(nullptr);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+  ASSERT_STATUS_OK(reader.Close());
+}
+
+TEST_F(PackedErrorStatusTest, ReaderMissingPackedMetadataIsMetadataCorrupted) {
+  auto parquet_path = path_ + "/plain.parquet";
+  ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(parquet_path));
+  ASSERT_STATUS_OK(::parquet::arrow::WriteTable(*table_, arrow::default_memory_pool(), sink, 2));
+  ASSERT_STATUS_OK(sink->Close());
+  std::vector<std::string> paths = {parquet_path};
+
+  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
+                                     "PackedMetadataCorrupted");
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
This change adds a dedicated v2 extend status detail for the packed layer, so packed failures can carry structured error codes instead of relying only on generic Arrow status text.

The packed codes split caller-side invalid input from storage-side and internal failures. Bad schemas, invalid column groups, null output pointers, and null batches now land in PackedInvalidArgs, while file open/read/write/flush/close failures are reported as storage I/O. Corrupted packed metadata, broken file layout, Arrow API failures, and unexpected exceptions each get their own bucket.

The implementation keeps the existing packed behavior intact on the normal path. Reader construction still throws when initialization fails, writer initialization still goes through the existing Result flow, and Write(nullptr) remains a successful no-op. The new catch blocks stay around packed APIs that already return Arrow status, so exceptions are converted only at the public packed boundary where callers can consume them.