### PR TITLE
fix: Share parsed parquet metadata across cached readers

### DIFF
--- a/cpp/benchmark/benchmark_format_read.cpp
+++ b/cpp/benchmark/benchmark_format_read.cpp
@@ -14,13 +14,186 @@
 
 #include "benchmark_format_common.h"
 
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
 #include <thread>
+#include <unordered_map>
+#include <utility>
+
+#if defined(__linux__)
+#include <unistd.h>
+#endif
+
 #include <arrow/table.h>
+#include "iceberg_bridge.h"
+#include "milvus-storage/format/format_reader.h"
+#include "milvus-storage/format/iceberg/iceberg_common.h"
+#include "milvus-storage/format/iceberg/iceberg_format_reader.h"
+#include "milvus-storage/format/lance/lance_table_reader.h"
+#include "milvus-storage/format/parquet/parquet_format_reader.h"
+#include "milvus-storage/format/parquet/parquet_writer.h"
+#include "milvus-storage/format/vortex/vortex_format_reader.h"
 #include "milvus-storage/thread_pool.h"
 
 namespace milvus_storage::benchmark {
 
 using namespace milvus_storage::api;
+
+namespace {
+
+struct PreparedReaderFile {
+  ColumnGroupFile file;
+  std::shared_ptr<arrow::Schema> read_schema;
+  std::vector<std::string> needed_columns;
+};
+
+constexpr size_t kOpenManyParquetFooterPaddingBytes = 486 * 1024;
+constexpr const char* kOpenManyParquetFooterPaddingKey = "open_many_format_readers_rss_footer_padding";
+
+int64_t GetCurrentRSS() {
+#if defined(__APPLE__)
+  mach_task_basic_info_data_t info;
+  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO, reinterpret_cast<task_info_t>(&info), &count) == KERN_SUCCESS) {
+    return static_cast<int64_t>(info.resident_size);
+  }
+  return 0;
+#elif defined(__linux__)
+  std::ifstream statm("/proc/self/statm");
+  long total_pages = 0;
+  long resident_pages = 0;
+  statm >> total_pages >> resident_pages;
+  if (!statm || resident_pages < 0) {
+    return 0;
+  }
+  return static_cast<int64_t>(resident_pages) * static_cast<int64_t>(sysconf(_SC_PAGESIZE));
+#else
+  return 0;
+#endif
+}
+
+const std::vector<std::string>& GetOpenManyFormatReaderFormats() {
+  static const std::vector<std::string> formats = {
+      LOON_FORMAT_PARQUET,
+      LOON_FORMAT_VORTEX,
+      LOON_FORMAT_LANCE_TABLE,
+      LOON_FORMAT_ICEBERG_TABLE,
+  };
+  return formats;
+}
+
+std::string GetOpenManyFormatReaderFormatByIndex(size_t idx) {
+  const auto& formats = GetOpenManyFormatReaderFormats();
+  assert(idx < formats.size() && "OpenManyFormatReadersRSS format index out of range");
+  return formats[idx];
+}
+
+arrow::Status EnsureOpenFileLimit(size_t reader_count) {
+  struct rlimit limit {};
+  if (getrlimit(RLIMIT_NOFILE, &limit) != 0) {
+    return arrow::Status::IOError("Failed to read RLIMIT_NOFILE: ", std::strerror(errno));
+  }
+
+  constexpr size_t kOpenFileMargin = 1024;
+  if (reader_count > std::numeric_limits<size_t>::max() - kOpenFileMargin) {
+    return arrow::Status::Invalid("OpenManyFormatReadersRSS reader_count is too large: ", reader_count);
+  }
+
+  auto required = static_cast<rlim_t>(reader_count + kOpenFileMargin);
+  if (limit.rlim_cur >= required) {
+    return arrow::Status::OK();
+  }
+  if (limit.rlim_max != RLIM_INFINITY && limit.rlim_max < required) {
+    return arrow::Status::Invalid("RLIMIT_NOFILE hard limit is too low for OpenManyFormatReadersRSS. [required=",
+                                  required, ", hard_limit=", limit.rlim_max, "]");
+  }
+
+  auto new_limit = limit;
+  new_limit.rlim_cur = required;
+  if (setrlimit(RLIMIT_NOFILE, &new_limit) != 0) {
+    return arrow::Status::IOError("Failed to raise RLIMIT_NOFILE for OpenManyFormatReadersRSS. [required=", required,
+                                  ", error=", std::strerror(errno), "]");
+  }
+  return arrow::Status::OK();
+}
+
+std::shared_ptr<arrow::Schema> ProjectSchema(const std::shared_ptr<arrow::Schema>& schema,
+                                             const std::vector<std::string>& columns) {
+  if (!schema || columns.empty()) {
+    return schema;
+  }
+
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  fields.reserve(columns.size());
+  for (const auto& column : columns) {
+    auto field = schema->GetFieldByName(column);
+    if (field) {
+      fields.emplace_back(std::move(field));
+    }
+  }
+  return arrow::schema(std::move(fields));
+}
+
+template <typename ReaderT>
+arrow::Result<std::vector<std::shared_ptr<FormatReader>>> OpenManyReadersFromSharedMetadata(
+    const ColumnGroupFile& file,
+    const Properties& properties,
+    const std::shared_ptr<arrow::Schema>& read_schema,
+    const std::vector<std::string>& needed_columns,
+    size_t reader_count,
+    int64_t* rss_after_metadata,
+    uint64_t* metadata_cache_size) {
+  ARROW_ASSIGN_OR_RAISE(auto metadata, FormatReader::load_metadata<ReaderT>(file, properties, nullptr));
+  if (metadata_cache_size) {
+    *metadata_cache_size = metadata ? metadata->cache_size : 0;
+  }
+  if (rss_after_metadata) {
+    *rss_after_metadata = GetCurrentRSS();
+  }
+
+  std::vector<std::shared_ptr<FormatReader>> readers;
+  readers.reserve(reader_count);
+  for (size_t i = 0; i < reader_count; ++i) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          FormatReader::create_from_metadata<ReaderT>(metadata, file, read_schema, needed_columns, ""));
+    readers.emplace_back(std::move(reader));
+  }
+  return readers;
+}
+
+arrow::Result<std::vector<std::shared_ptr<FormatReader>>> OpenManyReadersFromSharedMetadata(
+    const std::string& format,
+    const ColumnGroupFile& file,
+    const Properties& properties,
+    const std::shared_ptr<arrow::Schema>& read_schema,
+    const std::vector<std::string>& needed_columns,
+    size_t reader_count,
+    int64_t* rss_after_metadata,
+    uint64_t* metadata_cache_size) {
+  if (format == LOON_FORMAT_PARQUET) {
+    return OpenManyReadersFromSharedMetadata<parquet::ParquetFormatReader>(
+        file, properties, read_schema, needed_columns, reader_count, rss_after_metadata, metadata_cache_size);
+  }
+  if (format == LOON_FORMAT_VORTEX) {
+    return OpenManyReadersFromSharedMetadata<vortex::VortexFormatReader>(
+        file, properties, read_schema, needed_columns, reader_count, rss_after_metadata, metadata_cache_size);
+  }
+  if (format == LOON_FORMAT_LANCE_TABLE) {
+    return OpenManyReadersFromSharedMetadata<lance::LanceTableReader>(
+        file, properties, read_schema, needed_columns, reader_count, rss_after_metadata, metadata_cache_size);
+  }
+  if (format == LOON_FORMAT_ICEBERG_TABLE) {
+    return OpenManyReadersFromSharedMetadata<iceberg::IcebergFormatReader>(
+        file, properties, read_schema, needed_columns, reader_count, rss_after_metadata, metadata_cache_size);
+  }
+  return arrow::Status::Invalid("Unsupported OpenManyFormatReadersRSS format: ", format);
+}
+
+}  // namespace
 
 //=============================================================================
 // Read Performance Benchmark Base
@@ -33,6 +206,7 @@ class FormatReadBenchmark : public FormatBenchFixtureBase<> {
 
     // Get schema from data loader
     schema_ = GetLoaderSchema();
+    BENCH_ASSERT_AND_ASSIGN(fs_config_, GetFileSystemConfig(properties_), st);
   }
 
   void TearDown(::benchmark::State& st) override {
@@ -84,7 +258,176 @@ class FormatReadBenchmark : public FormatBenchFixtureBase<> {
     return projection;
   }
 
+  arrow::Result<PreparedReaderFile> PrepareReaderFile(const std::string& format) {
+    if (format == LOON_FORMAT_ICEBERG_TABLE) {
+      return PrepareIcebergReaderFile();
+    }
+    if (format == LOON_FORMAT_PARQUET) {
+      return PreparePaddedParquetReaderFile();
+    }
+
+    auto path = GetUniquePath(format + "_open_many_reader_test");
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSinglePolicy(format, schema_));
+    auto writer = Writer::create(path, schema_, std::move(policy), properties_);
+    if (!writer) {
+      return arrow::Status::Invalid("Failed to create writer for format: ", format);
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, GetLoaderBatchReader());
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
+      if (!batch) {
+        break;
+      }
+      ARROW_RETURN_NOT_OK(writer->write(batch));
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto cgs, writer->close());
+    if (!cgs) {
+      return arrow::Status::Invalid("Writer returned null column groups for format: ", format);
+    }
+
+    for (const auto& column_group : *cgs) {
+      if (!column_group || column_group->format != format || column_group->files.empty()) {
+        continue;
+      }
+      return PreparedReaderFile{
+          .file = column_group->files.front(),
+          .read_schema = ProjectSchema(schema_, column_group->columns),
+          .needed_columns = column_group->columns,
+      };
+    }
+    return arrow::Status::Invalid("PrepareTestData did not produce a readable file for format: ", format);
+  }
+
+  arrow::Result<PreparedReaderFile> PreparePaddedParquetReaderFile() {
+    auto path = GetUniquePath("parquet_open_many_reader_test") + "/data.parquet";
+    ARROW_ASSIGN_OR_RAISE(auto writer, parquet::ParquetFileWriter::Make(fs_, schema_, path, properties_));
+
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, GetLoaderBatchReader());
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
+      if (!batch) {
+        break;
+      }
+      ARROW_RETURN_NOT_OK(writer->Write(batch));
+    }
+
+    std::string padding(kOpenManyParquetFooterPaddingBytes, 'x');
+    ARROW_RETURN_NOT_OK(writer->AddUserMetadata({{kOpenManyParquetFooterPaddingKey, std::move(padding)}}));
+    ARROW_ASSIGN_OR_RAISE(auto file, writer->Close());
+
+    std::vector<std::string> needed_columns;
+    needed_columns.reserve(schema_->num_fields());
+    for (const auto& field : schema_->fields()) {
+      needed_columns.emplace_back(field->name());
+    }
+
+    return PreparedReaderFile{
+        .file = std::move(file),
+        .read_schema = schema_,
+        .needed_columns = std::move(needed_columns),
+    };
+  }
+
+  arrow::Result<PreparedReaderFile> PrepareIcebergReaderFile() const {
+    ARROW_ASSIGN_OR_RAISE(auto table_uri, MakeIcebergTableUri(GetUniquePath("iceberg_read_test")));
+
+    iceberg::IcebergTestTableInfo table_info;
+    std::vector<iceberg::IcebergFileInfo> file_infos;
+    try {
+      auto storage_options = iceberg::ToStorageOptions(fs_config_);
+      table_info =
+          iceberg::CreateTestTable(table_uri, static_cast<uint64_t>(GetLoaderNumRows()), false, {}, storage_options);
+      file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    } catch (const std::exception& e) {
+      return arrow::Status::IOError("Failed to create Iceberg benchmark table: ", e.what());
+    }
+
+    if (file_infos.empty()) {
+      return arrow::Status::Invalid("Iceberg PlanFiles returned no files");
+    }
+
+    const auto& file_info = file_infos.front();
+    auto data_file_path = file_info.data_file_path;
+    if (fs_config_.storage_type == "local") {
+      data_file_path = LocalReadablePath(data_file_path);
+    } else {
+      data_file_path = iceberg::ToMilvusUri(data_file_path, fs_config_.address);
+    }
+
+    std::unordered_map<std::string, std::string> file_properties;
+    if (!file_info.delete_metadata_json.empty()) {
+      file_properties[kPropertyMetadata] =
+          fs_config_.storage_type == "local"
+              ? std::string(file_info.delete_metadata_json.begin(), file_info.delete_metadata_json.end())
+              : iceberg::ConvertDeleteMetadataPaths(file_info.delete_metadata_json, fs_config_.address);
+    }
+
+    return PreparedReaderFile{
+        .file =
+            ColumnGroupFile{
+                .path = std::move(data_file_path),
+                .start_index = 0,
+                .end_index = static_cast<int64_t>(file_info.record_count),
+                .properties = std::move(file_properties),
+            },
+        .read_schema = nullptr,
+        .needed_columns = {"id", "name", "value"},
+    };
+  }
+
+  arrow::Result<std::string> MakeIcebergTableUri(const std::string& relative_path) const {
+    if (fs_config_.storage_type == "local") {
+      return AbsoluteLocalPath(relative_path);
+    }
+    if (fs_config_.bucket_name.empty()) {
+      return arrow::Status::Invalid("BUCKET_NAME env var must be set for remote Iceberg benchmark");
+    }
+
+    if (fs_config_.cloud_provider == kCloudProviderAzure) {
+      return "abfss://" + fs_config_.bucket_name + "/" + relative_path;
+    }
+    if (fs_config_.cloud_provider == kCloudProviderGCP) {
+      return "gs://" + fs_config_.bucket_name + "/" + relative_path;
+    }
+    if (fs_config_.cloud_provider == kCloudProviderAliyun) {
+      return "oss://" + fs_config_.bucket_name + "/" + relative_path;
+    }
+    return "s3://" + fs_config_.bucket_name + "/" + relative_path;
+  }
+
+  std::string AbsoluteLocalPath(const std::string& relative_path) const {
+    return (LocalRootPath() / relative_path).lexically_normal().string();
+  }
+
+  std::filesystem::path LocalRootPath() const {
+    std::filesystem::path root(fs_config_.root_path);
+    if (root.is_relative()) {
+      root = std::filesystem::absolute(root);
+    }
+    std::error_code error;
+    auto canonical_root = std::filesystem::weakly_canonical(root, error);
+    return error ? root.lexically_normal() : canonical_root;
+  }
+
+  std::string LocalReadablePath(const std::string& path) const {
+    auto root = LocalRootPath().string();
+    std::filesystem::path local_path(path);
+    std::error_code error;
+    auto canonical_path = std::filesystem::weakly_canonical(local_path, error);
+    auto normalized_path = (error ? local_path.lexically_normal() : canonical_path).string();
+    auto prefix = root + "/";
+    if (normalized_path.rfind(prefix, 0) == 0) {
+      return normalized_path.substr(prefix.size());
+    }
+    return normalized_path;
+  }
+
   std::shared_ptr<arrow::Schema> schema_;
+  ArrowFileSystemConfig fs_config_;
 };
 
 //=============================================================================
@@ -294,6 +637,75 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
         {1, 8},                  // Threads: 1, 8
         {1}                      // MemoryConfig: Default(1)
     })
+    ->Unit(::benchmark::kMillisecond)
+    ->UseRealTime();
+
+//=============================================================================
+// FormatReader RSS Benchmark
+//=============================================================================
+
+// Open many live FormatReaders from one shared metadata payload and report RSS.
+// Args: [format_idx, reader_count]
+BENCHMARK_DEFINE_F(FormatReadBenchmark, OpenManyFormatReadersRSS)(::benchmark::State& st) {
+  auto format_idx = static_cast<size_t>(st.range(0));
+  auto reader_count = static_cast<size_t>(st.range(1));
+
+  const auto format = GetOpenManyFormatReaderFormatByIndex(format_idx);
+  BENCH_ASSERT_STATUS_OK(EnsureOpenFileLimit(reader_count), st);
+
+  BENCH_ASSERT_AND_ASSIGN(auto prepared, PrepareReaderFile(format), st);
+
+  std::vector<std::shared_ptr<FormatReader>> readers;
+  int64_t rss_before_metadata = 0;
+  int64_t rss_after_metadata = 0;
+  int64_t rss_after_readers = 0;
+  uint64_t metadata_cache_size = 0;
+
+  for (auto _ : st) {
+    readers.clear();
+
+    st.PauseTiming();
+    rss_before_metadata = GetCurrentRSS();
+    st.ResumeTiming();
+
+    BENCH_ASSERT_AND_ASSIGN(readers,
+                            OpenManyReadersFromSharedMetadata(format, prepared.file, properties_, prepared.read_schema,
+                                                              prepared.needed_columns, reader_count,
+                                                              &rss_after_metadata, &metadata_cache_size),
+                            st);
+
+    st.PauseTiming();
+    rss_after_readers = GetCurrentRSS();
+    st.ResumeTiming();
+  }
+
+  const auto metadata_rss_delta = std::max<int64_t>(0, rss_after_metadata - rss_before_metadata);
+  const auto reader_rss_delta = std::max<int64_t>(0, rss_after_readers - rss_after_metadata);
+  const auto total_rss_delta = std::max<int64_t>(0, rss_after_readers - rss_before_metadata);
+  const auto reader_count_i64 = static_cast<int64_t>(reader_count);
+
+  ReportSize(st, "rss_before_metadata", rss_before_metadata, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "rss_after_metadata", rss_after_metadata, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "rss_after_readers", rss_after_readers, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "rss_metadata_delta", metadata_rss_delta, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "rss_reader_delta", reader_rss_delta, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "rss_reader_delta_per_reader", reader_count_i64 > 0 ? reader_rss_delta / reader_count_i64 : 0,
+             ::benchmark::Counter::kDefaults);
+  ReportSize(st, "rss_total_delta", total_rss_delta, ::benchmark::Counter::kDefaults);
+  ReportSize(st, "file_footer_size", static_cast<int64_t>(prepared.file.Get<uint64_t>(kPropertyFooterSize)),
+             ::benchmark::Counter::kDefaults);
+  ReportSize(st, "metadata_cache_size", static_cast<int64_t>(metadata_cache_size), ::benchmark::Counter::kDefaults);
+  st.counters["reader_count"] =
+      ::benchmark::Counter(static_cast<double>(reader_count), ::benchmark::Counter::kDefaults);
+  st.SetLabel(format + "/" + std::to_string(reader_count) + "readers/" + GetDataDescription());
+}
+
+BENCHMARK_REGISTER_F(FormatReadBenchmark, OpenManyFormatReadersRSS)
+    ->ArgsProduct({
+        {0, 1, 2, 3},  // parquet, vortex, lance-table, iceberg-table
+        {100, 10000},  // live FormatReader count
+    })
+    ->Iterations(1)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include <arrow/filesystem/filesystem.h>
-#include <arrow/buffer.h>
 #include <parquet/arrow/schema.h>
 #include <parquet/type_fwd.h>
 #include <parquet/arrow/reader.h>
@@ -36,7 +35,6 @@ class ParquetFormatReader final : public FormatReader {
   struct MetaTrait {
     struct Payload {
       std::shared_ptr<arrow::fs::FileSystem> fs;
-      std::shared_ptr<arrow::Buffer> footer_buffer;
       std::shared_ptr<::parquet::FileMetaData> parquet_metadata;
       api::Properties properties;
       milvus_storage::KeyRetriever key_retriever;

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -25,6 +25,7 @@
 #include <fmt/format.h>
 
 #include <arrow/array/util.h>
+#include <arrow/buffer.h>
 #include <arrow/extension_type.h>
 #include <arrow/io/caching.h>
 #include <arrow/record_batch.h>
@@ -235,8 +236,7 @@ static arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> create_parqu
     const std::function<std::string(const std::string&)>& key_retriever,
     std::shared_ptr<::parquet::FileMetaData> metadata = nullptr,
     uint64_t file_size = 0,
-    uint64_t footer_size = 0,
-    std::shared_ptr<arrow::Buffer>* footer_buffer_out = nullptr) {
+    uint64_t footer_size = 0) {
   std::unique_ptr<::parquet::arrow::FileReader> result;
 
   ::parquet::arrow::FileReaderBuilder builder;
@@ -282,9 +282,6 @@ static arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> create_parqu
 
   if (!key_retriever && footer_size > 0 && !metadata && file_size > 0 && footer_size <= file_size) {
     auto footer_buffer = try_read_footer_buffer(parquet_file, file_size, footer_size);
-    if (footer_buffer_out) {
-      *footer_buffer_out = footer_buffer;
-    }
     metadata = try_parse_footer_metadata(footer_buffer, reader_props);
   }
 
@@ -316,10 +313,8 @@ arrow::Result<ParquetFormatReader::MetaTrait::MetadataPtr> ParquetFormatReader::
   const auto file_size = file.Get<uint64_t>(api::kPropertyFileSize);
   const auto footer_size = file.Get<uint64_t>(api::kPropertyFooterSize);
 
-  std::shared_ptr<arrow::Buffer> footer_buffer;
-  ARROW_ASSIGN_OR_RAISE(auto file_reader,
-                        create_parquet_file_reader(fs, uri.key, properties, key_retriever, nullptr /* metadata */,
-                                                   file_size, footer_size, &footer_buffer));
+  ARROW_ASSIGN_OR_RAISE(auto file_reader, create_parquet_file_reader(fs, uri.key, properties, key_retriever,
+                                                                     nullptr /* metadata */, file_size, footer_size));
   if (!file_reader->parquet_reader()) {
     return arrow::Status::Invalid(fmt::format("Failed to open parquet reader metadata. [path={}]", uri.key));
   }
@@ -342,10 +337,9 @@ arrow::Result<ParquetFormatReader::MetaTrait::MetadataPtr> ParquetFormatReader::
   metadata->path = uri.key;
   metadata->file_schema = std::move(file_schema);
   metadata->row_group_infos = std::move(row_group_infos);
-  metadata->cache_size = footer_buffer ? static_cast<uint64_t>(footer_buffer->size()) : parquet_metadata->size();
+  metadata->cache_size = parquet_metadata->size();
   metadata->payload.fs = std::move(fs);
-  metadata->payload.footer_buffer = std::move(footer_buffer);
-  if (!metadata->payload.footer_buffer && !key_retriever) {
+  if (!key_retriever) {
     metadata->payload.parquet_metadata = std::move(parquet_metadata);
   }
   metadata->payload.properties = properties;
@@ -368,7 +362,7 @@ arrow::Result<std::shared_ptr<ParquetFormatReader>> ParquetFormatReader::MetaTra
     return arrow::Status::Invalid(
         fmt::format("Cannot open parquet reader from metadata without filesystem. [path={}]", metadata->path));
   }
-  if (!metadata->payload.key_retriever && !metadata->payload.footer_buffer && !metadata->payload.parquet_metadata) {
+  if (!metadata->payload.key_retriever && !metadata->payload.parquet_metadata) {
     return arrow::Status::Invalid(
         fmt::format("Cannot open parquet reader from metadata without parquet footer. [path={}]", metadata->path));
   }
@@ -376,14 +370,6 @@ arrow::Result<std::shared_ptr<ParquetFormatReader>> ParquetFormatReader::MetaTra
   std::shared_ptr<::parquet::FileMetaData> parquet_metadata;
   if (!metadata->payload.key_retriever) {
     parquet_metadata = metadata->payload.parquet_metadata;
-  }
-  if (!metadata->payload.key_retriever && metadata->payload.footer_buffer) {
-    parquet_metadata = try_parse_footer_metadata(metadata->payload.footer_buffer,
-                                                 make_reader_properties(metadata->payload.key_retriever));
-    if (!parquet_metadata) {
-      return arrow::Status::Invalid(
-          fmt::format("Cannot parse cached parquet footer metadata. [path={}]", metadata->path));
-    }
   }
 
   const auto file_size = file.Get<uint64_t>(api::kPropertyFileSize);

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -541,6 +541,40 @@ TEST_P(FormatReaderTest, ParquetCreateFromMetadataReappliesProjection) {
   }
 }
 
+TEST_P(FormatReaderTest, ParquetCreateFromMetadataSharesParsedMetadata) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/shared_metadata.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+  ASSERT_GT(file.Get<uint64_t>(api::kPropertyFileSize), 0);
+  ASSERT_GT(file.Get<uint64_t>(api::kPropertyFooterSize), 0);
+
+  ASSERT_AND_ASSIGN(auto metadata,
+                    FormatReader::load_metadata<parquet::ParquetFormatReader>(file, properties_, nullptr));
+  ASSERT_NE(nullptr, metadata->payload.parquet_metadata);
+  const auto metadata_ref_count = metadata->payload.parquet_metadata.use_count();
+
+  ASSERT_AND_ASSIGN(auto first_reader, FormatReader::create_from_metadata<parquet::ParquetFormatReader>(
+                                           metadata, file, schema_, {"id"}, ""));
+  ASSERT_AND_ASSIGN(auto second_reader, FormatReader::create_from_metadata<parquet::ParquetFormatReader>(
+                                            metadata, file, schema_, {"value"}, ""));
+
+  ASSERT_GE(metadata->payload.parquet_metadata.use_count(), metadata_ref_count + 2);
+
+  ASSERT_AND_ASSIGN(auto first_batch, first_reader->get_chunk(0));
+  ASSERT_AND_ASSIGN(auto second_batch, second_reader->get_chunk(0));
+  ASSERT_EQ(first_batch->num_columns(), 1);
+  ASSERT_EQ(second_batch->num_columns(), 1);
+  ASSERT_EQ(first_batch->schema()->field(0)->name(), "id");
+  ASSERT_EQ(second_batch->schema()->field(0)->name(), "value");
+}
+
 TEST_P(FormatReaderTest, NestedProjectionPreservesTopLevelColumns) {
   std::string format = GetParam();
   auto field_metadata = [](const std::string& field_id) {


### PR DESCRIPTION
This change makes cached non-encrypted Parquet readers share the decoded FileMetaData for the same file, instead of keeping a raw footer buffer and reparsing it every time a new ParquetFormatReader is created. The main goal is to keep memory growth under control when many live readers point at the same Parquet file, especially when the footer metadata is large.

The Parquet metadata path now stores the parsed parquet::FileMetaData in the format metadata payload and passes that shared pointer back into Arrow when creating readers from cached metadata. Encrypted Parquet still stays on the existing path, because decryptor setup depends on the normal Parquet reader open flow and should not reuse caller-supplied metadata blindly.

This also adds an OpenManyFormatReadersRSS benchmark to make the memory behavior visible for 100 and 10000 live readers. The benchmark covers parquet, vortex, lance-table, and iceberg-table without changing the global available-format list, and the Parquet case pads the footer to roughly 500KB so the shared-metadata behavior is easier to observe from RSS counters.