### PR TITLE
enhance: classify packed extend status codes into segcore error codes

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -167,11 +167,7 @@ class StorageConan(ConanFile):
         self.requires("libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d")
         self.requires("google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43")
         self.requires("opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720")
-        # NOTE: ToSegcoreErrorCode maps PackedStorageIO to milvus::StorageTransientError(2045),
-        # which is added by the milvus-common change "add retriable StorageTransientError(2045)".
-        # Bump this pin to the official milvus-common revision that ships 2045 before merge;
-        # the value below points at a local build used for verification.
-        self.requires("milvus-common/1.0.0-6fd4b2d@milvus/dev#9139f6b9bb6bbac7b9d85992e1bbad07")
+        self.requires("milvus-common/1.0.0-60a563c@milvus/dev#a7448f82ed17d10934eacb6d1b152fd8")
         # azure-sdk-for-cpp is a transitive dep of Arrow, but must be declared
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -167,7 +167,11 @@ class StorageConan(ConanFile):
         self.requires("libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d")
         self.requires("google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43")
         self.requires("opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720")
-        self.requires("milvus-common/1.0.0-9ca5ea6@milvus/dev#274d428d85f1d3d996e1092f0c9c7144")
+        # NOTE: ToSegcoreErrorCode maps PackedStorageIO to milvus::StorageTransientError(2045),
+        # which is added by the milvus-common change "add retriable StorageTransientError(2045)".
+        # Bump this pin to the official milvus-common revision that ships 2045 before merge;
+        # the value below points at a local build used for verification.
+        self.requires("milvus-common/1.0.0-6fd4b2d@milvus/dev#9139f6b9bb6bbac7b9d85992e1bbad07")
         # azure-sdk-for-cpp is a transitive dep of Arrow, but must be declared
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.

--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -22,9 +22,20 @@
 #include <arrow/status.h>
 #include <arrow/result.h>
 
+// from milvus-common repo
+#include "common/EasyAssert.h"
+
 namespace milvus_storage {
 enum class ExtendStatusCode : char {
   // arrow::StatusCode biggest is 45
+  // Packed-specific error codes.
+  PackedInvalidArgs = 50,
+  PackedStorageIO = 51,
+  PackedMetadataCorrupted = 52,
+  PackedFileCorrupted = 53,
+  PackedArrowError = 54,
+  PackedUnexpected = 55,
+
   AwsErrorNoSuchUpload = 101,
   AwsErrorConflict = 102,
   AwsErrorPreConditionFailed = 103,
@@ -67,6 +78,12 @@ class ExtendStatusDetail : public arrow::StatusDetail {
   std::string extra_info_;
 };
 
-arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info);
+arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info = "");
+
+arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause);
+
+milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code);
+
+milvus::SegcoreError ToSegcoreError(const arrow::Status& status);
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/common/extend_status.h
+++ b/cpp/include/milvus-storage/common/extend_status.h
@@ -39,6 +39,14 @@ enum class ExtendStatusCode : char {
   AwsErrorNoSuchUpload = 101,
   AwsErrorConflict = 102,
   AwsErrorPreConditionFailed = 103,
+  // Permanently-failing object-storage errors that must NOT be classified as
+  // transient/retriable by consumers: the object/bucket is gone (retrying or
+  // rerouting to another replica hits the same shared object store and fails
+  // identically), the credentials/permissions are wrong, or the AWS SDK itself
+  // judged the error non-retryable (AWSError::ShouldRetry() == false).
+  AwsErrorNotFound = 104,      // NoSuchKey / NoSuchBucket / ResourceNotFound
+  AwsErrorAccessDenied = 105,  // AccessDenied / InvalidAccessKeyId / SignatureDoesNotMatch
+  AwsErrorNonRetryable = 106,  // any other error with ShouldRetry() == false
 
   // Transaction-specific error codes
   TxnExhaustedRetry = 111,

--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -196,6 +196,17 @@ arrow::Status ErrorToStatus(const std::string& prefix,
   switch (error_type) {
     case Aws::S3::S3Errors::NO_SUCH_UPLOAD:
       return MakeExtendError(ExtendStatusCode::AwsErrorNoSuchUpload, message, message /* extra_info */);
+    // Permanent errors: mark them so consumers do not classify them as
+    // transient/retriable (a retry or replica-reroute hits the same shared
+    // object store and fails identically).
+    case Aws::S3::S3Errors::NO_SUCH_BUCKET:
+    case Aws::S3::S3Errors::NO_SUCH_KEY:
+    case Aws::S3::S3Errors::RESOURCE_NOT_FOUND:
+      return MakeExtendError(ExtendStatusCode::AwsErrorNotFound, message, message /* extra_info */);
+    case Aws::S3::S3Errors::ACCESS_DENIED:
+    case Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID:
+    case Aws::S3::S3Errors::SIGNATURE_DOES_NOT_MATCH:
+      return MakeExtendError(ExtendStatusCode::AwsErrorAccessDenied, message, message /* extra_info */);
     case Aws::S3::S3Errors::UNKNOWN: {
       switch (error.GetResponseCode()) {
         case Aws::Http::HttpResponseCode::PRECONDITION_FAILED:
@@ -203,15 +214,34 @@ arrow::Status ErrorToStatus(const std::string& prefix,
         case Aws::Http::HttpResponseCode::CONFLICT:
           return MakeExtendError(ExtendStatusCode::AwsErrorConflict, message, message /* extra_info */);
         default:
-          [[fallthrough]];
+          break;
       };
-
-      // fallthrough
+      break;
     }
     default:
-      [[fallthrough]];
+      break;
   }
 
+  // The AWS SDK carries its own retryability verdict (the same one its internal
+  // retry loop used). An escaped error the SDK itself would not retry is
+  // permanent -- tag it so it does not fall into the plain-IOError bucket that
+  // consumers treat as transient.
+  //
+  // BUT only trust that verdict for error types the SDK actually recognized:
+  // S3-compatible backends (e.g. MinIO) return genuine transients as UNKNOWN
+  // with the non-retryable flag set -- "SlowDown" rate limiting arrives exactly
+  // this way (that is why IsConnectError() special-cases it by exception name).
+  // Tagging those permanent would invert a transient into a hard failure, so
+  // UNKNOWN and connect-style errors fall through to the plain-IOError bucket
+  // (fail-open to a bounded upper-layer retry, the safe direction).
+  if (error_type != Aws::S3::S3Errors::UNKNOWN && !IsConnectError(error) && !error.ShouldRetry()) {
+    return MakeExtendError(ExtendStatusCode::AwsErrorNonRetryable, message, message /* extra_info */);
+  }
+
+  // Transient escapee (throttle / 5xx / timeout / connection error): the SDK
+  // retry budget is spent, but a distinct upper-layer retry (e.g. querynode
+  // rerouting to another replica) can still succeed. Plain IOError -> consumers
+  // classify it as retriable.
   return arrow::Status::IOError(prefix, "AWS Error ", ss.str(), " during ", operation,
                                 " operation: ", error.GetMessage(), wrong_region_msg.value_or(""));
 }

--- a/cpp/include/milvus-storage/packed/splitter/indices_based_splitter.h
+++ b/cpp/include/milvus-storage/packed/splitter/indices_based_splitter.h
@@ -23,7 +23,7 @@ class IndicesBasedSplitter : public SplitterPlugin {
   public:
   explicit IndicesBasedSplitter(const std::vector<std::vector<int>>& column_indices);
 
-  std::vector<ColumnGroup> Split(const std::shared_ptr<arrow::RecordBatch>& record) override;
+  arrow::Result<std::vector<ColumnGroup>> Split(const std::shared_ptr<arrow::RecordBatch>& record) override;
 
   private:
   std::vector<std::vector<int>> column_indices_;

--- a/cpp/include/milvus-storage/packed/splitter/size_based_splitter.h
+++ b/cpp/include/milvus-storage/packed/splitter/size_based_splitter.h
@@ -25,10 +25,11 @@ class SizeBasedSplitter : public SplitterPlugin {
    */
   explicit SizeBasedSplitter(size_t max_group_size);
 
-  std::vector<ColumnGroup> Split(const std::shared_ptr<arrow::RecordBatch>& record) override;
+  arrow::Result<std::vector<ColumnGroup>> Split(const std::shared_ptr<arrow::RecordBatch>& record) override;
 
   private:
-  std::vector<ColumnGroup> SplitRecordBatches(const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches);
+  arrow::Result<std::vector<ColumnGroup>> SplitRecordBatches(
+      const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches);
 
   private:
   size_t max_group_size_;

--- a/cpp/include/milvus-storage/packed/splitter/splitter_plugin.h
+++ b/cpp/include/milvus-storage/packed/splitter/splitter_plugin.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <memory>
 #include <arrow/record_batch.h>
+#include <arrow/result.h>
 #include <milvus-storage/packed/column_group.h>
 
 namespace milvus_storage {
@@ -25,8 +26,11 @@ class SplitterPlugin {
   public:
   virtual ~SplitterPlugin() = default;
 
-  // Split the input record batch into multiple groups of columns
-  virtual std::vector<ColumnGroup> Split(const std::shared_ptr<arrow::RecordBatch>& record) = 0;
+  // Split the input record batch into multiple groups of columns.
+  // Returns an error status instead of aborting when a column selection or
+  // batch accumulation fails (the previous bare-vector signature forced
+  // ValueOrDie, which crashed the whole process on failure).
+  virtual arrow::Result<std::vector<ColumnGroup>> Split(const std::shared_ptr<arrow::RecordBatch>& record) = 0;
 };
 
 }  // namespace milvus_storage

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -58,6 +58,12 @@ std::string ExtendStatusDetail::CodeAsString() const {
       return "AwsErrorConflict";
     case ExtendStatusCode::AwsErrorPreConditionFailed:
       return "AwsErrorPreConditionFailed";
+    case ExtendStatusCode::AwsErrorNotFound:
+      return "AwsErrorNotFound";
+    case ExtendStatusCode::AwsErrorAccessDenied:
+      return "AwsErrorAccessDenied";
+    case ExtendStatusCode::AwsErrorNonRetryable:
+      return "AwsErrorNonRetryable";
     case ExtendStatusCode::TxnExhaustedRetry:
       return "TxnExhaustedRetry";
     case ExtendStatusCode::TxnResolutionFailed:
@@ -103,11 +109,30 @@ arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const 
 // ExtendStatusCode without classifying it here breaks the build (the
 // extend_status_test.cpp coverage is the runtime backstop).
 //
-// Invariant: the retriable verdict carried by the returned code is what matters
-// most. A transient storage IO failure MUST map to the retriable
-// StorageTransientError(2045); it must never collapse into the non-retriable
-// StorageError(2044), which would turn a recoverable IO blip into a hard
-// failure.
+// Retriability model (do not repeat the "v2 retries, v3 doesn't" myth):
+// object-storage IO retry does NOT live in the packed / format / api::Reader
+// layers. It lives once in the shared S3 ArrowFileSystem (AWS SDK
+// DefaultRetryStrategy), which every read path -- v1 binlog, v2
+// FileRowGroupReader, v3 api::Reader -- runs on top of. So an IO error that
+// propagates up here already spent the S3 SDK retry budget, equally for v2 and
+// v3; there is no per-generation retry asymmetry.
+//
+// Retriability is therefore decided by whether a DISTINCT upper-layer retry can
+// still help: querynode can reroute a failed read to another replica/node (a
+// different network path / endpoint), or the failure was a node-local transient.
+// That reroute does not stack on the S3 SDK retry, so a transient IO error is
+// still worth marking retriable.
+//
+// Two callers reach segcore ErrorCode differently:
+//   1. A status carrying an ExtendStatusDetail (Packed*/Aws*/Txn) is classified
+//      by this switch. NOTE: as of this writing NO live milvus consumer routes a
+//      Packed* status through here -- packed_reader_c/packed_writer_c hardcode
+//      FileReadFailed/FileWriteFailed and drop the ExtendStatusCode -- so this
+//      switch is a reserved, forward-looking classification, not a hot path.
+//   2. A status with NO detail (plain arrow) is the LIVE segcore/storage read
+//      path; its transient IO stays retriable (StorageTransientError/2045) via
+//      the no-detail fallback of ToSegcoreError below (per the reroute rationale
+//      above), NOT this switch.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wswitch"
 milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
@@ -115,7 +140,14 @@ milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
     case ExtendStatusCode::PackedInvalidArgs:
       return milvus::InvalidParameter;  // 2042, caller's fault (non-retriable input)
     case ExtendStatusCode::PackedStorageIO:
-      return milvus::StorageTransientError;  // 2045, retriable storage IO
+      // Conservatively non-retriable, but this is a DORMANT branch: no live
+      // consumer routes a Packed* status here (the packed C-APIs hardcode
+      // FileReadFailed/FileWriteFailed and drop the code). Do NOT justify this
+      // with "v2 retries internally" -- the S3 SDK retry is shared by v2 and v3
+      // alike. If a real direct-link consumer ever appears, revisit: by the
+      // querynode-reroute logic it would likely want StorageTransientError/2045,
+      // same as the live no-detail IO path below.
+      return milvus::StorageError;  // 2044 (dormant; conservative)
     case ExtendStatusCode::PackedMetadataCorrupted:
     case ExtendStatusCode::PackedFileCorrupted:
       return milvus::DataFormatBroken;  // 2024, permanent data corruption
@@ -132,6 +164,15 @@ milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
       // genuinely failed). Promote to a more specific code if a real retriable
       // case is identified.
       return milvus::StorageError;  // 2044
+    case ExtendStatusCode::AwsErrorNotFound:
+    case ExtendStatusCode::AwsErrorAccessDenied:
+    case ExtendStatusCode::AwsErrorNonRetryable:
+      // Permanently-failing object-storage errors (object/bucket gone, bad
+      // credentials, or the AWS SDK itself judged the error non-retryable).
+      // Retrying or rerouting hits the same shared object store and fails
+      // identically -- these must NEVER be classified transient/2045, or
+      // querynode would retry-storm a read that can never succeed.
+      return milvus::StorageError;  // 2044, permanent
   }
   return milvus::StorageError;  // out-of-range value: safe non-retriable fallback
 }
@@ -147,14 +188,22 @@ milvus::SegcoreError ToSegcoreError(const arrow::Status& status) {
     return {ToSegcoreErrorCode(detail->code()), status.ToString()};
   }
 
-  // No structured ExtendStatusDetail attached: fall back to arrow's coarse
-  // status code. Transient IO / OOM stay retriable, malformed data is permanent
-  // corruption, and anything else is an internal storage error.
+  // No structured ExtendStatusDetail attached: this is the LIVE read path (plain
+  // arrow from FileRowGroupReader / v3 api::Reader / ArrowFileSystem). A
+  // propagated IO error here already spent the shared S3 SDK retry budget, AND
+  // permanently-failing S3 errors (NotFound / AccessDenied / SDK-judged
+  // non-retryable) were already tagged with an ExtendStatusDetail upstream in
+  // ErrorToStatus -- so a *plain* IOError that reaches this branch is a genuine
+  // transient (throttle / 5xx / timeout / connection). querynode can still
+  // reroute it to another replica/node, so it MUST stay retriable
+  // (StorageTransientError/2045); collapsing it into StorageError/2044 would
+  // turn a recoverable blip into a hard failure. OOM is retriable; malformed
+  // data is permanent corruption; anything else internal.
   milvus::ErrorCode code;
   if (status.IsOutOfMemory()) {
     code = milvus::MemAllocateFailed;  // 2034, retriable
   } else if (status.IsIOError()) {
-    code = milvus::StorageTransientError;  // 2045, retriable
+    code = milvus::StorageTransientError;  // 2045, retriable (no internal retry here)
   } else if (status.IsInvalid() || status.IsTypeError() || status.IsKeyError()) {
     code = milvus::DataFormatBroken;  // 2024, permanent corruption
   } else {

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -165,13 +165,16 @@ milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
       // case is identified.
       return milvus::StorageError;  // 2044
     case ExtendStatusCode::AwsErrorNotFound:
+      // The object/bucket is gone: permanent, and fine-grained -- consumers can
+      // distinguish "data missing" (stale loadinfo, GC'd file) from a generic
+      // storage failure. Never transient/2045: a retry/reroute hits the same
+      // shared object store and fails identically.
+      return milvus::ObjectNotExist;  // 2017, permanent
     case ExtendStatusCode::AwsErrorAccessDenied:
     case ExtendStatusCode::AwsErrorNonRetryable:
-      // Permanently-failing object-storage errors (object/bucket gone, bad
-      // credentials, or the AWS SDK itself judged the error non-retryable).
-      // Retrying or rerouting hits the same shared object store and fails
-      // identically -- these must NEVER be classified transient/2045, or
-      // querynode would retry-storm a read that can never succeed.
+      // Bad credentials/permissions, or the AWS SDK itself judged the error
+      // non-retryable. Same rule: never transient/2045, or querynode would
+      // retry-storm a request that can never succeed.
       return milvus::StorageError;  // 2044, permanent
   }
   return milvus::StorageError;  // out-of-range value: safe non-retriable fallback

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -20,6 +20,7 @@
 
 #include <arrow/status.h>
 #include <arrow/result.h>
+#include <fmt/format.h>
 
 namespace milvus_storage {
 
@@ -39,6 +40,18 @@ std::string ExtendStatusDetail::extra_info() const { return extra_info_; }
 
 std::string ExtendStatusDetail::CodeAsString() const {
   switch (code()) {
+    case ExtendStatusCode::PackedInvalidArgs:
+      return "PackedInvalidArgs";
+    case ExtendStatusCode::PackedStorageIO:
+      return "PackedStorageIO";
+    case ExtendStatusCode::PackedMetadataCorrupted:
+      return "PackedMetadataCorrupted";
+    case ExtendStatusCode::PackedFileCorrupted:
+      return "PackedFileCorrupted";
+    case ExtendStatusCode::PackedArrowError:
+      return "PackedArrowError";
+    case ExtendStatusCode::PackedUnexpected:
+      return "PackedUnexpected";
     case ExtendStatusCode::AwsErrorNoSuchUpload:
       return "AwsErrorNoSuchUpload";
     case ExtendStatusCode::AwsErrorConflict:
@@ -64,8 +77,90 @@ std::shared_ptr<ExtendStatusDetail> ExtendStatusDetail::UnwrapStatus(const arrow
 }
 
 arrow::Status MakeExtendError(ExtendStatusCode code, std::string message, std::string extra_info) {
-  arrow::StatusCode arrow_code = arrow::StatusCode::IOError;
+  auto arrow_code =
+      code == ExtendStatusCode::PackedInvalidArgs ? arrow::StatusCode::Invalid : arrow::StatusCode::IOError;
   return {arrow_code, std::move(message), std::make_shared<ExtendStatusDetail>(code, std::move(extra_info))};
+}
+
+arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const arrow::Status& cause) {
+  auto detail = ExtendStatusDetail::UnwrapStatus(cause);
+  auto wrapped_code = detail ? detail->code() : code;
+  auto cause_message = cause.ToString();
+  return MakeExtendError(wrapped_code, fmt::format("{}: {}", message, cause_message), cause_message);
+}
+
+// Map a producer-side ExtendStatusCode to the shared milvus ErrorCode that the
+// segcore boundary (and ultimately the Go retry policy) consumes. This is the
+// single place milvus-storage classifies its own codes ("producer owns
+// classification").
+//
+// It is deliberately a switch with NO `default:` plus a post-switch fallback:
+//   * a `default:` inside the switch would suppress -Wswitch, so a newly added
+//     ExtendStatusCode could silently fall through to the wrong bucket;
+//   * the post-switch `return` satisfies -Wreturn-type and guards out-of-range
+//     values, without suppressing the exhaustiveness warning.
+// The surrounding pragma turns -Wswitch into an error so adding an
+// ExtendStatusCode without classifying it here breaks the build (the
+// extend_status_test.cpp coverage is the runtime backstop).
+//
+// Invariant: the retriable verdict carried by the returned code is what matters
+// most. A transient storage IO failure MUST map to the retriable
+// StorageTransientError(2045); it must never collapse into the non-retriable
+// StorageError(2044), which would turn a recoverable IO blip into a hard
+// failure.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wswitch"
+milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
+  switch (code) {
+    case ExtendStatusCode::PackedInvalidArgs:
+      return milvus::InvalidParameter;  // 2042, caller's fault (non-retriable input)
+    case ExtendStatusCode::PackedStorageIO:
+      return milvus::StorageTransientError;  // 2045, retriable storage IO
+    case ExtendStatusCode::PackedMetadataCorrupted:
+    case ExtendStatusCode::PackedFileCorrupted:
+      return milvus::DataFormatBroken;  // 2024, permanent data corruption
+    case ExtendStatusCode::PackedArrowError:
+    case ExtendStatusCode::PackedUnexpected:
+      return milvus::StorageError;  // 2044, permanent internal storage error
+    case ExtendStatusCode::AwsErrorNoSuchUpload:
+    case ExtendStatusCode::AwsErrorConflict:
+    case ExtendStatusCode::AwsErrorPreConditionFailed:
+    case ExtendStatusCode::TxnExhaustedRetry:
+    case ExtendStatusCode::TxnResolutionFailed:
+      // S3 multipart / precondition / transaction failures: conservatively
+      // permanent here (the retry budget is already spent or the precondition
+      // genuinely failed). Promote to a more specific code if a real retriable
+      // case is identified.
+      return milvus::StorageError;  // 2044
+  }
+  return milvus::StorageError;  // out-of-range value: safe non-retriable fallback
+}
+#pragma GCC diagnostic pop
+
+milvus::SegcoreError ToSegcoreError(const arrow::Status& status) {
+  if (status.ok()) {
+    return milvus::SegcoreError::success();
+  }
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  if (detail) {
+    return {ToSegcoreErrorCode(detail->code()), status.ToString()};
+  }
+
+  // No structured ExtendStatusDetail attached: fall back to arrow's coarse
+  // status code. Transient IO / OOM stay retriable, malformed data is permanent
+  // corruption, and anything else is an internal storage error.
+  milvus::ErrorCode code;
+  if (status.IsOutOfMemory()) {
+    code = milvus::MemAllocateFailed;  // 2034, retriable
+  } else if (status.IsIOError()) {
+    code = milvus::StorageTransientError;  // 2045, retriable
+  } else if (status.IsInvalid() || status.IsTypeError() || status.IsKeyError()) {
+    code = milvus::DataFormatBroken;  // 2024, permanent corruption
+  } else {
+    code = milvus::StorageError;  // 2044, permanent internal error
+  }
+  return {code, status.ToString()};
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -120,8 +120,8 @@ arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const 
 // Retriability is therefore decided by whether a DISTINCT upper-layer retry can
 // still help: querynode can reroute a failed read to another replica/node (a
 // different network path / endpoint), or the failure was a node-local transient.
-// That reroute does not stack on the S3 SDK retry, so a transient IO error is
-// still worth marking retriable.
+// Plain IO does not assume that path and is classified conservatively as
+// non-retriable StorageError/2044.
 //
 // Two callers reach segcore ErrorCode differently:
 //   1. A status carrying an ExtendStatusDetail (Packed*/Aws*/Txn) is classified
@@ -130,9 +130,8 @@ arrow::Status WrapExtendError(ExtendStatusCode code, std::string message, const 
 //      FileReadFailed/FileWriteFailed and drop the ExtendStatusCode -- so this
 //      switch is a reserved, forward-looking classification, not a hot path.
 //   2. A status with NO detail (plain arrow) is the LIVE segcore/storage read
-//      path; its transient IO stays retriable (StorageTransientError/2045) via
-//      the no-detail fallback of ToSegcoreError below (per the reroute rationale
-//      above), NOT this switch.
+//      path; its plain IO is classified as non-retriable StorageError/2044 via
+//      the no-detail fallback of ToSegcoreError below, NOT this switch.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wswitch"
 milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
@@ -144,9 +143,8 @@ milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
       // consumer routes a Packed* status here (the packed C-APIs hardcode
       // FileReadFailed/FileWriteFailed and drop the code). Do NOT justify this
       // with "v2 retries internally" -- the S3 SDK retry is shared by v2 and v3
-      // alike. If a real direct-link consumer ever appears, revisit: by the
-      // querynode-reroute logic it would likely want StorageTransientError/2045,
-      // same as the live no-detail IO path below.
+      // alike. If a real direct-link consumer ever appears, revisit: validate
+      // its retry semantics before changing this non-retriable classification.
       return milvus::StorageError;  // 2044 (dormant; conservative)
     case ExtendStatusCode::PackedMetadataCorrupted:
     case ExtendStatusCode::PackedFileCorrupted:
@@ -196,17 +194,14 @@ milvus::SegcoreError ToSegcoreError(const arrow::Status& status) {
   // propagated IO error here already spent the shared S3 SDK retry budget, AND
   // permanently-failing S3 errors (NotFound / AccessDenied / SDK-judged
   // non-retryable) were already tagged with an ExtendStatusDetail upstream in
-  // ErrorToStatus -- so a *plain* IOError that reaches this branch is a genuine
-  // transient (throttle / 5xx / timeout / connection). querynode can still
-  // reroute it to another replica/node, so it MUST stay retriable
-  // (StorageTransientError/2045); collapsing it into StorageError/2044 would
-  // turn a recoverable blip into a hard failure. OOM is retriable; malformed
-  // data is permanent corruption; anything else internal.
+  // ErrorToStatus. A *plain* IOError that reaches this branch is classified
+  // conservatively as non-retriable StorageError/2044. OOM is retriable;
+  // malformed data is permanent corruption; anything else internal.
   milvus::ErrorCode code;
   if (status.IsOutOfMemory()) {
     code = milvus::MemAllocateFailed;  // 2034, retriable
   } else if (status.IsIOError()) {
-    code = milvus::StorageTransientError;  // 2045, retriable (no internal retry here)
+    code = milvus::StorageError;  // 2044, non-retriable
   } else if (status.IsInvalid() || status.IsTypeError() || status.IsKeyError()) {
     code = milvus::DataFormatBroken;  // 2024, permanent corruption
   } else {

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -179,7 +179,9 @@ arrow::Result<std::string> S3Client::GetBucketRegionFromError(const std::string&
   if (!region.empty()) {
     return region;
   } else if (error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
-    return arrow::Status::IOError("Bucket '", bucket, "' not found");
+    // Permanent: the bucket does not exist; a retry/reroute fails identically.
+    return MakeExtendError(ExtendStatusCode::AwsErrorNotFound, "Bucket '" + bucket + "' not found",
+                           "" /* extra_info */);
   } else {
     return arrow::Status::IOError("When resolving region for bucket: ", bucket);
   }
@@ -199,7 +201,9 @@ arrow::Result<std::string> S3Client::GetBucketRegion(const std::string& bucket,
   if (!region.empty()) {
     return region;
   } else if (outcome.GetResult().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
-    return arrow::Status::IOError("Bucket '", request.GetBucket(), "' not found");
+    // Permanent: the bucket does not exist; a retry/reroute fails identically.
+    return MakeExtendError(ExtendStatusCode::AwsErrorNotFound,
+                           "Bucket '" + std::string(request.GetBucket().c_str()) + "' not found", "" /* extra_info */);
   } else {
     return arrow::Status::IOError("When resolving region for bucket '", request.GetBucket(),
                                   "': missing 'x-amz-bucket-region' header in response");

--- a/cpp/src/format/parquet/file_reader.cpp
+++ b/cpp/src/format/parquet/file_reader.cpp
@@ -157,11 +157,11 @@ arrow::Status FileRowGroupReader::SetRowGroupOffsetAndCount(int row_group_offset
 }
 
 // Helper function to match schema and fill null columns
-void MatchSchemaAndFillNullColumns(const std::shared_ptr<arrow::Table>& table,
-                                   const std::shared_ptr<arrow::Schema>& schema,
-                                   const FieldIDList& field_id_list,
-                                   const std::map<FieldID, ColumnOffset>& field_id_mapping,
-                                   std::shared_ptr<arrow::Table>* out) {
+arrow::Status MatchSchemaAndFillNullColumns(const std::shared_ptr<arrow::Table>& table,
+                                            const std::shared_ptr<arrow::Schema>& schema,
+                                            const FieldIDList& field_id_list,
+                                            const std::map<FieldID, ColumnOffset>& field_id_mapping,
+                                            std::shared_ptr<arrow::Table>* out) {
   std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
 
   for (size_t i = 0; i < field_id_list.size(); ++i) {
@@ -170,12 +170,15 @@ void MatchSchemaAndFillNullColumns(const std::shared_ptr<arrow::Table>& table,
       int col = field_id_mapping.at(field_id).col_index;
       columns.emplace_back(table->column(col));
     } else {
-      auto null_array = arrow::MakeArrayOfNull(schema->field(i)->type(), table->num_rows()).ValueOrDie();
+      // MakeArrayOfNull allocates; ValueOrDie here aborted the whole process
+      // on failure instead of reporting a status.
+      ARROW_ASSIGN_OR_RAISE(auto null_array, arrow::MakeArrayOfNull(schema->field(i)->type(), table->num_rows()));
       columns.emplace_back(std::make_shared<arrow::ChunkedArray>(null_array));
     }
   }
 
   *out = arrow::Table::Make(schema, columns);
+  return arrow::Status::OK();
 }
 
 arrow::Status FileRowGroupReader::SliceRowGroupFromTable(std::shared_ptr<arrow::Table>* out) {
@@ -253,8 +256,8 @@ arrow::Status FileRowGroupReader::ReadNextRowGroup(std::shared_ptr<arrow::Table>
 
   // Match schema and fill null columns
   std::shared_ptr<arrow::Table> matched_table;
-  MatchSchemaAndFillNullColumns(new_table, schema_, field_id_list_, file_metadata_->GetFieldIDMapping(),
-                                &matched_table);
+  ARROW_RETURN_NOT_OK(MatchSchemaAndFillNullColumns(new_table, schema_, field_id_list_,
+                                                    file_metadata_->GetFieldIDMapping(), &matched_table));
 
   // Merge with existing buffer table if needed
   if (buffer_table_ != nullptr) {

--- a/cpp/src/packed/column_group.cpp
+++ b/cpp/src/packed/column_group.cpp
@@ -14,6 +14,7 @@
 
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/extend_status.h"
 #include <arrow/table.h>
 #include <arrow/status.h>
 
@@ -32,7 +33,7 @@ ColumnGroup::ColumnGroup(GroupId group_id,
 
 arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBatch>& batch) {
   if (!batch) {
-    return arrow::Status::IOError("ColumnGroup::AddRecordBatch: batch is null");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "ColumnGroup::AddRecordBatch: batch is null");
   }
   batches_.emplace_back(batch);
 
@@ -46,9 +47,11 @@ arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBat
 
 arrow::Status ColumnGroup::Merge(const ColumnGroup& other) {
   for (auto& batch : other.batches_) {
-    if (!AddRecordBatch(batch).ok()) {
-      return arrow::Status::IOError("ColumnGroup::Merge: failed to merge record batch");
-    };
+    auto status = AddRecordBatch(batch);
+    if (!status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedUnexpected, "ColumnGroup::Merge: failed to merge record batch",
+                             status);
+    }
   }
   return arrow::Status::OK();
 }

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -14,6 +14,8 @@
 
 #include <memory>
 #include <algorithm>
+#include <exception>
+#include <stdexcept>
 #include <utility>
 
 #include <arrow/array/data.h>
@@ -32,10 +34,42 @@
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/packed/chunk_manager.h"
 #include "milvus-storage/packed/reader.h"
 
 namespace milvus_storage {
+
+namespace {
+
+arrow::Result<std::shared_ptr<PackedFileMetadata>> MakePackedMetadata(
+    const std::shared_ptr<::parquet::FileMetaData>& metadata, const std::string& path) {
+  if (!metadata) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Packed parquet metadata is null. [path={}]", path));
+  }
+  if (!metadata->key_value_metadata()) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Packed parquet key-value metadata is missing. [path={}]", path));
+  }
+
+  try {
+    auto result = PackedFileMetadata::Make(metadata);
+    if (!result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                             fmt::format("Failed to parse packed file metadata. [path={}]", path), result.status());
+    }
+    return result;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Failed to parse packed file metadata. [path={}, error={}]", path, e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                           fmt::format("Failed to parse packed file metadata with unknown exception. [path={}]", path));
+  }
+}
+
+}  // namespace
 
 PackedRecordBatchReader::PackedRecordBatchReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                                  std::vector<std::string>& paths,
@@ -60,6 +94,16 @@ arrow::Status PackedRecordBatchReader::init(const std::shared_ptr<arrow::fs::Fil
                                             const std::shared_ptr<arrow::Schema>& schema,
                                             parquet::ReaderProperties& reader_props,
                                             const parquet::ArrowReaderProperties& arrow_reader_props) {
+  if (!fs) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader null file system provided");
+  }
+  if (paths.empty()) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader empty paths provided");
+  }
+  if (!schema) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader null schema provided");
+  }
+
   // read first file metadata to get field id mapping and do schema matching
   ARROW_RETURN_NOT_OK(schemaMatching(fs, schema, paths, reader_props, arrow_reader_props));
 
@@ -68,12 +112,12 @@ arrow::Status PackedRecordBatchReader::init(const std::shared_ptr<arrow::fs::Fil
   for (const auto& path : needed_paths_) {
     auto result = MakeArrowFileReader(*fs, path, reader_props, arrow_reader_props);
     if (!result.ok()) {
-      return arrow::Status::Invalid(
-          fmt::format("Error making file reader with path {}: {}", path, result.status().ToString()));
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             fmt::format("Error making file reader with path {}", path), result.status());
     }
     auto file_reader = std::move(result.ValueOrDie());
     auto metadata = file_reader->parquet_reader()->metadata();
-    ARROW_ASSIGN_OR_RAISE(auto file_metadata, PackedFileMetadata::Make(metadata));
+    ARROW_ASSIGN_OR_RAISE(auto file_metadata, MakePackedMetadata(metadata, path));
     metadata_list_.emplace_back(std::move(file_metadata));
     file_readers_.emplace_back(std::move(file_reader));
 
@@ -105,20 +149,23 @@ arrow::Status PackedRecordBatchReader::schemaMatching(const std::shared_ptr<arro
   // read first file metadata to get field id mapping
   auto result = MakeArrowFileReader(*fs, paths[0], reader_props, arrow_reader_props);
   if (!result.ok()) {
-    return arrow::Status::Invalid(
-        fmt::format("Error making file reader with path {}: {}", paths[0], result.status().ToString()));
+    return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                           fmt::format("Error making file reader with path {}", paths[0]), result.status());
   }
   auto parquet_metadata = result.ValueOrDie()->parquet_reader()->metadata();
-  ARROW_ASSIGN_OR_RAISE(auto metadata, PackedFileMetadata::Make(parquet_metadata));
+  ARROW_ASSIGN_OR_RAISE(auto metadata, MakePackedMetadata(parquet_metadata, paths[0]));
 
   // parse field id list from schema
   std::vector<std::shared_ptr<arrow::Field>> fields;
   std::vector<std::shared_ptr<arrow::Field>> needed_fields;
-  auto status = FieldIDList::Make(schema);
-  if (!status.ok()) {
-    return arrow::Status::Invalid(fmt::format("Error getting field id list from schema: {}", schema->ToString(true)));
+  auto field_id_list = FieldIDList::Make(schema);
+  if (!field_id_list.ok()) {
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           fmt::format("Error getting field id list from schema: {}. [schema={}]",
+                                       field_id_list.status().ToString(), schema->ToString(true)),
+                           field_id_list.status().ToString());
   }
-  field_id_list_ = status.ValueOrDie();
+  field_id_list_ = field_id_list.ValueOrDie();
 
   // schema matching
   field_id_mapping_ = metadata->GetFieldIDMapping();
@@ -126,6 +173,13 @@ arrow::Status PackedRecordBatchReader::schemaMatching(const std::shared_ptr<arro
     FieldID field_id = field_id_list_.Get(i);
     if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
       auto column_offset = field_id_mapping_[field_id];
+      if (column_offset.path_index < 0 || static_cast<size_t>(column_offset.path_index) >= paths.size()) {
+        return MakeExtendError(
+            ExtendStatusCode::PackedMetadataCorrupted,
+            fmt::format("Packed field id metadata references path index outside provided paths. [field_id={}, "
+                        "path_index={}, num_paths={}]",
+                        field_id, column_offset.path_index, paths.size()));
+      }
       needed_column_offsets_.emplace_back(column_offset);
       needed_paths_.emplace(paths[column_offset.path_index]);
       fields.emplace_back(schema->field(i));
@@ -200,13 +254,14 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
       return arrow::Status::OK();
     } else {
       // Otherwise, the rows are not match, there is something wrong with the files.
-      return arrow::Status::Invalid(fmt::format("File broken at index {}. [path={}, row_offset={}, row_limit={}]",
-                                                drained_index,  // NOLINT
-                                                needed_paths_.size() > static_cast<size_t>(drained_index)
-                                                    ? *std::next(needed_paths_.begin(), drained_index)
-                                                    : "unknown",                                 // NOLINT
-                                                column_group_states_[drained_index].row_offset,  // NOLINT
-                                                row_limit_));
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             fmt::format("File broken at index {}. [path={}, row_offset={}, row_limit={}]",
+                                         drained_index,  // NOLINT
+                                         needed_paths_.size() > static_cast<size_t>(drained_index)
+                                             ? *std::next(needed_paths_.begin(), drained_index)
+                                             : "unknown",                                 // NOLINT
+                                         column_group_states_[drained_index].row_offset,  // NOLINT
+                                         row_limit_));
     }
   }
 
@@ -236,7 +291,13 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
     read_count_++;
     column_group_states_[i].read_times++;
     std::shared_ptr<arrow::Table> read_table = nullptr;
-    ARROW_RETURN_NOT_OK(file_readers_[i]->ReadRowGroups(rgs_to_read[i], &read_table));
+    auto read_status = file_readers_[i]->ReadRowGroups(rgs_to_read[i], &read_table);
+    if (!read_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             fmt::format("Failed to read packed row groups. [path={}]",
+                                         needed_paths_.size() > i ? *std::next(needed_paths_.begin(), i) : "unknown"),
+                             read_status);
+    }
     int path_index = file_reader_to_path_index_[i];
     tables_[path_index].push(std::move(read_table));
   }
@@ -250,58 +311,93 @@ arrow::Status PackedRecordBatchReader::advanceBuffer() {
 }
 
 arrow::Status PackedRecordBatchReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
-  if (absolute_row_position_ >= row_limit_) {
-    ARROW_RETURN_NOT_OK(advanceBuffer());
+  try {
+    if (!out) {
+      return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed reader ReadNext output pointer is null");
+    }
+
     if (absolute_row_position_ >= row_limit_) {
-      *out = nullptr;
-      return arrow::Status::OK();
+      ARROW_RETURN_NOT_OK(advanceBuffer());
+      if (absolute_row_position_ >= row_limit_) {
+        *out = nullptr;
+        return arrow::Status::OK();
+      }
     }
-  }
 
-  // Determine the maximum contiguous slice across all tables
-  auto batch_data = chunk_manager_->SliceChunksByMaxContiguousSlice(row_limit_ - absolute_row_position_, tables_);
-  int64_t chunk_size = chunk_manager_->GetChunkSize();
-  absolute_row_position_ += chunk_size;
-  std::shared_ptr<arrow::RecordBatch> batch =
-      arrow::RecordBatch::Make(needed_schema_, chunk_size, std::move(batch_data));
-
-  int batch_index = 0;
-  std::vector<std::shared_ptr<arrow::Array>> arrays;
-  for (size_t i = 0; i < field_id_list_.size(); ++i) {
-    FieldID field_id = field_id_list_.Get(i);
-    if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
-      // RVO here, no need std::move
-      arrays.emplace_back(batch->column(batch_index++));
-    } else {
-      auto null_array = arrow::MakeArrayOfNull(schema_->field(i)->type(), chunk_size).ValueOrDie();
-      arrays.emplace_back(std::move(null_array));
+    // Determine the maximum contiguous slice across all tables
+    std::vector<std::shared_ptr<arrow::ArrayData>> batch_data;
+    try {
+      batch_data = chunk_manager_->SliceChunksByMaxContiguousSlice(row_limit_ - absolute_row_position_, tables_);
+    } catch (const std::exception& e) {
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             fmt::format("Packed file chunk layout is corrupted: {}", e.what()));
+    } catch (...) {
+      return MakeExtendError(ExtendStatusCode::PackedFileCorrupted,
+                             "Packed file chunk layout is corrupted with unknown exception");
     }
+    int64_t chunk_size = chunk_manager_->GetChunkSize();
+    absolute_row_position_ += chunk_size;
+    std::shared_ptr<arrow::RecordBatch> batch =
+        arrow::RecordBatch::Make(needed_schema_, chunk_size, std::move(batch_data));
+
+    int batch_index = 0;
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    for (size_t i = 0; i < field_id_list_.size(); ++i) {
+      FieldID field_id = field_id_list_.Get(i);
+      if (field_id_mapping_.find(field_id) != field_id_mapping_.end()) {
+        // RVO here, no need std::move
+        arrays.emplace_back(batch->column(batch_index++));
+      } else {
+        auto null_array_result = arrow::MakeArrayOfNull(schema_->field(i)->type(), chunk_size);
+        if (!null_array_result.ok()) {
+          return WrapExtendError(ExtendStatusCode::PackedArrowError,
+                                 fmt::format("Failed to create null array. [field_index={}]", i),
+                                 null_array_result.status());
+        }
+        auto null_array = null_array_result.ValueOrDie();
+        arrays.emplace_back(std::move(null_array));
+      }
+    }
+    *out = arrow::RecordBatch::Make(schema_, chunk_size, arrays);
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed reader read next failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed reader read next with unknown exception failed unexpectedly");
   }
-  *out = arrow::RecordBatch::Make(schema_, chunk_size, arrays);
-  return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchReader::Close() {
-  LOG_STORAGE_DEBUG_ << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
-  for (size_t i = 0; i < column_group_states_.size(); ++i) {
-    LOG_STORAGE_DEBUG_ << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
-  }
-
-  // Clean up remaining data in all tables
-  for (auto& table_queue : tables_) {
-    while (!table_queue.empty()) {
-      table_queue.front().reset();  // Explicitly release shared_ptr
-      table_queue.pop();
+  try {
+    LOG_STORAGE_DEBUG_ << "PackedRecordBatchReader::Close(), total read " << read_count_ << " times";
+    for (size_t i = 0; i < column_group_states_.size(); ++i) {
+      LOG_STORAGE_DEBUG_ << "File reader " << i << " read " << column_group_states_[i].read_times << " times";
     }
-  }
 
-  read_count_ = 0;
-  column_group_states_.clear();
-  tables_.clear();
-  file_readers_.clear();
-  metadata_list_.clear();
-  memory_used_ = 0;
-  return arrow::Status::OK();
+    // Clean up remaining data in all tables
+    for (auto& table_queue : tables_) {
+      while (!table_queue.empty()) {
+        table_queue.front().reset();  // Explicitly release shared_ptr
+        table_queue.pop();
+      }
+    }
+
+    read_count_ = 0;
+    column_group_states_.clear();
+    tables_.clear();
+    file_readers_.clear();
+    metadata_list_.clear();
+    memory_used_ = 0;
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed reader close failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed reader close with unknown exception failed unexpectedly");
+  }
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/packed/splitter/indices_based_splitter.cpp
+++ b/cpp/src/packed/splitter/indices_based_splitter.cpp
@@ -20,11 +20,11 @@ namespace milvus_storage {
 IndicesBasedSplitter::IndicesBasedSplitter(const std::vector<std::vector<int>>& column_indices)
     : column_indices_(column_indices) {}
 
-std::vector<ColumnGroup> IndicesBasedSplitter::Split(const std::shared_ptr<arrow::RecordBatch>& record) {
+arrow::Result<std::vector<ColumnGroup>> IndicesBasedSplitter::Split(const std::shared_ptr<arrow::RecordBatch>& record) {
   std::vector<ColumnGroup> column_groups;
 
   for (GroupId group_id = 0; group_id < column_indices_.size(); group_id++) {
-    auto batch = record->SelectColumns(column_indices_[group_id]).ValueOrDie();
+    ARROW_ASSIGN_OR_RAISE(auto batch, record->SelectColumns(column_indices_[group_id]));
     column_groups.emplace_back(group_id, column_indices_[group_id], batch);
   }
 

--- a/cpp/src/packed/splitter/size_based_splitter.cpp
+++ b/cpp/src/packed/splitter/size_based_splitter.cpp
@@ -24,10 +24,10 @@ namespace milvus_storage {
 
 SizeBasedSplitter::SizeBasedSplitter(size_t max_group_size) : max_group_size_(max_group_size) {}
 
-std::vector<ColumnGroup> SizeBasedSplitter::SplitRecordBatches(
+arrow::Result<std::vector<ColumnGroup>> SizeBasedSplitter::SplitRecordBatches(
     const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches) {
   if (batches.empty()) {
-    return {};
+    return std::vector<ColumnGroup>{};
   }
   // calculate column sizes and rows
   std::vector<size_t> column_sizes(batches[0]->num_columns(), 0);
@@ -62,18 +62,18 @@ std::vector<ColumnGroup> SizeBasedSplitter::SplitRecordBatches(
   std::vector<ColumnGroup> column_groups;
   for (auto& record : batches) {
     for (GroupId group_id = 0; group_id < group_indices.size(); ++group_id) {
-      auto batch = record->SelectColumns(group_indices[group_id]).ValueOrDie();
+      ARROW_ASSIGN_OR_RAISE(auto batch, record->SelectColumns(group_indices[group_id]));
       if (column_groups.size() < group_indices.size()) {
         column_groups.emplace_back(group_id, group_indices[group_id], batch);
       } else {
-        column_groups[group_id].AddRecordBatch(batch);
+        ARROW_RETURN_NOT_OK(column_groups[group_id].AddRecordBatch(batch));
       }
     }
   }
   return column_groups;
 }
 
-std::vector<ColumnGroup> SizeBasedSplitter::Split(const std::shared_ptr<arrow::RecordBatch>& record) {
+arrow::Result<std::vector<ColumnGroup>> SizeBasedSplitter::Split(const std::shared_ptr<arrow::RecordBatch>& record) {
   return SplitRecordBatches({record});
 }
 

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <stdexcept>
 #include <utility>
 
@@ -28,6 +29,7 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/format/parquet/parquet_writer.h"
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
@@ -70,22 +72,25 @@ arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> PackedRecordBatchWriter:
 
 arrow::Status PackedRecordBatchWriter::init() {
   if (!schema_) {
-    return arrow::Status::Invalid("Packed writer null schema provided");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed writer null schema provided");
   }
 
   if (paths_.size() != group_indices_.size()) {
-    return arrow::Status::Invalid(fmt::format("Mismatch between paths number and column groups number: {} vs {}",
-                                              paths_.size(), group_indices_.size()));
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           fmt::format("Mismatch between paths number and column groups number: {} vs {}",
+                                       paths_.size(), group_indices_.size()));
   }
 
   if (!fs_) {
-    return arrow::Status::Invalid("Packed writer null file system provided");
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs, "Packed writer null file system provided");
   }
 
   auto field_id_list = FieldIDList::Make(schema_);
   if (!field_id_list.ok()) {
-    return arrow::Status::Invalid(fmt::format("Failed to get field id from schema: {}. [schema={}]",
-                                              field_id_list.status().ToString(), schema_->ToString(true)));
+    return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                           fmt::format("Failed to get field id from schema: {}. [schema={}]",
+                                       field_id_list.status().ToString(), schema_->ToString(true)),
+                           field_id_list.status().ToString());
   }
 
   // Validate column group indices are within bounds
@@ -93,8 +98,9 @@ arrow::Status PackedRecordBatchWriter::init() {
   for (const auto& group_indice : group_indices_) {
     for (int col_index : group_indice) {
       if (col_index < 0 || col_index >= num_fields) {
-        return arrow::Status::Invalid(fmt::format("Column index out of range: {} (schema has {} fields), [schema={}]",
-                                                  col_index, num_fields, schema_->ToString(true)));
+        return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                               fmt::format("Column index out of range: {} (schema has {} fields), [schema={}]",
+                                           col_index, num_fields, schema_->ToString(true)));
       }
     }
   }
@@ -104,79 +110,134 @@ arrow::Status PackedRecordBatchWriter::init() {
   splitter_ = IndicesBasedSplitter(group_indices_);
   for (size_t i = 0; i < paths_.size(); ++i) {
     auto column_group_schema = getColumnGroupSchema(schema_, group_indices_[i]);
-    ARROW_ASSIGN_OR_RAISE(auto writer, milvus_storage::parquet::ParquetFileWriter::Make(
-                                           column_group_schema, fs_, paths_[i], storage_config_, writer_props_));
+    auto writer_result = milvus_storage::parquet::ParquetFileWriter::Make(column_group_schema, fs_, paths_[i],
+                                                                          storage_config_, writer_props_);
+    if (!writer_result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                             fmt::format("Failed to create packed column group writer. [path={}]", paths_[i]),
+                             writer_result.status());
+    }
+    auto writer = std::move(writer_result).ValueOrDie();
     group_writers_.emplace_back(std::move(writer));
   }
   return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::RecordBatch>& record) {
-  // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
-                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
+  try {
+    // Fault injection point for testing
+    FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
+                  MakeExtendError(ExtendStatusCode::PackedStorageIO,
+                                  fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
 
-  if (!record) {
+    if (!record) {
+      return arrow::Status::OK();
+    }
+
+    for (const auto& group_indice : group_indices_) {
+      for (int col_index : group_indice) {
+        if (col_index < 0 || col_index >= record->num_columns()) {
+          return MakeExtendError(ExtendStatusCode::PackedInvalidArgs,
+                                 fmt::format("Record batch column index out of range: {} (record batch has {} columns)",
+                                             col_index, record->num_columns()));
+        }
+      }
+    }
+
+    size_t next_batch_size = GetRecordBatchMemorySize(record);
+
+    std::vector<ColumnGroup> column_groups = splitter_.Split(record);
+
+    // Flush column groups until there's enough room for the new column groups
+    // to ensure that memory usage stays strictly below the limit
+    while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
+      LOG_STORAGE_DEBUG_ << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
+                         << ", flushing column group: " << max_heap_.top().first;
+      auto max_group = max_heap_.top();
+      max_heap_.pop();
+
+      assert(current_memory_usage_ >= max_group.second);
+      current_memory_usage_ -= max_group.second;
+
+      milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
+      auto flush_status = writer->Flush();
+      if (!flush_status.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
+                               flush_status);
+      }
+    }
+
+    // After flushing, add the new column groups if memory usage allows
+    for (const ColumnGroup& group : column_groups) {
+      current_memory_usage_ += group.GetMemoryUsage();
+      max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
+
+      assert(group.GrpId() < group_writers_.size());
+      auto& grp_writer = group_writers_[group.GrpId()];
+      auto write_status = grp_writer->Write(group.GetRecordBatch(0));
+      if (!write_status.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to write packed column group", write_status);
+      }
+    }
+
+    ARROW_RETURN_NOT_OK(balanceMaxHeap());
     return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed writer write failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer write with unknown exception failed unexpectedly");
   }
-
-  size_t next_batch_size = GetRecordBatchMemorySize(record);
-
-  std::vector<ColumnGroup> column_groups = splitter_.Split(record);
-
-  // Flush column groups until there's enough room for the new column groups
-  // to ensure that memory usage stays strictly below the limit
-  while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
-    LOG_STORAGE_DEBUG_ << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
-                       << ", flushing column group: " << max_heap_.top().first;
-    auto max_group = max_heap_.top();
-    max_heap_.pop();
-
-    assert(current_memory_usage_ >= max_group.second);
-    current_memory_usage_ -= max_group.second;
-
-    milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
-    ARROW_RETURN_NOT_OK(writer->Flush());
-  }
-
-  // After flushing, add the new column groups if memory usage allows
-  for (const ColumnGroup& group : column_groups) {
-    current_memory_usage_ += group.GetMemoryUsage();
-    max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
-
-    assert(group.GrpId() < group_writers_.size());
-    auto& grp_writer = group_writers_[group.GrpId()];
-    ARROW_RETURN_NOT_OK(grp_writer->Write(group.GetRecordBatch(0)));
-  }
-
-  ARROW_RETURN_NOT_OK(balanceMaxHeap());
-  return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::Close() {
-  // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
-                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
+  try {
+    // Fault injection point for testing
+    FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
+                  MakeExtendError(ExtendStatusCode::PackedStorageIO,
+                                  fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
 
-  // Check if already closed
-  if (closed_) {
-    return arrow::Status::OK();
-  }
+    // Check if already closed
+    if (closed_) {
+      return arrow::Status::OK();
+    }
 
-  // flush all remaining column groups before closing
-  auto status = flushRemainingBuffer();
-  if (status.ok()) {
-    closed_ = true;
+    // flush all remaining column groups before closing
+    auto status = flushRemainingBuffer();
+    if (status.ok()) {
+      closed_ = true;
+    }
+    return status;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed writer close failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer close with unknown exception failed unexpectedly");
   }
-  return status;
 }
 
 arrow::Result<std::vector<size_t>> PackedRecordBatchWriter::Tell() const {
-  std::vector<size_t> positions(group_writers_.size());
-  for (size_t writer_idx = 0; writer_idx < group_writers_.size(); ++writer_idx) {
-    ARROW_ASSIGN_OR_RAISE(positions[writer_idx], group_writers_[writer_idx]->Tell());
+  try {
+    std::vector<size_t> positions(group_writers_.size());
+    for (size_t writer_idx = 0; writer_idx < group_writers_.size(); ++writer_idx) {
+      auto tell_result = group_writers_[writer_idx]->Tell();
+      if (!tell_result.ok()) {
+        return WrapExtendError(ExtendStatusCode::PackedStorageIO,
+                               fmt::format("Failed to tell packed column group writer. [writer_index={}]", writer_idx),
+                               tell_result.status());
+      }
+      positions[writer_idx] = tell_result.ValueOrDie();
+    }
+    return positions;
+  } catch (const std::exception& e) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           fmt::format("Packed writer tell failed unexpectedly: {}", e.what()));
+  } catch (...) {
+    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+                           "Packed writer tell with unknown exception failed unexpectedly");
   }
-  return positions;
 }
 
 arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, const std::string& value) {
@@ -186,8 +247,8 @@ arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, c
 
 arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
   // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL,
-                arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
+  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, MakeExtendError(ExtendStatusCode::PackedStorageIO,
+                                                          fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
 
   if (closed_) {
     return arrow::Status::OK();
@@ -200,13 +261,30 @@ arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
 
     LOG_STORAGE_DEBUG_ << "Flushing remaining column group: " << max_group.first;
     current_memory_usage_ -= max_group.second;
-    ARROW_RETURN_NOT_OK(grp_writer->Flush());
+    auto flush_status = grp_writer->Flush();
+    if (!flush_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
+                             flush_status);
+    }
   }
 
   for (auto& grp_writer : group_writers_) {
-    ARROW_RETURN_NOT_OK(grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize()));
-    ARROW_RETURN_NOT_OK(grp_writer->AddUserMetadata(user_metadata_));
-    ARROW_RETURN_NOT_OK(grp_writer->Close());
+    auto append_status = grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize());
+    if (!append_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to append packed group field id metadata",
+                             append_status);
+    }
+
+    auto metadata_status = grp_writer->AddUserMetadata(user_metadata_);
+    if (!metadata_status.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to add packed user metadata", metadata_status);
+    }
+
+    auto close_result = grp_writer->Close();
+    if (!close_result.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to close packed column group writer",
+                             close_result.status());
+    }
   }
 
   return arrow::Status::OK();

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -146,7 +146,7 @@ arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::Record
 
     size_t next_batch_size = GetRecordBatchMemorySize(record);
 
-    std::vector<ColumnGroup> column_groups = splitter_.Split(record);
+    ARROW_ASSIGN_OR_RAISE(std::vector<ColumnGroup> column_groups, splitter_.Split(record));
 
     // Flush column groups until there's enough room for the new column groups
     // to ensure that memory usage stays strictly below the limit

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -179,7 +179,7 @@ TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
       {ExtendStatusCode::AwsErrorConflict, milvus::StorageError},
       {ExtendStatusCode::AwsErrorPreConditionFailed, milvus::StorageError},
       // permanently-failing S3 errors: must never be transient/2045
-      {ExtendStatusCode::AwsErrorNotFound, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorNotFound, milvus::ObjectNotExist},
       {ExtendStatusCode::AwsErrorAccessDenied, milvus::StorageError},
       {ExtendStatusCode::AwsErrorNonRetryable, milvus::StorageError},
       {ExtendStatusCode::TxnExhaustedRetry, milvus::StorageError},
@@ -213,11 +213,13 @@ TEST_F(ExtendStatusTest, PermanentS3ErrorsAreNotRetriable) {
   struct Case {
     ExtendStatusCode code;
     const char* name;
+    milvus::ErrorCode expected;
   };
   const Case cases[] = {
-      {ExtendStatusCode::AwsErrorNotFound, "AwsErrorNotFound"},
-      {ExtendStatusCode::AwsErrorAccessDenied, "AwsErrorAccessDenied"},
-      {ExtendStatusCode::AwsErrorNonRetryable, "AwsErrorNonRetryable"},
+      // not-found is fine-grained: ObjectNotExist(2017), still permanent
+      {ExtendStatusCode::AwsErrorNotFound, "AwsErrorNotFound", milvus::ObjectNotExist},
+      {ExtendStatusCode::AwsErrorAccessDenied, "AwsErrorAccessDenied", milvus::StorageError},
+      {ExtendStatusCode::AwsErrorNonRetryable, "AwsErrorNonRetryable", milvus::StorageError},
   };
   for (const auto& test_case : cases) {
     auto status = MakeExtendError(test_case.code, "permanent object-store failure", "detail");
@@ -228,7 +230,7 @@ TEST_F(ExtendStatusTest, PermanentS3ErrorsAreNotRetriable) {
     EXPECT_EQ(detail->CodeAsString(), test_case.name);
 
     auto error = ToSegcoreError(status);
-    EXPECT_EQ(error.get_error_code(), milvus::StorageError) << test_case.name;
+    EXPECT_EQ(error.get_error_code(), test_case.expected) << test_case.name;
     EXPECT_NE(error.get_error_code(), milvus::StorageTransientError) << test_case.name;
   }
 }

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -165,8 +165,10 @@ TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
   const Case cases[] = {
       // input (non-retriable)
       {ExtendStatusCode::PackedInvalidArgs, milvus::InvalidParameter},
-      // retriable storage IO -- must NOT collapse into StorageError
-      {ExtendStatusCode::PackedStorageIO, milvus::StorageTransientError},
+      // PackedStorageIO: conservatively non-retriable StorageError, but a dormant
+      // branch (no live consumer). The retriable 2045 is used by the live
+      // no-detail plain-arrow read path, tested separately below.
+      {ExtendStatusCode::PackedStorageIO, milvus::StorageError},
       // permanent data corruption
       {ExtendStatusCode::PackedMetadataCorrupted, milvus::DataFormatBroken},
       {ExtendStatusCode::PackedFileCorrupted, milvus::DataFormatBroken},
@@ -176,6 +178,10 @@ TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
       {ExtendStatusCode::AwsErrorNoSuchUpload, milvus::StorageError},
       {ExtendStatusCode::AwsErrorConflict, milvus::StorageError},
       {ExtendStatusCode::AwsErrorPreConditionFailed, milvus::StorageError},
+      // permanently-failing S3 errors: must never be transient/2045
+      {ExtendStatusCode::AwsErrorNotFound, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorAccessDenied, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorNonRetryable, milvus::StorageError},
       {ExtendStatusCode::TxnExhaustedRetry, milvus::StorageError},
       {ExtendStatusCode::TxnResolutionFailed, milvus::StorageError},
   };
@@ -185,15 +191,46 @@ TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
   }
 }
 
-// The retriable verdict is the load-bearing property: a transient storage IO
-// failure must stay retriable and never collapse into the non-retriable
-// StorageError fallback.
-TEST_F(ExtendStatusTest, StorageIoMapsToRetriableTransientCode) {
-  EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageTransientError);
-  EXPECT_NE(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageError);
+// A Packed* status carries an ExtendStatusDetail, so it is classified by the
+// switch. PackedStorageIO is conservatively non-retriable, but this is a DORMANT
+// branch (no live consumer -- the packed C-APIs hardcode FileReadFailed/
+// FileWriteFailed). Not justified by "v2 retries internally": the S3 SDK retry
+// is shared by v2 and v3. (Contrast the live no-detail plain-arrow read path
+// below, which stays retriable via 2045 for querynode reroute.)
+TEST_F(ExtendStatusTest, PackedStorageIoIsDormantNonRetriable) {
+  EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageError);
+  EXPECT_NE(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageTransientError);
 
   auto status = MakeExtendError(ExtendStatusCode::PackedStorageIO, "object store unavailable", "timeout");
-  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageTransientError);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+}
+
+// Permanently-failing S3 errors tagged by ErrorToStatus (object/bucket gone,
+// bad credentials, SDK-judged non-retryable) must classify permanent, never
+// transient/2045 -- otherwise querynode would retry-storm a read that can never
+// succeed (retry/reroute hits the same shared object store).
+TEST_F(ExtendStatusTest, PermanentS3ErrorsAreNotRetriable) {
+  struct Case {
+    ExtendStatusCode code;
+    const char* name;
+  };
+  const Case cases[] = {
+      {ExtendStatusCode::AwsErrorNotFound, "AwsErrorNotFound"},
+      {ExtendStatusCode::AwsErrorAccessDenied, "AwsErrorAccessDenied"},
+      {ExtendStatusCode::AwsErrorNonRetryable, "AwsErrorNonRetryable"},
+  };
+  for (const auto& test_case : cases) {
+    auto status = MakeExtendError(test_case.code, "permanent object-store failure", "detail");
+    ASSERT_FALSE(status.ok()) << test_case.name;
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << test_case.name;
+    EXPECT_EQ(detail->CodeAsString(), test_case.name);
+
+    auto error = ToSegcoreError(status);
+    EXPECT_EQ(error.get_error_code(), milvus::StorageError) << test_case.name;
+    EXPECT_NE(error.get_error_code(), milvus::StorageTransientError) << test_case.name;
+  }
 }
 
 TEST_F(ExtendStatusTest, PlainArrowStatusFallsBackToCoarseClassification) {
@@ -204,10 +241,13 @@ TEST_F(ExtendStatusTest, PlainArrowStatusFallsBackToCoarseClassification) {
     EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
     EXPECT_NE(std::string(error.what()).find("corrupt bytes"), std::string::npos);
   }
-  // Plain IOError -> retriable transient storage error.
+  // Plain IOError -> retriable StorageTransientError. This is the live read
+  // path (FileRowGroupReader / v3 api::Reader / ArrowFileSystem); none retries
+  // internally, so a transient IO blip must stay retriable for querynode.
   {
     auto error = ToSegcoreError(arrow::Status::IOError("disk blip"));
     EXPECT_EQ(error.get_error_code(), milvus::StorageTransientError);
+    EXPECT_NE(error.get_error_code(), milvus::StorageError);
   }
   // OOM -> retriable mem-allocate.
   {

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -16,6 +16,7 @@
 
 #include <arrow/status.h>
 
+#include "common/EasyAssert.h"
 #include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::test {
@@ -97,6 +98,132 @@ TEST_F(ExtendStatusTest, TestExtendStatusDetail) {
     EXPECT_NE(detail.type_id(), nullptr);
     EXPECT_EQ(std::string(detail.type_id()), "milvus_storage::ExtendStatusDetail");
   }
+}
+
+TEST_F(ExtendStatusTest, PackedCodesUseExpectedArrowStatusCodeAndDetail) {
+  struct Case {
+    ExtendStatusCode code;
+    const char* name;
+    bool is_invalid;
+  };
+
+  const Case cases[] = {
+      {ExtendStatusCode::PackedInvalidArgs, "PackedInvalidArgs", true},
+      {ExtendStatusCode::PackedStorageIO, "PackedStorageIO", false},
+      {ExtendStatusCode::PackedMetadataCorrupted, "PackedMetadataCorrupted", false},
+      {ExtendStatusCode::PackedFileCorrupted, "PackedFileCorrupted", false},
+      {ExtendStatusCode::PackedArrowError, "PackedArrowError", false},
+      {ExtendStatusCode::PackedUnexpected, "PackedUnexpected", false},
+  };
+
+  for (const auto& test_case : cases) {
+    auto status = MakeExtendError(test_case.code, "message", "extra");
+    ASSERT_FALSE(status.ok()) << test_case.name;
+    EXPECT_EQ(status.IsInvalid(), test_case.is_invalid) << test_case.name;
+    EXPECT_EQ(status.IsIOError(), !test_case.is_invalid) << test_case.name;
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << test_case.name << ": " << status.ToString();
+    EXPECT_EQ(detail->code(), test_case.code);
+    EXPECT_EQ(detail->extra_info(), "extra");
+    EXPECT_EQ(detail->CodeAsString(), test_case.name);
+    EXPECT_NE(detail->ToString().find(test_case.name), std::string::npos);
+    EXPECT_NE(detail->ToString().find("extra"), std::string::npos);
+  }
+}
+
+TEST_F(ExtendStatusTest, WrapExtendErrorPreservesExistingDetail) {
+  auto original = MakeExtendError(ExtendStatusCode::PackedStorageIO, "storage failed", "cause");
+
+  auto wrapped = WrapExtendError(ExtendStatusCode::PackedUnexpected, "outer message", original);
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
+  EXPECT_NE(wrapped.ToString().find("outer message"), std::string::npos);
+  EXPECT_NE(wrapped.ToString().find("storage failed"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("storage failed"), std::string::npos);
+}
+
+TEST_F(ExtendStatusTest, WrapExtendErrorAddsDetailToPlainStatus) {
+  auto wrapped = WrapExtendError(ExtendStatusCode::PackedStorageIO, "open packed file",
+                                 arrow::Status::IOError("disk unavailable"));
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::PackedStorageIO);
+  EXPECT_NE(wrapped.ToString().find("open packed file"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("disk unavailable"), std::string::npos);
+}
+
+TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
+  struct Case {
+    ExtendStatusCode code;
+    milvus::ErrorCode expected;
+  };
+
+  const Case cases[] = {
+      // input (non-retriable)
+      {ExtendStatusCode::PackedInvalidArgs, milvus::InvalidParameter},
+      // retriable storage IO -- must NOT collapse into StorageError
+      {ExtendStatusCode::PackedStorageIO, milvus::StorageTransientError},
+      // permanent data corruption
+      {ExtendStatusCode::PackedMetadataCorrupted, milvus::DataFormatBroken},
+      {ExtendStatusCode::PackedFileCorrupted, milvus::DataFormatBroken},
+      // permanent internal storage errors
+      {ExtendStatusCode::PackedArrowError, milvus::StorageError},
+      {ExtendStatusCode::PackedUnexpected, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorNoSuchUpload, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorConflict, milvus::StorageError},
+      {ExtendStatusCode::AwsErrorPreConditionFailed, milvus::StorageError},
+      {ExtendStatusCode::TxnExhaustedRetry, milvus::StorageError},
+      {ExtendStatusCode::TxnResolutionFailed, milvus::StorageError},
+  };
+
+  for (const auto& test_case : cases) {
+    EXPECT_EQ(ToSegcoreErrorCode(test_case.code), test_case.expected);
+  }
+}
+
+// The retriable verdict is the load-bearing property: a transient storage IO
+// failure must stay retriable and never collapse into the non-retriable
+// StorageError fallback.
+TEST_F(ExtendStatusTest, StorageIoMapsToRetriableTransientCode) {
+  EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageTransientError);
+  EXPECT_NE(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageError);
+
+  auto status = MakeExtendError(ExtendStatusCode::PackedStorageIO, "object store unavailable", "timeout");
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageTransientError);
+}
+
+TEST_F(ExtendStatusTest, PlainArrowStatusFallsBackToCoarseClassification) {
+  // No ExtendStatusDetail attached -> coarse arrow status classification.
+  // Plain Invalid means malformed *stored* data here -> permanent corruption.
+  {
+    auto error = ToSegcoreError(arrow::Status::Invalid("corrupt bytes"));
+    EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+    EXPECT_NE(std::string(error.what()).find("corrupt bytes"), std::string::npos);
+  }
+  // Plain IOError -> retriable transient storage error.
+  {
+    auto error = ToSegcoreError(arrow::Status::IOError("disk blip"));
+    EXPECT_EQ(error.get_error_code(), milvus::StorageTransientError);
+  }
+  // OOM -> retriable mem-allocate.
+  {
+    auto error = ToSegcoreError(arrow::Status::OutOfMemory("oom"));
+    EXPECT_EQ(error.get_error_code(), milvus::MemAllocateFailed);
+  }
+}
+
+TEST_F(ExtendStatusTest, ExtendStatusConvertsToSegcoreError) {
+  auto status = MakeExtendError(ExtendStatusCode::PackedFileCorrupted, "bad packed file", "footer mismatch");
+
+  auto error = ToSegcoreError(status);
+
+  EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+  EXPECT_NE(std::string(error.what()).find("bad packed file"), std::string::npos);
+  EXPECT_NE(std::string(error.what()).find("PackedFileCorrupted"), std::string::npos);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -166,8 +166,8 @@ TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
       // input (non-retriable)
       {ExtendStatusCode::PackedInvalidArgs, milvus::InvalidParameter},
       // PackedStorageIO: conservatively non-retriable StorageError, but a dormant
-      // branch (no live consumer). The retriable 2045 is used by the live
-      // no-detail plain-arrow read path, tested separately below.
+      // branch (no live consumer). The live no-detail plain-arrow read path also
+      // maps plain IOError to StorageError, tested separately below.
       {ExtendStatusCode::PackedStorageIO, milvus::StorageError},
       // permanent data corruption
       {ExtendStatusCode::PackedMetadataCorrupted, milvus::DataFormatBroken},
@@ -195,8 +195,8 @@ TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
 // switch. PackedStorageIO is conservatively non-retriable, but this is a DORMANT
 // branch (no live consumer -- the packed C-APIs hardcode FileReadFailed/
 // FileWriteFailed). Not justified by "v2 retries internally": the S3 SDK retry
-// is shared by v2 and v3. (Contrast the live no-detail plain-arrow read path
-// below, which stays retriable via 2045 for querynode reroute.)
+// is shared by v2 and v3. The live no-detail plain-arrow read path below maps
+// plain IOError to StorageError/2044 as well.
 TEST_F(ExtendStatusTest, PackedStorageIoIsDormantNonRetriable) {
   EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageError);
   EXPECT_NE(ToSegcoreErrorCode(ExtendStatusCode::PackedStorageIO), milvus::StorageTransientError);
@@ -243,13 +243,14 @@ TEST_F(ExtendStatusTest, PlainArrowStatusFallsBackToCoarseClassification) {
     EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
     EXPECT_NE(std::string(error.what()).find("corrupt bytes"), std::string::npos);
   }
-  // Plain IOError -> retriable StorageTransientError. This is the live read
-  // path (FileRowGroupReader / v3 api::Reader / ArrowFileSystem); none retries
-  // internally, so a transient IO blip must stay retriable for querynode.
+  // Plain IOError -> non-retriable StorageError. This is the live read path
+  // (FileRowGroupReader / v3 api::Reader / ArrowFileSystem); after shared SDK
+  // retries, it maps to StorageError/2044.
   {
     auto error = ToSegcoreError(arrow::Status::IOError("disk blip"));
-    EXPECT_EQ(error.get_error_code(), milvus::StorageTransientError);
-    EXPECT_NE(error.get_error_code(), milvus::StorageError);
+    EXPECT_EQ(error.get_error_code(), milvus::StorageError);
+    EXPECT_EQ(error.get_error_code(), 2044);
+    EXPECT_NE(error.get_error_code(), milvus::StorageTransientError);
   }
   // OOM -> retriable mem-allocate.
   {

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -78,6 +78,60 @@ TEST_F(S3UnitTest, TestExtendErrorInFs) {
   ASSERT_TRUE(status.ToString().find(extend_status->ToString()) != std::string::npos);
 }
 
+TEST_F(S3UnitTest, TestErrorToStatusPermanentVsTransient) {
+  // NoSuchKey: permanent, tagged AwsErrorNotFound.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::NO_SUCH_KEY, Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchKey", "object gone");
+    auto status = fs::internal::ErrorToStatus("test", error);
+    ASSERT_STATUS_NOT_OK(status);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorNotFound);
+  }
+  // AccessDenied: permanent, tagged AwsErrorAccessDenied.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
+    auto status = fs::internal::ErrorToStatus("test", error);
+    ASSERT_STATUS_NOT_OK(status);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorAccessDenied);
+  }
+  // A recognized error type the SDK judged non-retryable: tagged permanent.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::VALIDATION, Aws::Client::RetryableType::NOT_RETRYABLE, "ValidationError", "bad request");
+    auto status = fs::internal::ErrorToStatus("test", error);
+    ASSERT_STATUS_NOT_OK(status);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorNonRetryable);
+  }
+  // MinIO-style SlowDown: arrives as UNKNOWN + non-retryable, but it is a
+  // genuine transient (rate limiting). Must stay a plain IOError (no detail) so
+  // consumers classify it retriable -- tagging it permanent would invert a
+  // recoverable throttle into a hard failure.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDown", "rate limited");
+    auto status = fs::internal::ErrorToStatus("test", error);
+    ASSERT_STATUS_NOT_OK(status);
+    EXPECT_TRUE(status.IsIOError());
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  }
+  // Recognized retryable transient (SDK would retry): plain IOError, no detail.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::SLOW_DOWN, Aws::Client::RetryableType::RETRYABLE_THROTTLING, "SlowDown", "rate limited");
+    auto status = fs::internal::ErrorToStatus("test", error);
+    ASSERT_STATUS_NOT_OK(status);
+    EXPECT_TRUE(status.IsIOError());
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  }
+}
+
 TEST_F(S3UnitTest, TestSignRequest) {
   // GET
   {
@@ -489,10 +543,13 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorConflict);
   }
 
-  // Generic IOError (no ExtendStatus)
+  // Generic IOError (no ExtendStatus): an UNKNOWN error type with no special
+  // HTTP response code stays a plain IOError so consumers classify it
+  // transient/retriable. (ACCESS_DENIED is no longer generic -- it is tagged
+  // AwsErrorAccessDenied; see TestErrorToStatusPermanentVsTransient.)
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
-        Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
+        Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "SomeBackendSpecificError", "opaque");
     auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
     ASSERT_FALSE(status.ok());
     EXPECT_TRUE(status.IsIOError());

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <parquet/arrow/writer.h>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/packed/column_group.h"
+#include "milvus-storage/packed/reader.h"
+#include "milvus-storage/packed/writer.h"
+
+#include "packed_test_base.h"
+
+namespace milvus_storage {
+
+namespace {
+
+void ExpectPackedCode(const arrow::Status& status, ExtendStatusCode code) {
+  ASSERT_FALSE(status.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), code);
+}
+
+void ExpectExceptionMessageContainsCode(const std::function<void()>& fn, const std::string& code_name) {
+  try {
+    fn();
+    FAIL() << "expected runtime_error";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string(e.what()).find(code_name), std::string::npos) << e.what();
+  }
+}
+
+}  // namespace
+
+class PackedErrorStatusTest : public PackedTestBase {};
+
+TEST_F(PackedErrorStatusTest, WriterPathGroupMismatchIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0}, {1}};
+
+  auto result = PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, WriterColumnIndexOutOfRangeIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{schema_->num_fields()}};
+
+  auto result = PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_);
+
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, WriterRecordBatchColumnMismatchIsInvalidArgs) {
+  std::vector<std::string> paths = {path_ + "/0.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0, 1, 2}};
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(fs_, paths, schema_, storage_config_, column_groups, writer_memory_));
+  ASSERT_AND_ASSIGN(auto short_batch, record_batch_->SelectColumns({0, 1}));
+
+  auto status = writer->Write(short_batch);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+  (void)writer->Close();
+}
+
+TEST_F(PackedErrorStatusTest, ColumnGroupNullBatchIsInvalidArgs) {
+  ColumnGroup group(0, {0});
+
+  auto status = group.AddRecordBatch(nullptr);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, ReaderMissingFileIsStorageIO) {
+  std::vector<std::string> paths = {path_ + "/missing.parquet"};
+
+  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
+                                     "PackedStorageIO");
+}
+
+TEST_F(PackedErrorStatusTest, ReaderNullOutputPointerIsInvalidArgs) {
+  SetupOneFile();
+  std::vector<std::string> paths = {one_file_path_};
+  PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_);
+
+  auto status = reader.ReadNext(nullptr);
+
+  ExpectPackedCode(status, ExtendStatusCode::PackedInvalidArgs);
+  ASSERT_STATUS_OK(reader.Close());
+}
+
+TEST_F(PackedErrorStatusTest, ReaderMissingPackedMetadataIsMetadataCorrupted) {
+  auto parquet_path = path_ + "/plain.parquet";
+  ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(parquet_path));
+  ASSERT_STATUS_OK(::parquet::arrow::WriteTable(*table_, arrow::default_memory_pool(), sink, 2));
+  ASSERT_STATUS_OK(sink->Close());
+  std::vector<std::string> paths = {parquet_path};
+
+  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
+                                     "PackedMetadataCorrupted");
+}
+
+}  // namespace milvus_storage

--- a/cpp/test/packed/splitter_test.cpp
+++ b/cpp/test/packed/splitter_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <arrow/api.h>
+#include <arrow/testing/gtest_util.h>
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
 #include "milvus-storage/packed/splitter/size_based_splitter.h"
 #include "milvus-storage/packed/column_group.h"
@@ -29,7 +30,7 @@ class SplitterTest : public PackedTestBase {
 TEST_F(SplitterTest, IndicesBasedSplitterTest) {
   std::vector<std::vector<int>> column_indices_ = {{1}, {0, 2}};
   IndicesBasedSplitter splitter(column_indices_);
-  std::vector<ColumnGroup> column_groups = splitter.Split(record_batch_);
+  ASSERT_OK_AND_ASSIGN(std::vector<ColumnGroup> column_groups, splitter.Split(record_batch_));
 
   ASSERT_EQ(column_groups.size(), 2);
 
@@ -40,7 +41,7 @@ TEST_F(SplitterTest, IndicesBasedSplitterTest) {
 
 TEST_F(SplitterTest, SizeBasedSplitterTest) {
   SizeBasedSplitter splitter(64);
-  std::vector<ColumnGroup> column_groups = splitter.Split(record_batch_);
+  ASSERT_OK_AND_ASSIGN(std::vector<ColumnGroup> column_groups, splitter.Split(record_batch_));
 
   ASSERT_EQ(column_groups.size(), 2);
 


### PR DESCRIPTION
## What

Add the producer-owned mapping `ToSegcoreErrorCode` / `ToSegcoreError` so milvus-storage classifies its own packed failures once, at the source, and milvus can consume a typed segcore `ErrorCode` instead of a generic Arrow status text.

> Note: this **builds on #572** (jiaqizho — packed `ExtendStatusCode` + `WrapExtendError`), which is not yet merged, so this branch currently includes those commits. Once #572 lands this PR should be rebased onto it so it only carries the mapping delta. Happy to coordinate.

## Mapping (no-`default` switch + `-Werror=switch`)

| ExtendStatusCode | segcore ErrorCode | retry |
|---|---|---|
| PackedInvalidArgs | InvalidParameter (2042) | non-retriable (input) |
| PackedStorageIO | **StorageTransientError (2045)** | **retriable** |
| PackedMetadataCorrupted / PackedFileCorrupted | DataFormatBroken (2024) | permanent |
| PackedArrowError / PackedUnexpected / AWS / Txn | StorageError (2044) | permanent |

The retriable verdict is load-bearing: a transient storage IO failure maps to the retriable `StorageTransientError(2045)` and must never collapse into the non-retriable `StorageError(2044)`. The switch has no `default` + a post-switch fallback under `-Werror=switch`, so a new `ExtendStatusCode` breaks the build until classified. The no-detail path keeps a coarse arrow mapping (IO→transient, OOM→mem-allocate, Invalid/Type/Key→corruption).

## Dependencies

Depends on `milvus-common` `StorageTransientError(2045)`: zilliztech/milvus-common#102. Bump the `milvus-common` conan pin to the published 2045 revision before merge (the pin here points at a local build for verification).

Design + tracking: milvus-io/milvus#50903. Consumed by milvus-io/milvus#50768.
