### PR TITLE
feat: add MergeResolver and idempotent append for concurrency-safe manifest commits

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -645,7 +645,19 @@ FFI_EXPORT void loon_reader_destroy(LoonReaderHandle reader);
 typedef uintptr_t LoonTransactionHandle;
 
 #define LOON_TRANSACTION_RESOLVE_FAIL 0
+// MERGE (default write mode): apply updates onto the LATEST manifest, deduplicating
+// already-present appended files / delta logs / lob files / column groups. Concurrent
+// commits to the same manifest are preserved (layered), never silently reverted.
+#define LOON_TRANSACTION_RESOLVE_MERGE 1
+// OVERWRITE (deprecated): rebuild from the stale read manifest, dropping any concurrent
+// commit made after the pinned read_version. Retained for compatibility; do not use for
+// new call sites. Prefer MERGE (in-place, concurrency-safe) or INSERT (birth/create).
 #define LOON_TRANSACTION_RESOLVE_OVERWRITE 2
+// INSERT (birth/create): apply updates onto the read manifest without reconciling against
+// concurrent changes. Use ONLY when the target manifest is brand-new / not yet announced
+// (read_version == 0 or a freshly-created, task-local manifest), so there is no concurrent
+// writer to preserve.
+#define LOON_TRANSACTION_RESOLVE_INSERT 3
 
 /**
  * @brief Opens a transaction at the specified base path

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -144,10 +144,18 @@ class Resolver {
  *
  * @param manifest Base manifest to apply updates to
  * @param updates Updates to apply
+ * @param dedup When true, appended files / delta logs / lob files / column groups whose
+ *        identity (storage path, or column set for column groups) already exists in the
+ *        base manifest are skipped instead of appended. This makes re-application of the
+ *        same updates onto a base that already contains them idempotent — required when a
+ *        resolver applies updates onto the latest manifest (MergeResolver), which under
+ *        commit retries may already carry a prior attempt's writes. Defaults to false so
+ *        the create/overwrite paths keep their existing append-always semantics.
  * @return New manifest with updates applied, or error status
  */
 arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Manifest>& manifest,
-                                                      const Updates& updates);
+                                                      const Updates& updates,
+                                                      bool dedup = false);
 
 // ==================== Helper Resolver Functions ====================
 
@@ -171,6 +179,30 @@ extern const Resolver& OverwriteResolver;
  * version drift, since the resolver only inspects manifests when versions match.
  */
 extern const Resolver& FailResolver;
+
+/**
+ * @brief Resolver for create / first-write (birth) commits.
+ *
+ * Applies updates onto the read manifest without reconciling against concurrent changes.
+ * Use ONLY when the target manifest is brand-new / not yet announced (read_version == 0 or
+ * a freshly-created, task-local manifest), so no concurrent writer's commit can be lost.
+ * Same behavior as the deprecated OverwriteResolver, but named to make birth intent explicit.
+ *
+ * requireLatest() == false.
+ */
+extern const Resolver& InsertResolver;
+
+/**
+ * @brief Default resolver for in-place writes onto a live (announced) segment's manifest.
+ *
+ * Applies updates onto the LATEST committed manifest, so a concurrent commit made after this
+ * transaction pinned its read_version is preserved (layered) instead of being silently
+ * reverted. Re-application is idempotent: appended files / delta logs / lob files / column
+ * groups already present in the latest manifest are skipped, making commit retries safe.
+ *
+ * requireLatest() == true — Commit() loads the latest manifest so it can be merged into.
+ */
+extern const Resolver& MergeResolver;
 
 class Transaction {
   public:

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -48,15 +48,23 @@ LoonFFIResult loon_transaction_begin(const char* base_path,
       RETURN_ERROR(LOON_INVALID_PROPERTIES, "Failed to parse properties [", opt->c_str(), "]");
     }
 
-    // Select resolver based on resolve_id
+    // Select resolver based on resolve_id. The default is MERGE: in-place commits that
+    // don't explicitly opt into another mode are reconciled against the latest manifest
+    // (concurrency-safe), never silently overwriting a concurrent commit.
     const Resolver* resolver = nullptr;
     switch (resolve_id) {
+      case LOON_TRANSACTION_RESOLVE_FAIL:
+        resolver = &FailResolver;
+        break;
       case LOON_TRANSACTION_RESOLVE_OVERWRITE:
         resolver = &OverwriteResolver;
         break;
-      case LOON_TRANSACTION_RESOLVE_FAIL:
+      case LOON_TRANSACTION_RESOLVE_INSERT:
+        resolver = &InsertResolver;
+        break;
+      case LOON_TRANSACTION_RESOLVE_MERGE:
       default:
-        resolver = &FailResolver;
+        resolver = &MergeResolver;
         break;
     }
 

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -80,8 +80,37 @@ const std::vector<LobFileInfo>& Updates::GetAddedLobFiles() const { return added
 
 // ==================== Helper Functions ====================
 
+namespace {
+// Identity predicates used by applyUpdates' idempotent (dedup) mode: an appended item is
+// "already present" when the base manifest already carries an entry with the same identity
+// (files/delta logs/lob files) or the same columns (column groups). Under MergeResolver a
+// commit retry may re-apply updates onto a latest manifest that already contains a prior
+// attempt's writes; skipping already-present items makes that re-application idempotent.
+//
+// Identity is the FILENAME, not the full path: Manifest::toRelativePaths / ToAbsolutePaths
+// rewrite the *directory* prefix on the relative<->absolute round-trip, so a full-path string
+// is not stable across a commit (the base manifest here has been read back and re-absolutized).
+// The filename is never rewritten, and file / delta-log / lob names are unique ids, so it is
+// the stable identity for "the same entry".
+inline std::string pathBaseName(const std::string& path) {
+  const auto pos = path.find_last_of('/');
+  return pos == std::string::npos ? path : path.substr(pos + 1);
+}
+
+template <typename FileVec>
+bool fileWithPathPresent(const FileVec& files, const std::string& path) {
+  const auto name = pathBaseName(path);
+  return std::any_of(files.begin(), files.end(), [&](const auto& f) { return pathBaseName(f.path) == name; });
+}
+
+bool columnGroupPresent(const std::shared_ptr<Manifest>& base, const std::shared_ptr<ColumnGroup>& cg) {
+  return !cg->columns.empty() && base->getColumnGroup(cg->columns.front()) != nullptr;
+}
+}  // namespace
+
 arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Manifest>& manifest,
-                                                      const Updates& updates) {
+                                                      const Updates& updates,
+                                                      bool dedup) {
   // Deep copy the entire manifest to avoid mutating the (potentially cached) original
   auto base = std::make_shared<Manifest>(*manifest);
 
@@ -118,6 +147,11 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
   for (const auto& new_cg : updates.GetAddedColumnGroups()) {
     if (!new_cg) {
       return arrow::Status::Invalid("Cannot add null column group");
+    }
+    // Idempotent retry (dedup): this column group was already applied by a prior attempt
+    // that is now part of the base; skip both the "already exists" validation and the add.
+    if (dedup && columnGroupPresent(base, new_cg)) {
+      continue;
     }
     for (const auto& column_name : new_cg->columns) {
       if (base->getColumnGroup(column_name) != nullptr) {
@@ -213,6 +247,9 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
 
   // Apply delta logs
   for (const auto& dl : updates.GetAddedDeltaLogs()) {
+    if (dedup && fileWithPathPresent(delta_logs, dl.path)) {
+      continue;
+    }
     delta_logs.push_back(dl);
   }
 
@@ -223,6 +260,9 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
 
   // Apply LOB files
   for (const auto& lob_file : updates.GetAddedLobFiles()) {
+    if (dedup && fileWithPathPresent(lob_files, lob_file.path)) {
+      continue;
+    }
     lob_files.push_back(lob_file);
   }
 
@@ -234,6 +274,9 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
       for (size_t i = 0; i < cgs.size() && i < new_cgs.size(); ++i) {
         if (cgs[i] && new_cgs[i]) {
           for (const auto& file : new_cgs[i]->files) {
+            if (dedup && fileWithPathPresent(cgs[i]->files, file.path)) {
+              continue;
+            }
             cgs[i]->files.push_back(file);
           }
         }
@@ -243,6 +286,9 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
 
   // Apply add column groups
   for (const auto& cg : updates.GetAddedColumnGroups()) {
+    if (dedup && columnGroupPresent(base, cg)) {
+      continue;
+    }
     cgs.push_back(cg);
   }
 
@@ -289,13 +335,57 @@ class FailResolverImpl final : public Resolver {
   [[nodiscard]] bool requireLatest() const override { return false; }
 };
 
+// InsertResolver: create / first-write. Applies updates onto the read manifest without
+// reconciling against concurrent changes. Intended ONLY for birth commits (a brand-new /
+// not-yet-announced segment: read_version == 0 or a freshly-created, task-local manifest),
+// where by construction there is no concurrent writer whose commit could be lost. Behaves
+// like the (deprecated) OverwriteResolver, but names the intent so that every remaining
+// non-merge write site is an explicit, auditable "this is a create".
+class InsertResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& read_manifest,
+                                                   int64_t /*read_version*/,
+                                                   const std::shared_ptr<Manifest>& /*latest_manifest*/,
+                                                   int64_t /*latest_version*/,
+                                                   const Updates& updates) const override {
+    return applyUpdates(read_manifest, updates);
+  }
+
+  [[nodiscard]] bool requireLatest() const override { return false; }
+};
+
+// MergeResolver: the default in-place write mode. Applies updates onto the LATEST committed
+// manifest (not the stale read manifest), so a concurrent commit made after this transaction
+// pinned its read_version is preserved (layered on top) rather than silently reverted.
+// dedup=true makes re-application idempotent: on a commit retry the latest may already carry
+// a prior attempt's appended files / delta logs / lob files / column groups, which are
+// skipped instead of duplicated. requireLatest() == true so Commit() loads latest_manifest.
+class MergeResolverImpl final : public Resolver {
+  public:
+  arrow::Result<std::shared_ptr<Manifest>> resolve(const std::shared_ptr<Manifest>& read_manifest,
+                                                   int64_t /*read_version*/,
+                                                   const std::shared_ptr<Manifest>& latest_manifest,
+                                                   int64_t /*latest_version*/,
+                                                   const Updates& updates) const override {
+    // requireLatest() == true guarantees latest_manifest is non-null here (Commit() passes
+    // read_manifest_ when versions match, else reads the latest); guard defensively anyway.
+    return applyUpdates(latest_manifest ? latest_manifest : read_manifest, updates, /*dedup=*/true);
+  }
+
+  [[nodiscard]] bool requireLatest() const override { return true; }
+};
+
 const OverwriteResolverImpl g_overwrite_resolver;
 const FailResolverImpl g_fail_resolver;
+const InsertResolverImpl g_insert_resolver;
+const MergeResolverImpl g_merge_resolver;
 
 }  // namespace
 
 const Resolver& OverwriteResolver = g_overwrite_resolver;
 const Resolver& FailResolver = g_fail_resolver;
+const Resolver& InsertResolver = g_insert_resolver;
+const Resolver& MergeResolver = g_merge_resolver;
 
 // ==================== Transaction Implementation ====================
 

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -273,6 +273,232 @@ TEST_F(TransactionTest, ConflictResolveOverwriteTest) {
   }
 }
 
+// MergeResolver applies updates onto the LATEST manifest, so a commit that landed after this
+// transaction pinned its read_version is preserved rather than dropped. OverwriteResolver
+// would rebuild from the stale read manifest and lose the concurrent file. This is the core
+// fix for milvus#51376 (schema-bump / in-place commits silently dropping a concurrent index).
+TEST_F(TransactionTest, MergeResolverPreservesConcurrentCommit) {
+  // v1: one file on the base column group.
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/a.parquet", {"id", "name"}));
+    txn->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+
+  // Open a MergeResolver transaction pinned at read_version=1 (before the concurrent commit).
+  ASSERT_AND_ASSIGN(auto merge_txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+
+  // A concurrent transaction commits v2, appending a different file.
+  {
+    ASSERT_AND_ASSIGN(auto other, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/b.parquet", {"id", "name"}));
+    other->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, other->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // The merge transaction appends its own file and commits onto the latest (v2), not v1.
+  ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/c.parquet", {"id", "name"}));
+  merge_txn->AppendFiles(m->columnGroups());
+  ASSERT_AND_ASSIGN(auto committed, merge_txn->Commit());
+  ASSERT_EQ(committed, 3);
+
+  // Latest must contain all three files: the concurrent /b.parquet is preserved, not reverted.
+  {
+    ASSERT_AND_ASSIGN(auto read_txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto latest, read_txn->GetManifest());
+    ASSERT_EQ(latest->columnGroups().size(), 1);
+    ASSERT_EQ(latest->columnGroups()[0]->files.size(), 3);
+  }
+}
+
+// applyUpdates(dedup=true) skips appended files already present in the base (by path), so a
+// MergeResolver commit retry that re-applies updates onto a latest already carrying a prior
+// attempt's writes does not duplicate them. With dedup=false the file is appended as-is.
+TEST_F(TransactionTest, ApplyUpdatesDedupSkipsAlreadyPresentFile) {
+  // Base manifest already contains /a.parquet.
+  ASSERT_AND_ASSIGN(auto base, CreateSampleManifest("/a.parquet", {"id", "name"}));
+
+  // Updates that append the SAME file path onto the same column group.
+  Updates updates;
+  ASSERT_AND_ASSIGN(auto same, CreateSampleManifest("/a.parquet", {"id", "name"}));
+  updates.AppendFiles(same->columnGroups());
+
+  // dedup=true: the already-present /a.parquet is skipped -> still one file.
+  ASSERT_AND_ASSIGN(auto merged, applyUpdates(base, updates, /*dedup=*/true));
+  ASSERT_EQ(merged->columnGroups().size(), 1);
+  ASSERT_EQ(merged->columnGroups()[0]->files.size(), 1);
+
+  // dedup=false (create / overwrite semantics): the file is appended -> two entries.
+  ASSERT_AND_ASSIGN(auto appended, applyUpdates(base, updates, /*dedup=*/false));
+  ASSERT_EQ(appended->columnGroups()[0]->files.size(), 2);
+}
+
+// MergeResolver preserves a concurrent DELTA LOG (not just column-group files).
+TEST_F(TransactionTest, MergeResolverPreservesConcurrentDeltaLog) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/base.parquet", {"id", "name"}));
+    txn->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  ASSERT_AND_ASSIGN(auto merge_txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+
+  // Concurrent commit adds delta D1.
+  {
+    ASSERT_AND_ASSIGN(auto other, Transaction::Open(fs_, base_path_));
+    DeltaLog d1;
+    d1.path = base_path_ + "/_delta/d1.parquet";
+    d1.type = DeltaLogType::PRIMARY_KEY;
+    d1.num_entries = 10;
+    other->AddDeltaLog(d1);
+    ASSERT_AND_ASSIGN(auto v, other->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // Merge transaction adds delta D2 onto latest; D1 must survive.
+  DeltaLog d2;
+  d2.path = base_path_ + "/_delta/d2.parquet";
+  d2.type = DeltaLogType::PRIMARY_KEY;
+  d2.num_entries = 20;
+  merge_txn->AddDeltaLog(d2);
+  ASSERT_AND_ASSIGN(auto committed, merge_txn->Commit());
+  ASSERT_EQ(committed, 3);
+
+  ASSERT_AND_ASSIGN(auto read_txn, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto latest, read_txn->GetManifest());
+  ASSERT_EQ(latest->deltaLogs().size(), 2);  // D1 preserved, D2 added
+}
+
+// MergeResolver preserves a concurrent ADD-COLUMN-GROUP (bump-style materialization).
+TEST_F(TransactionTest, MergeResolverPreservesConcurrentColumnGroup) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/base.parquet", {"id", "name"}));
+    txn->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  ASSERT_AND_ASSIGN(auto merge_txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+
+  // Concurrent commit adds a new column group on distinct column "value".
+  {
+    ASSERT_AND_ASSIGN(auto other, Transaction::Open(fs_, base_path_));
+    auto cg = std::make_shared<ColumnGroup>();
+    cg->columns = {"value"};
+    cg->files = {{.path = base_path_ + "/value.parquet"}};
+    cg->format = LOON_FORMAT_PARQUET;
+    other->AddColumnGroup(cg);
+    ASSERT_AND_ASSIGN(auto v, other->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // Merge adds a new column group on "vector" onto latest; "value" must survive.
+  auto cg = std::make_shared<ColumnGroup>();
+  cg->columns = {"vector"};
+  cg->files = {{.path = base_path_ + "/vector.parquet"}};
+  cg->format = LOON_FORMAT_PARQUET;
+  merge_txn->AddColumnGroup(cg);
+  ASSERT_AND_ASSIGN(auto committed, merge_txn->Commit());
+  ASSERT_EQ(committed, 3);
+
+  ASSERT_AND_ASSIGN(auto read_txn, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto latest, read_txn->GetManifest());
+  ASSERT_EQ(latest->columnGroups().size(), 3);  // {id,name} + value + vector
+}
+
+// MergeResolver merges STATS by key: a concurrently-added stat key survives.
+TEST_F(TransactionTest, MergeResolverMergesStatsByKey) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/base.parquet", {"id", "name"}));
+    txn->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  ASSERT_AND_ASSIGN(auto merge_txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+
+  // Concurrent commit registers stat "bm25.101".
+  {
+    ASSERT_AND_ASSIGN(auto other, Transaction::Open(fs_, base_path_));
+    Statistics s;
+    s.paths = {base_path_ + "/_stats/bm25.101"};
+    other->UpdateStat("bm25.101", s);
+    ASSERT_AND_ASSIGN(auto v, other->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // Merge registers "bloom.100" onto latest; both keys must be present.
+  Statistics s;
+  s.paths = {base_path_ + "/_stats/bloom.100"};
+  merge_txn->UpdateStat("bloom.100", s);
+  ASSERT_AND_ASSIGN(auto committed, merge_txn->Commit());
+  ASSERT_EQ(committed, 3);
+
+  ASSERT_AND_ASSIGN(auto read_txn, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto latest, read_txn->GetManifest());
+  ASSERT_EQ(latest->stats().count("bm25.101"), 1u);   // concurrent stat preserved
+  ASSERT_EQ(latest->stats().count("bloom.100"), 1u);  // merge stat added
+}
+
+// MergeResolver commit is idempotent: re-appending a file already in the latest manifest
+// (as a retry would) does not duplicate it. Exercises the dedup path through the real Commit.
+TEST_F(TransactionTest, MergeResolverCommitDedupsDuplicateFile) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/dup.parquet", {"id", "name"}));
+    txn->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+
+  // Merge-commit the SAME file path again (the shape of a re-applied retry).
+  ASSERT_AND_ASSIGN(auto merge_txn, Transaction::Open(fs_, base_path_, 1, MergeResolver));
+  ASSERT_AND_ASSIGN(auto same, CreateSampleManifest("/dup.parquet", {"id", "name"}));
+  merge_txn->AppendFiles(same->columnGroups());
+  ASSERT_AND_ASSIGN(auto committed, merge_txn->Commit());
+  ASSERT_EQ(committed, 2);
+
+  ASSERT_AND_ASSIGN(auto read_txn, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto latest, read_txn->GetManifest());
+  ASSERT_EQ(latest->columnGroups().size(), 1);
+  ASSERT_EQ(latest->columnGroups()[0]->files.size(), 1);  // not duplicated
+}
+
+// MergeResolver commit dedups a duplicate DELTA LOG on re-apply.
+TEST_F(TransactionTest, MergeResolverCommitDedupsDuplicateDeltaLog) {
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto m, CreateSampleManifest("/base.parquet", {"id", "name"}));
+    txn->AppendFiles(m->columnGroups());
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 1);
+  }
+  DeltaLog d;
+  d.path = base_path_ + "/_delta/dup.parquet";
+  d.type = DeltaLogType::PRIMARY_KEY;
+  d.num_entries = 10;
+  {
+    ASSERT_AND_ASSIGN(auto txn, Transaction::Open(fs_, base_path_));
+    txn->AddDeltaLog(d);
+    ASSERT_AND_ASSIGN(auto v, txn->Commit());
+    ASSERT_EQ(v, 2);
+  }
+
+  // Merge-commit the SAME delta path again.
+  ASSERT_AND_ASSIGN(auto merge_txn, Transaction::Open(fs_, base_path_, 2, MergeResolver));
+  merge_txn->AddDeltaLog(d);
+  ASSERT_AND_ASSIGN(auto committed, merge_txn->Commit());
+  ASSERT_EQ(committed, 3);
+
+  ASSERT_AND_ASSIGN(auto read_txn, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto latest, read_txn->GetManifest());
+  ASSERT_EQ(latest->deltaLogs().size(), 1);  // not duplicated
+}
+
 // Regression for issue #49069: when the resolver doesn't need the latest manifest,
 // Commit() must not block on reading manifest-N.avro from storage. A transient read
 // failure on an otherwise-unused manifest used to fail an entire successful commit.


### PR DESCRIPTION
## What / why

StorageV3 manifest commits default to `OverwriteResolver`, which rebuilds the committed
manifest from the transaction's **stale pinned `read_version`** and silently drops any
commit another task made to the same segment's manifest in between — a lost update. The
version-newer acceptance never catches it, because an overwrite commit's version is always
`latest + 1`.

This is the root mechanism behind milvus-io/milvus#51376 (schema-bump / in-place commits
dropping a concurrently-built index). A sealed segment's manifest has many concurrent,
independent writers by design (bump / function materialization, bloom / bm25, text / json
index, L0 deletes), so this is a structural race, not an isolated bug.

## What this PR does (storage-layer foundation)

- **`MergeResolver`** (new default write mode): applies updates onto the **latest** committed
  manifest, so a concurrent commit made after `read_version` was pinned is preserved (layered)
  instead of overwritten. `requireLatest() == true`.
- **`InsertResolver`**: explicit create / first-write semantics for **birth** commits
  (a brand-new / not-yet-announced manifest), so every remaining non-merge write site is an
  auditable "this is a create". `OVERWRITE` is retained but deprecated.
- **Idempotent `dedup`** in `applyUpdates` (used only by `MergeResolver`): skips appended
  files / delta logs / lob files / column groups already present in the base, so a commit
  retry that re-applies the same updates does not duplicate them. Identity is the
  **filename**, not the full path — `Manifest::toRelativePaths` / `ToAbsolutePaths` rewrite
  the directory prefix on the relative⇄absolute round-trip, so full-path equality is not
  stable across a commit.
- **FFI**: `LOON_TRANSACTION_RESOLVE_MERGE = 1`, `LOON_TRANSACTION_RESOLVE_INSERT = 3`; the
  resolver switch now defaults to `MERGE`.

## Tests

`MergeResolver` preserves concurrent file / delta-log / column-group / stats-by-key commits;
Commit-level dedup for duplicate file / delta-log. Full transaction suite green (34 passed,
1 skipped).

**Not covered here:** the threaded `AlreadyExists → retry` path requires remote storage with
conditional write (CAS) and is only exercised by the existing remote-only concurrency test,
not the local-fs suite.

## Follow-up (milvus side)

This is only the storage-layer mechanism. The actual fix for #51376 needs the milvus repo to
(a) flip non-birth manifest write sites (bump / stats / L0) to `MERGE` and mark birth sites
`INSERT`, and (b) rework the datacoord acceptance to adopt-if-version-newer and drop the
`errStatsResultStale` / `BaseManifest` machinery (which would otherwise discard
correctly-merged results). Those land in a separate milvus PR.

Relates to milvus-io/milvus#51376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
