### PR TITLE
enhance: Configure storage runtimes and simplify Vortex writer ownership

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -333,6 +333,18 @@ FFI_EXPORT char* loon_column_groups_debug_string(const LoonColumnGroups* cgroups
 FFI_EXPORT LoonFFIResult loon_thread_pool_singleton(size_t num_of_thread);
 
 /**
+ * @brief Configure storage runtimes before first Rust bridge use.
+ *
+ * This configures Arrow CPU/IO pools and the shared Rust Tokio runtime. It must
+ * be called during process initialization before Lance/Iceberg/Vortex touches
+ * the Rust bridge; late or duplicate configuration returns an error.
+ *
+ * @param num_of_cpu_threads Number of Arrow CPU pool and Tokio worker threads
+ * @param num_of_io_threads Number of Arrow IO pool and Tokio blocking threads
+ */
+FFI_EXPORT LoonFFIResult loon_configure_storage_runtime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads);
+
+/**
  * @brief Release the thread pool singleton
  *        If current singleton thread pool is not null, waiting
  *        all threads join and release the thread pool singleton

--- a/cpp/include/milvus-storage/thread_pool.h
+++ b/cpp/include/milvus-storage/thread_pool.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -20,6 +21,8 @@
 #include <folly/executors/ThreadPoolExecutor.h>
 
 namespace milvus_storage {
+
+void ConfigureStorageRuntime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads);
 
 class ThreadPoolHolder {
   public:

--- a/cpp/include/milvus-storage/thread_pool.h
+++ b/cpp/include/milvus-storage/thread_pool.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 #pragma once
 
+#include <arrow/status.h>
+
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -22,7 +24,17 @@
 
 namespace milvus_storage {
 
-void ConfigureStorageRuntime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads);
+/// Configure shared process-wide runtimes used by storage.
+///
+/// This must be called once during process initialization before any Rust
+/// bridge code touches its Tokio runtime. Tokio is initialized lazily on first
+/// use and cannot be resized afterwards, so a late or duplicate configuration
+/// returns a non-OK status.
+///
+/// num_of_cpu_threads configures Arrow's CPU pool and Tokio worker threads.
+/// num_of_io_threads configures Arrow's IO pool and Tokio blocking threads,
+/// which Rust uses for blocking work such as synchronous object-store IO.
+arrow::Status ConfigureStorageRuntime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads);
 
 class ThreadPoolHolder {
   public:

--- a/cpp/src/ffi/threadpool_c.cpp
+++ b/cpp/src/ffi/threadpool_c.cpp
@@ -33,4 +33,23 @@ LoonFFIResult loon_thread_pool_singleton(size_t num_of_thread) {
   RETURN_UNREACHABLE();
 }
 
+LoonFFIResult loon_configure_storage_runtime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads) {
+  if (num_of_cpu_threads == 0 || num_of_io_threads == 0) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "num_of_cpu_threads and num_of_io_threads must be greater than 0");
+  }
+
+  try {
+    if (auto status = ConfigureStorageRuntime(num_of_cpu_threads, num_of_io_threads); !status.ok()) {
+      RETURN_ERROR(LOON_ARROW_ERROR, status.ToString());
+    }
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  } catch (...) {
+    RETURN_EXCEPTION("unknown exception");
+  }
+
+  RETURN_UNREACHABLE();
+}
+
 void loon_thread_pool_singleton_release() { ThreadPoolHolder::Release(); }

--- a/cpp/src/format/bridge/rust/include/rust_runtime.h
+++ b/cpp/src/format/bridge/rust/include/rust_runtime.h
@@ -1,0 +1,30 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace milvus_storage {
+
+/// Configure the shared Rust Tokio runtime before first Rust bridge use.
+///
+/// Returns std::nullopt on success, or the failure reason if either thread
+/// count is zero, if the runtime was already configured, or if the runtime was
+/// already initialized.
+std::optional<std::string> ConfigureRustRuntime(uint32_t worker_threads, uint32_t max_blocking_threads);
+
+}  // namespace milvus_storage

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -1,7 +1,8 @@
+use std::any::Any;
 use std::collections::hash_map::DefaultHasher;
-use std::ffi::c_void;
+use std::ffi::{CString, c_void};
 use std::hash::{Hash, Hasher};
-use std::io::Write;
+use std::io::{self, Write};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "io-trace")]
@@ -20,6 +21,7 @@ use vortex::buffer::{ByteBuffer, ByteBufferMut};
 use vortex::error::{VortexError, VortexResult, vortex_err};
 use vortex::io::file::{CoalesceWindow, IntoReadSource, IoRequest, ReadSource, ReadSourceRef};
 use vortex::io::runtime::Handle;
+use vortex::io::{IoBuf, VortexWrite};
 
 //=============================================================================
 // IO Trace Collector
@@ -480,117 +482,245 @@ impl<T> Clone for ThreadSafePtr<T> {
     }
 }
 
+enum WriterSlot {
+    Unopened,
+    Open(ThreadSafePtr<c_void>),
+    Closed,
+}
+
+struct ObjectStoreWriterInner {
+    inner: ThreadSafePtr<c_void>,
+    path: CString,
+    writer: Mutex<WriterSlot>,
+}
+
+impl ObjectStoreWriterInner {
+    fn new(fs_rawptr: *mut c_void, path: &str) -> Result<Self, VortexError> {
+        Ok(Self {
+            inner: ThreadSafePtr::new(fs_rawptr),
+            path: CString::new(path).map_err(
+                |e| vortex_err!(Generic: "ObjectStoreWriterCpp path contains nul byte: {}", e),
+            )?,
+            writer: Mutex::new(WriterSlot::Unopened),
+        })
+    }
+
+    fn open_writer(&self) -> Result<ThreadSafePtr<c_void>, VortexError> {
+        let mut writer_raw: *mut c_void = std::ptr::null_mut();
+        let mut result = unsafe {
+            loon_filesystem_open_writer(
+                self.inner.as_ptr(),
+                self.path.as_ptr() as *const u8,
+                self.path.as_bytes().len() as u32,
+                std::ptr::null(), // meta_array
+                0 as u32,         // num_of_meta
+                false,            // conditional
+                &mut writer_raw,
+            )
+        };
+        check_loon_ffi_result(&mut result, "Failed to open ObjectStoreWriterCpp")?;
+        Ok(ThreadSafePtr::new(writer_raw))
+    }
+
+    fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        let mut writer = self.writer.lock().unwrap();
+        let writer_ptr = match &mut *writer {
+            WriterSlot::Unopened => {
+                let opened = self
+                    .open_writer()
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+                let writer_ptr = opened.as_ptr();
+                *writer = WriterSlot::Open(opened);
+                writer_ptr
+            }
+            WriterSlot::Open(writer) => writer.as_ptr(),
+            WriterSlot::Closed => {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "cannot write: ObjectStoreWriterCpp is closed",
+                ));
+            }
+        };
+
+        let mut result =
+            unsafe { loon_filesystem_writer_write(writer_ptr, buf.as_ptr(), buf.len() as u64) };
+        check_loon_ffi_result(&mut result, "Failed to write data to ObjectStoreWriterCpp")
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+        Ok(buf.len())
+    }
+
+    fn flush(&self) -> Result<(), VortexError> {
+        let writer = self.writer.lock().unwrap();
+        match &*writer {
+            WriterSlot::Unopened => Ok(()),
+            WriterSlot::Open(writer) => {
+                let mut result = unsafe { loon_filesystem_writer_flush(writer.as_ptr()) };
+                check_loon_ffi_result(&mut result, "Failed to flush data to ObjectStoreWriterCpp")
+            }
+            WriterSlot::Closed => Err(vortex_err!(
+                Generic: "cannot flush: ObjectStoreWriterCpp is closed"
+            )),
+        }
+    }
+
+    fn close(&self) -> Result<(), VortexError> {
+        let mut writer = self.writer.lock().unwrap();
+        match std::mem::replace(&mut *writer, WriterSlot::Closed) {
+            WriterSlot::Unopened | WriterSlot::Closed => Ok(()),
+            WriterSlot::Open(writer) => {
+                let writer_raw = writer.as_raw_ptr();
+                let mut result = unsafe { loon_filesystem_writer_close(writer_raw) };
+                let close_result =
+                    check_loon_ffi_result(&mut result, "Failed to close ObjectStoreWriterCpp");
+                unsafe { loon_filesystem_writer_destroy(writer_raw) };
+                close_result
+            }
+        }
+    }
+}
+
+impl Drop for ObjectStoreWriterInner {
+    fn drop(&mut self) {
+        let mut writer = self.writer.lock().unwrap();
+        let writer = std::mem::replace(&mut *writer, WriterSlot::Closed);
+        if let WriterSlot::Open(writer) = writer {
+            // Only explicit close may complete the object. Drop can run after writer
+            // errors, so calling close here would finalize partial data; release only
+            // the C++ wrapper.
+            unsafe { loon_filesystem_writer_destroy(writer.as_raw_ptr()) };
+        }
+    }
+}
+
+struct ObjectStoreWriter {
+    inner: Arc<ObjectStoreWriterInner>,
+    handle: Handle,
+}
+
+impl ObjectStoreWriter {
+    fn new(
+        fs_rawptr: *mut c_void,
+        path: &str,
+        handle: Handle,
+    ) -> Result<(ObjectStoreWriterCpp, ObjectStoreWriterHandle), VortexError> {
+        let inner = Arc::new(ObjectStoreWriterInner::new(fs_rawptr, path)?);
+        let writer = Self {
+            inner: inner.clone(),
+            handle: handle.clone(),
+        };
+        let control = Self { inner, handle };
+
+        Ok((
+            ObjectStoreWriterCpp { writer },
+            ObjectStoreWriterHandle { writer: control },
+        ))
+    }
+
+    async fn write_byte_buffer(&self, buffer: ByteBuffer) -> io::Result<ByteBuffer> {
+        let inner = self.inner.clone();
+        self.handle
+            .spawn_blocking(move || {
+                inner.write(buffer.as_slice())?;
+                Ok::<ByteBuffer, io::Error>(buffer)
+            })
+            .await
+    }
+
+    async fn flush(&self) -> Result<(), VortexError> {
+        let inner = self.inner.clone();
+        self.handle.spawn_blocking(move || inner.flush()).await
+    }
+
+    async fn close(&self) -> Result<(), VortexError> {
+        let inner = self.inner.clone();
+        self.handle.spawn_blocking(move || inner.close()).await
+    }
+}
+
 pub struct ObjectStoreWriterHandle {
-    writer: Arc<Mutex<ThreadSafePtr<std::ffi::c_void>>>,
+    writer: ObjectStoreWriter,
 }
 
 impl ObjectStoreWriterHandle {
-    pub fn flush(&self) -> Result<(), VortexError> {
-        let writer = self.writer.lock().unwrap();
-        if writer.as_ptr().is_null() {
-            return Ok(());
-        }
-
-        let mut result = unsafe { loon_filesystem_writer_flush(writer.as_ptr()) };
-        check_loon_ffi_result(&mut result, "Failed to flush data to ObjectStoreWriterCpp")
+    pub async fn flush(&self) -> Result<(), VortexError> {
+        self.writer.flush().await
     }
 
-    pub fn close(&self) -> Result<(), VortexError> {
-        let mut writer = self.writer.lock().unwrap();
-        if writer.as_ptr().is_null() {
-            return Ok(());
-        }
-
-        let writer_raw = writer.as_raw_ptr();
-        let mut result = unsafe { loon_filesystem_writer_close(writer_raw) };
-        let close_result =
-            check_loon_ffi_result(&mut result, "Failed to close ObjectStoreWriterCpp");
-        unsafe { loon_filesystem_writer_destroy(writer_raw) };
-        *writer = ThreadSafePtr::new(std::ptr::null_mut());
-        close_result
-    }
-}
-
-impl Drop for ObjectStoreWriterHandle {
-    fn drop(&mut self) {
-        let mut writer = self.writer.lock().unwrap();
-        if writer.as_ptr().is_null() {
-            return;
-        }
-
-        // Only explicit close may complete the object. Drop can run after writer
-        // errors, so calling close here would finalize partial data; release only
-        // the C++ wrapper.
-        let writer_raw = writer.as_raw_ptr();
-        unsafe { loon_filesystem_writer_destroy(writer_raw) };
-        *writer = ThreadSafePtr::new(std::ptr::null_mut());
+    pub async fn close(&self) -> Result<(), VortexError> {
+        self.writer.close().await
     }
 }
 
 pub struct ObjectStoreWriterCpp {
-    inner: ThreadSafePtr<std::ffi::c_void>,
-    path: String,
-    writer: Arc<Mutex<ThreadSafePtr<std::ffi::c_void>>>,
+    writer: ObjectStoreWriter,
 }
 
 impl ObjectStoreWriterCpp {
-    pub fn new(fs_rawptr: *mut std::ffi::c_void, path: &String) -> Result<Self, VortexError> {
-        Ok(Self {
-            inner: ThreadSafePtr::new(fs_rawptr),
-            path: path.clone(),
-            writer: Arc::new(Mutex::new(ThreadSafePtr::new(std::ptr::null_mut()))),
-        })
-    }
-
-    pub fn handle(&self) -> ObjectStoreWriterHandle {
-        ObjectStoreWriterHandle {
-            writer: self.writer.clone(),
-        }
+    pub fn new(
+        fs_rawptr: *mut c_void,
+        path: &str,
+        handle: Handle,
+    ) -> Result<(Self, ObjectStoreWriterHandle), VortexError> {
+        ObjectStoreWriter::new(fs_rawptr, path, handle)
     }
 }
 
 impl Write for ObjectStoreWriterCpp {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let written = unsafe {
-            let mut writer = self.writer.lock().unwrap();
-            if writer.as_ptr().is_null() {
-                let mut writer_raw: *mut c_void = std::ptr::null_mut();
-                let path = std::ffi::CString::new(self.path.clone()).unwrap();
-                let mut result = loon_filesystem_open_writer(
-                    self.inner.as_ptr(),
-                    path.as_ptr() as *const u8,
-                    path.as_bytes().len() as u32,
-                    std::ptr::null(), // meta_array
-                    0 as u32,         // num_of_meta
-                    false,            // conditional
-                    &mut writer_raw,
-                );
-                check_loon_ffi_result(&mut result, "Failed to open ObjectStoreWriterCpp")
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
-
-                *writer = ThreadSafePtr::new(writer_raw);
-            }
-
-            let mut result =
-                loon_filesystem_writer_write(writer.as_ptr(), buf.as_ptr(), buf.len() as u64);
-            check_loon_ffi_result(&mut result, "Failed to write data to ObjectStoreWriterCpp")
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
-
-            buf.len()
-        };
-
-        Ok(written as usize)
+        self.writer.inner.write(buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        let writer = self.writer.lock().unwrap();
-        if writer.as_ptr().is_null() {
-            return Ok(());
-        }
+        self.writer
+            .inner
+            .flush()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+    }
+}
 
-        let mut result = unsafe { loon_filesystem_writer_flush(writer.as_ptr()) };
-        check_loon_ffi_result(&mut result, "Failed to flush data to ObjectStoreWriterCpp")
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+fn into_vortex_write_byte_buffer<B: IoBuf>(buffer: B) -> Result<ByteBuffer, B> {
+    let buffer: Box<dyn Any> = Box::new(buffer);
+    match buffer.downcast::<ByteBuffer>() {
+        Ok(buffer) => Ok(*buffer),
+        Err(buffer) => Err(*buffer
+            .downcast::<B>()
+            .unwrap_or_else(|_| unreachable!("write buffer type changed during downcast"))),
+    }
+}
+
+fn from_vortex_write_byte_buffer<B: IoBuf>(buffer: ByteBuffer) -> B {
+    let buffer: Box<dyn Any> = Box::new(buffer);
+    *buffer
+        .downcast::<B>()
+        .unwrap_or_else(|_| unreachable!("ByteBuffer write result requested as a different type"))
+}
+
+impl VortexWrite for ObjectStoreWriterCpp {
+    async fn write_all<B: IoBuf>(&mut self, buffer: B) -> io::Result<B> {
+        let buffer = into_vortex_write_byte_buffer(buffer).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                "ObjectStoreWriterCpp only supports ByteBuffer writes without copying",
+            )
+        })?;
+        self.writer
+            .write_byte_buffer(buffer)
+            .await
+            .map(from_vortex_write_byte_buffer)
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+        self.writer
+            .flush()
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+    }
+
+    async fn shutdown(&mut self) -> io::Result<()> {
+        // The current Vortex file writer does not call VortexWrite::shutdown()
+        // during finish(); it only flushes. Keep this a no-op so object commit
+        // remains controlled by ObjectStoreWriterHandle::close() after finish().
         Ok(())
     }
 }
@@ -811,5 +941,46 @@ impl ReadSource for ObjectStoreIoSourceCpp {
             .buffer_unordered(CONCURRENCY)
             .collect::<()>()
             .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_vortex_write<T: vortex::io::VortexWrite + Unpin>() {}
+
+    #[test]
+    fn byte_buffer_write_input_round_trips_without_copy() {
+        let buffer = ByteBuffer::copy_from([1_u8, 2, 3, 4]);
+        let ptr = buffer.as_ptr();
+
+        let buffer = match into_vortex_write_byte_buffer(buffer) {
+            Ok(buffer) => buffer,
+            Err(_) => panic!("ByteBuffer should be accepted"),
+        };
+        assert_eq!(buffer.as_ptr(), ptr);
+
+        let buffer: ByteBuffer = from_vortex_write_byte_buffer(buffer);
+        assert_eq!(buffer.as_ptr(), ptr);
+        assert_eq!(buffer.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn non_byte_buffer_write_input_is_rejected() {
+        let buffer = vec![1_u8, 2, 3, 4];
+        let ptr = buffer.as_ptr();
+
+        let buffer = match into_vortex_write_byte_buffer(buffer) {
+            Ok(_) => panic!("Vec<u8> should not be accepted"),
+            Err(buffer) => buffer,
+        };
+        assert_eq!(buffer.as_ptr(), ptr);
+        assert_eq!(buffer.as_slice(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn object_store_writer_cpp_is_a_vortex_write_sink() {
+        assert_vortex_write::<ObjectStoreWriterCpp>();
     }
 }

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -18,6 +18,7 @@ mod iceberg_bridgeimpl;
 mod iceberg_testutil;
 mod lance_bridgeimpl;
 mod predicate_parser;
+mod rust_runtime;
 mod vortex_bridgeimpl;
 mod vortex_layout_strategy_v2;
 
@@ -25,6 +26,7 @@ mod filesystem_c;
 use iceberg_bridgeimpl::*;
 use iceberg_testutil::*;
 use lance_bridgeimpl::*;
+use rust_runtime::configure_rust_runtime;
 use vortex_bridgeimpl::*;
 
 use std::sync::LazyLock;
@@ -39,19 +41,14 @@ use vortex::session::VortexSession;
 
 use crate::vortex_layout_strategy_v2::RowGroupZoneMapLayoutEncoding;
 
-/// Use a multi-thread Tokio runtime so that Vortex IO operations can run concurrently.
-/// max_blocking_threads is set to 64 to match Lance's thread pool size,
-/// preventing excessive thread creation under concurrent reader load.
-static VORTEX_TOKIO_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
-    tokio::runtime::Builder::new_multi_thread()
-        .max_blocking_threads(256)
-        .enable_all()
-        .build()
-        .expect("Failed to create Vortex tokio runtime")
-});
+pub(crate) use rust_runtime::TOKIO_RT;
 
+/// Vortex runtime adapter backed by the shared Tokio runtime.
+///
+/// This is not a second Tokio runtime; it only gives Vortex APIs a
+/// `BlockingRuntime` view over `TOKIO_RT`.
 static VORTEX_RT: LazyLock<TokioRuntime> =
-    LazyLock::new(|| TokioRuntime::new(VORTEX_TOKIO_RT.handle().clone()));
+    LazyLock::new(|| TokioRuntime::new(TOKIO_RT.handle().clone()));
 
 static VORTEX_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
     let session = VortexSession::default().with_handle(VORTEX_RT.handle());
@@ -61,12 +58,12 @@ static VORTEX_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
     session
 });
 
-static TOKIO_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("Failed to create tokio runtime")
-});
+#[cxx::bridge(namespace = "milvus_storage::rust_bridge::ffi")]
+pub mod rust_runtime_ffi {
+    extern "Rust" {
+        fn configure_rust_runtime(worker_threads: u32, max_blocking_threads: u32) -> Result<()>;
+    }
+}
 
 #[cxx::bridge(namespace = "milvus_storage::lance::ffi")]
 pub mod lance_ffi {

--- a/cpp/src/format/bridge/rust/src/rust_runtime.cpp
+++ b/cpp/src/format/bridge/rust/src/rust_runtime.cpp
@@ -1,0 +1,32 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rust_runtime.h"
+
+#include "rust/cxx.h"
+#include "rust-bridge/lib.h"
+
+namespace milvus_storage {
+
+// Return std::nullopt on success; otherwise return the Rust bridge error.
+std::optional<std::string> ConfigureRustRuntime(uint32_t worker_threads, uint32_t max_blocking_threads) {
+  try {
+    rust_bridge::ffi::configure_rust_runtime(worker_threads, max_blocking_threads);
+  } catch (const rust::cxxbridge1::Error& e) {
+    return std::string(e.what());
+  }
+  return std::nullopt;
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/format/bridge/rust/src/rust_runtime.rs
+++ b/cpp/src/format/bridge/rust/src/rust_runtime.rs
@@ -1,0 +1,307 @@
+use std::sync::{LazyLock, Mutex};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RustRuntimeConfig {
+    worker_threads: usize,
+    max_blocking_threads: usize,
+}
+
+#[derive(Default)]
+struct RustRuntimeState {
+    config: Option<RustRuntimeConfig>,
+    initialized: bool,
+}
+
+struct RustRuntime {
+    state: Mutex<RustRuntimeState>,
+}
+
+impl RustRuntime {
+    const fn new() -> Self {
+        Self {
+            state: Mutex::new(RustRuntimeState {
+                config: None,
+                initialized: false,
+            }),
+        }
+    }
+
+    fn configure(&self, worker_threads: usize, max_blocking_threads: usize) -> anyhow::Result<()> {
+        if worker_threads == 0 {
+            anyhow::bail!("worker_threads must be greater than 0");
+        }
+        if max_blocking_threads == 0 {
+            anyhow::bail!("max_blocking_threads must be greater than 0");
+        }
+
+        let mut state = self.state.lock().unwrap();
+        if state.initialized {
+            anyhow::bail!(
+                "Rust runtime has already been initialized; call ConfigureRustRuntime before first Rust bridge use"
+            );
+        }
+        if state.config.is_some() {
+            anyhow::bail!("Rust runtime has already been configured");
+        }
+
+        state.config = Some(RustRuntimeConfig {
+            worker_threads,
+            max_blocking_threads,
+        });
+        Ok(())
+    }
+}
+
+pub(crate) fn configure_rust_runtime(
+    worker_threads: u32,
+    max_blocking_threads: u32,
+) -> anyhow::Result<()> {
+    RUST_RUNTIME.configure(worker_threads as usize, max_blocking_threads as usize)
+}
+
+static RUST_RUNTIME: RustRuntime = RustRuntime::new();
+
+fn default_runtime_thread_count() -> usize {
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(32)
+}
+
+/// Shared Tokio runtime for async work in the Rust bridge.
+///
+/// Lance, Iceberg, and Vortex all run through this runtime so the bridge does
+/// not create separate Tokio worker and blocking thread pools per format.
+pub(crate) static TOKIO_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    let config = {
+        let mut state = RUST_RUNTIME.state.lock().unwrap();
+        state.initialized = true;
+        state.config
+    };
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    if let Some(config) = config {
+        builder.worker_threads(config.worker_threads);
+        builder.max_blocking_threads(config.max_blocking_threads);
+    } else {
+        let thread_count = default_runtime_thread_count();
+        builder.worker_threads(thread_count);
+        builder.max_blocking_threads(thread_count);
+    }
+    builder.build().expect("Failed to create tokio runtime")
+});
+
+#[cfg(test)]
+mod runtime_config_tests {
+    use super::*;
+    use std::sync::{
+        Arc, Condvar,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    #[derive(Default)]
+    struct RuntimeProbe {
+        running: AtomicUsize,
+        peak_running: AtomicUsize,
+        started: AtomicUsize,
+        release: Mutex<bool>,
+        cv: Condvar,
+    }
+
+    impl RuntimeProbe {
+        fn run(&self) {
+            let running = self.running.fetch_add(1, Ordering::SeqCst) + 1;
+            self.update_peak(running);
+            self.started.fetch_add(1, Ordering::SeqCst);
+            self.cv.notify_all();
+
+            let mut release = self.release.lock().unwrap();
+            while !*release {
+                release = self.cv.wait(release).unwrap();
+            }
+
+            self.running.fetch_sub(1, Ordering::SeqCst);
+        }
+
+        fn update_peak(&self, value: usize) {
+            let mut current = self.peak_running.load(Ordering::SeqCst);
+            while value > current {
+                match self.peak_running.compare_exchange_weak(
+                    current,
+                    value,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => break,
+                    Err(next) => current = next,
+                }
+            }
+        }
+
+        fn wait_until_started(&self, configured_threads: usize) {
+            let release = self.release.lock().unwrap();
+            let result = self
+                .cv
+                .wait_timeout_while(release, Duration::from_secs(5), |_| {
+                    self.started.load(Ordering::SeqCst) < configured_threads
+                })
+                .unwrap();
+            assert!(
+                !result.1.timed_out(),
+                "runtime did not start configured number of tasks"
+            );
+        }
+
+        fn release(&self) {
+            *self.release.lock().unwrap() = true;
+            self.cv.notify_all();
+        }
+
+        fn peak_running(&self) -> usize {
+            self.peak_running.load(Ordering::SeqCst)
+        }
+    }
+
+    fn probe_worker_parallelism(configured_threads: usize, num_tasks: usize) -> usize {
+        let probe = Arc::new(RuntimeProbe::default());
+        let handles = (0..num_tasks)
+            .map(|_| {
+                let probe = Arc::clone(&probe);
+                TOKIO_RT.spawn(async move {
+                    probe.run();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        probe.wait_until_started(configured_threads);
+        std::thread::sleep(Duration::from_millis(200));
+        probe.release();
+
+        TOKIO_RT.block_on(async {
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        });
+
+        probe.peak_running()
+    }
+
+    fn probe_blocking_parallelism(configured_threads: usize, num_tasks: usize) -> usize {
+        let probe = Arc::new(RuntimeProbe::default());
+        let handles = (0..num_tasks)
+            .map(|_| {
+                let probe = Arc::clone(&probe);
+                TOKIO_RT.spawn_blocking(move || {
+                    probe.run();
+                })
+            })
+            .collect::<Vec<_>>();
+
+        probe.wait_until_started(configured_threads);
+        std::thread::sleep(Duration::from_millis(200));
+        probe.release();
+
+        TOKIO_RT.block_on(async {
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        });
+
+        probe.peak_running()
+    }
+
+    fn runtime_config(runtime: &RustRuntime) -> Option<RustRuntimeConfig> {
+        runtime.state.lock().unwrap().config
+    }
+
+    fn runtime_initialized(runtime: &RustRuntime) -> bool {
+        runtime.state.lock().unwrap().initialized
+    }
+
+    #[test]
+    fn configure_runtime_before_initialization_records_config() {
+        let runtime = RustRuntime::new();
+
+        runtime.configure(2, 3).unwrap();
+
+        assert_eq!(
+            runtime_config(&runtime),
+            Some(RustRuntimeConfig {
+                worker_threads: 2,
+                max_blocking_threads: 3,
+            })
+        );
+        assert!(!runtime_initialized(&runtime));
+    }
+
+    #[test]
+    fn configure_runtime_rejects_zero_thread_counts() {
+        let runtime = RustRuntime::new();
+
+        assert!(runtime.configure(0, 3).is_err());
+        assert!(runtime.configure(2, 0).is_err());
+    }
+
+    #[test]
+    fn configure_runtime_fails_after_initialization() {
+        let runtime = RustRuntime::new();
+
+        runtime.state.lock().unwrap().initialized = true;
+
+        let error = runtime.configure(2, 3).unwrap_err().to_string();
+        assert!(error.contains("already been initialized"));
+    }
+
+    #[test]
+    fn configure_runtime_fails_when_called_twice() {
+        let runtime = RustRuntime::new();
+
+        runtime.configure(2, 3).unwrap();
+
+        let error = runtime.configure(2, 3).unwrap_err().to_string();
+        assert!(error.contains("already been configured"));
+    }
+
+    #[test]
+    fn default_runtime_thread_count_uses_available_parallelism() {
+        let expected = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(32);
+
+        assert_eq!(default_runtime_thread_count(), expected);
+    }
+
+    // This test mutates process-global runtime state and must be run alone.
+    #[test]
+    #[ignore]
+    fn global_tokio_runtime_limits_worker_and_blocking_parallelism() {
+        const WORKER_THREADS: usize = 2;
+        const MAX_BLOCKING_THREADS: usize = 3;
+        const TASKS_PER_THREAD: usize = 32;
+
+        configure_rust_runtime(WORKER_THREADS as u32, MAX_BLOCKING_THREADS as u32).unwrap();
+
+        let worker_peak =
+            probe_worker_parallelism(WORKER_THREADS, WORKER_THREADS * TASKS_PER_THREAD);
+        println!("worker_peak={worker_peak}");
+        assert!(
+            worker_peak <= WORKER_THREADS,
+            "worker peak {} exceeded configured worker threads {}",
+            worker_peak,
+            WORKER_THREADS
+        );
+
+        let blocking_peak = probe_blocking_parallelism(
+            MAX_BLOCKING_THREADS,
+            MAX_BLOCKING_THREADS * TASKS_PER_THREAD,
+        );
+        println!("blocking_peak={blocking_peak}");
+        assert!(
+            blocking_peak <= MAX_BLOCKING_THREADS,
+            "blocking peak {} exceeded configured max blocking threads {}",
+            blocking_peak,
+            MAX_BLOCKING_THREADS
+        );
+    }
+}

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -26,9 +26,8 @@ use vortex::dtype::arrow::FromArrowType;
 use vortex::dtype::{DType as RustDType, DecimalDType, FieldName, Nullability, PType as RustPType};
 use vortex::error::VortexError;
 use vortex::expr::Expression;
-use vortex::file::{BlockingWriter, OpenOptionsSessionExt, SegmentSpec};
+use vortex::file::{OpenOptionsSessionExt, SegmentSpec, Writer};
 use vortex::io::runtime::BlockingRuntime;
-use vortex::io::runtime::tokio::TokioRuntime;
 use vortex::layout::layouts::row_idx::row_idx;
 use vortex::layout::{LayoutChildType, LayoutRef};
 use vortex::scan::ScanBuilder;
@@ -941,7 +940,7 @@ const VORTEX_FORMAT_V2: u32 = 2;
 pub(crate) struct VortexWriter {
     pub fswrapper_ptr: *mut u8,
     pub path: String,
-    pub inner_writer: Option<BlockingWriter<'static, 'static, TokioRuntime>>,
+    pub inner_writer: Option<Writer<'static>>,
     pub writer_handle: Option<ObjectStoreWriterHandle>,
     pub enable_stats: bool,
     pub format_version: u32,
@@ -993,9 +992,13 @@ impl VortexWriter {
 
         // lazy init the inner_writer
         if self.inner_writer.is_none() {
-            let objw = ObjectStoreWriterCpp::new(self.fswrapper_ptr as *mut c_void, &self.path)
-                .map_err(|e| VortexError::from(e))?;
-            self.writer_handle = Some(objw.handle());
+            let (objw, writer_handle) = ObjectStoreWriterCpp::new(
+                self.fswrapper_ptr as *mut c_void,
+                &self.path,
+                VORTEX_RT.handle(),
+            )
+            .map_err(|e| VortexError::from(e))?;
+            self.writer_handle = Some(writer_handle);
 
             // stats options
             let stats_options = if self.enable_stats {
@@ -1015,18 +1018,17 @@ impl VortexWriter {
                     .build()
             };
 
-            let blocking_writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
+            let writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
                 .with_file_statistics(stats_options)
                 .with_strategy(strategy)
-                .blocking(&*VORTEX_RT)
                 .writer(objw, vortex_schema);
 
-            self.inner_writer = Some(blocking_writer);
+            self.inner_writer = Some(writer);
         }
         let mut inner_writer = self.inner_writer.take().unwrap();
 
-        inner_writer
-            .push(ArrayRef::from_arrow(&converted_array, false))
+        VORTEX_RT
+            .block_on(inner_writer.push(ArrayRef::from_arrow(&converted_array, false)))
             .map_err(|e| Box::new(VortexError::from(e)))?;
 
         self.inner_writer = Some(inner_writer);
@@ -1035,8 +1037,8 @@ impl VortexWriter {
 
     pub(crate) unsafe fn flush(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(writer_handle) = self.writer_handle.as_ref() {
-            writer_handle
-                .flush()
+            VORTEX_RT
+                .block_on(writer_handle.flush())
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
         }
         Ok(())
@@ -1046,12 +1048,12 @@ impl VortexWriter {
         &mut self,
     ) -> Result<crate::vortex_ffi::VortexWriteSummary, Box<dyn std::error::Error>> {
         if let Some(w) = self.inner_writer.take() {
-            let summary = w
-                .finish()
+            let summary = VORTEX_RT
+                .block_on(w.finish())
                 .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
             if let Some(writer_handle) = self.writer_handle.take() {
-                writer_handle
-                    .close()
+                VORTEX_RT
+                    .block_on(writer_handle.close())
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
             }
             let file_size = summary.size();

--- a/cpp/src/thread_pool.cpp
+++ b/cpp/src/thread_pool.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/thread_pool.h"
+
+#include <arrow/io/type_fwd.h>
+#include <arrow/util/thread_pool.h>
+
+#include "milvus-storage/common/log.h"
+#include "rust_runtime.h"
+
+namespace milvus_storage {
+
+void ConfigureStorageRuntime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads) {
+  if (auto error = ConfigureRustRuntime(num_of_cpu_threads, num_of_io_threads); error.has_value()) {
+    LOG_STORAGE_WARNING_ << "Failed to configure Rust runtime: " << *error;
+  }
+  if (auto status = arrow::SetCpuThreadPoolCapacity(num_of_cpu_threads); !status.ok()) {
+    LOG_STORAGE_WARNING_ << "Failed to configure Arrow CPU thread pool: " << status.ToString();
+  }
+  if (auto status = arrow::io::SetIOThreadPoolCapacity(num_of_io_threads); !status.ok()) {
+    LOG_STORAGE_WARNING_ << "Failed to configure Arrow IO thread pool: " << status.ToString();
+  }
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/thread_pool.cpp
+++ b/cpp/src/thread_pool.cpp
@@ -17,21 +17,21 @@
 #include <arrow/io/type_fwd.h>
 #include <arrow/util/thread_pool.h>
 
-#include "milvus-storage/common/log.h"
 #include "rust_runtime.h"
 
 namespace milvus_storage {
 
-void ConfigureStorageRuntime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads) {
+arrow::Status ConfigureStorageRuntime(uint32_t num_of_cpu_threads, uint32_t num_of_io_threads) {
   if (auto error = ConfigureRustRuntime(num_of_cpu_threads, num_of_io_threads); error.has_value()) {
-    LOG_STORAGE_WARNING_ << "Failed to configure Rust runtime: " << *error;
+    return arrow::Status::Invalid("Failed to configure Rust runtime: ", *error);
   }
   if (auto status = arrow::SetCpuThreadPoolCapacity(num_of_cpu_threads); !status.ok()) {
-    LOG_STORAGE_WARNING_ << "Failed to configure Arrow CPU thread pool: " << status.ToString();
+    return arrow::Status::IOError("Failed to configure Arrow CPU thread pool: ", status.ToString());
   }
   if (auto status = arrow::io::SetIOThreadPoolCapacity(num_of_io_threads); !status.ok()) {
-    LOG_STORAGE_WARNING_ << "Failed to configure Arrow IO thread pool: " << status.ToString();
+    return arrow::Status::IOError("Failed to configure Arrow IO thread pool: ", status.ToString());
   }
+  return arrow::Status::OK();
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/common/arrow_thread_limit_test.cpp
+++ b/cpp/test/common/arrow_thread_limit_test.cpp
@@ -26,7 +26,6 @@
 #include <arrow/io/interfaces.h>
 #include <arrow/util/thread_pool.h>
 
-#include "milvus-storage/thread_pool.h"
 #include "test_env.h"
 
 namespace milvus_storage::test {
@@ -159,12 +158,13 @@ class StorageRuntimeTest : public ::testing::Test {
 
 }  // namespace
 
-TEST_F(StorageRuntimeTest, ConfigureStorageRuntimeLimitsArrowRuntimeParallelism) {
+TEST_F(StorageRuntimeTest, SetArrowThreadPoolCapacityLimitsRuntimeParallelism) {
   constexpr int kCpuThreads = 2;
   constexpr int kIoThreads = 3;
   constexpr int kTasksPerThread = 32;
 
-  ASSERT_STATUS_OK(ConfigureStorageRuntime(kCpuThreads, kIoThreads));
+  ASSERT_STATUS_OK(arrow::SetCpuThreadPoolCapacity(kCpuThreads));
+  ASSERT_STATUS_OK(arrow::io::SetIOThreadPoolCapacity(kIoThreads));
 
   int cpu_peak_running = 0;
   ASSERT_STATUS_OK(MeasureExecutorPeakParallelism(arrow::internal::GetCpuThreadPool(), kCpuThreads,

--- a/cpp/test/common/arrow_thread_limit_test.cpp
+++ b/cpp/test/common/arrow_thread_limit_test.cpp
@@ -1,0 +1,182 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <arrow/io/interfaces.h>
+#include <arrow/util/thread_pool.h>
+
+#include "milvus-storage/thread_pool.h"
+#include "test_env.h"
+
+namespace milvus_storage::test {
+
+namespace {
+
+constexpr auto kProbeTimeout = std::chrono::seconds(5);
+constexpr auto kSaturationHoldTime = std::chrono::milliseconds(200);
+
+struct RuntimeProbeState {
+  std::atomic<int> running{0};
+  std::atomic<int> peak_running{0};
+  std::atomic<int> started{0};
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool release = false;
+};
+
+void UpdatePeak(std::atomic<int>& peak, int value) {
+  int current = peak.load();
+  while (value > current && !peak.compare_exchange_weak(current, value)) {
+  }
+}
+
+void ReleaseProbeTasks(const std::shared_ptr<RuntimeProbeState>& state) {
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->release = true;
+  }
+  state->cv.notify_all();
+}
+
+void RunBlockingProbeTask(const std::shared_ptr<RuntimeProbeState>& state) {
+  auto running = state->running.fetch_add(1) + 1;
+  UpdatePeak(state->peak_running, running);
+  state->started.fetch_add(1);
+  state->cv.notify_all();
+
+  std::unique_lock<std::mutex> lock(state->mutex);
+  state->cv.wait(lock, [&state] { return state->release; });
+
+  state->running.fetch_sub(1);
+}
+
+arrow::Status SubmitBlockingProbeTasks(arrow::internal::Executor* executor,
+                                       const std::shared_ptr<RuntimeProbeState>& state,
+                                       int num_tasks,
+                                       std::vector<arrow::Future<>>* futures) {
+  futures->reserve(num_tasks);
+  for (int i = 0; i < num_tasks; ++i) {
+    auto maybe_future = executor->Submit([state] { RunBlockingProbeTask(state); });
+    if (!maybe_future.ok()) {
+      return maybe_future.status();
+    }
+    futures->push_back(std::move(maybe_future).ValueOrDie());
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status WaitUntilExecutorIsSaturated(const std::shared_ptr<RuntimeProbeState>& state, int configured_threads) {
+  std::unique_lock<std::mutex> lock(state->mutex);
+  if (!state->cv.wait_for(lock, kProbeTimeout,
+                          [&state, configured_threads] { return state->started.load() >= configured_threads; })) {
+    return arrow::Status::Invalid("runtime did not start configured number of tasks");
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status WaitForProbeTasks(std::vector<arrow::Future<>>* futures) {
+  for (auto& future : *futures) {
+    if (!future.Wait(kProbeTimeout.count())) {
+      return arrow::Status::Invalid("runtime task did not finish");
+    }
+    auto status = arrow::FutureToSync(future);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status MeasureExecutorPeakParallelism(arrow::internal::Executor* executor,
+                                             int configured_threads,
+                                             int num_tasks,
+                                             int* peak_running) {
+  auto state = std::make_shared<RuntimeProbeState>();
+  std::vector<arrow::Future<>> futures;
+
+  auto status = SubmitBlockingProbeTasks(executor, state, num_tasks, &futures);
+  if (!status.ok()) {
+    ReleaseProbeTasks(state);
+    auto wait_status = WaitForProbeTasks(&futures);
+    return wait_status.ok() ? status : wait_status;
+  }
+
+  status = WaitUntilExecutorIsSaturated(state, configured_threads);
+  if (!status.ok()) {
+    ReleaseProbeTasks(state);
+    auto wait_status = WaitForProbeTasks(&futures);
+    return wait_status.ok() ? status : wait_status;
+  }
+
+  std::this_thread::sleep_for(kSaturationHoldTime);
+
+  ReleaseProbeTasks(state);
+  status = WaitForProbeTasks(&futures);
+  if (!status.ok()) {
+    return status;
+  }
+
+  *peak_running = state->peak_running.load();
+  return arrow::Status::OK();
+}
+
+class StorageRuntimeTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    cpu_threads_ = arrow::GetCpuThreadPoolCapacity();
+    io_threads_ = arrow::io::GetIOThreadPoolCapacity();
+  }
+
+  void TearDown() override {
+    ASSERT_STATUS_OK(arrow::SetCpuThreadPoolCapacity(cpu_threads_));
+    ASSERT_STATUS_OK(arrow::io::SetIOThreadPoolCapacity(io_threads_));
+  }
+
+  int cpu_threads_;
+  int io_threads_;
+};
+
+}  // namespace
+
+TEST_F(StorageRuntimeTest, ConfigureStorageRuntimeLimitsArrowRuntimeParallelism) {
+  constexpr int kCpuThreads = 2;
+  constexpr int kIoThreads = 3;
+  constexpr int kTasksPerThread = 32;
+
+  ConfigureStorageRuntime(kCpuThreads, kIoThreads);
+
+  int cpu_peak_running = 0;
+  ASSERT_STATUS_OK(MeasureExecutorPeakParallelism(arrow::internal::GetCpuThreadPool(), kCpuThreads,
+                                                  kCpuThreads * kTasksPerThread, &cpu_peak_running));
+  std::cout << "cpu_peak_running=" << cpu_peak_running << std::endl;
+  EXPECT_LE(cpu_peak_running, kCpuThreads);
+
+  int io_peak_running = 0;
+  ASSERT_STATUS_OK(MeasureExecutorPeakParallelism(arrow::io::default_io_context().executor(), kIoThreads,
+                                                  kIoThreads * kTasksPerThread, &io_peak_running));
+  std::cout << "io_peak_running=" << io_peak_running << std::endl;
+  EXPECT_LE(io_peak_running, kIoThreads);
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/common/arrow_thread_limit_test.cpp
+++ b/cpp/test/common/arrow_thread_limit_test.cpp
@@ -164,7 +164,7 @@ TEST_F(StorageRuntimeTest, ConfigureStorageRuntimeLimitsArrowRuntimeParallelism)
   constexpr int kIoThreads = 3;
   constexpr int kTasksPerThread = 32;
 
-  ConfigureStorageRuntime(kCpuThreads, kIoThreads);
+  ASSERT_STATUS_OK(ConfigureStorageRuntime(kCpuThreads, kIoThreads));
 
   int cpu_peak_running = 0;
   ASSERT_STATUS_OK(MeasureExecutorPeakParallelism(arrow::internal::GetCpuThreadPool(), kCpuThreads,

--- a/cpp/test/ffi/ffi_runtime_test.c
+++ b/cpp/test/ffi/ffi_runtime_test.c
@@ -1,0 +1,44 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/ffi_c.h"
+#include "test_runner.h"
+
+static void test_configure_storage_runtime_rejects_zero_threads(void) {
+  LoonFFIResult rc = loon_configure_storage_runtime(0, 1);
+  ck_assert_msg(!loon_ffi_is_success(&rc), "expected zero CPU thread count to fail");
+  ck_assert_int_eq(rc.err_code, LOON_INVALID_ARGS);
+  loon_ffi_free_result(&rc);
+}
+
+static void test_configure_storage_runtime_success(void) {
+  LoonFFIResult rc = loon_configure_storage_runtime(2, 3);
+  const char* msg = loon_ffi_get_errmsg(&rc);
+  ck_assert_msg(loon_ffi_is_success(&rc), "expected storage runtime configuration to succeed, got code=%d: %s",
+                rc.err_code, msg ? msg : "<null>");
+  loon_ffi_free_result(&rc);
+}
+
+static void test_configure_storage_runtime_duplicate_fails(void) {
+  LoonFFIResult rc = loon_configure_storage_runtime(2, 3);
+  ck_assert_msg(!loon_ffi_is_success(&rc), "expected duplicate storage runtime configuration to fail");
+  ck_assert_int_eq(rc.err_code, LOON_ARROW_ERROR);
+  loon_ffi_free_result(&rc);
+}
+
+void run_runtime_suite(void) {
+  RUN_TEST(test_configure_storage_runtime_rejects_zero_threads);
+  RUN_TEST(test_configure_storage_runtime_success);
+  RUN_TEST(test_configure_storage_runtime_duplicate_fails);
+}

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -29,9 +29,11 @@ void run_external_suite(void);
 void run_filesystem_suite(void);
 void run_fiu_suite(void);
 void run_segment_suite(void);
+void run_runtime_suite(void);
 
 int main(void) {
   loon_thread_pool_singleton(4);
+  run_runtime_suite();
   run_manifest_suite();
   run_properties_suite();
   run_writer_suite();


### PR DESCRIPTION
This change cleans up the Vortex object-store writer path so the Rust side has a clearer ownership model. Instead of cloning writer-like objects around flush and close calls, the opened C++ writer now lives behind one shared inner state with explicit unopened, open, and closed states. Writes, flushes, and close all go through the same state machine, so a flush no longer accidentally drops or destroys the underlying C++ writer while the file is still being written.

The Vortex writer is also moved onto the async Vortex writer API backed by the shared bridge runtime. That keeps blocking C++ filesystem calls offloaded through the runtime, while still preserving the existing close semantics where finishing the Vortex file and closing the object-store writer are controlled separately.

This also adds a first-use runtime configuration path for the Rust bridge. C++ can now configure the shared Tokio runtime before it is initialized, and the same storage-level API wires that together with Arrow CPU and IO thread pool limits. If the Rust runtime has already been initialized or configured, the storage configuration path reports that as a warning instead of turning runtime setup into a hard failure.

Overall, the intent is to make storage runtime sizing explicit from C++, keep Lance, Iceberg, and Vortex on one shared Rust runtime, and remove the lifecycle ambiguity around Vortex object-store writes without changing the external write/flush/close behavior.