### PR TITLE
enhance: use a global LRU cache for format metadata

### DIFF
--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -88,6 +88,10 @@
     loon_take;
     loon_reader_destroy;
 
+    # Metadata cache interface
+    loon_init_metadata_cache;
+    loon_clear_metadata_cache;
+
     # ChunkReader interface
     loon_get_chunk;
     loon_get_chunks;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -86,6 +86,10 @@ _loon_get_chunk_reader
 _loon_take
 _loon_reader_destroy
 
+# Metadata cache interface
+_loon_init_metadata_cache
+_loon_clear_metadata_cache
+
 # ChunkReader interface
 _loon_get_chunk
 _loon_get_chunks

--- a/cpp/include/milvus-storage/common/fiu_local.h
+++ b/cpp/include/milvus-storage/common/fiu_local.h
@@ -72,6 +72,9 @@
 // ColumnGroup fault points
 #define FIUKEY_COLUMN_GROUP_WRITE_FAIL "column_group.write.fail"
 
+// Vortex fault points
+#define FIUKEY_VORTEX_METADATA_CACHE_SIZE_FAIL "vortex.metadata_cache_size.fail"
+
 // ==================== Fault Injection Macros ====================
 
 #ifdef BUILD_WITH_FIU

--- a/cpp/include/milvus-storage/common/lru_memory_cache.h
+++ b/cpp/include/milvus-storage/common/lru_memory_cache.h
@@ -1,0 +1,120 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+
+namespace milvus_storage {
+
+template <typename K, typename V>
+class LRUMemoryCache final {
+  public:
+  explicit LRUMemoryCache(uint64_t capacity_bytes = 0) noexcept : capacity_bytes_(capacity_bytes) {}
+
+  void set_capacity(uint64_t capacity_bytes) {
+    std::unique_lock lock(mutex_);
+    capacity_bytes_ = capacity_bytes;
+    evict_until_within_capacity();
+  }
+
+  [[nodiscard]] std::optional<V> get(const K& key) {
+    std::unique_lock lock(mutex_);
+    auto it = cache_.find(key);
+    if (it == cache_.end()) {
+      return std::nullopt;
+    }
+
+    lru_list_.splice(lru_list_.begin(), lru_list_, it->second.lru_it);
+    return it->second.value;
+  }
+
+  bool put(const K& key, const V& value, uint64_t size_bytes) {
+    std::unique_lock lock(mutex_);
+
+    auto existing = cache_.find(key);
+    if (existing != cache_.end()) {
+      current_bytes_ -= existing->second.size_bytes;
+      lru_list_.erase(existing->second.lru_it);
+      cache_.erase(existing);
+    }
+
+    if (size_bytes == 0 || size_bytes > capacity_bytes_) {
+      return false;
+    }
+
+    lru_list_.push_front(key);
+    cache_.emplace(key, Entry{value, size_bytes, lru_list_.begin()});
+    current_bytes_ += size_bytes;
+
+    evict_until_within_capacity();
+    return true;
+  }
+
+  [[nodiscard]] size_t size() const {
+    std::shared_lock lock(mutex_);
+    return cache_.size();
+  }
+
+  void remove(const K& key) {
+    std::unique_lock lock(mutex_);
+    auto it = cache_.find(key);
+    if (it == cache_.end()) {
+      return;
+    }
+
+    current_bytes_ -= it->second.size_bytes;
+    lru_list_.erase(it->second.lru_it);
+    cache_.erase(it);
+  }
+
+  void clear() {
+    std::unique_lock lock(mutex_);
+    cache_.clear();
+    lru_list_.clear();
+    current_bytes_ = 0;
+  }
+
+  private:
+  struct Entry {
+    V value;
+    uint64_t size_bytes;
+    typename std::list<K>::iterator lru_it;
+  };
+
+  void evict_until_within_capacity() {
+    while (current_bytes_ > capacity_bytes_ && !lru_list_.empty()) {
+      auto last_key = lru_list_.back();
+      auto it = cache_.find(last_key);
+      if (it != cache_.end()) {
+        current_bytes_ -= it->second.size_bytes;
+        cache_.erase(it);
+      }
+      lru_list_.pop_back();
+    }
+  }
+
+  mutable std::shared_mutex mutex_;
+  std::list<K> lru_list_;
+  std::map<K, Entry> cache_;
+  uint64_t capacity_bytes_;
+  uint64_t current_bytes_ = 0;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -341,6 +341,21 @@ FFI_EXPORT void loon_thread_pool_singleton_release();
 
 // ==================== End of ThreadPool C Interface ====================
 
+// ==================== Metadata Cache C Interface ====================
+/**
+ * @brief Configure the process-wide metadata cache capacity in bytes.
+ *
+ * @param capacity_bytes Maximum retained metadata bytes. 0 clears and disables retention.
+ */
+FFI_EXPORT void loon_init_metadata_cache(uint64_t capacity_bytes);
+
+/**
+ * @brief Clear completed entries in the process-wide metadata cache.
+ */
+FFI_EXPORT void loon_clear_metadata_cache(void);
+
+// ==================== End of Metadata Cache C Interface ====================
+
 // ==================== Writer C Interface ====================
 typedef uintptr_t LoonWriterHandle;
 

--- a/cpp/include/milvus-storage/format/column_group_lazy_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_lazy_reader.h
@@ -19,7 +19,6 @@
 
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/properties.h"
-#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/format_reader.h"
 #include "milvus-storage/thread_pool.h"
 
@@ -45,8 +44,7 @@ class ColumnGroupLazyReader {
       const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
       const milvus_storage::api::Properties& properties,
       const std::vector<std::string>& needed_columns,
-      const std::function<std::string(const std::string&)>& key_retriever,
-      const milvus_storage::MetadataCache& cache = milvus_storage::MetadataCache());
+      const std::function<std::string(const std::string&)>& key_retriever);
 };
 
 };  // namespace milvus_storage::api

--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -18,7 +18,6 @@
 
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/properties.h"
-#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/format_reader.h"
 #include "milvus-storage/thread_pool.h"
 
@@ -60,8 +59,7 @@ class ColumnGroupReader {
       const std::vector<std::string>& needed_columns,
       const milvus_storage::api::Properties& properties,
       const std::function<std::string(const std::string&)>& key_retriever,
-      const std::string& predicate = "",
-      const milvus_storage::MetadataCache& cache = milvus_storage::MetadataCache());
+      const std::string& predicate = "");
 };
 
 }  // namespace milvus_storage::api

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -113,7 +113,7 @@ class FormatReader {
 
   // Load reusable file metadata without applying read-time state such as
   // projection or predicate. The returned metadata is safe to share through
-  // MetadataCache and later reuse to create independent readers.
+  // the process-wide metadata cache and later reuse to create independent readers.
   template <typename ReaderT>
   static arrow::Result<MetadataPtr<ReaderT>> load_metadata(const api::ColumnGroupFile& file,
                                                            const api::Properties& properties,
@@ -127,6 +127,7 @@ class FormatReader {
   template <typename ReaderT>
   static arrow::Result<std::shared_ptr<ReaderT>> create_from_metadata(MetadataPtr<ReaderT> metadata,
                                                                       const api::ColumnGroupFile& file,
+                                                                      const api::Properties& properties,
                                                                       const std::shared_ptr<arrow::Schema>& read_schema,
                                                                       const std::vector<std::string>& needed_columns,
                                                                       const std::string& predicate);
@@ -149,6 +150,7 @@ concept FormatReaderWithMetadata =
                                                          const KeyRetriever& key_retriever,
                                                          typename ReaderT::MetaTrait::MetadataPtr metadata,
                                                          const api::ColumnGroupFile& metadata_file,
+                                                         const api::Properties& metadata_properties,
                                                          const std::shared_ptr<arrow::Schema>& read_schema,
                                                          const std::vector<std::string>& needed_columns,
                                                          const std::string& predicate) {
@@ -166,7 +168,8 @@ concept FormatReaderWithMetadata =
         ReaderT::MetaTrait::load_metadata(file, properties, key_retriever)
       } -> std::same_as<arrow::Result<typename ReaderT::MetaTrait::MetadataPtr>>;
       {
-        ReaderT::MetaTrait::create_from_metadata(metadata, metadata_file, read_schema, needed_columns, predicate)
+        ReaderT::MetaTrait::create_from_metadata(metadata, metadata_file, metadata_properties, read_schema,
+                                                 needed_columns, predicate)
       } -> std::same_as<arrow::Result<std::shared_ptr<ReaderT>>>;
       { metadata->row_group_infos } -> std::same_as<const std::vector<RowGroupInfo>&>;
       { metadata->file_schema } -> std::same_as<const std::shared_ptr<arrow::Schema>&>;
@@ -186,13 +189,14 @@ template <typename ReaderT>
 arrow::Result<std::shared_ptr<ReaderT>> FormatReader::create_from_metadata(
     MetadataPtr<ReaderT> metadata,
     const api::ColumnGroupFile& file,
+    const api::Properties& properties,
     const std::shared_ptr<arrow::Schema>& read_schema,
     const std::vector<std::string>& needed_columns,
     const std::string& predicate) {
   static_assert(FormatReaderWithMetadata<ReaderT>,
                 "ReaderT must derive from FormatReader and define MetaTrait with Payload, Metadata, MetadataPtr, "
                 "cache_key, load_metadata, and create_from_metadata.");
-  return ReaderT::MetaTrait::create_from_metadata(metadata, file, read_schema, needed_columns, predicate);
+  return ReaderT::MetaTrait::create_from_metadata(metadata, file, properties, read_schema, needed_columns, predicate);
 }
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/format_reader_cache.h
+++ b/cpp/include/milvus-storage/format/format_reader_cache.h
@@ -16,12 +16,12 @@
 
 #include <concepts>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
-#include <typeindex>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -29,29 +29,33 @@
 #include <arrow/result.h>
 #include <arrow/status.h>
 
+#include "milvus-storage/column_groups.h"
 #include "milvus-storage/format/format_reader.h"
+#include "milvus-storage/properties.h"
 
 namespace milvus_storage {
 
-namespace iceberg {
-class IcebergFormatReader;
-}  // namespace iceberg
+// Configure the process-wide completed metadata cache byte capacity. Setting
+// capacity to 0 evicts existing entries and prevents future retention, while
+// loaders still return metadata to their callers.
+void InitMetadataCache(uint64_t capacity_bytes);
 
-namespace lance {
-class LanceTableReader;
-}  // namespace lance
+// Clear completed metadata entries from the process-wide cache. This is not a
+// barrier for in-flight loads; a load already running may still complete and
+// populate the cache after this call returns.
+void ClearMetadataCache();
 
-namespace parquet {
-class ParquetFormatReader;
-}  // namespace parquet
-
-namespace vortex {
-class VortexFormatReader;
-}  // namespace vortex
+arrow::Result<std::string> MakeFormatReaderMetadataCacheKey(const api::ColumnGroupFile& file,
+                                                            const api::Properties& properties,
+                                                            const std::string& format_cache_key);
 
 // Thread-safe metadata cache for one concrete FormatReader type.
 // Cached metadata is immutable and can be reused to create independent
-// stateful readers with different projections or predicates.
+// stateful readers with different projections or predicates. Completed entries
+// are stored process-wide, but each direct FormatReaderMetadataCache instance
+// owns its own singleflight state. Production reader code should obtain typed
+// caches through GetGlobalFormatReaderMetadataCache<ReaderT>() when process-wide
+// singleflight is required.
 template <typename ReaderT>
 class FormatReaderMetadataCache final {
   static_assert(FormatReaderWithMetadata<ReaderT>,
@@ -66,15 +70,14 @@ class FormatReaderMetadataCache final {
 
   std::optional<MetadataPtr> get(const std::string& key) const;
 
+  // Adds metadata to the process-wide completed-entry cache. Null metadata is
+  // rejected. Zero-size metadata, and metadata larger than the current global
+  // capacity, is accepted but not retained.
   arrow::Status add(std::string key, MetadataPtr metadata);
 
   arrow::Result<MetadataPtr> get_or_open(const std::string& key, const MetadataLoader& load_fn);
 
   private:
-  struct Entry {
-    MetadataPtr metadata;
-  };
-
   // Per-key singleflight state. The first cache miss creates this marker and
   // runs load_fn outside mutex_; waiters for the same key block on cv while
   // unrelated keys can still load concurrently.
@@ -86,7 +89,6 @@ class FormatReaderMetadataCache final {
   };
 
   mutable std::mutex mutex_;
-  std::unordered_map<std::string, Entry> entries_;
   std::unordered_map<std::string, std::shared_ptr<InFlightLoad>> in_flight_loads_;
 };
 
@@ -108,58 +110,7 @@ class FormatReaderMetadataCaches final {
   std::tuple<std::shared_ptr<FormatReaderMetadataCache<ReaderTs>>...> caches_;
 };
 
-// Public cache handle carried by ReaderImpl and passed down to column-group
-// readers. Concrete reader headers are intentionally not included here, so
-// installed consumers can include public reader headers without private bridge
-// headers from the source tree.
-class MetadataCache final {
-  public:
-  explicit MetadataCache(bool enabled = true);
-
-  [[nodiscard]] bool enabled() const { return enabled_; }
-
-  template <typename ReaderT>
-  [[nodiscard]] std::shared_ptr<FormatReaderMetadataCache<ReaderT>> get() const {
-    static_assert(FormatReaderWithMetadata<ReaderT>,
-                  "ReaderT must derive from FormatReader and define MetaTrait with Payload, Metadata, MetadataPtr, "
-                  "cache_key, load_metadata, and create_from_metadata.");
-
-    std::lock_guard<std::mutex> lock(state_->mutex);
-    auto [it, inserted] = state_->caches.try_emplace(std::type_index(typeid(ReaderT)));
-    if (inserted || !it->second) {
-      it->second = std::make_shared<FormatReaderMetadataCache<ReaderT>>();
-    }
-    return std::static_pointer_cast<FormatReaderMetadataCache<ReaderT>>(it->second);
-  }
-
-  template <typename Visitor>
-  auto dispatch(const std::string& format, Visitor&& visitor) const {
-    using ReturnT = decltype(std::forward<Visitor>(visitor)(get<parquet::ParquetFormatReader>()));
-
-    if (format == LOON_FORMAT_PARQUET) {
-      return std::forward<Visitor>(visitor)(get<parquet::ParquetFormatReader>());
-    }
-    if (format == LOON_FORMAT_VORTEX) {
-      return std::forward<Visitor>(visitor)(get<vortex::VortexFormatReader>());
-    }
-    if (format == LOON_FORMAT_LANCE_TABLE) {
-      return std::forward<Visitor>(visitor)(get<lance::LanceTableReader>());
-    }
-    if (format == LOON_FORMAT_ICEBERG_TABLE) {
-      return std::forward<Visitor>(visitor)(get<iceberg::IcebergFormatReader>());
-    }
-
-    return ReturnT(arrow::Status::Invalid("Unknown column group format: ", format));
-  }
-
-  private:
-  struct State {
-    mutable std::mutex mutex;
-    std::unordered_map<std::type_index, std::shared_ptr<void>> caches;
-  };
-
-  bool enabled_ = true;
-  std::shared_ptr<State> state_ = std::make_shared<State>();
-};
+template <typename ReaderT>
+std::shared_ptr<FormatReaderMetadataCache<ReaderT>> GetGlobalFormatReaderMetadataCache();
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/iceberg/iceberg_format_reader.h
+++ b/cpp/include/milvus-storage/format/iceberg/iceberg_format_reader.h
@@ -36,7 +36,6 @@ class IcebergFormatReader final : public FormatReader {
       parquet::ParquetFormatReader::MetaTrait::MetadataPtr data_metadata;
       std::string data_file_uri;
       std::vector<uint8_t> delete_metadata;
-      api::Properties properties;
       std::shared_ptr<const std::unordered_set<int64_t>> deleted_positions;
       std::shared_ptr<const std::vector<int64_t>> sorted_deletions;
     };
@@ -51,6 +50,7 @@ class IcebergFormatReader final : public FormatReader {
     static arrow::Result<std::shared_ptr<IcebergFormatReader>> create_from_metadata(
         MetadataPtr metadata,
         const api::ColumnGroupFile& file,
+        const api::Properties& properties,
         const std::shared_ptr<arrow::Schema>& read_schema,
         const std::vector<std::string>& needed_columns,
         const std::string& predicate);

--- a/cpp/include/milvus-storage/format/lance/lance_common.h
+++ b/cpp/include/milvus-storage/format/lance/lance_common.h
@@ -24,6 +24,8 @@
 
 namespace milvus_storage::lance {
 
+inline constexpr const char* kLanceTableVersionProperty = "lance.table.version";
+
 /// Convert ArrowFileSystemConfig to Lance storage options.
 /// Key format: aws_access_key_id, aws_secret_access_key, aws_region, aws_endpoint, etc.
 /// @throws std::runtime_error for unsupported providers (Tencent, Huawei)

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -49,7 +49,6 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
       uint64_t physical_row_count = 0;
       uint64_t num_deletions = 0;
       uint64_t logical_chunk_rows = 0;
-      milvus_storage::api::Properties properties;
     };
 
     using Metadata = FormatReaderMetadata<Payload>;
@@ -64,6 +63,7 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
     static arrow::Result<std::shared_ptr<LanceTableReader>> create_from_metadata(
         MetadataPtr metadata,
         const milvus_storage::api::ColumnGroupFile& file,
+        const milvus_storage::api::Properties& properties,
         const std::shared_ptr<arrow::Schema>& read_schema,
         const std::vector<std::string>& needed_columns,
         const std::string& predicate);

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -35,10 +35,8 @@ class ParquetFormatReader final : public FormatReader {
   public:
   struct MetaTrait {
     struct Payload {
-      std::shared_ptr<arrow::fs::FileSystem> fs;
       std::shared_ptr<arrow::Buffer> footer_buffer;
       std::shared_ptr<::parquet::FileMetaData> parquet_metadata;
-      api::Properties properties;
       milvus_storage::KeyRetriever key_retriever;
     };
 
@@ -52,6 +50,7 @@ class ParquetFormatReader final : public FormatReader {
     static arrow::Result<std::shared_ptr<ParquetFormatReader>> create_from_metadata(
         MetadataPtr metadata,
         const api::ColumnGroupFile& file,
+        const api::Properties& properties,
         const std::shared_ptr<arrow::Schema>& read_schema,
         const std::vector<std::string>& needed_columns,
         const std::string& predicate);

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -45,8 +45,9 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
     struct Payload {
       std::shared_ptr<FileSystemWrapper> fs_holder;
       std::shared_ptr<VortexFile> vxfile;
-      uint64_t logical_chunk_rows = 0;
-      api::Properties properties;
+      std::vector<uint64_t> row_ranges;
+      uint64_t row_count = 0;
+      uint64_t memory_usage = 0;
     };
 
     using Metadata = FormatReaderMetadata<Payload>;
@@ -61,6 +62,7 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
     static arrow::Result<std::shared_ptr<VortexFormatReader>> create_from_metadata(
         MetadataPtr metadata,
         const api::ColumnGroupFile& file,
+        const api::Properties& properties,
         const std::shared_ptr<arrow::Schema>& read_schema,
         const std::vector<std::string>& needed_columns,
         const std::string& predicate);
@@ -132,6 +134,9 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   VortexFormatReader(MetaTrait::MetadataPtr metadata,
                      uint64_t file_size,
                      uint64_t footer_size,
+                     milvus_storage::api::Properties properties,
+                     uint64_t logical_chunk_rows,
+                     std::vector<RowGroupInfo> row_group_infos,
                      const std::shared_ptr<arrow::Schema>& read_schema,
                      const std::vector<std::string>& needed_columns);
 

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -25,12 +25,17 @@
 #include "milvus-storage/transaction/transaction.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/format/format_reader_cache.h"
 
 // Forward declaration
 extern void destroy_column_groups_contents(LoonColumnGroups* cgroups);
 
 using namespace milvus_storage::api;
 using namespace milvus_storage::api::transaction;
+
+void loon_init_metadata_cache(uint64_t capacity_bytes) { milvus_storage::InitMetadataCache(capacity_bytes); }
+
+void loon_clear_metadata_cache(void) { milvus_storage::ClearMetadataCache(); }
 
 LoonFFIResult loon_transaction_begin(const char* base_path,
                                      const ::LoonProperties* properties,
@@ -420,5 +425,6 @@ char* loon_manifest_debug_string(const LoonManifest* manifest) {
 void loon_reset_context(void) {
   milvus_storage::api::Manifest::CleanCache();
   milvus_storage::FilesystemCache::getInstance().clean();
+  milvus_storage::ClearMetadataCache();
 }
 #endif

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -6310,6 +6310,7 @@ dependencies = [
  "chrono",
  "cxx",
  "cxx-build",
+ "deepsize",
  "futures",
  "hmac",
  "iceberg",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib"]
 [dependencies]
 # common dependencies
 anyhow = "1.0.99"
+deepsize = "0.2.0"
 futures = "0.3.31"
 paste = "1.0.15"
 take_mut = "0.2.2"

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -77,6 +77,9 @@ class BlockingDataset {
 
   void WriteArrowArrayStream(struct ArrowArrayStream* stream);
 
+  uint64_t Version() const;
+  uint64_t ManifestDeepSize() const;
+
   BlockingDataset(BlockingDataset&&) noexcept = default;
   BlockingDataset& operator=(BlockingDataset&&) noexcept = default;
 

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -247,6 +247,9 @@ class VortexFile {
   /// Get [offset, length] for the complete footer/tail region.
   std::vector<uint64_t> FooterByteRange(uint64_t file_size) const;
 
+  /// Get the serialized footer body size, excluding the EOF marker.
+  uint64_t FooterSize() const;
+
   /// Get [offset, length] for a given flat segment ID.
   std::vector<uint64_t> SegmentBytes(uint64_t flat_segment_id) const;
 

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -120,6 +120,22 @@ void BlockingDataset::WriteArrowArrayStream(struct ArrowArrayStream* stream) {
   }
 }
 
+uint64_t BlockingDataset::Version() const {
+  try {
+    return impl_->dataset_version();
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw LanceException(e.what());
+  }
+}
+
+uint64_t BlockingDataset::ManifestDeepSize() const {
+  try {
+    return impl_->manifest_deep_size();
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw LanceException(e.what());
+  }
+}
+
 std::unique_ptr<BlockingFragmentReader> BlockingFragmentReader::Open(const BlockingDataset& dataset,
                                                                      uint64_t fragment_id,
                                                                      ArrowSchema& schema) {

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -18,6 +18,7 @@ use arrow_array::Array;
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_array::{RecordBatch, RecordBatchReader, StructArray};
 use arrow_schema::Schema as ArrowSchema;
+use deepsize::DeepSizeOf;
 
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::cleanup::{CleanupPolicy, RemovalStats};
@@ -181,6 +182,14 @@ impl BlockingDataset {
 
     pub fn version(&self) -> Result<Version> {
         Ok(self.inner.version())
+    }
+
+    pub fn dataset_version(&self) -> Result<u64> {
+        Ok(self.inner.version().version)
+    }
+
+    pub fn manifest_deep_size(&self) -> Result<u64> {
+        Ok(self.inner.manifest.deep_size_of() as u64)
     }
 
     pub fn checkout_version(&mut self, version: u64) -> Result<Self> {

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -102,6 +102,8 @@ pub mod lance_ffi {
         ) -> Result<Box<BlockingDataset>>;
 
         pub unsafe fn write_stream(self: &mut BlockingDataset, stream_ptr: *mut u8) -> Result<()>;
+        pub fn dataset_version(self: &BlockingDataset) -> Result<u64>;
+        pub fn manifest_deep_size(self: &BlockingDataset) -> Result<u64>;
         pub fn get_all_fragment_ids(self: &BlockingDataset) -> Vec<u64>;
         pub fn dataset_delete_rows(dataset: &mut BlockingDataset, predicate: &str) -> Result<()>;
         pub fn get_fragment_deletion_positions(
@@ -288,6 +290,7 @@ pub mod vortex_ffi {
         fn row_group_zone_map_data_before_zones(self: &VortexFile) -> Result<bool>;
         fn zone_map_segment_ids(self: &VortexFile) -> Result<Vec<u64>>;
         fn footer_byte_range(self: &VortexFile, file_size: u64) -> Result<Vec<u64>>;
+        fn footer_size(self: &VortexFile) -> Result<u64>;
         fn segment_bytes(self: &VortexFile, flat_segment_id: u64) -> Result<Vec<u64>>;
         fn field_layout_units(self: &VortexFile, field_name: &str) -> Result<Vec<u64>>;
         fn prune_row_groups(

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -297,6 +297,14 @@ std::vector<uint64_t> VortexFile::FooterByteRange(uint64_t file_size) const {
   }
 }
 
+uint64_t VortexFile::FooterSize() const {
+  try {
+    return impl_->footer_size();
+  } catch (const rust::cxxbridge1::Error& e) {
+    throw VortexException(e.what());
+  }
+}
+
 std::vector<uint64_t> VortexFile::SegmentBytes(uint64_t flat_segment_id) const {
   try {
     ::rust::Vec<::rust::u64> rs = impl_->segment_bytes(flat_segment_id);

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -67,6 +67,28 @@ fn footer_start_from_segments(segments: &[SegmentSpec]) -> Result<u64, VortexErr
         })
 }
 
+fn footer_size_from_segments(segments: &[SegmentSpec], file_size: u64) -> Result<u64, VortexError> {
+    let footer_start = footer_start_from_segments(segments)?;
+    if footer_start > file_size {
+        return Err(vortex::error::vortex_err!(
+            "Vortex footer start {} exceeds file size {}",
+            footer_start,
+            file_size
+        ));
+    }
+
+    let tail_size = file_size - footer_start;
+    let eof_size = vortex::file::EOF_SIZE as u64;
+    if tail_size < eof_size {
+        return Err(vortex::error::vortex_err!(
+            "Vortex footer tail size {} is smaller than EOF size {}",
+            tail_size,
+            eof_size
+        ));
+    }
+    Ok(tail_size - eof_size)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1056,28 +1078,8 @@ impl VortexWriter {
             }
             let file_size = summary.size();
 
-            let footer = summary.footer();
-            let footer_start = footer_start_from_segments(footer.segment_map())
+            let footer_size = footer_size_from_segments(summary.footer().segment_map(), file_size)
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
-
-            if footer_start > file_size {
-                return Err(Box::new(vortex::error::vortex_err!(
-                    "Vortex footer start {} exceeds file size {}",
-                    footer_start,
-                    file_size
-                )));
-            }
-
-            let tail_size = file_size - footer_start;
-            let eof_size = vortex::file::EOF_SIZE as u64;
-            if tail_size < eof_size {
-                return Err(Box::new(vortex::error::vortex_err!(
-                    "Vortex footer tail size {} is smaller than EOF size {}",
-                    tail_size,
-                    eof_size
-                )));
-            }
-            let footer_size = tail_size - eof_size;
 
             return Ok(crate::vortex_ffi::VortexWriteSummary {
                 file_size,
@@ -1346,6 +1348,27 @@ impl VortexFile {
         } else {
             Ok(vec![footer_start, file_size - footer_start])
         }
+    }
+
+    pub(crate) fn footer_size(&self) -> Result<u64> {
+        let footer = self.inner.footer();
+        if self.file_size > 0 {
+            return Ok(footer_size_from_segments(footer.segment_map(), self.file_size)?);
+        }
+
+        let footer_start = footer_start_from_segments(footer.segment_map())?;
+        // When the manifest has no file_size, re-serialize the already-opened footer with its
+        // original offset to derive an equivalent file_size without extra filesystem IO.
+        let buffers = footer
+            .clone()
+            .into_serializer()
+            .with_offset(footer_start)
+            .serialize()?;
+        let tail_size = buffers.iter().map(|buffer| buffer.len() as u64).sum::<u64>();
+        Ok(footer_size_from_segments(
+            footer.segment_map(),
+            footer_start + tail_size,
+        )?)
     }
 
     /// Returns [offset, length] for a given flat segment ID.

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -35,6 +35,7 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/macro.h"  // for UNLIKELY
 #include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
@@ -49,8 +50,7 @@ class ColumnGroupLazyReaderImpl : public ColumnGroupLazyReader {
                             const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
                             const milvus_storage::api::Properties& properties,
                             const std::vector<std::string>& needed_columns,
-                            const std::function<std::string(const std::string&)>& key_retriever,
-                            const milvus_storage::MetadataCache& cache);
+                            const std::function<std::string(const std::string&)>& key_retriever);
 
   ~ColumnGroupLazyReaderImpl() override = default;
 
@@ -67,7 +67,6 @@ class ColumnGroupLazyReaderImpl : public ColumnGroupLazyReader {
   milvus_storage::api::Properties properties_;
   std::vector<std::string> needed_columns_;
   std::function<std::string(const std::string&)> key_retriever_;
-  milvus_storage::MetadataCache cache_;
 };
 
 static inline arrow::Result<std::pair<uint32_t, int64_t>> get_index_and_offset_of_file(
@@ -153,7 +152,9 @@ arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupLazyReaderImpl<ReaderT>::open
   }
 
   auto file = column_group_->files[file_index];
-  if (!cache_.enabled()) {
+  const bool cache_enabled =
+      GetValueNoError<bool>(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE) && !key_retriever_;
+  if (!cache_enabled) {
     ARROW_ASSIGN_OR_RAISE(auto reader, FormatReader::create(schema_, column_group_->format, file, properties_,
                                                             needed_columns_, key_retriever_));
     auto typed_reader = std::dynamic_pointer_cast<ReaderT>(reader);
@@ -163,11 +164,13 @@ arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupLazyReaderImpl<ReaderT>::open
     }
     return typed_reader;
   } else {
-    auto key = ReaderT::MetaTrait::cache_key(file);
-    ARROW_ASSIGN_OR_RAISE(auto metadata, cache_.get<ReaderT>()->get_or_open(key, [this, file]() {
-      return FormatReader::load_metadata<ReaderT>(file, properties_, key_retriever_);
-    }));
-    return FormatReader::create_from_metadata<ReaderT>(metadata, file, schema_, needed_columns_, "");
+    ARROW_ASSIGN_OR_RAISE(auto key,
+                          MakeFormatReaderMetadataCacheKey(file, properties_, ReaderT::MetaTrait::cache_key(file)));
+    ARROW_ASSIGN_OR_RAISE(auto metadata,
+                          GetGlobalFormatReaderMetadataCache<ReaderT>()->get_or_open(key, [this, file]() {
+                            return FormatReader::load_metadata<ReaderT>(file, properties_, key_retriever_);
+                          }));
+    return FormatReader::create_from_metadata<ReaderT>(metadata, file, properties_, schema_, needed_columns_, "");
   }
 
   return arrow::Status::Invalid("Unreachable code");
@@ -288,27 +291,22 @@ ColumnGroupLazyReaderImpl<ReaderT>::ColumnGroupLazyReaderImpl(
     const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
     const milvus_storage::api::Properties& properties,
     const std::vector<std::string>& needed_columns,
-    const std::function<std::string(const std::string&)>& key_retriever,
-    const milvus_storage::MetadataCache& cache)
+    const std::function<std::string(const std::string&)>& key_retriever)
     : schema_(schema),
       column_group_(column_group),
       properties_(properties),
       needed_columns_(needed_columns),
-      key_retriever_(key_retriever),
-      cache_(cache) {}
+      key_retriever_(key_retriever) {}
 
 arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> ColumnGroupLazyReader::create(
     const std::shared_ptr<arrow::Schema>& schema,
     const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
     const milvus_storage::api::Properties& properties,
     const std::vector<std::string>& needed_columns,
-    const std::function<std::string(const std::string&)>& key_retriever,
-    const milvus_storage::MetadataCache& cache) {
+    const std::function<std::string(const std::string&)>& key_retriever) {
   if (!column_group) {
     return arrow::Status::Invalid("Column group cannot be null");
   }
-  const bool cache_enabled =
-      cache.enabled() && GetValueNoError<bool>(properties, PROPERTY_READER_METADATA_CACHE_ENABLE);
 
   std::shared_ptr<arrow::Schema> out_schema;
   std::vector<std::string> filtered_columns;
@@ -331,25 +329,25 @@ arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> ColumnGroupLazyReader::cre
   // When schema is nullptr, out_schema stays nullptr;
   // the RecordBatches returned by the format reader will carry the file schema.
 
-  auto create_reader = [&](const milvus_storage::MetadataCache& metadata_cache) {
-    return metadata_cache.dispatch(
-        column_group->format, [&](auto typed_cache) -> arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> {
-          if (!typed_cache) {
-            return arrow::Status::Invalid("Format reader metadata cache is null");
-          }
-
-          using TypedCache = typename decltype(typed_cache)::element_type;
-          using ReaderT = typename TypedCache::ReaderType;
-          return std::make_unique<ColumnGroupLazyReaderImpl<ReaderT>>(out_schema, column_group, properties,
-                                                                      filtered_columns, key_retriever, metadata_cache);
-        });
+  auto create_reader = [&]<typename ReaderT>() -> arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> {
+    return std::make_unique<ColumnGroupLazyReaderImpl<ReaderT>>(out_schema, column_group, properties, filtered_columns,
+                                                                key_retriever);
   };
 
-  if (!cache_enabled) {
-    return create_reader(milvus_storage::MetadataCache(false));
+  if (column_group->format == LOON_FORMAT_PARQUET) {
+    return create_reader.template operator()<parquet::ParquetFormatReader>();
+  }
+  if (column_group->format == LOON_FORMAT_VORTEX) {
+    return create_reader.template operator()<vortex::VortexFormatReader>();
+  }
+  if (column_group->format == LOON_FORMAT_LANCE_TABLE) {
+    return create_reader.template operator()<lance::LanceTableReader>();
+  }
+  if (column_group->format == LOON_FORMAT_ICEBERG_TABLE) {
+    return create_reader.template operator()<iceberg::IcebergFormatReader>();
   }
 
-  return create_reader(cache);
+  return arrow::Status::Invalid("Unknown column group format: ", column_group->format);
 }
 
 };  // namespace milvus_storage::api

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -40,6 +40,7 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/macro.h"  // for UNLIKELY
 #include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
@@ -49,6 +50,7 @@ namespace milvus_storage::api {
 
 using milvus_storage::RowGroupInfo;
 using ChunkRBMapResult = arrow::Result<std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>>;
+
 struct ChunkInfo {
   public:
   size_t file_index;               // current chunk belong which file
@@ -70,7 +72,6 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
                         const milvus_storage::api::Properties& properties,
                         const std::vector<std::string>& needed_columns,
                         const std::function<std::string(const std::string&)>& key_retriever,
-                        const milvus_storage::MetadataCache& cache,
                         const std::string& predicate = "");
 
   ~ColumnGroupReaderImpl() override = default;
@@ -100,7 +101,6 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
   milvus_storage::api::Properties properties_;
   std::vector<std::string> needed_columns_;
   std::function<std::string(const std::string&)> key_retriever_;
-  milvus_storage::MetadataCache cache_;
   std::string predicate_;
 
   // will be initialized after call open()
@@ -144,30 +144,15 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
           fmt::format("Invalid start/end index in [file_index={}, path={}]", file_idx, cg_file.path));
     }
 
-    std::vector<RowGroupInfo> row_group_in_file;
-    if (cache_.enabled()) {
-      auto key = ReaderT::MetaTrait::cache_key(cg_file);
-      ARROW_ASSIGN_OR_RAISE(auto metadata, cache_.get<ReaderT>()->get_or_open(key, [this, cg_file]() {
-        return FormatReader::load_metadata<ReaderT>(cg_file, properties_, key_retriever_);
-      }));
-      row_group_in_file = metadata->row_group_infos;
-      if (!file_schema_ && metadata->file_schema) {
-        file_schema_ = metadata->file_schema;
-      }
-    } else {
-      ARROW_ASSIGN_OR_RAISE(format_readers_[file_idx], open_reader_for_file(file_idx));
-      ARROW_ASSIGN_OR_RAISE(row_group_in_file, format_readers_[file_idx]->get_row_group_infos());
-      if (!file_schema_) {
-        file_schema_ = format_readers_[file_idx]->get_schema();
-      }
-    }
-    row_group_infos_[file_idx] = row_group_in_file;
-    if (row_group_in_file.empty()) {
-      continue;
+    ARROW_ASSIGN_OR_RAISE(format_readers_[file_idx], open_reader_for_file(file_idx));
+    ARROW_ASSIGN_OR_RAISE(row_group_infos_[file_idx], format_readers_[file_idx]->get_row_group_infos());
+    if (!file_schema_) {
+      file_schema_ = format_readers_[file_idx]->get_schema();
     }
 
-    if (cache_.enabled()) {
-      ARROW_ASSIGN_OR_RAISE(format_readers_[file_idx], open_reader_for_file(file_idx));
+    const auto& row_group_in_file = row_group_infos_[file_idx];
+    if (row_group_in_file.empty()) {
+      continue;
     }
 
     size_t rows_in_file = 0;
@@ -231,7 +216,9 @@ arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupReaderImpl<ReaderT>::open_rea
   }
 
   auto file = column_group_->files[file_index];
-  if (!cache_.enabled()) {
+  const bool cache_enabled =
+      GetValueNoError<bool>(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE) && !key_retriever_;
+  if (!cache_enabled) {
     ARROW_ASSIGN_OR_RAISE(auto reader, FormatReader::create(schema_, column_group_->format, file, properties_,
                                                             needed_columns_, key_retriever_));
     if (!predicate_.empty()) {
@@ -250,11 +237,14 @@ arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupReaderImpl<ReaderT>::open_rea
     }
     return typed_reader;
   } else {
-    auto key = ReaderT::MetaTrait::cache_key(file);
-    ARROW_ASSIGN_OR_RAISE(auto metadata, cache_.get<ReaderT>()->get_or_open(key, [this, file]() {
-      return FormatReader::load_metadata<ReaderT>(file, properties_, key_retriever_);
-    }));
-    return FormatReader::create_from_metadata<ReaderT>(metadata, file, schema_, needed_columns_, predicate_);
+    ARROW_ASSIGN_OR_RAISE(auto key,
+                          MakeFormatReaderMetadataCacheKey(file, properties_, ReaderT::MetaTrait::cache_key(file)));
+    ARROW_ASSIGN_OR_RAISE(auto metadata,
+                          GetGlobalFormatReaderMetadataCache<ReaderT>()->get_or_open(key, [this, file]() {
+                            return FormatReader::load_metadata<ReaderT>(file, properties_, key_retriever_);
+                          }));
+    return FormatReader::create_from_metadata<ReaderT>(metadata, file, properties_, schema_, needed_columns_,
+                                                       predicate_);
   }
 
   return arrow::Status::Invalid("Unreachable code");
@@ -540,14 +530,12 @@ ColumnGroupReaderImpl<ReaderT>::ColumnGroupReaderImpl(
     const api::Properties& properties,
     const std::vector<std::string>& needed_columns,
     const std::function<std::string(const std::string&)>& key_retriever,
-    const milvus_storage::MetadataCache& cache,
     const std::string& predicate)
     : schema_(schema),
       column_group_(column_group),
       properties_(properties),
       needed_columns_(needed_columns),
       key_retriever_(key_retriever),
-      cache_(cache),
       predicate_(predicate) {}
 
 arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
@@ -556,13 +544,10 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     const std::vector<std::string>& needed_columns,
     const milvus_storage::api::Properties& properties,
     const std::function<std::string(const std::string&)>& key_retriever,
-    const std::string& predicate,
-    const milvus_storage::MetadataCache& cache) {
+    const std::string& predicate) {
   if (!column_group) {
     return arrow::Status::Invalid("Column group cannot be null");
   }
-  const bool cache_enabled =
-      cache.enabled() && GetValueNoError<bool>(properties, PROPERTY_READER_METADATA_CACHE_ENABLE);
 
   // Generate the output schema with only the needed columns
   std::shared_ptr<arrow::Schema> out_schema;
@@ -588,27 +573,27 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     out_schema = std::make_shared<arrow::Schema>(fields);
   }
 
-  auto create_reader = [&](const milvus_storage::MetadataCache& metadata_cache) {
-    return metadata_cache.dispatch(
-        column_group->format, [&](auto typed_cache) -> arrow::Result<std::unique_ptr<ColumnGroupReader>> {
-          if (!typed_cache) {
-            return arrow::Status::Invalid("Format reader metadata cache is null");
-          }
-
-          using TypedCache = typename decltype(typed_cache)::element_type;
-          using ReaderT = typename TypedCache::ReaderType;
-          std::unique_ptr<ColumnGroupReader> reader = std::make_unique<ColumnGroupReaderImpl<ReaderT>>(
-              out_schema, column_group, properties, filtered_columns, key_retriever, metadata_cache, predicate);
-          ARROW_RETURN_NOT_OK(reader->open());
-          return reader;
-        });
+  auto create_reader = [&]<typename ReaderT>() -> arrow::Result<std::unique_ptr<ColumnGroupReader>> {
+    std::unique_ptr<ColumnGroupReader> reader = std::make_unique<ColumnGroupReaderImpl<ReaderT>>(
+        out_schema, column_group, properties, filtered_columns, key_retriever, predicate);
+    ARROW_RETURN_NOT_OK(reader->open());
+    return reader;
   };
 
-  if (!cache_enabled) {
-    return create_reader(milvus_storage::MetadataCache(false));
+  if (column_group->format == LOON_FORMAT_PARQUET) {
+    return create_reader.template operator()<parquet::ParquetFormatReader>();
+  }
+  if (column_group->format == LOON_FORMAT_VORTEX) {
+    return create_reader.template operator()<vortex::VortexFormatReader>();
+  }
+  if (column_group->format == LOON_FORMAT_LANCE_TABLE) {
+    return create_reader.template operator()<lance::LanceTableReader>();
+  }
+  if (column_group->format == LOON_FORMAT_ICEBERG_TABLE) {
+    return create_reader.template operator()<iceberg::IcebergFormatReader>();
   }
 
-  return create_reader(cache);
+  return arrow::Status::Invalid("Unknown column group format: ", column_group->format);
 }
 
 }  // namespace milvus_storage::api

--- a/cpp/src/format/format_reader_cache.cpp
+++ b/cpp/src/format/format_reader_cache.cpp
@@ -15,8 +15,13 @@
 #include "milvus-storage/format/format_reader_cache.h"
 
 #include <exception>
+#include <memory>
+#include <string>
 #include <utility>
+#include <variant>
 
+#include "milvus-storage/common/lru_memory_cache.h"
+#include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
@@ -24,17 +29,73 @@
 
 namespace milvus_storage {
 
-MetadataCache::MetadataCache(bool enabled) : enabled_(enabled) {}
+constexpr uint64_t kDefaultMetadataCacheCapacityBytes = 1ULL * 1024 * 1024 * 1024;
+
+using GlobalFormatReaderMetadataCaches = FormatReaderMetadataCaches<parquet::ParquetFormatReader,
+                                                                    vortex::VortexFormatReader,
+                                                                    lance::LanceTableReader,
+                                                                    iceberg::IcebergFormatReader>;
+
+using GlobalCompletedMetadata = std::variant<FormatReaderMetadataCache<parquet::ParquetFormatReader>::MetadataPtr,
+                                             FormatReaderMetadataCache<vortex::VortexFormatReader>::MetadataPtr,
+                                             FormatReaderMetadataCache<lance::LanceTableReader>::MetadataPtr,
+                                             FormatReaderMetadataCache<iceberg::IcebergFormatReader>::MetadataPtr>;
+
+LRUMemoryCache<std::string, GlobalCompletedMetadata>& GlobalCompletedMetadataCache() {
+  static LRUMemoryCache<std::string, GlobalCompletedMetadata> cache(kDefaultMetadataCacheCapacityBytes);
+  return cache;
+}
+
+GlobalFormatReaderMetadataCaches& GlobalTypedMetadataCaches() {
+  static GlobalFormatReaderMetadataCaches caches;
+  return caches;
+}
+
+template <typename ReaderT>
+std::optional<typename FormatReaderMetadataCache<ReaderT>::MetadataPtr> GetGlobalMetadata(const std::string& key) {
+  auto cached = GlobalCompletedMetadataCache().get(key);
+  if (!cached.has_value()) {
+    return std::nullopt;
+  }
+
+  using MetadataPtr = typename FormatReaderMetadataCache<ReaderT>::MetadataPtr;
+  auto* metadata = std::get_if<MetadataPtr>(&cached.value());
+  if (metadata == nullptr) {
+    return std::nullopt;
+  }
+  return *metadata;
+}
+
+template <typename ReaderT>
+bool PutGlobalMetadata(const std::string& key,
+                       typename FormatReaderMetadataCache<ReaderT>::MetadataPtr metadata,
+                       uint64_t size_bytes) {
+  return GlobalCompletedMetadataCache().put(key, GlobalCompletedMetadata{std::move(metadata)}, size_bytes);
+}
+
+void InitMetadataCache(uint64_t capacity_bytes) { GlobalCompletedMetadataCache().set_capacity(capacity_bytes); }
+
+void ClearMetadataCache() { GlobalCompletedMetadataCache().clear(); }
+
+arrow::Result<std::string> MakeFormatReaderMetadataCacheKey(const api::ColumnGroupFile& file,
+                                                            const api::Properties& properties,
+                                                            const std::string& format_cache_key) {
+  ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, file.path));
+  return format_cache_key + "|fs_cache_key=" + fs_config.GetCacheKey();
+}
+
+template <typename ReaderT>
+std::shared_ptr<FormatReaderMetadataCache<ReaderT>> GetGlobalFormatReaderMetadataCache() {
+  static_assert(FormatReaderWithMetadata<ReaderT>,
+                "ReaderT must derive from FormatReader and define MetaTrait with Payload, Metadata, MetadataPtr, "
+                "cache_key, load_metadata, and create_from_metadata.");
+  return GlobalTypedMetadataCaches().get<ReaderT>();
+}
 
 template <typename ReaderT>
 std::optional<typename FormatReaderMetadataCache<ReaderT>::MetadataPtr> FormatReaderMetadataCache<ReaderT>::get(
     const std::string& key) const {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto it = entries_.find(key);
-  if (it == entries_.end()) {
-    return std::nullopt;
-  }
-  return it->second.metadata;
+  return GetGlobalMetadata<ReaderT>(key);
 }
 
 template <typename ReaderT>
@@ -44,8 +105,8 @@ arrow::Status FormatReaderMetadataCache<ReaderT>::add(
     return arrow::Status::Invalid("Cannot add null format reader metadata to cache");
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  entries_[std::move(key)] = Entry{std::move(metadata)};
+  const auto size_bytes = metadata->cache_size;
+  PutGlobalMetadata<ReaderT>(key, std::move(metadata), size_bytes);
   return arrow::Status::OK();
 }
 
@@ -55,9 +116,9 @@ arrow::Result<typename FormatReaderMetadataCache<ReaderT>::MetadataPtr> FormatRe
   std::shared_ptr<InFlightLoad> in_flight_load;
   {
     std::unique_lock<std::mutex> lock(mutex_);
-    auto cached = entries_.find(key);
-    if (cached != entries_.end()) {
-      return cached->second.metadata;
+    auto cached = GetGlobalMetadata<ReaderT>(key);
+    if (cached.has_value()) {
+      return cached.value();
     }
 
     auto [it, inserted] = in_flight_loads_.try_emplace(key, std::make_shared<InFlightLoad>());
@@ -91,11 +152,11 @@ arrow::Result<typename FormatReaderMetadataCache<ReaderT>::MetadataPtr> FormatRe
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (status.ok()) {
-      auto cached = entries_.find(key);
-      if (cached != entries_.end()) {
-        metadata = cached->second.metadata;
-      } else {
-        entries_.emplace(key, Entry{metadata});
+      auto cached = GetGlobalMetadata<ReaderT>(key);
+      if (cached.has_value()) {
+        metadata = cached.value();
+      } else if (metadata->cache_size != 0) {
+        PutGlobalMetadata<ReaderT>(key, metadata, metadata->cache_size);
       }
     }
 
@@ -111,6 +172,15 @@ arrow::Result<typename FormatReaderMetadataCache<ReaderT>::MetadataPtr> FormatRe
   }
   return metadata;
 }
+
+template std::shared_ptr<FormatReaderMetadataCache<parquet::ParquetFormatReader>>
+GetGlobalFormatReaderMetadataCache<parquet::ParquetFormatReader>();
+template std::shared_ptr<FormatReaderMetadataCache<vortex::VortexFormatReader>>
+GetGlobalFormatReaderMetadataCache<vortex::VortexFormatReader>();
+template std::shared_ptr<FormatReaderMetadataCache<lance::LanceTableReader>>
+GetGlobalFormatReaderMetadataCache<lance::LanceTableReader>();
+template std::shared_ptr<FormatReaderMetadataCache<iceberg::IcebergFormatReader>>
+GetGlobalFormatReaderMetadataCache<iceberg::IcebergFormatReader>();
 
 template class FormatReaderMetadataCache<parquet::ParquetFormatReader>;
 template class FormatReaderMetadataCache<vortex::VortexFormatReader>;

--- a/cpp/src/format/iceberg/iceberg_format_reader.cpp
+++ b/cpp/src/format/iceberg/iceberg_format_reader.cpp
@@ -186,6 +186,10 @@ std::string IcebergFormatReader::MetaTrait::cache_key(const api::ColumnGroupFile
   std::string key = fmt::format("iceberg:path={};file_size={};footer_size={}", file.path, file_size, footer_size);
   auto metadata_it = file.properties.find(api::kPropertyMetadata);
   if (metadata_it != file.properties.end()) {
+    // FIXME: Current Iceberg planning keeps positional delete files under the same table storage
+    // configuration as the data file, so the data-file FS identity added by
+    // MakeFormatReaderMetadataCacheKey is enough. If future versions allow delete files to resolve
+    // through separate extfs/credential configs, include each delete file's FS identity in the cache key.
     key += fmt::format(";delete_metadata_size={};delete_metadata={}", metadata_it->second.size(), metadata_it->second);
   }
   return key;
@@ -218,7 +222,6 @@ arrow::Result<IcebergFormatReader::MetaTrait::MetadataPtr> IcebergFormatReader::
   metadata->payload.data_metadata = std::move(data_metadata);
   metadata->payload.data_file_uri = file.path;
   metadata->payload.delete_metadata = std::move(delete_metadata);
-  metadata->payload.properties = properties;
   metadata->payload.deleted_positions = std::move(deleted_positions);
   metadata->payload.sorted_deletions = std::move(sorted_deletions);
 
@@ -229,6 +232,7 @@ arrow::Result<IcebergFormatReader::MetaTrait::MetadataPtr> IcebergFormatReader::
 arrow::Result<std::shared_ptr<IcebergFormatReader>> IcebergFormatReader::MetaTrait::create_from_metadata(
     MetadataPtr metadata,
     const api::ColumnGroupFile& file,
+    const api::Properties& properties,
     const std::shared_ptr<arrow::Schema>& read_schema,
     const std::vector<std::string>& needed_columns,
     const std::string& predicate) {
@@ -242,7 +246,7 @@ arrow::Result<std::shared_ptr<IcebergFormatReader>> IcebergFormatReader::MetaTra
 
   ARROW_ASSIGN_OR_RAISE(auto inner_reader,
                         parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
-                            metadata->payload.data_metadata, file, read_schema, needed_columns, predicate));
+                            metadata->payload.data_metadata, file, properties, read_schema, needed_columns, predicate));
   auto deleted_positions =
       metadata->payload.deleted_positions ? metadata->payload.deleted_positions : EmptyDeletedPositions();
   auto sorted_deletions =
@@ -250,9 +254,9 @@ arrow::Result<std::shared_ptr<IcebergFormatReader>> IcebergFormatReader::MetaTra
   ARROW_ASSIGN_OR_RAISE(auto projected_schema, build_projected_schema(metadata->file_schema, needed_columns));
 
   return std::shared_ptr<IcebergFormatReader>(new IcebergFormatReader(
-      std::move(inner_reader), metadata->payload.data_file_uri, metadata->payload.properties,
-      metadata->payload.delete_metadata, std::move(deleted_positions), std::move(sorted_deletions),
-      metadata->row_group_infos, needed_columns, std::move(projected_schema)));
+      std::move(inner_reader), metadata->payload.data_file_uri, properties, metadata->payload.delete_metadata,
+      std::move(deleted_positions), std::move(sorted_deletions), metadata->row_group_infos, needed_columns,
+      std::move(projected_schema)));
 }
 
 IcebergFormatReader::IcebergFormatReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,

--- a/cpp/src/format/lance/lance_format.cpp
+++ b/cpp/src/format/lance/lance_format.cpp
@@ -18,6 +18,8 @@
 #include "milvus-storage/format/lance/lance_common.h"
 #include "milvus-storage/filesystem/fs.h"
 
+#include <string>
+
 #ifdef BUILD_GTEST
 #include "milvus-storage/format/lance/lance_table_writer.h"
 #endif
@@ -35,6 +37,7 @@ arrow::Result<std::vector<api::ColumnGroupFile>> LanceFormat::explore(const std:
 
   auto dataset = lance::BlockingDataset::Open(lance_base_uri, storage_options);
   auto fragment_ids = dataset->GetAllFragmentIds();
+  auto table_version = dataset->Version();
 
   std::vector<api::ColumnGroupFile> files;
   for (auto frag_id : fragment_ids) {
@@ -46,7 +49,7 @@ arrow::Result<std::vector<api::ColumnGroupFile>> LanceFormat::explore(const std:
         lance::MakeLanceUri(lance::ToMilvusLanceUri(lance_base_uri, fs_config.address), frag_id),
         0,
         static_cast<int64_t>(row_count),
-        {},
+        {{lance::kLanceTableVersionProperty, std::to_string(table_version)}},
     });
   }
 

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -111,6 +111,10 @@ std::string LanceTableReader::MetaTrait::cache_key(const milvus_storage::api::Co
   auto cache_key = fmt::format("lance-table|path:{}|file_size:{}|footer_size:{}", file.path,
                                file.Get<uint64_t>(milvus_storage::api::kPropertyFileSize),
                                file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize));
+  auto table_version_it = file.properties.find(kLanceTableVersionProperty);
+  if (table_version_it != file.properties.end()) {
+    cache_key += fmt::format("|{}:{}", kLanceTableVersionProperty, table_version_it->second);
+  }
   auto metadata_it = file.properties.find(milvus_storage::api::kPropertyMetadata);
   if (metadata_it != file.properties.end()) {
     cache_key += "|metadata:" + metadata_it->second;
@@ -165,14 +169,20 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
   ARROW_ASSIGN_OR_RAISE(auto logical_chunk_rows,
                         milvus_storage::api::GetValue<uint64_t>(properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
 
+  const auto has_table_version = file.properties.find(kLanceTableVersionProperty) != file.properties.end();
+
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key(file);
   metadata->path = file.path;
   metadata->file_schema = std::move(file_schema);
   metadata->row_group_infos = create_row_group_infos(logical_rows, logical_chunk_rows);
-  metadata->cache_size = file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize);
-  if (metadata->cache_size == 0) {
-    metadata->cache_size = sizeof(Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo);
+  if (has_table_version) {
+    metadata->cache_size =
+        dataset->ManifestDeepSize() + sizeof(Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo);
+  } else {
+    // Older column group files do not carry the table version, so keep them
+    // readable but do not retain their metadata in the global cache.
+    metadata->cache_size = 0;
   }
   metadata->payload = Payload{
       .base_uri = std::move(base_uri),
@@ -182,7 +192,6 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
       .physical_row_count = physical_rows,
       .num_deletions = physical_rows - logical_rows,
       .logical_chunk_rows = logical_chunk_rows,
-      .properties = properties,
   };
 
   MetadataPtr result = metadata;
@@ -192,6 +201,7 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
 arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::create_from_metadata(
     MetadataPtr metadata,
     const milvus_storage::api::ColumnGroupFile& file,
+    const milvus_storage::api::Properties& properties,
     const std::shared_ptr<arrow::Schema>& read_schema,
     const std::vector<std::string>& needed_columns,
     const std::string& predicate) {
@@ -204,13 +214,16 @@ arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::cr
     return arrow::Status::Invalid("Cannot open Lance reader from metadata with null dataset");
   }
 
+  ARROW_ASSIGN_OR_RAISE(auto logical_chunk_rows,
+                        milvus_storage::api::GetValue<uint64_t>(properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
+
   auto reader = std::make_shared<LanceTableReader>(metadata->payload.dataset, metadata->payload.fragment_id,
-                                                   read_schema, metadata->payload.properties, needed_columns);
+                                                   read_schema, properties, needed_columns);
   reader->uri_ = metadata->payload.base_uri;
   reader->file_schema_ = metadata->file_schema;
-  reader->logical_chunk_rows_ = metadata->payload.logical_chunk_rows;
+  reader->logical_chunk_rows_ = logical_chunk_rows;
   reader->num_deletions_ = metadata->payload.num_deletions;
-  reader->row_group_infos_ = metadata->row_group_infos;
+  reader->row_group_infos_ = create_row_group_infos(metadata->payload.logical_row_count, logical_chunk_rows);
 
   ARROW_ASSIGN_OR_RAISE(auto requested_schema, build_read_schema(reader->file_schema_, read_schema, needed_columns));
   ArrowSchema c_arrow_schema;

--- a/cpp/src/format/lance/lance_table_writer.cpp
+++ b/cpp/src/format/lance/lance_table_writer.cpp
@@ -147,9 +147,15 @@ arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
   // so the reader can resolve the right extfs.<alias>.* by address+bucket. The
   // reader strips address back to standard form before handing to Lance.
   auto milvus_lance_uri = ToMilvusLanceUri(lance_uri, fs_config.address);
+  auto table_version = dataset_->Version();
 
   if (current_fids.size() == origin_fids_.size()) {
-    return api::ColumnGroupFile{.path = milvus_lance_uri, .start_index = 0, .end_index = written_rows_};
+    return api::ColumnGroupFile{
+        .path = milvus_lance_uri,
+        .start_index = 0,
+        .end_index = written_rows_,
+        .properties = {{kLanceTableVersionProperty, std::to_string(table_version)}},
+    };
   }
 
   if (!fids_contains(origin_fids_, current_fids)) {
@@ -165,6 +171,7 @@ arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
       .path = MakeLanceUri(milvus_lance_uri, append_fids[0]),
       .start_index = 0,
       .end_index = written_rows_,
+      .properties = {{kLanceTableVersionProperty, std::to_string(table_version)}},
   };
 }
 

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -321,12 +321,10 @@ arrow::Result<ParquetFormatReader::MetaTrait::MetadataPtr> ParquetFormatReader::
   metadata->file_schema = std::move(file_schema);
   metadata->row_group_infos = std::move(row_group_infos);
   metadata->cache_size = footer_buffer ? static_cast<uint64_t>(footer_buffer->size()) : parquet_metadata->size();
-  metadata->payload.fs = std::move(fs);
   metadata->payload.footer_buffer = std::move(footer_buffer);
   if (!metadata->payload.footer_buffer && !key_retriever) {
     metadata->payload.parquet_metadata = std::move(parquet_metadata);
   }
-  metadata->payload.properties = properties;
   metadata->payload.key_retriever = key_retriever;
 
   MetadataPtr metadata_ptr = std::move(metadata);
@@ -336,15 +334,12 @@ arrow::Result<ParquetFormatReader::MetaTrait::MetadataPtr> ParquetFormatReader::
 arrow::Result<std::shared_ptr<ParquetFormatReader>> ParquetFormatReader::MetaTrait::create_from_metadata(
     MetadataPtr metadata,
     const api::ColumnGroupFile& file,
+    const api::Properties& properties,
     const std::shared_ptr<arrow::Schema>& /*read_schema*/,
     const std::vector<std::string>& needed_columns,
     const std::string& /*predicate*/) {
   if (!metadata) {
     return arrow::Status::Invalid("Cannot open parquet reader from null metadata");
-  }
-  if (!metadata->payload.fs) {
-    return arrow::Status::Invalid(
-        fmt::format("Cannot open parquet reader from metadata without filesystem. [path={}]", metadata->path));
   }
   if (!metadata->payload.key_retriever && !metadata->payload.footer_buffer && !metadata->payload.parquet_metadata) {
     return arrow::Status::Invalid(
@@ -366,15 +361,14 @@ arrow::Result<std::shared_ptr<ParquetFormatReader>> ParquetFormatReader::MetaTra
 
   const auto file_size = file.Get<uint64_t>(api::kPropertyFileSize);
   const auto footer_size = file.Get<uint64_t>(api::kPropertyFooterSize);
+  ARROW_ASSIGN_OR_RAISE(auto fs, FilesystemCache::getInstance().get(properties, file.path));
 
-  ARROW_ASSIGN_OR_RAISE(
-      auto file_reader,
-      create_parquet_file_reader(metadata->payload.fs, metadata->path, metadata->payload.properties,
-                                 metadata->payload.key_retriever, std::move(parquet_metadata), file_size, footer_size));
+  ARROW_ASSIGN_OR_RAISE(auto file_reader,
+                        create_parquet_file_reader(fs, metadata->path, properties, metadata->payload.key_retriever,
+                                                   std::move(parquet_metadata), file_size, footer_size));
 
-  auto reader =
-      std::make_shared<ParquetFormatReader>(metadata->payload.fs, metadata->path, metadata->payload.properties,
-                                            needed_columns, metadata->payload.key_retriever, file_size, footer_size);
+  auto reader = std::make_shared<ParquetFormatReader>(fs, metadata->path, properties, needed_columns,
+                                                      metadata->payload.key_retriever, file_size, footer_size);
   reader->schema_ = metadata->file_schema;
   reader->row_group_infos_ = metadata->row_group_infos;
   reader->file_reader_ = std::shared_ptr<::parquet::arrow::FileReader>(std::move(file_reader));

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -25,12 +25,13 @@
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
 #include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
-#include <arrow/status.h>
-#include <arrow/result.h>
 #include <fmt/format.h>
 
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/filesystem/fs.h"
 
 namespace milvus_storage::vortex {
@@ -320,6 +321,20 @@ static uint64_t compute_total_mem_usage(const VortexFile& vxfile) {
   return total_size;
 }
 
+static arrow::Result<uint64_t> get_metadata_cache_size(uint64_t footer_size, const VortexFile& vxfile) {
+  if (footer_size != 0) {
+    return footer_size;
+  }
+
+  try {
+    FIU_DO_ON(FIUKEY_VORTEX_METADATA_CACHE_SIZE_FAIL,
+              { throw VortexException(fmt::format("Injected fault: {}", FIUKEY_VORTEX_METADATA_CACHE_SIZE_FAIL)); });
+    return vxfile.FooterSize();
+  } catch (const VortexException&) {
+    return uint64_t{0};
+  }
+}
+
 }  // namespace
 
 std::string VortexFormatReader::MetaTrait::cache_key(const api::ColumnGroupFile& file) {
@@ -355,19 +370,22 @@ arrow::Result<VortexFormatReader::MetaTrait::MetadataPtr> VortexFormatReader::Me
   const auto memory_usage = compute_total_mem_usage(*vxfile);
   auto row_group_infos =
       create_row_group_infos(memory_usage, vxfile->RowCount(), recalc_row_ranges(row_ranges, logical_chunk_rows));
+  auto row_count = vxfile->RowCount();
+  ARROW_ASSIGN_OR_RAISE(auto cache_size, get_metadata_cache_size(footer_size, *vxfile));
 
   auto metadata = std::make_shared<Metadata>(Metadata{
       .cache_key = std::move(key),
       .path = uri.key,
       .file_schema = std::move(file_schema),
       .row_group_infos = std::move(row_group_infos),
-      .cache_size = footer_size,
+      .cache_size = cache_size,
       .payload =
           Payload{
               .fs_holder = std::move(fs_holder),
               .vxfile = std::move(vxfile),
-              .logical_chunk_rows = logical_chunk_rows,
-              .properties = properties,
+              .row_ranges = std::move(row_ranges),
+              .row_count = row_count,
+              .memory_usage = memory_usage,
           },
   });
   return std::static_pointer_cast<const Metadata>(metadata);
@@ -376,19 +394,29 @@ arrow::Result<VortexFormatReader::MetaTrait::MetadataPtr> VortexFormatReader::Me
 arrow::Result<std::shared_ptr<VortexFormatReader>> VortexFormatReader::MetaTrait::create_from_metadata(
     MetadataPtr metadata,
     const api::ColumnGroupFile& file,
+    const api::Properties& properties,
     const std::shared_ptr<arrow::Schema>& read_schema,
     const std::vector<std::string>& needed_columns,
     const std::string& predicate) {
-  if (!metadata || !metadata->payload.vxfile || !metadata->payload.fs_holder) {
+  if (!metadata) {
+    return arrow::Status::Invalid("Cannot open vortex reader from null metadata");
+  }
+  if (!metadata->payload.vxfile || !metadata->payload.fs_holder) {
     return arrow::Status::Invalid("Cannot open vortex reader from incomplete metadata");
   }
 
+  ARROW_ASSIGN_OR_RAISE(auto logical_chunk_rows,
+                        api::GetValue<uint64_t>(properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
+  const auto file_size = file.Get<uint64_t>(api::kPropertyFileSize);
+  const auto footer_size = file.Get<uint64_t>(api::kPropertyFooterSize);
+  auto row_group_infos = create_row_group_infos(metadata->payload.memory_usage, metadata->payload.row_count,
+                                                recalc_row_ranges(metadata->payload.row_ranges, logical_chunk_rows));
+
   auto reader = std::shared_ptr<VortexFormatReader>(
-      new VortexFormatReader(metadata, file.Get<uint64_t>(api::kPropertyFileSize),
-                             file.Get<uint64_t>(api::kPropertyFooterSize), read_schema, needed_columns));
-  ARROW_ASSIGN_OR_RAISE(
-      auto split_row_indices_mode,
-      api::GetValue<std::string>(metadata->payload.properties, PROPERTY_READER_VORTEX_SPLIT_ROW_INDICES));
+      new VortexFormatReader(metadata, file_size, footer_size, properties, logical_chunk_rows,
+                             std::move(row_group_infos), read_schema, needed_columns));
+  ARROW_ASSIGN_OR_RAISE(auto split_row_indices_mode,
+                        api::GetValue<std::string>(properties, PROPERTY_READER_VORTEX_SPLIT_ROW_INDICES));
   ARROW_ASSIGN_OR_RAISE(reader->split_row_indices_,
                         VortexFormatReader::parse_split_row_indices_override(split_row_indices_mode));
   try {
@@ -433,18 +461,21 @@ arrow::Result<std::optional<bool>> VortexFormatReader::parse_split_row_indices_o
 VortexFormatReader::VortexFormatReader(MetaTrait::MetadataPtr metadata,
                                        uint64_t file_size,
                                        uint64_t footer_size,
+                                       milvus_storage::api::Properties properties,
+                                       uint64_t logical_chunk_rows,
+                                       std::vector<RowGroupInfo> row_group_infos,
                                        const std::shared_ptr<arrow::Schema>& read_schema,
                                        const std::vector<std::string>& needed_columns)
     : fs_holder_(metadata->payload.fs_holder),
       proj_cols_(needed_columns),
       path_(metadata->path),
       read_schema_(read_schema),
-      properties_(metadata->payload.properties),
+      properties_(std::move(properties)),
       file_size_(file_size),
       footer_size_(footer_size),
       file_schema_(metadata->file_schema),
-      logical_chunk_rows_(metadata->payload.logical_chunk_rows),
-      row_group_infos_(metadata->row_group_infos),
+      logical_chunk_rows_(logical_chunk_rows),
+      row_group_infos_(std::move(row_group_infos)),
       vxfile_(metadata->payload.vxfile) {
   if (read_schema_ && read_schema_->num_fields() == 0) {
     read_schema_ = nullptr;

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -15,7 +15,6 @@
 #include "milvus-storage/reader.h"
 
 #include <cstdio>
-#include <mutex>
 #include <memory>
 #include <numeric>
 #include <algorithm>
@@ -40,21 +39,12 @@
 
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/thread_pool.h"
-#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/column_group_reader.h"
 #include "milvus-storage/format/column_group_lazy_reader.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/common/macro.h"
 
 namespace milvus_storage::api {
-
-namespace {
-
-bool metadata_cache_enabled(const Properties& properties) {
-  return GetValueNoError<bool>(properties, PROPERTY_READER_METADATA_CACHE_ENABLE);
-}
-
-}  // namespace
 
 class PackedRecordBatchReader final : public arrow::RecordBatchReader {
   public:
@@ -67,14 +57,12 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
    * @param reader_props The reader properties.
    */
   PackedRecordBatchReader(const std::vector<std::shared_ptr<ColumnGroup>>& column_groups,
-                          MetadataCache metadata_cache,
                           const std::shared_ptr<arrow::Schema>& schema,
                           const std::vector<std::string>& needed_columns,
                           const Properties& properties,
                           const std::function<std::string(const std::string&)>& key_retriever,
                           const std::string& predicate = "")
       : column_groups_(column_groups),
-        metadata_cache_(std::move(metadata_cache)),
         schema_(schema),
         needed_columns_(needed_columns),
         out_field_map_(needed_columns.size()),
@@ -116,7 +104,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
     for (size_t i = 0; i < column_groups_.size(); ++i) {
       ARROW_ASSIGN_OR_RAISE(chunk_readers_[i],
                             ColumnGroupReader::create(schema_, column_groups_[i], needed_columns_, properties_,
-                                                      key_retriever_callback_, predicate_, metadata_cache_));
+                                                      key_retriever_callback_, predicate_));
       number_of_chunks_per_cg_[i] = chunk_readers_[i]->total_number_of_chunks();
       if (number_of_chunks_per_cg_[i] == 0) {
         return arrow::Status::Invalid(
@@ -459,7 +447,6 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
 
   private:
   std::vector<std::shared_ptr<ColumnGroup>> column_groups_;
-  MetadataCache metadata_cache_;
   std::shared_ptr<arrow::Schema> schema_;
   std::vector<std::string> needed_columns_;
   std::vector<std::pair<std::int32_t, std::int32_t>> out_field_map_;
@@ -508,8 +495,7 @@ class ChunkReaderImpl : public ChunkReader {
                   const std::shared_ptr<ColumnGroup>& column_group,
                   const std::vector<std::string>& needed_columns,
                   const Properties& properties,
-                  const std::function<std::string(const std::string&)>& key_retriever,
-                  MetadataCache metadata_cache);
+                  const std::function<std::string(const std::string&)>& key_retriever);
 
   // open the reader
   arrow::Status open();
@@ -534,7 +520,6 @@ class ChunkReaderImpl : public ChunkReader {
   std::vector<std::string> needed_columns_;    ///< Subset of columns to read (empty = all columns)
   Properties properties_;
   std::function<std::string(const std::string&)> key_retriever_callback_;
-  MetadataCache metadata_cache_;
   std::unique_ptr<ColumnGroupReader> chunk_reader_;
 };
 
@@ -544,14 +529,12 @@ ChunkReaderImpl::ChunkReaderImpl(const std::shared_ptr<arrow::Schema>& schema,
                                  const std::shared_ptr<ColumnGroup>& column_group,
                                  const std::vector<std::string>& needed_columns,
                                  const Properties& properties,
-                                 const std::function<std::string(const std::string&)>& key_retriever,
-                                 MetadataCache metadata_cache)
+                                 const std::function<std::string(const std::string&)>& key_retriever)
     : schema_(schema),
       column_group_(column_group),
       needed_columns_(needed_columns),
       properties_(properties),
-      key_retriever_callback_(key_retriever),
-      metadata_cache_(std::move(metadata_cache)) {}
+      key_retriever_callback_(key_retriever) {}
 
 arrow::Status ChunkReaderImpl::open() {
   // The case is:
@@ -580,7 +563,7 @@ arrow::Status ChunkReaderImpl::open() {
   }
 
   ARROW_ASSIGN_OR_RAISE(chunk_reader_, ColumnGroupReader::create(schema_, column_group_, needed_columns_, properties_,
-                                                                 key_retriever_callback_, "", metadata_cache_));
+                                                                 key_retriever_callback_, ""));
   return arrow::Status::OK();
 }
 
@@ -705,8 +688,7 @@ class ReaderImpl : public Reader {
         schema_(schema),
         needed_columns_(needed_columns),
         properties_(properties),
-        key_retriever_callback_(nullptr),
-        metadata_cache_(metadata_cache_enabled(properties)) {
+        key_retriever_callback_(nullptr) {
     // Validate required parameters
     assert(cgs_);
   }
@@ -733,10 +715,9 @@ class ReaderImpl : public Reader {
 
     ARROW_ASSIGN_OR_RAISE(auto resolved_columns, resolve_needed_columns(schema_, needed_columns_));
 
-    // Collect required column groups and share the ReaderImpl-owned metadata cache.
+    // Collect required column groups; format metadata is reused through the process-wide cache when enabled.
     auto needed_column_group_indices = collect_required_column_group_indices(resolved_columns);
     ARROW_ASSIGN_OR_RAISE(auto needed_column_groups, column_groups_from_indices(needed_column_group_indices));
-    auto metadata_cache = get_metadata_cache();
 
     // Build projected schema: from user-provided schema or nullptr
     std::shared_ptr<arrow::Schema> projected_schema = nullptr;
@@ -751,9 +732,8 @@ class ReaderImpl : public Reader {
       projected_schema = arrow::schema(needed_fields);
     }
 
-    auto reader =
-        std::make_shared<PackedRecordBatchReader>(needed_column_groups, std::move(metadata_cache), projected_schema,
-                                                  resolved_columns, properties_, key_retriever_callback_, predicate);
+    auto reader = std::make_shared<PackedRecordBatchReader>(needed_column_groups, projected_schema, resolved_columns,
+                                                            properties_, key_retriever_callback_, predicate);
     ARROW_RETURN_NOT_OK(reader->open());
     return reader;
   }
@@ -778,9 +758,8 @@ class ReaderImpl : public Reader {
     ARROW_ASSIGN_OR_RAISE(auto resolved_columns,
                           resolve_needed_columns(schema_, effective_needed_columns(needed_columns)));
 
-    auto metadata_cache = get_metadata_cache();
     auto chunk_reader = std::make_unique<ChunkReaderImpl>(schema_, column_group, resolved_columns, properties_,
-                                                          key_retriever_callback_, std::move(metadata_cache));
+                                                          key_retriever_callback_);
     ARROW_RETURN_NOT_OK(chunk_reader->open());
     return chunk_reader;
   }
@@ -811,9 +790,8 @@ class ReaderImpl : public Reader {
 
     auto needed_column_group_indices = collect_required_column_group_indices(resolved_columns);
     ARROW_ASSIGN_OR_RAISE(auto needed_column_groups, column_groups_from_indices(needed_column_group_indices));
-    auto metadata_cache = get_metadata_cache();
 
-    // Create lazy readers fresh each call; metadata is still reused through ReaderImpl-owned caches.
+    // Create lazy readers fresh each call; metadata is still reused through the process-wide cache.
     std::vector<std::unique_ptr<ColumnGroupLazyReader>> lazy_readers(needed_column_groups.size());
     for (size_t i = 0; i < needed_column_groups.size(); ++i) {
       if (!needed_column_groups[i]) {
@@ -821,7 +799,7 @@ class ReaderImpl : public Reader {
       }
       ARROW_ASSIGN_OR_RAISE(lazy_readers[i],
                             ColumnGroupLazyReader::create(schema_, needed_column_groups[i], properties_,
-                                                          resolved_columns, key_retriever_callback_, metadata_cache));
+                                                          resolved_columns, key_retriever_callback_));
     }
 
     for (const auto& lazy_reader : lazy_readers) {
@@ -886,8 +864,6 @@ class ReaderImpl : public Reader {
   Properties properties_;                                     ///< Configuration properties including encryption
   std::function<std::string(const std::string&)>
       key_retriever_callback_;  ///< Callback function for retrieving encryption keys
-  mutable std::mutex metadata_cache_mutex_;
-  MetadataCache metadata_cache_;
 
   /**
    * @brief Returns the per-call needed_columns if non-null and non-empty, otherwise falls back to the default.
@@ -1033,14 +1009,7 @@ class ReaderImpl : public Reader {
     return column_groups;
   }
 
-  MetadataCache get_metadata_cache() const {
-    std::lock_guard<std::mutex> lock(metadata_cache_mutex_);
-    return metadata_cache_;
-  }
-
   void set_keyretriever(const std::function<std::string(const std::string&)>& callback) override {
-    std::lock_guard<std::mutex> lock(metadata_cache_mutex_);
-    metadata_cache_ = MetadataCache(metadata_cache_enabled(properties_));
     key_retriever_callback_ = callback;
   }
 };

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -37,6 +37,7 @@
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/format/column_group_lazy_reader.h"
 #include "milvus-storage/format/column_group_reader.h"
+#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/column_group_writer.h"
 #include "milvus-storage/manifest.h"
 #include "milvus-storage/transaction/transaction.h"
@@ -1612,6 +1613,7 @@ TEST_P(APIWriterReaderTest, EnrypytionWriterReaderTest) {
   if (format != LOON_FORMAT_PARQUET) {
     GTEST_SKIP() << "CMEK test is only applicable for Parquet format currently.";
   }
+  milvus_storage::ClearMetadataCache();
 
   // Test CMEK integrationfile_reader.cc:304
   ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
@@ -1637,11 +1639,11 @@ TEST_P(APIWriterReaderTest, EnrypytionWriterReaderTest) {
   // Test reading with encryption
   auto reader = Reader::create(cgs, schema_, nullptr, properties);
   ASSERT_NE(reader, nullptr);
-  int called_keyretriever = 0;
-  std::string key_id_used;
-  reader->set_keyretriever([&called_keyretriever, &key_id_used](const std::string& key_id) -> std::string {
-    called_keyretriever++;
-    key_id_used = key_id;
+  int first_keyretriever_calls = 0;
+  std::string first_key_id_used;
+  reader->set_keyretriever([&first_keyretriever_calls, &first_key_id_used](const std::string& key_id) -> std::string {
+    first_keyretriever_calls++;
+    first_key_id_used = key_id;
     return "footer_key_16B__";
   });
 
@@ -1649,20 +1651,29 @@ TEST_P(APIWriterReaderTest, EnrypytionWriterReaderTest) {
   ASSERT_TRUE(batch_reader_result.ok()) << batch_reader_result.status().ToString();
   auto batch_reader = std::move(batch_reader_result).ValueOrDie();
   ASSERT_NE(batch_reader, nullptr);
-  ASSERT_GE(called_keyretriever, 1);
-  ASSERT_EQ(key_id_used, "encryption_meta_data");
+  ASSERT_GE(first_keyretriever_calls, 1);
+  ASSERT_EQ(first_key_id_used, "encryption_meta_data");
+
+  int second_keyretriever_calls = 0;
+  std::string second_key_id_used;
+  reader->set_keyretriever([&second_keyretriever_calls, &second_key_id_used](const std::string& key_id) -> std::string {
+    second_keyretriever_calls++;
+    second_key_id_used = key_id;
+    return "footer_key_16B__";
+  });
 
   auto chunk_reader_result = reader->get_chunk_reader(0);
   ASSERT_TRUE(chunk_reader_result.ok()) << chunk_reader_result.status().ToString();
   auto chunk_reader = std::move(chunk_reader_result).ValueOrDie();
   ASSERT_NE(chunk_reader, nullptr);
-  ASSERT_GE(called_keyretriever, 1);
-  ASSERT_EQ(key_id_used, "encryption_meta_data");
+  ASSERT_GE(second_keyretriever_calls, 1);
+  ASSERT_EQ(second_key_id_used, "encryption_meta_data");
 
   auto chunk_result = chunk_reader->get_chunk(0);
   ASSERT_TRUE(chunk_result.ok()) << chunk_result.status().ToString();
   ASSERT_NE(chunk_result.ValueOrDie(), nullptr);
-  ASSERT_GE(called_keyretriever, 1);
+  ASSERT_GE(second_keyretriever_calls, 1);
+  milvus_storage::ClearMetadataCache();
 }
 
 TEST_P(APIWriterReaderTest, DisabledMetadataCacheReopensEncryptedParquetMetadata) {

--- a/cpp/test/format/format_reader_cache_test.cpp
+++ b/cpp/test/format/format_reader_cache_test.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <future>
@@ -38,6 +39,7 @@
 #include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/iceberg/iceberg_common.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
+#include "milvus-storage/format/lance/lance_common.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
@@ -56,22 +58,18 @@ using TestMetadataCaches = FormatReaderMetadataCaches<parquet::ParquetFormatRead
                                                       lance::LanceTableReader,
                                                       iceberg::IcebergFormatReader>;
 
+constexpr uint64_t kDefaultTestMetadataCacheCapacity = 256 * 1024 * 1024;
+
 template <typename CacheT>
-typename CacheT::MetadataPtr MakeMetadata(std::string cache_key) {
+typename CacheT::MetadataPtr MakeMetadata(std::string cache_key, uint64_t cache_size = 1) {
   using Metadata = typename CacheT::Trait::Metadata;
 
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key;
   metadata->path = "/tmp/" + cache_key;
+  metadata->cache_size = cache_size;
   typename CacheT::MetadataPtr ptr = metadata;
   return ptr;
-}
-
-template <typename Visitor>
-arrow::Status VisitMetadataCacheForFormat(const std::string& format, Visitor&& visitor) {
-  MetadataCache cache;
-  return cache.dispatch(
-      format, [&](const auto& typed_cache) -> arrow::Status { return std::forward<Visitor>(visitor)(typed_cache); });
 }
 
 template <typename Visitor>
@@ -89,6 +87,23 @@ arrow::Status VisitFormatReaderMetadataCachesForFormat(const std::string& format
   }
   if (format == LOON_FORMAT_ICEBERG_TABLE) {
     return std::forward<Visitor>(visitor)(caches.get<iceberg::IcebergFormatReader>());
+  }
+  return arrow::Status::Invalid("Unknown column group format: ", format);
+}
+
+template <typename Visitor>
+arrow::Status VisitGlobalMetadataCacheForFormat(const std::string& format, Visitor&& visitor) {
+  if (format == LOON_FORMAT_PARQUET) {
+    return std::forward<Visitor>(visitor)(GetGlobalFormatReaderMetadataCache<parquet::ParquetFormatReader>());
+  }
+  if (format == LOON_FORMAT_VORTEX) {
+    return std::forward<Visitor>(visitor)(GetGlobalFormatReaderMetadataCache<vortex::VortexFormatReader>());
+  }
+  if (format == LOON_FORMAT_LANCE_TABLE) {
+    return std::forward<Visitor>(visitor)(GetGlobalFormatReaderMetadataCache<lance::LanceTableReader>());
+  }
+  if (format == LOON_FORMAT_ICEBERG_TABLE) {
+    return std::forward<Visitor>(visitor)(GetGlobalFormatReaderMetadataCache<iceberg::IcebergFormatReader>());
   }
   return arrow::Status::Invalid("Unknown column group format: ", format);
 }
@@ -119,6 +134,51 @@ arrow::Status ValidateChunkRead(const std::vector<std::shared_ptr<arrow::RecordB
     return arrow::Status::Invalid("unexpected row count: ", actual_rows, " != ", expected_rows);
   }
   return arrow::Status::OK();
+}
+
+template <typename CacheT>
+arrow::Status ExpectGlobalMetadataCacheEntries(const std::shared_ptr<api::ColumnGroups>& column_groups,
+                                               const std::shared_ptr<CacheT>& cache,
+                                               const std::string& format,
+                                               const api::Properties& properties,
+                                               bool expect_cached) {
+  using ReaderT = typename CacheT::ReaderType;
+
+  if (!column_groups) {
+    return arrow::Status::Invalid("column groups is null");
+  }
+
+  size_t checked_files = 0;
+  for (const auto& column_group : *column_groups) {
+    if (!column_group || column_group->format != format) {
+      continue;
+    }
+    for (const auto& file : column_group->files) {
+      ARROW_ASSIGN_OR_RAISE(auto key,
+                            MakeFormatReaderMetadataCacheKey(file, properties, ReaderT::MetaTrait::cache_key(file)));
+      auto cached = cache->get(key);
+      if (expect_cached) {
+        EXPECT_TRUE(cached.has_value()) << "Expected cached metadata for key: " << key;
+      } else {
+        EXPECT_FALSE(cached.has_value()) << "Unexpected cached metadata for key: " << key;
+      }
+      ++checked_files;
+    }
+  }
+
+  if (checked_files == 0) {
+    return arrow::Status::Invalid("no files checked for format: ", format);
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status ExpectGlobalMetadataCacheEntriesForFormat(const std::shared_ptr<api::ColumnGroups>& column_groups,
+                                                        const std::string& format,
+                                                        const api::Properties& properties,
+                                                        bool expect_cached) {
+  return VisitGlobalMetadataCacheForFormat(format, [&](const auto& cache) -> arrow::Status {
+    return ExpectGlobalMetadataCacheEntries(column_groups, cache, format, properties, expect_cached);
+  });
 }
 
 arrow::Status ReadProjectedChunks(api::Reader* reader,
@@ -324,11 +384,25 @@ arrow::Status RunSingleflightsConcurrentSameKey(const std::shared_ptr<CacheT>& c
 
 }  // namespace
 
-class FormatReaderMetadataCacheParamTest : public ::testing::TestWithParam<std::string> {};
+class FormatReaderMetadataCacheParamTest : public ::testing::TestWithParam<std::string> {
+  protected:
+  void SetUp() override {
+    InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+    ClearMetadataCache();
+  }
+
+  void TearDown() override {
+    InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+    ClearMetadataCache();
+  }
+};
 
 class FormatReaderMetadataCacheStressTest : public ::testing::TestWithParam<std::string> {
   protected:
   void SetUp() override {
+    InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+    ClearMetadataCache();
+
     ASSERT_STATUS_OK(InitTestProperties(properties_));
     ASSERT_AND_ASSIGN(fs_config_, GetFileSystemConfig(properties_));
     ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
@@ -346,8 +420,11 @@ class FormatReaderMetadataCacheStressTest : public ::testing::TestWithParam<std:
   }
 
   void TearDown() override {
-    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    auto delete_status = DeleteTestDir(fs_, base_path_);
     ThreadPoolHolder::Release();
+    InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+    ClearMetadataCache();
+    ASSERT_STATUS_OK(delete_status);
   }
 
   arrow::Result<std::shared_ptr<api::ColumnGroups>> WriteStressData(const std::string& format) {
@@ -604,46 +681,42 @@ TEST_P(FormatReaderMetadataCacheParamTest, FormatReaderMetadataCachesOwnsTypedCa
   }));
 }
 
-TEST_P(FormatReaderMetadataCacheParamTest, MetadataCacheOwnsTypedCache) {
-  MetadataCache cache;
-
-  ASSERT_STATUS_OK(cache.dispatch(GetParam(), [&](const auto& typed_cache) -> arrow::Status {
+TEST_P(FormatReaderMetadataCacheParamTest, GlobalMetadataCacheReturnsStableTypedCache) {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [&](const auto& typed_cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*typed_cache)>;
     using ReaderT = typename CacheT::ReaderType;
-    auto typed_cache_again = cache.get<ReaderT>();
+    auto typed_cache_again = GetGlobalFormatReaderMetadataCache<ReaderT>();
 
     if (!typed_cache || !typed_cache_again) {
-      return arrow::Status::Invalid("metadata cache returned null typed cache");
+      return arrow::Status::Invalid("global metadata cache returned null typed cache");
     }
     EXPECT_EQ(typed_cache.get(), typed_cache_again.get());
     return arrow::Status::OK();
   }));
 }
 
-TEST_P(FormatReaderMetadataCacheParamTest, MetadataCacheTracksEnabledStateAcrossCopies) {
-  MetadataCache enabled_cache;
-  EXPECT_TRUE(enabled_cache.enabled());
+TEST(FormatReaderMetadataCacheTest, GlobalCompletedMetadataCacheDoesNotCastWrongReaderType) {
+  InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+  ClearMetadataCache();
 
-  MetadataCache disabled_cache(false);
-  EXPECT_FALSE(disabled_cache.enabled());
+  using ParquetCache = FormatReaderMetadataCache<parquet::ParquetFormatReader>;
 
-  MetadataCache disabled_copy = disabled_cache;
-  EXPECT_FALSE(disabled_copy.enabled());
-  ASSERT_STATUS_OK(disabled_cache.dispatch(GetParam(), [&](const auto& original_cache) -> arrow::Status {
-    using CacheT = std::decay_t<decltype(*original_cache)>;
-    using ReaderT = typename CacheT::ReaderType;
-    auto copied_cache = disabled_copy.get<ReaderT>();
+  auto parquet_cache = GetGlobalFormatReaderMetadataCache<parquet::ParquetFormatReader>();
+  auto vortex_cache = GetGlobalFormatReaderMetadataCache<vortex::VortexFormatReader>();
+  const std::string key = "same-raw-key";
+  auto parquet_metadata = MakeMetadata<ParquetCache>(key);
 
-    if (!copied_cache) {
-      return arrow::Status::Invalid("metadata cache copy returned null typed cache");
-    }
-    EXPECT_EQ(original_cache.get(), copied_cache.get());
-    return arrow::Status::OK();
-  }));
+  ASSERT_STATUS_OK(parquet_cache->add(key, parquet_metadata));
+  auto cached_parquet = parquet_cache->get(key);
+  ASSERT_TRUE(cached_parquet.has_value());
+  EXPECT_EQ(cached_parquet.value().get(), parquet_metadata.get());
+  EXPECT_FALSE(vortex_cache->get(key).has_value());
+
+  ClearMetadataCache();
 }
 
 TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenCachesLoaderResult) {
-  ASSERT_STATUS_OK(VisitMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*cache)>;
     const std::string key = "metadata-cache-hit";
     auto metadata = MakeMetadata<CacheT>(key);
@@ -667,8 +740,136 @@ TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenCachesLoaderResult) {
   }));
 }
 
+TEST_P(FormatReaderMetadataCacheParamTest, ClearMetadataCacheCausesReload) {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+    using CacheT = std::decay_t<decltype(*cache)>;
+    const std::string key = "clear-metadata-cache";
+    auto first = MakeMetadata<CacheT>(key);
+    auto second = MakeMetadata<CacheT>(key);
+    int loader_calls = 0;
+
+    ARROW_ASSIGN_OR_RAISE(auto first_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return first;
+                          }));
+
+    ClearMetadataCache();
+
+    ARROW_ASSIGN_OR_RAISE(auto second_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return second;
+                          }));
+
+    EXPECT_EQ(loader_calls, 2);
+    EXPECT_EQ(first_metadata.get(), first.get());
+    EXPECT_EQ(second_metadata.get(), second.get());
+    return arrow::Status::OK();
+  }));
+}
+
+TEST_P(FormatReaderMetadataCacheParamTest, InitMetadataCacheZeroPreventsCaching) {
+  InitMetadataCache(0);
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+    using CacheT = std::decay_t<decltype(*cache)>;
+    const std::string key = "zero-capacity-cache";
+    auto first = MakeMetadata<CacheT>(key);
+    auto second = MakeMetadata<CacheT>(key);
+    int loader_calls = 0;
+
+    ARROW_ASSIGN_OR_RAISE(auto first_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return first;
+                          }));
+    ARROW_ASSIGN_OR_RAISE(auto second_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return second;
+                          }));
+
+    EXPECT_EQ(loader_calls, 2);
+    EXPECT_EQ(first_metadata.get(), first.get());
+    EXPECT_EQ(second_metadata.get(), second.get());
+    EXPECT_FALSE(cache->get(key).has_value());
+    return arrow::Status::OK();
+  }));
+}
+
+TEST_P(FormatReaderMetadataCacheParamTest, ZeroCacheSizeMetadataReloads) {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+    using CacheT = std::decay_t<decltype(*cache)>;
+    const std::string key = "zero-size-metadata";
+    auto first = MakeMetadata<CacheT>(key, 0);
+    auto second = MakeMetadata<CacheT>(key, 0);
+    int loader_calls = 0;
+
+    ARROW_ASSIGN_OR_RAISE(auto first_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return first;
+                          }));
+    ARROW_ASSIGN_OR_RAISE(auto second_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return second;
+                          }));
+
+    EXPECT_EQ(loader_calls, 2);
+    EXPECT_EQ(first_metadata.get(), first.get());
+    EXPECT_EQ(second_metadata.get(), second.get());
+    EXPECT_FALSE(cache->get(key).has_value());
+    return arrow::Status::OK();
+  }));
+}
+
+TEST_P(FormatReaderMetadataCacheParamTest, AddZeroCacheSizeMetadataClearsExistingEntry) {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+    using CacheT = std::decay_t<decltype(*cache)>;
+    const std::string key = "add-zero-size-clears-existing";
+    auto cached = MakeMetadata<CacheT>(key);
+    auto uncached = MakeMetadata<CacheT>(key, 0);
+
+    ARROW_RETURN_NOT_OK(cache->add(key, cached));
+    EXPECT_TRUE(cache->get(key).has_value());
+
+    ARROW_RETURN_NOT_OK(cache->add(key, uncached));
+    EXPECT_FALSE(cache->get(key).has_value());
+    return arrow::Status::OK();
+  }));
+}
+
+TEST_P(FormatReaderMetadataCacheParamTest, OversizedMetadataReloads) {
+  InitMetadataCache(1);
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+    using CacheT = std::decay_t<decltype(*cache)>;
+    const std::string key = "oversized-metadata";
+    auto first = MakeMetadata<CacheT>(key, 2);
+    auto second = MakeMetadata<CacheT>(key, 2);
+    int loader_calls = 0;
+
+    ARROW_ASSIGN_OR_RAISE(auto first_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return first;
+                          }));
+    ARROW_ASSIGN_OR_RAISE(auto second_metadata,
+                          cache->get_or_open(key, [&]() -> arrow::Result<typename CacheT::MetadataPtr> {
+                            ++loader_calls;
+                            return second;
+                          }));
+
+    EXPECT_EQ(loader_calls, 2);
+    EXPECT_EQ(first_metadata.get(), first.get());
+    EXPECT_EQ(second_metadata.get(), second.get());
+    EXPECT_FALSE(cache->get(key).has_value());
+    return arrow::Status::OK();
+  }));
+}
+
 TEST_P(FormatReaderMetadataCacheParamTest, AddRejectsNullMetadataAndLeavesKeyAbsent) {
-  ASSERT_STATUS_OK(VisitMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*cache)>;
     const std::string key = "null-add";
     typename CacheT::MetadataPtr null_metadata;
@@ -682,7 +883,7 @@ TEST_P(FormatReaderMetadataCacheParamTest, AddRejectsNullMetadataAndLeavesKeyAbs
 }
 
 TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenErrorDoesNotPoisonCache) {
-  ASSERT_STATUS_OK(VisitMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*cache)>;
     const std::string key = "error-retry";
     auto metadata = MakeMetadata<CacheT>(key);
@@ -713,7 +914,7 @@ TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenErrorDoesNotPoisonCache) {
 }
 
 TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenNullMetadataDoesNotPoisonCache) {
-  ASSERT_STATUS_OK(VisitMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*cache)>;
     const std::string key = "null-retry";
     auto metadata = MakeMetadata<CacheT>(key);
@@ -744,56 +945,47 @@ TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenNullMetadataDoesNotPoisonCac
 }
 
 TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenThrowingLoaderNotifiesWaitersAndAllowsRetry) {
-  ASSERT_STATUS_OK(VisitMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*cache)>;
     return RunThrowingLoaderNotifiesWaitersAndAllowsRetry<CacheT>(cache);
   }));
 }
 
 TEST_P(FormatReaderMetadataCacheParamTest, GetOrOpenSingleflightsConcurrentSameKey) {
-  ASSERT_STATUS_OK(VisitMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
+  ASSERT_STATUS_OK(VisitGlobalMetadataCacheForFormat(GetParam(), [](const auto& cache) -> arrow::Status {
     using CacheT = std::decay_t<decltype(*cache)>;
     return RunSingleflightsConcurrentSameKey<CacheT>(cache);
   }));
 }
 
-TEST_P(FormatReaderMetadataCacheParamTest, MetadataCacheCopySharesTypedCaches) {
-  MetadataCache original;
-  MetadataCache copy = original;
+TEST(FormatReaderMetadataCacheTest, FormatCacheKeysKeepFormatSpecificIdentity) {
+  api::ColumnGroupFile file;
+  file.path = "s3://bucket/path/data-file";
+  file.properties[api::kPropertyFileSize] = "1024";
+  file.properties[api::kPropertyFooterSize] = "128";
+  file.properties[api::kPropertyMetadata] = "manifest-metadata";
 
-  ASSERT_STATUS_OK(original.dispatch(GetParam(), [&](const auto& original_cache) -> arrow::Status {
-    using CacheT = std::decay_t<decltype(*original_cache)>;
-    using ReaderT = typename CacheT::ReaderType;
-    auto copied_cache = copy.get<ReaderT>();
-
-    if (!copied_cache) {
-      return arrow::Status::Invalid("metadata cache copy returned null typed cache");
-    }
-    EXPECT_EQ(original_cache.get(), copied_cache.get());
-    return arrow::Status::OK();
-  }));
+  EXPECT_NE(parquet::ParquetFormatReader::MetaTrait::cache_key(file), file.path);
+  EXPECT_NE(vortex::VortexFormatReader::MetaTrait::cache_key(file), file.path);
+  EXPECT_NE(lance::LanceTableReader::MetaTrait::cache_key(file), file.path);
+  EXPECT_NE(iceberg::IcebergFormatReader::MetaTrait::cache_key(file), file.path);
 }
 
-TEST_P(FormatReaderMetadataCacheParamTest, MetadataCacheDispatchSelectsCorrectTypedCache) {
-  MetadataCache cache;
+TEST(FormatReaderMetadataCacheTest, LanceCacheKeyIncludesTableVersionWhenPresent) {
+  api::ColumnGroupFile file;
+  file.path = "s3://bucket/path/table?fragment_id=7";
+  file.properties[api::kPropertyFileSize] = "0";
+  file.properties[api::kPropertyFooterSize] = "0";
 
-  ASSERT_STATUS_OK(cache.dispatch(GetParam(), [&](const auto& expected_cache) -> arrow::Status {
-    auto dispatch_result = cache.dispatch(
-        GetParam(), [](const auto& typed_cache) -> arrow::Result<const void*> { return typed_cache.get(); });
-    if (!dispatch_result.ok()) {
-      return dispatch_result.status();
-    }
-    EXPECT_EQ(dispatch_result.ValueOrDie(), expected_cache.get());
-    return arrow::Status::OK();
-  }));
-}
+  file.properties[lance::kLanceTableVersionProperty] = "3";
+  auto version_3_key = lance::LanceTableReader::MetaTrait::cache_key(file);
 
-TEST(FormatReaderMetadataCacheTest, MetadataCacheDispatchRejectsUnknownFormat) {
-  MetadataCache cache;
+  file.properties[lance::kLanceTableVersionProperty] = "4";
+  auto version_4_key = lance::LanceTableReader::MetaTrait::cache_key(file);
 
-  auto unknown_result = cache.dispatch(
-      "unknown-format", [](const auto& typed_cache) -> arrow::Result<const void*> { return typed_cache.get(); });
-  EXPECT_TRUE(unknown_result.status().IsInvalid()) << unknown_result.status().ToString();
+  EXPECT_NE(version_3_key, version_4_key);
+  EXPECT_NE(version_3_key.find("lance.table.version:3"), std::string::npos);
+  EXPECT_NE(version_4_key.find("lance.table.version:4"), std::string::npos);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -819,6 +1011,138 @@ TEST_P(FormatReaderMetadataCacheStressTest, ConcurrentReaderCacheOpenAndRead) {
 
   ASSERT_AND_ASSIGN(auto iterations, RunConcurrentReadStress(reader.get()));
   EXPECT_EQ(iterations.size(), static_cast<size_t>(kThreadCount));
+}
+
+TEST_P(FormatReaderMetadataCacheStressTest, ReaderDisabledMetadataCacheBypassesGlobalCache) {
+  const auto format = GetParam();
+  const auto* use_azurite = std::getenv("USE_AZURITE");
+  if (format == LOON_FORMAT_ICEBERG_TABLE && fs_config_.cloud_provider == kCloudProviderAzure && use_azurite &&
+      std::string(use_azurite) == "true") {
+    GTEST_SKIP() << "Iceberg test table creation does not support Azurite endpoint normalization";
+  }
+
+  ASSERT_AND_ASSIGN(auto cgs, WriteStressData(format));
+  ASSERT_EQ(cgs->size(), 1);
+  ASSERT_NE((*cgs)[0], nullptr);
+  ASSERT_FALSE((*cgs)[0]->files.empty());
+
+  api::SetValue(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE, "true");
+  auto enabled_reader = api::Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(enabled_reader, nullptr);
+  ASSERT_STATUS_OK(ReadProjectedChunks(enabled_reader.get(), {"id"}, kExpectedRows, kReadParallelism));
+  ASSERT_STATUS_OK(ExpectGlobalMetadataCacheEntriesForFormat(cgs, format, properties_, true));
+
+  auto disabled_properties = properties_;
+  api::SetValue(disabled_properties, PROPERTY_READER_METADATA_CACHE_ENABLE, "false");
+  api::SetValue(disabled_properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "128");
+  auto disabled_reader = api::Reader::create(cgs, schema_, nullptr, disabled_properties);
+  ASSERT_NE(disabled_reader, nullptr);
+  auto projected_columns = std::make_shared<std::vector<std::string>>();
+  projected_columns->emplace_back("id");
+  ASSERT_AND_ASSIGN(auto disabled_chunk_reader, disabled_reader->get_chunk_reader(0, projected_columns));
+  if (format != LOON_FORMAT_ICEBERG_TABLE) {
+    EXPECT_EQ(disabled_chunk_reader->total_number_of_chunks(), static_cast<size_t>((kExpectedRows + 127) / 128));
+  }
+  ASSERT_STATUS_OK(ReadProjectedChunks(disabled_reader.get(), {"id"}, kExpectedRows, kReadParallelism));
+  ASSERT_STATUS_OK(ExpectGlobalMetadataCacheEntriesForFormat(cgs, format, properties_, true));
+}
+
+TEST_P(FormatReaderMetadataCacheStressTest, ReaderMetadataCacheUsesCurrentProperties) {
+  const auto format = GetParam();
+  if (format != LOON_FORMAT_VORTEX && format != LOON_FORMAT_LANCE_TABLE) {
+    GTEST_SKIP() << "logical chunk rows only changes cached reader chunking for Vortex and Lance";
+  }
+
+  ASSERT_AND_ASSIGN(auto cgs, WriteStressData(format));
+  ASSERT_EQ(cgs->size(), 1);
+  ASSERT_NE((*cgs)[0], nullptr);
+  ASSERT_FALSE((*cgs)[0]->files.empty());
+
+  api::SetValue(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE, "true");
+  api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "512");
+  auto warm_reader = api::Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(warm_reader, nullptr);
+  ASSERT_STATUS_OK(ReadProjectedChunks(warm_reader.get(), {"id"}, kExpectedRows, kReadParallelism));
+  ASSERT_STATUS_OK(ExpectGlobalMetadataCacheEntriesForFormat(cgs, format, properties_, true));
+
+  auto changed_properties = properties_;
+  api::SetValue(changed_properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "128");
+  auto changed_reader = api::Reader::create(cgs, schema_, nullptr, changed_properties);
+  ASSERT_NE(changed_reader, nullptr);
+  auto projected_columns = std::make_shared<std::vector<std::string>>();
+  projected_columns->emplace_back("id");
+  ASSERT_AND_ASSIGN(auto changed_chunk_reader, changed_reader->get_chunk_reader(0, projected_columns));
+  EXPECT_EQ(changed_chunk_reader->total_number_of_chunks(), static_cast<size_t>((kExpectedRows + 127) / 128));
+  ASSERT_STATUS_OK(ReadProjectedChunks(changed_reader.get(), {"id"}, kExpectedRows, kReadParallelism));
+  ASSERT_STATUS_OK(ExpectGlobalMetadataCacheEntriesForFormat(cgs, format, properties_, true));
+}
+
+TEST_P(FormatReaderMetadataCacheStressTest, CachedMetadataUsesCurrentFilesystemProperties) {
+  const auto format = GetParam();
+  if (format != LOON_FORMAT_PARQUET && format != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Parquet reopens with current properties; Vortex separates cached handles by filesystem identity";
+  }
+  if (!IsLocalFileSystem(fs_)) {
+    GTEST_SKIP() << "local root_path switch is required to prove current filesystem properties are used";
+  }
+
+  ASSERT_AND_ASSIGN(auto cgs, WriteStressData(format));
+  ASSERT_EQ(cgs->size(), 1);
+  ASSERT_NE((*cgs)[0], nullptr);
+  ASSERT_FALSE((*cgs)[0]->files.empty());
+
+  auto warm_reader = api::Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(warm_reader, nullptr);
+  ASSERT_STATUS_OK(ReadProjectedChunks(warm_reader.get(), {"id"}, kExpectedRows, kReadParallelism));
+  ASSERT_STATUS_OK(ExpectGlobalMetadataCacheEntriesForFormat(cgs, format, properties_, true));
+
+  auto changed_properties = properties_;
+  const auto missing_root = std::filesystem::path("/tmp") / ("milvus-storage-cache-missing-root-" + format);
+  std::filesystem::remove_all(missing_root);
+  api::SetValue(changed_properties, PROPERTY_FS_ROOT_PATH, missing_root.string().c_str());
+
+  auto changed_reader = api::Reader::create(cgs, schema_, nullptr, changed_properties);
+  ASSERT_NE(changed_reader, nullptr);
+  auto status = ReadProjectedChunks(changed_reader.get(), {"id"}, kExpectedRows, kReadParallelism);
+  EXPECT_FALSE(status.ok()) << "metadata cache reused a filesystem object from the warm reader";
+
+  std::filesystem::remove_all(missing_root);
+}
+
+TEST_P(FormatReaderMetadataCacheStressTest, VortexCachesMetadataWithoutManifestFileSizes) {
+  const auto format = GetParam();
+  if (format != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Vortex should cache metadata after resolving missing file sizes";
+  }
+
+  ASSERT_AND_ASSIGN(auto cgs, WriteStressData(format));
+  ASSERT_EQ(cgs->size(), 1);
+  ASSERT_NE((*cgs)[0], nullptr);
+  ASSERT_FALSE((*cgs)[0]->files.empty());
+
+  std::vector<uint64_t> expected_footer_sizes;
+  expected_footer_sizes.reserve((*cgs)[0]->files.size());
+  for (auto& file : (*cgs)[0]->files) {
+    expected_footer_sizes.emplace_back(file.Get<uint64_t>(api::kPropertyFooterSize));
+    file.properties.erase(api::kPropertyFileSize);
+    file.properties.erase(api::kPropertyFooterSize);
+  }
+
+  auto reader = api::Reader::create(cgs, schema_, nullptr, properties_);
+  ASSERT_NE(reader, nullptr);
+  ASSERT_STATUS_OK(ReadProjectedChunks(reader.get(), {"id"}, kExpectedRows, kReadParallelism));
+  ASSERT_STATUS_OK(ExpectGlobalMetadataCacheEntriesForFormat(cgs, format, properties_, true));
+
+  auto cache = GetGlobalFormatReaderMetadataCache<vortex::VortexFormatReader>();
+  for (size_t i = 0; i < (*cgs)[0]->files.size(); ++i) {
+    const auto& file = (*cgs)[0]->files[i];
+    ASSERT_GT(expected_footer_sizes[i], 0u);
+    ASSERT_AND_ASSIGN(auto key, MakeFormatReaderMetadataCacheKey(
+                                    file, properties_, vortex::VortexFormatReader::MetaTrait::cache_key(file)));
+    auto cached = cache->get(key);
+    ASSERT_TRUE(cached.has_value()) << "Expected cached metadata for key: " << key;
+    EXPECT_EQ(cached.value()->cache_size, expected_footer_sizes[i]);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -408,7 +408,7 @@ TEST_P(FormatReaderTest, ParquetCreateFromMetadataReappliesProjection) {
   ASSERT_EQ(id_metadata.get(), value_metadata.get());
 
   ASSERT_AND_ASSIGN(auto id_reader, FormatReader::create_from_metadata<parquet::ParquetFormatReader>(
-                                        id_metadata, file, two_cols_schema, {"id"}, ""));
+                                        id_metadata, file, properties_, two_cols_schema, {"id"}, ""));
   ASSERT_AND_ASSIGN(auto id_batch, id_reader->get_chunk(0));
   ASSERT_EQ(id_batch->num_rows(), two_cols_batch->num_rows());
   ASSERT_EQ(id_batch->num_columns(), 1);
@@ -420,7 +420,7 @@ TEST_P(FormatReaderTest, ParquetCreateFromMetadataReappliesProjection) {
   }
 
   ASSERT_AND_ASSIGN(auto value_reader, FormatReader::create_from_metadata<parquet::ParquetFormatReader>(
-                                           value_metadata, file, two_cols_schema, {"value"}, ""));
+                                           value_metadata, file, properties_, two_cols_schema, {"value"}, ""));
   ASSERT_AND_ASSIGN(auto value_batch, value_reader->get_chunk(0));
   ASSERT_EQ(value_batch->num_rows(), two_cols_batch->num_rows());
   ASSERT_EQ(value_batch->num_columns(), 1);
@@ -591,9 +591,9 @@ TEST_P(FormatReaderTest, NestedProjectionPreservesTopLevelColumns) {
   const std::vector<std::string> extension_needed_columns = {"note", "extension_profile"};
   ASSERT_AND_ASSIGN(auto extension_expected_batch,
                     extension_storage_batch->SelectColumns(extension_projected_field_indices));
-  ASSERT_AND_ASSIGN(auto extension_reader,
-                    parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
-                        metadata, extension_file, extension_expected_batch->schema(), extension_needed_columns, ""));
+  ASSERT_AND_ASSIGN(auto extension_reader, parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
+                                               metadata, extension_file, properties_,
+                                               extension_expected_batch->schema(), extension_needed_columns, ""));
 
   ASSERT_AND_ASSIGN(auto extension_chunk, extension_reader->get_chunk(0));
   assert_batch_equal(extension_chunk, extension_expected_batch);

--- a/cpp/test/format/fs_cache_test.cpp
+++ b/cpp/test/format/fs_cache_test.cpp
@@ -20,6 +20,7 @@
 
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/common/lrucache.h"
+#include "milvus-storage/common/lru_memory_cache.h"
 #include "test_env.h"
 
 namespace milvus_storage {
@@ -75,6 +76,91 @@ TEST_F(FileSystemCacheTest, LRUCacheInstantiation) {
   // Test get on non-existent key returns std::nullopt
   auto s2 = c1.get(999);
   EXPECT_FALSE(s2.has_value());
+}
+
+TEST_F(FileSystemCacheTest, LRUMemoryCacheCachesAndRetrievesNonZeroEntries) {
+  LRUMemoryCache<int, std::string> cache(16);
+
+  EXPECT_TRUE(cache.put(1, "value_1", 8));
+  auto value = cache.get(1);
+
+  ASSERT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "value_1");
+  EXPECT_EQ(cache.size(), 1u);
+}
+
+TEST_F(FileSystemCacheTest, LRUMemoryCacheHitsUpdateLRUOrder) {
+  LRUMemoryCache<int, std::string> cache(10);
+
+  EXPECT_TRUE(cache.put(1, "a", 5));
+  EXPECT_TRUE(cache.put(2, "b", 5));
+  ASSERT_TRUE(cache.get(1).has_value());
+  EXPECT_TRUE(cache.put(3, "c", 5));
+
+  EXPECT_EQ(cache.get(1).value(), "a");
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_EQ(cache.get(3).value(), "c");
+  EXPECT_EQ(cache.size(), 2u);
+}
+
+TEST_F(FileSystemCacheTest, LRUMemoryCacheEvictsLRUEntriesOverByteCapacity) {
+  LRUMemoryCache<int, std::string> cache(10);
+
+  EXPECT_TRUE(cache.put(1, "a", 3));
+  EXPECT_TRUE(cache.put(2, "b", 3));
+  EXPECT_TRUE(cache.put(3, "c", 3));
+  EXPECT_TRUE(cache.put(4, "d", 6));
+
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_EQ(cache.get(3).value(), "c");
+  EXPECT_EQ(cache.get(4).value(), "d");
+  EXPECT_EQ(cache.size(), 2u);
+}
+
+TEST_F(FileSystemCacheTest, LRUMemoryCacheRejectsOversizedAndZeroSizedEntries) {
+  LRUMemoryCache<int, std::string> cache(10);
+
+  EXPECT_TRUE(cache.put(1, "cached", 4));
+  EXPECT_FALSE(cache.put(1, "zero", 0));
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_EQ(cache.size(), 0u);
+
+  EXPECT_TRUE(cache.put(2, "cached", 4));
+  EXPECT_FALSE(cache.put(2, "oversized", 11));
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST_F(FileSystemCacheTest, LRUMemoryCacheUpdateAdjustsChargedSizeAndEvictsOthers) {
+  LRUMemoryCache<int, std::string> cache(10);
+
+  EXPECT_TRUE(cache.put(1, "a", 4));
+  EXPECT_TRUE(cache.put(2, "b", 4));
+  EXPECT_TRUE(cache.put(1, "a_larger", 8));
+
+  EXPECT_EQ(cache.get(1).value(), "a_larger");
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_EQ(cache.size(), 1u);
+}
+
+TEST_F(FileSystemCacheTest, LRUMemoryCacheShrinkingCapacityEvictsImmediately) {
+  LRUMemoryCache<int, std::string> cache(10);
+
+  EXPECT_TRUE(cache.put(1, "a", 4));
+  EXPECT_TRUE(cache.put(2, "b", 4));
+  EXPECT_TRUE(cache.put(3, "c", 2));
+
+  cache.set_capacity(6);
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_EQ(cache.get(2).value(), "b");
+  EXPECT_EQ(cache.get(3).value(), "c");
+  EXPECT_EQ(cache.size(), 2u);
+
+  cache.set_capacity(0);
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_FALSE(cache.get(3).has_value());
 }
 
 TEST_F(FileSystemCacheTest, Basic) {

--- a/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
@@ -31,9 +31,14 @@ using namespace milvus_storage::api;
 
 static_assert(milvus_storage::FormatReaderWithMetadata<IcebergFormatReader>);
 
+constexpr uint64_t kDefaultTestMetadataCacheCapacity = 256ULL * 1024ULL * 1024ULL;
+
 class IcebergFormatReaderTest : public ::testing::Test {
   protected:
   void SetUp() override {
+    milvus_storage::InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+    milvus_storage::ClearMetadataCache();
+
     ASSERT_STATUS_OK(InitTestProperties(properties_));
     ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
 
@@ -45,7 +50,11 @@ class IcebergFormatReaderTest : public ::testing::Test {
     delete_file_path_ = base_path_ + "/pos-delete.parquet";
   }
 
-  void TearDown() override { ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_)); }
+  void TearDown() override {
+    milvus_storage::InitMetadataCache(kDefaultTestMetadataCacheCapacity);
+    milvus_storage::ClearMetadataCache();
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+  }
 
   // Write a data file with columns: id (int64), value (string)
   void WriteDataFile(int64_t num_rows) {
@@ -210,15 +219,15 @@ TEST_F(IcebergFormatReaderTest, CacheCreateReaderReappliesProjectionWhenAllRowsD
   }));
   ASSERT_EQ(cached_metadata.get(), cached_metadata_again.get());
 
-  ASSERT_AND_ASSIGN(auto id_reader,
-                    IcebergFormatReader::MetaTrait::create_from_metadata(cached_metadata, file, nullptr, {"id"}, ""));
+  ASSERT_AND_ASSIGN(auto id_reader, IcebergFormatReader::MetaTrait::create_from_metadata(
+                                        cached_metadata, file, properties_, nullptr, {"id"}, ""));
   ASSERT_AND_ASSIGN(auto id_batch, id_reader->get_chunk(0));
   ASSERT_EQ(id_batch->num_rows(), 0);
   ASSERT_EQ(id_batch->num_columns(), 1);
   ASSERT_EQ(id_batch->schema()->field(0)->name(), "id");
 
-  ASSERT_AND_ASSIGN(auto value_reader, IcebergFormatReader::MetaTrait::create_from_metadata(cached_metadata, file,
-                                                                                            nullptr, {"value"}, ""));
+  ASSERT_AND_ASSIGN(auto value_reader, IcebergFormatReader::MetaTrait::create_from_metadata(
+                                           cached_metadata, file, properties_, nullptr, {"value"}, ""));
   ASSERT_AND_ASSIGN(auto value_batch, value_reader->get_chunk(0));
   ASSERT_EQ(value_batch->num_rows(), 0);
   ASSERT_EQ(value_batch->num_columns(), 1);
@@ -253,8 +262,8 @@ TEST_F(IcebergFormatReaderTest, CacheCreateReaderReappliesProjectionWithPartialD
   ASSERT_EQ(cached_metadata.get(), cached_metadata_again.get());
 
   const std::vector<int64_t> expected_ids = {0, 1, 3, 4, 6, 7, 9};
-  ASSERT_AND_ASSIGN(auto id_reader,
-                    IcebergFormatReader::MetaTrait::create_from_metadata(cached_metadata, file, nullptr, {"id"}, ""));
+  ASSERT_AND_ASSIGN(auto id_reader, IcebergFormatReader::MetaTrait::create_from_metadata(
+                                        cached_metadata, file, properties_, nullptr, {"id"}, ""));
   ASSERT_AND_ASSIGN(auto id_batch, id_reader->get_chunk(0));
   ASSERT_EQ(id_batch->num_rows(), static_cast<int64_t>(expected_ids.size()));
   ASSERT_EQ(id_batch->num_columns(), 1);
@@ -265,8 +274,8 @@ TEST_F(IcebergFormatReaderTest, CacheCreateReaderReappliesProjectionWithPartialD
     ASSERT_EQ(id_array->Value(i), expected_ids[i]) << "Mismatch at index " << i;
   }
 
-  ASSERT_AND_ASSIGN(auto value_reader, IcebergFormatReader::MetaTrait::create_from_metadata(cached_metadata, file,
-                                                                                            nullptr, {"value"}, ""));
+  ASSERT_AND_ASSIGN(auto value_reader, IcebergFormatReader::MetaTrait::create_from_metadata(
+                                           cached_metadata, file, properties_, nullptr, {"value"}, ""));
   ASSERT_AND_ASSIGN(auto value_batch, value_reader->get_chunk(0));
   ASSERT_EQ(value_batch->num_rows(), static_cast<int64_t>(expected_ids.size()));
   ASSERT_EQ(value_batch->num_columns(), 1);

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -39,6 +39,7 @@
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/lance/lance_format.h"
 #include "milvus-storage/format/lance/lance_table_writer.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/lance/lance_common.h"
@@ -232,11 +233,78 @@ TEST_F(LanceBasicTest, TestCachedOpenRejectsMissingNeededColumnWithoutReadSchema
   ASSERT_AND_ASSIGN(auto metadata,
                     LanceTableReader::MetaTrait::load_metadata(cgfile, properties_, nullptr /* key_retriever */));
 
-  auto reader_result = LanceTableReader::MetaTrait::create_from_metadata(metadata, cgfile, nullptr /* read_schema */,
-                                                                         {"id", "missing_column"}, "");
+  auto reader_result = LanceTableReader::MetaTrait::create_from_metadata(
+      metadata, cgfile, properties_, nullptr /* read_schema */, {"id", "missing_column"}, "");
   ASSERT_FALSE(reader_result.ok());
   EXPECT_TRUE(reader_result.status().IsInvalid());
   EXPECT_NE(reader_result.status().ToString().find("missing_column"), std::string::npos);
+}
+
+TEST_F(LanceBasicTest, WriterSetsTableVersionProperty) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+
+  auto version_it = cgfile.properties.find(kLanceTableVersionProperty);
+  ASSERT_NE(version_it, cgfile.properties.end());
+  EXPECT_FALSE(version_it->second.empty());
+}
+
+TEST_F(LanceBasicTest, ExploreSetsTableVersionProperty) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto written_file, writer.Close());
+  auto written_version_it = written_file.properties.find(kLanceTableVersionProperty);
+  ASSERT_NE(written_version_it, written_file.properties.end());
+
+  LanceFormat format;
+  ASSERT_AND_ASSIGN(auto explored_files, format.explore(base_path_, properties_));
+  ASSERT_FALSE(explored_files.empty());
+
+  for (const auto& explored_file : explored_files) {
+    auto explored_version_it = explored_file.properties.find(kLanceTableVersionProperty);
+    ASSERT_NE(explored_version_it, explored_file.properties.end());
+    EXPECT_EQ(explored_version_it->second, written_version_it->second);
+  }
+}
+
+TEST_F(LanceBasicTest, UnversionedMetadataBypassesGlobalRetention) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+  cgfile.properties.erase(kLanceTableVersionProperty);
+
+  ASSERT_AND_ASSIGN(auto metadata,
+                    LanceTableReader::MetaTrait::load_metadata(cgfile, properties_, nullptr /* key_retriever */));
+  EXPECT_EQ(metadata->cache_size, 0);
+}
+
+TEST_F(LanceBasicTest, VersionedMetadataChargesDatasetManifest) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+
+  ASSERT_AND_ASSIGN(auto metadata,
+                    LanceTableReader::MetaTrait::load_metadata(cgfile, properties_, nullptr /* key_retriever */));
+  const auto fallback_charge =
+      sizeof(LanceTableReader::MetaTrait::Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo);
+  EXPECT_GT(metadata->cache_size, fallback_charge);
 }
 
 TEST_F(LanceBasicTest, CachedCreateReaderReappliesProjection) {
@@ -255,7 +323,7 @@ TEST_F(LanceBasicTest, CachedCreateReaderReappliesProjection) {
   ASSERT_EQ(id_metadata.get(), value_metadata.get());
 
   ASSERT_AND_ASSIGN(auto id_reader, LanceTableReader::MetaTrait::create_from_metadata(
-                                        id_metadata, cgfile, nullptr /* read_schema */, {"id"}, ""));
+                                        id_metadata, cgfile, properties_, nullptr /* read_schema */, {"id"}, ""));
   ASSERT_AND_ASSIGN(auto id_rgs, id_reader->get_row_group_infos());
   ASSERT_FALSE(id_rgs.empty());
   ASSERT_AND_ASSIGN(auto id_chunk, id_reader->get_chunk(0));
@@ -268,8 +336,9 @@ TEST_F(LanceBasicTest, CachedCreateReaderReappliesProjection) {
     ASSERT_EQ(id_array->Value(i), static_cast<int64_t>(id_rgs[0].start_offset) + i);
   }
 
-  ASSERT_AND_ASSIGN(auto value_reader, LanceTableReader::MetaTrait::create_from_metadata(
-                                           value_metadata, cgfile, nullptr /* read_schema */, {"value"}, ""));
+  ASSERT_AND_ASSIGN(auto value_reader,
+                    LanceTableReader::MetaTrait::create_from_metadata(value_metadata, cgfile, properties_,
+                                                                      nullptr /* read_schema */, {"value"}, ""));
   ASSERT_AND_ASSIGN(auto value_rgs, value_reader->get_row_group_infos());
   ASSERT_FALSE(value_rgs.empty());
   ASSERT_AND_ASSIGN(auto value_chunk, value_reader->get_chunk(0));

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -976,19 +976,39 @@ TEST_P(VortexBasicTest, CachedCreateReaderKeepsProjectionForEmptyPredicateResult
   auto id_schema = arrow::schema({schema_->field(0)});
   ASSERT_AND_ASSIGN(auto filtered_reader,
                     vortex::VortexFormatReader::MetaTrait::create_from_metadata(
-                        metadata, cgfile, id_schema, std::vector<std::string>{"id"}, "id > 1000000"));
+                        metadata, cgfile, properties_, id_schema, std::vector<std::string>{"id"}, "id > 1000000"));
   ASSERT_AND_ASSIGN(auto empty_batch, filtered_reader->get_chunk(0));
   ASSERT_EQ(0, empty_batch->num_rows());
   ASSERT_EQ(1, empty_batch->num_columns());
   ASSERT_EQ("id", empty_batch->schema()->field(0)->name());
 
   auto value_schema = arrow::schema({schema_->field(2)});
-  ASSERT_AND_ASSIGN(auto unfiltered_reader, vortex::VortexFormatReader::MetaTrait::create_from_metadata(
-                                                metadata, cgfile, value_schema, std::vector<std::string>{"value"}, ""));
+  ASSERT_AND_ASSIGN(auto unfiltered_reader,
+                    vortex::VortexFormatReader::MetaTrait::create_from_metadata(
+                        metadata, cgfile, properties_, value_schema, std::vector<std::string>{"value"}, ""));
   ASSERT_AND_ASSIGN(auto value_batch, unfiltered_reader->get_chunk(0));
   ASSERT_GT(value_batch->num_rows(), 0);
   ASSERT_EQ(1, value_batch->num_columns());
   ASSERT_EQ("value", value_batch->schema()->field(0)->name());
+}
+
+TEST_P(VortexBasicTest, CachedMetadataFallsBackWhenFooterSizeAccountingFails) {
+  auto vx_writer = vortex::VortexFileWriter(file_system_, schema_, test_file_name_, properties_);
+  for (const auto& rb : record_batches_) {
+    ASSERT_STATUS_OK(vx_writer.Write(rb));
+  }
+  ASSERT_STATUS_OK(vx_writer.Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer.Close());
+
+  const auto footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  ASSERT_GT(footer_size, 0u);
+  cgfile.Set(api::kPropertyFooterSize, uint64_t{0});
+
+  KeyRetriever key_retriever;
+  ScopedFiuFault fault(FIUKEY_VORTEX_METADATA_CACHE_SIZE_FAIL, /*one_time=*/true);
+  ASSERT_AND_ASSIGN(auto metadata,
+                    vortex::VortexFormatReader::MetaTrait::load_metadata(cgfile, properties_, key_retriever));
+  EXPECT_EQ(metadata->cache_size, 0);
 }
 
 TEST_P(VortexBasicTest, TestBasicTake) {

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -203,6 +203,10 @@ _ffi.cdef(
     LoonFFIResult loon_thread_pool_singleton(size_t num_of_thread);
     void loon_thread_pool_singleton_release();
 
+    // ==================== Metadata Cache C Interface ====================
+    void loon_init_metadata_cache(uint64_t capacity_bytes);
+    void loon_clear_metadata_cache(void);
+
     // ==================== Writer C Interface ====================
     typedef uintptr_t LoonWriterHandle;
 


### PR DESCRIPTION
This change moves format reader metadata reuse from reader-local state to a process-wide cache, so repeated readers can share expensive immutable file metadata across calls instead of warming it up again for every Reader instance. The cache is still gated by the existing reader metadata cache property, and encrypted Parquet reads with a key retriever continue to bypass metadata reuse so the decryption path stays correct.

The implementation adds a byte-bounded LRU cache for completed metadata entries and keeps the per-format singleflight behavior so concurrent opens for the same file only load metadata once. Cache keys now include the resolved filesystem identity, which keeps entries separated across different storage configurations while still allowing immutable files to be reused safely within the same process.

Each format reader now separates reusable file metadata from per-read state more clearly. Parquet, Vortex, Lance, and Iceberg can rebuild independent readers from cached metadata while applying the current projection, predicate, filesystem properties, and logical chunk settings at reader creation time. Vortex also records a real metadata cache size when manifest file size fields are not available.