### PR TITLE
enhance: add per-column memory size estimates for chunks

### DIFF
--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -194,6 +194,7 @@
     loon_fiukey_take_rows_fail;
     loon_fiukey_chunk_reader_read_fail;
     loon_fiukey_reader_open_fail;
+    loon_fiukey_memory_size_estimation_fail;
     # Transaction/Manifest
     loon_fiukey_manifest_commit_fail;
     loon_fiukey_manifest_read_fail;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -192,6 +192,7 @@ _loon_fiukey_column_group_read_fail
 _loon_fiukey_take_rows_fail
 _loon_fiukey_chunk_reader_read_fail
 _loon_fiukey_reader_open_fail
+_loon_fiukey_memory_size_estimation_fail
 # Transaction/Manifest
 _loon_fiukey_manifest_commit_fail
 _loon_fiukey_manifest_read_fail

--- a/cpp/include/milvus-storage/common/fiu_local.h
+++ b/cpp/include/milvus-storage/common/fiu_local.h
@@ -48,6 +48,7 @@
 #define FIUKEY_TAKE_ROWS_FAIL "take_rows.fail"
 #define FIUKEY_CHUNK_READER_READ_FAIL "chunk_reader.read.fail"
 #define FIUKEY_READER_OPEN_FAIL "reader.open.fail"
+#define FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL "memory_size_estimation.fail"
 
 // Transaction/Manifest fault points
 #define FIUKEY_MANIFEST_COMMIT_FAIL "manifest.commit.fail"

--- a/cpp/include/milvus-storage/ffi_fiu_c.h
+++ b/cpp/include/milvus-storage/ffi_fiu_c.h
@@ -70,6 +70,9 @@ FFI_EXPORT extern const char* loon_fiukey_chunk_reader_read_fail;
 /** Fault point: Fail during Reader open operation (FFI layer) */
 FFI_EXPORT extern const char* loon_fiukey_reader_open_fail;
 
+/** Fault point: Fail format reader memory size estimation */
+FFI_EXPORT extern const char* loon_fiukey_memory_size_estimation_fail;
+
 // --- Transaction/Manifest fault points ---
 /** Fault point: Fail during Transaction/Manifest commit */
 FFI_EXPORT extern const char* loon_fiukey_manifest_commit_fail;

--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -39,7 +39,8 @@ class ColumnGroupReader {
   virtual arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
       const std::vector<int64_t>& chunk_indices, size_t parallelism = 1) = 0;
 
-  virtual arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) = 0;
+  virtual arrow::Result<uint64_t> get_chunk_estimated_size(int64_t chunk_index) = 0;
+  virtual arrow::Result<uint64_t> get_chunk_column_estimated_size(int64_t chunk_index, int col_idx) = 0;
   virtual arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) = 0;
 
   // get the file schema of this column group (always derived from file metadata, not projected)

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -40,6 +40,10 @@ struct RowGroupInfo {
   size_t end_offset;
   uint64_t memory_size;
   std::vector<uint64_t> column_memory_sizes;
+  // `memory_size` is only a placeholder when this is false. The original
+  // statistics failure is intentionally not retained; public estimate APIs
+  // return a generic NotImplemented status instead.
+  bool memory_size_available = true;
 
   std::string ToString() const;
 };

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -38,10 +38,13 @@ struct RowGroupInfo {
   public:
   size_t start_offset;
   size_t end_offset;
-  size_t memory_size;
+  uint64_t memory_size;
+  std::vector<uint64_t> column_memory_sizes;
 
   std::string ToString() const;
 };
+
+arrow::Result<std::vector<uint64_t>> DistributeMemorySizes(uint64_t total_size, const std::vector<uint64_t>& weights);
 
 template <typename Payload>
 struct FormatReaderMetadata {

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -108,7 +108,7 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   size_t rows() const;
 
   // get the total memory usage(uncompressed memory) of the file
-  uint64_t total_mem_usage();
+  arrow::Result<uint64_t> total_mem_usage();
 
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> streaming_read(
       uint64_t row_start, uint64_t row_end, const ffi::CoalescingWindow& coalescing_window);

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -149,11 +149,10 @@ class ChunkReader {
  * including column groups, data layout, and metadata, providing optimized access
  * patterns for analytical workloads.
  *
- * Some formats validate column-level memory-estimation metadata while opening
- * their underlying format readers. If that metadata is unavailable,
- * get_record_batch_reader(), get_chunk_reader(), or take() may return
- * arrow::Status::NotImplemented. Callers must handle this status; no usable
- * RecordBatchReader, ChunkReader, or Table is returned in that case.
+ * Memory-estimation metadata is optional and is not required for normal data
+ * reads. When it is unavailable, reader creation and data access remain usable;
+ * only the chunk-size estimation APIs return arrow::Status::NotImplemented.
+ * The underlying statistics failure is not exposed through those APIs.
  */
 class Reader {
   public:

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -90,10 +90,13 @@ class ChunkReader {
   /**
    * @brief Returns the estimated decoded-memory size of every chunk.
    *
-   * The result is indexed by chunk. Estimates are derived from format metadata
-   * and may be zero when a chunk has no live rows or its known decoded-memory
-   * size is zero. Unavailable estimates are returned as an error, typically
-   * arrow::Status::NotImplemented, rather than being represented by zero.
+   * The result is indexed by chunk. When per-column metadata is available, each
+   * estimate is the sum of the logical column group's fields, independently of
+   * the active projection; fields present only in a physical file are excluded.
+   * Formats without per-column metadata retain their aggregate estimate.
+   * Estimates may be zero when a chunk has no live rows or its known
+   * decoded-memory size is zero. Unavailable estimates are returned as an
+   * error, typically arrow::Status::NotImplemented, rather than as zero.
    *
    * @return One estimated size in bytes per chunk, or an error status.
    */
@@ -102,11 +105,12 @@ class ChunkReader {
   /**
    * @brief Returns the estimated decoded-memory size of a top-level field in every chunk.
    *
-   * The field is resolved against the complete file schema, independently of
-   * the active projection. A successful zero value is a known zero estimate;
-   * unavailable estimates are returned as an error rather than as zero.
+   * The field is resolved against the logical column group, independently of
+   * the active projection. A field absent from a particular physical file has
+   * a known zero estimate for that chunk. Unavailable statistics are returned
+   * as an error rather than as zero.
    *
-   * @param field_name Name of a unique top-level field in the complete file schema.
+   * @param field_name Name of a unique top-level field in the column group.
    * @return One estimated size in bytes per chunk, or an error status.
    */
   [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_size(
@@ -115,7 +119,7 @@ class ChunkReader {
   /**
    * @brief Returns estimated decoded-memory sizes for every top-level field and chunk.
    *
-   * The outer dimension follows complete file-schema order and the inner
+   * The outer dimension follows logical column-group order and the inner
    * dimension is indexed by chunk: result[column_index][chunk_index]. Results
    * are independent of the active projection. Individual estimates may be
    * zero only when the corresponding estimate is known to be zero. Unavailable

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -88,9 +88,52 @@ class ChunkReader {
       const std::vector<int64_t>& chunk_indices, size_t parallelism = 1) = 0;
 
   /**
-   * @brief Retrieves the metadata of chunks
+   * @brief Returns the estimated decoded-memory size of every chunk.
+   *
+   * The result is indexed by chunk. Estimates are derived from format metadata
+   * and may be zero when a chunk has no live rows or its known decoded-memory
+   * size is zero. Unavailable estimates are returned as an error, typically
+   * arrow::Status::NotImplemented, rather than being represented by zero.
+   *
+   * @return One estimated size in bytes per chunk, or an error status.
    */
-  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_size() = 0;
+  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_estimated_size() = 0;
+
+  /**
+   * @brief Returns the estimated decoded-memory size of a top-level field in every chunk.
+   *
+   * The field is resolved against the complete file schema, independently of
+   * the active projection. A successful zero value is a known zero estimate;
+   * unavailable estimates are returned as an error rather than as zero.
+   *
+   * @param field_name Name of a unique top-level field in the complete file schema.
+   * @return One estimated size in bytes per chunk, or an error status.
+   */
+  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_size(
+      const std::string& field_name) = 0;
+
+  /**
+   * @brief Returns estimated decoded-memory sizes for every top-level field and chunk.
+   *
+   * The outer dimension follows complete file-schema order and the inner
+   * dimension is indexed by chunk: result[column_index][chunk_index]. Results
+   * are independent of the active projection. Individual estimates may be
+   * zero only when the corresponding estimate is known to be zero. Unavailable
+   * estimates are returned as an error rather than as zero.
+   *
+   * @return Estimated sizes in bytes arranged as [column][chunk], or an error status.
+   */
+  [[nodiscard]] virtual arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_estimated_size() = 0;
+
+  /**
+   * @brief Returns the exact logical row count of every chunk.
+   *
+   * Unlike the estimated-size APIs, failures are returned as an error status
+   * and are never converted to a zero fallback. A returned zero is an exact
+   * row count for an empty logical chunk.
+   *
+   * @return One exact row count per chunk, or an error status.
+   */
   [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_rows() = 0;
 };
 
@@ -105,6 +148,12 @@ class ChunkReader {
  * This reader leverages the manifest system to understand the dataset structure,
  * including column groups, data layout, and metadata, providing optimized access
  * patterns for analytical workloads.
+ *
+ * Some formats validate column-level memory-estimation metadata while opening
+ * their underlying format readers. If that metadata is unavailable,
+ * get_record_batch_reader(), get_chunk_reader(), or take() may return
+ * arrow::Status::NotImplemented. Callers must handle this status; no usable
+ * RecordBatchReader, ChunkReader, or Table is returned in that case.
  */
 class Reader {
   public:

--- a/cpp/src/ffi/ffi_fiu_c.cpp
+++ b/cpp/src/ffi/ffi_fiu_c.cpp
@@ -36,6 +36,7 @@ const char* loon_fiukey_column_group_read_fail = FIUKEY_COLUMN_GROUP_READ_FAIL;
 const char* loon_fiukey_take_rows_fail = FIUKEY_TAKE_ROWS_FAIL;
 const char* loon_fiukey_chunk_reader_read_fail = FIUKEY_CHUNK_READER_READ_FAIL;
 const char* loon_fiukey_reader_open_fail = FIUKEY_READER_OPEN_FAIL;
+const char* loon_fiukey_memory_size_estimation_fail = FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL;
 
 // Transaction/Manifest fault points
 const char* loon_fiukey_manifest_commit_fail = FIUKEY_MANIFEST_COMMIT_FAIL;
@@ -124,6 +125,7 @@ void loon_fiu_disable_all(void) {
       FIUKEY_TAKE_ROWS_FAIL,
       FIUKEY_CHUNK_READER_READ_FAIL,
       FIUKEY_READER_OPEN_FAIL,
+      FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL,
       // Transaction/Manifest
       FIUKEY_MANIFEST_COMMIT_FAIL,
       FIUKEY_MANIFEST_READ_FAIL,

--- a/cpp/src/ffi/reader_c.cpp
+++ b/cpp/src/ffi/reader_c.cpp
@@ -176,7 +176,7 @@ LoonFFIResult loon_get_chunk_metadatas(LoonChunkReaderHandle reader,
 
     out_chunk_metadata->metadatas_size = 0;
     if (metadata_type & LOON_CHUNK_METADATA_ESTIMATED_MEMORY) {
-      auto estimated_mem_result = cpp_reader->get_chunk_size();
+      auto estimated_mem_result = cpp_reader->get_chunk_estimated_size();
       if (!estimated_mem_result.ok()) {
         // must be 0 because calloc and `number_of_chunks` will be updated at last.
         loon_free_chunk_metadatas(out_chunk_metadata);

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -102,7 +102,8 @@ class BlockingDataset {
 
   uint64_t EstimateFragmentMemory(uint64_t fragment_id) const;
 
-  // Get the schema of a specific fragment, exported as Arrow C schema
+  // Lance 7 exposes the current dataset schema through FileFragment::schema().
+  // It can include evolved nullable columns that are not physically stored in this fragment.
   void GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const;
 
   // Dataset-level scan: create a scanner for projected columns

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <stdexcept>
 #include <arrow/c/abi.h>
+#include <arrow/result.h>
 
 #include "rust/cxx.h"
 #include "rust-bridge/lib.h"
@@ -95,6 +96,9 @@ class BlockingDataset {
   uint64_t GetFragmentPhysicalRowCount(uint64_t fragment_id) const;
 
   uint64_t GetFragmentRowCount(uint64_t fragment_id) const;
+
+  // Top-level dataset columns in schema order; returns NotImplemented when estimation is unavailable.
+  arrow::Result<std::vector<uint64_t>> EstimateFragmentColumnMemory(uint64_t fragment_id) const;
 
   uint64_t EstimateFragmentMemory(uint64_t fragment_id) const;
 

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -104,6 +104,20 @@ uint64_t BlockingDataset::GetFragmentRowCount(uint64_t fragment_id) const {
   }
 }
 
+arrow::Result<std::vector<uint64_t>> BlockingDataset::EstimateFragmentColumnMemory(uint64_t fragment_id) const {
+  try {
+    auto estimates = ffi::estimate_fragment_column_memory(*impl_, fragment_id);
+    std::vector<uint64_t> memory_sizes;
+    memory_sizes.reserve(estimates.size());
+    for (const auto& estimate : estimates) {
+      memory_sizes.push_back(estimate.memory_size);
+    }
+    return memory_sizes;
+  } catch (const rust::cxxbridge1::Error& e) {
+    return arrow::Status::NotImplemented("Lance column memory size estimation is not available: ", e.what());
+  }
+}
+
 uint64_t BlockingDataset::EstimateFragmentMemory(uint64_t fragment_id) const {
   try {
     return ffi::estimate_fragment_memory(*impl_, fragment_id);

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -1031,9 +1031,10 @@ pub unsafe fn get_fragment_schema(
             location: snafu::location!(),
         })?;
 
-    // Lance only exposes fragment schema via FileFragment::schema(), which requires an
-    // Arc<Dataset>. The clone here is cheap — Dataset internally wraps state in Arcs, so
-    // this is essentially a ref-count bump rather than a deep copy.
+    // In Lance 7, FileFragment::schema() returns the current dataset schema. It
+    // includes evolved nullable fields that may not be physically stored in this
+    // fragment, matching the schema order used by the column memory estimator.
+    // The clone is cheap because Dataset internally wraps state in Arcs.
     let file_fragment = FileFragment::new(Arc::new(dataset.inner.clone()), fragment_meta);
     let lance_schema = file_fragment.schema();
     let arrow_schema: ArrowSchema = lance_schema.into();

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -15,8 +15,11 @@
 #include "milvus-storage/format/column_group_reader.h"
 
 #include <numeric>
+#include <limits>
 #include <unordered_map>
+#include <unordered_set>
 #include <future>
+#include <string_view>
 #include <vector>
 #include <algorithm>
 
@@ -38,6 +41,7 @@
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"  // for UNLIKELY
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
@@ -49,6 +53,33 @@ namespace milvus_storage::api {
 
 using milvus_storage::RowGroupInfo;
 using ChunkRBMapResult = arrow::Result<std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>>;
+using ColumnMemorySizes = std::unordered_map<std::string, uint64_t>;
+using ColumnMemorySizesPtr = std::shared_ptr<const ColumnMemorySizes>;
+
+namespace {
+
+arrow::Result<ColumnMemorySizesPtr> BuildColumnMemorySizes(const arrow::Schema& file_schema,
+                                                           const std::vector<uint64_t>& sizes) {
+  if (sizes.empty()) {
+    return ColumnMemorySizesPtr{};
+  }
+  if (sizes.size() != static_cast<size_t>(file_schema.num_fields())) {
+    return arrow::Status::Invalid("Column memory size count does not match the file schema");
+  }
+
+  auto column_memory_sizes = std::make_shared<ColumnMemorySizes>();
+  column_memory_sizes->reserve(sizes.size());
+  for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
+    const auto& field_name = file_schema.field(field_index)->name();
+    if (!column_memory_sizes->emplace(field_name, sizes[field_index]).second) {
+      return arrow::Status::Invalid("Duplicate field name in file schema: ", field_name);
+    }
+  }
+  return std::static_pointer_cast<const ColumnMemorySizes>(column_memory_sizes);
+}
+
+}  // namespace
+
 struct ChunkInfo {
   public:
   size_t file_index;               // current chunk belong which file
@@ -58,9 +89,9 @@ struct ChunkInfo {
   size_t row_group_index_in_file;  // the index of this row group in its file
   size_t global_row_end;           // the ending row offset of this row group in the whole chunk reader
   uint64_t avg_memory_size;        // average memory usage of this row group
-  // FIXME(jiaqizho): Use shared_ptr for immutable column metadata so cached readers and full chunks can share it;
-  // only partial row groups should materialize scaled copies.
-  std::vector<uint64_t> column_memory_sizes;
+  // Keyed by the current file's field names so chunks from files with different
+  // physical column orders can share immutable metadata without normalization.
+  ColumnMemorySizesPtr column_memory_sizes;
   // False means avg_memory_size is only a placeholder and column_memory_sizes is unavailable.
   bool memory_size_available;
 
@@ -151,22 +182,43 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
     }
 
     std::vector<RowGroupInfo> row_group_in_file;
+    std::shared_ptr<arrow::Schema> current_file_schema;
     if (cache_.enabled()) {
       auto key = ReaderT::MetaTrait::cache_key(cg_file);
       ARROW_ASSIGN_OR_RAISE(auto metadata, cache_.get<ReaderT>()->get_or_open(key, [this, cg_file]() {
         return FormatReader::load_metadata<ReaderT>(cg_file, properties_, key_retriever_);
       }));
       row_group_in_file = metadata->row_group_infos;
-      if (!file_schema_ && metadata->file_schema) {
-        file_schema_ = metadata->file_schema;
-      }
+      current_file_schema = metadata->file_schema;
     } else {
       ARROW_ASSIGN_OR_RAISE(format_readers_[file_idx], open_reader_for_file(file_idx));
       ARROW_ASSIGN_OR_RAISE(row_group_in_file, format_readers_[file_idx]->get_row_group_infos());
-      if (!file_schema_) {
-        file_schema_ = format_readers_[file_idx]->get_schema();
-      }
+      current_file_schema = format_readers_[file_idx]->get_schema();
     }
+    if (!file_schema_ && current_file_schema) {
+      file_schema_ = current_file_schema;
+    }
+
+    auto build_column_memory_sizes = [&](const std::vector<uint64_t>& sizes) -> ColumnMemorySizesPtr {
+      if (sizes.empty()) {
+        return nullptr;
+      }
+      if (!current_file_schema) {
+        LOG_STORAGE_DEBUG_ << "Column memory sizes are unavailable because the file schema is missing"
+                           << ", path=" << cg_file.path;
+        return nullptr;
+      }
+      auto result = BuildColumnMemorySizes(*current_file_schema, sizes);
+      if (!result.ok()) {
+        // Column estimates are optional. Preserve the total chunk estimate and
+        // normal reads; the public column-estimate API returns NotImplemented.
+        LOG_STORAGE_DEBUG_ << "Column memory sizes are unavailable"
+                           << ", path=" << cg_file.path << ", status=" << result.status().ToString();
+        return nullptr;
+      }
+      return std::move(result).ValueOrDie();
+    };
+
     row_group_infos_[file_idx] = row_group_in_file;
     if (row_group_in_file.empty()) {
       continue;
@@ -201,13 +253,17 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
             chunk_memory_size = static_cast<uint64_t>(static_cast<unsigned __int128>(row_group_in_file[j].memory_size) *
                                                       overlap_rows / row_group_rows);
           }
-          auto column_memory_sizes = row_group_in_file[j].column_memory_sizes;
-          if (row_group_in_file[j].memory_size_available && !column_memory_sizes.empty()) {
+          ColumnMemorySizesPtr column_memory_sizes;
+          if (row_group_in_file[j].memory_size_available && !row_group_in_file[j].column_memory_sizes.empty()) {
             // Use the same row-count scaling as avg_memory_size when this chunk
             // contains only part of the row group.
-            ARROW_ASSIGN_OR_RAISE(column_memory_sizes, DistributeMemorySizes(chunk_memory_size, column_memory_sizes));
-          } else if (!row_group_in_file[j].memory_size_available) {
-            column_memory_sizes.clear();
+            auto scaled_sizes = DistributeMemorySizes(chunk_memory_size, row_group_in_file[j].column_memory_sizes);
+            if (scaled_sizes.ok()) {
+              column_memory_sizes = build_column_memory_sizes(*scaled_sizes);
+            } else {
+              LOG_STORAGE_DEBUG_ << "Column memory size scaling is unavailable"
+                                 << ", path=" << cg_file.path << ", status=" << scaled_sizes.status().ToString();
+            }
           }
 
           rows_in_file += (overlap_end - overlap_start);
@@ -219,7 +275,7 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
               .row_group_index_in_file = j,
               .global_row_end = rows_in_all_files + rows_in_file,
               .avg_memory_size = chunk_memory_size,
-              .column_memory_sizes = std::move(column_memory_sizes),
+              .column_memory_sizes = column_memory_sizes,
               .memory_size_available = row_group_in_file[j].memory_size_available,
           });
         }
@@ -236,7 +292,9 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
             .row_group_index_in_file = j,
             .global_row_end = rows_in_all_files + rows_in_file,
             .avg_memory_size = row_group_in_file[j].memory_size,
-            .column_memory_sizes = row_group_in_file[j].column_memory_sizes,
+            .column_memory_sizes = row_group_in_file[j].memory_size_available
+                                       ? build_column_memory_sizes(row_group_in_file[j].column_memory_sizes)
+                                       : nullptr,
             .memory_size_available = row_group_in_file[j].memory_size_available,
         });
       }
@@ -536,10 +594,33 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_estimated_size
     return arrow::Status::Invalid(
         fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
   }
-  if (!chunk_infos_[chunk_index].memory_size_available) {
+  const auto& chunk_info = chunk_infos_[chunk_index];
+  if (!chunk_info.memory_size_available) {
     return arrow::Status::NotImplemented("Chunk memory size estimate is not available");
   }
-  return chunk_infos_[chunk_index].avg_memory_size;
+  if (!chunk_info.column_memory_sizes) {
+    return chunk_info.avg_memory_size;
+  }
+
+  // Files in one column group may have evolved physical schemas and can retain
+  // columns removed from the logical group. Sum the logical column estimates
+  // so physical-only columns are excluded while the result remains independent
+  // of the active projection.
+  uint64_t total_size = 0;
+  std::unordered_set<std::string_view> seen_columns;
+  seen_columns.reserve(column_group_->columns.size());
+  for (size_t col_idx = 0; col_idx < column_group_->columns.size(); ++col_idx) {
+    const auto& column_name = column_group_->columns[col_idx];
+    if (!seen_columns.emplace(column_name).second) {
+      return arrow::Status::Invalid("Duplicate column in column group: ", column_name);
+    }
+    ARROW_ASSIGN_OR_RAISE(auto column_size, get_chunk_column_estimated_size(chunk_index, static_cast<int>(col_idx)));
+    if (column_size > std::numeric_limits<uint64_t>::max() - total_size) {
+      return arrow::Status::Invalid("Chunk column memory sizes exceed the uint64_t range");
+    }
+    total_size += column_size;
+  }
+  return total_size;
 }
 
 template <typename ReaderT>
@@ -556,14 +637,15 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_estimat
   if (!chunk_info.memory_size_available) {
     return arrow::Status::NotImplemented("Column memory size estimate is not available");
   }
-  if (column_memory_sizes.empty()) {
+  if (!column_memory_sizes) {
     return arrow::Status::NotImplemented("Column memory size metadata is not available for this format");
   }
-  if (UNLIKELY(col_idx < 0 || static_cast<size_t>(col_idx) >= column_memory_sizes.size())) {
+  if (UNLIKELY(col_idx < 0 || static_cast<size_t>(col_idx) >= column_group_->columns.size())) {
     return arrow::Status::Invalid(
-        fmt::format("Column index out of range: {} out of {}", col_idx, column_memory_sizes.size()));
+        fmt::format("Column index out of range: {} out of {}", col_idx, column_group_->columns.size()));
   }
-  return column_memory_sizes[col_idx];
+  const auto it = column_memory_sizes->find(column_group_->columns[col_idx]);
+  return it == column_memory_sizes->end() ? uint64_t{0} : it->second;
 }
 
 template <typename ReaderT>

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -58,7 +58,11 @@ struct ChunkInfo {
   size_t row_group_index_in_file;  // the index of this row group in its file
   size_t global_row_end;           // the ending row offset of this row group in the whole chunk reader
   uint64_t avg_memory_size;        // average memory usage of this row group
+  // FIXME(jiaqizho): Use shared_ptr for immutable column metadata so cached readers and full chunks can share it;
+  // only partial row groups should materialize scaled copies.
   std::vector<uint64_t> column_memory_sizes;
+  // False means avg_memory_size is only a placeholder and column_memory_sizes is unavailable.
+  bool memory_size_available;
 
   [[nodiscard]] std::string ToString() const;
 };
@@ -192,13 +196,18 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
           const auto overlap_rows = overlap_end - overlap_start;
           const auto row_group_rows = rg_end - rg_start;
           // overlap_rows <= row_group_rows, so the quotient is at most memory_size and is safe to cast to uint64_t.
-          const auto chunk_memory_size = static_cast<uint64_t>(
-              static_cast<unsigned __int128>(row_group_in_file[j].memory_size) * overlap_rows / row_group_rows);
+          uint64_t chunk_memory_size = 0;
+          if (row_group_in_file[j].memory_size_available) {
+            chunk_memory_size = static_cast<uint64_t>(static_cast<unsigned __int128>(row_group_in_file[j].memory_size) *
+                                                      overlap_rows / row_group_rows);
+          }
           auto column_memory_sizes = row_group_in_file[j].column_memory_sizes;
-          if (!column_memory_sizes.empty()) {
+          if (row_group_in_file[j].memory_size_available && !column_memory_sizes.empty()) {
             // Use the same row-count scaling as avg_memory_size when this chunk
             // contains only part of the row group.
             ARROW_ASSIGN_OR_RAISE(column_memory_sizes, DistributeMemorySizes(chunk_memory_size, column_memory_sizes));
+          } else if (!row_group_in_file[j].memory_size_available) {
+            column_memory_sizes.clear();
           }
 
           rows_in_file += (overlap_end - overlap_start);
@@ -211,6 +220,7 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
               .global_row_end = rows_in_all_files + rows_in_file,
               .avg_memory_size = chunk_memory_size,
               .column_memory_sizes = std::move(column_memory_sizes),
+              .memory_size_available = row_group_in_file[j].memory_size_available,
           });
         }
       }
@@ -227,6 +237,7 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
             .global_row_end = rows_in_all_files + rows_in_file,
             .avg_memory_size = row_group_in_file[j].memory_size,
             .column_memory_sizes = row_group_in_file[j].column_memory_sizes,
+            .memory_size_available = row_group_in_file[j].memory_size_available,
         });
       }
     }
@@ -525,6 +536,9 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_estimated_size
     return arrow::Status::Invalid(
         fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
   }
+  if (!chunk_infos_[chunk_index].memory_size_available) {
+    return arrow::Status::NotImplemented("Chunk memory size estimate is not available");
+  }
   return chunk_infos_[chunk_index].avg_memory_size;
 }
 
@@ -537,7 +551,11 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_estimat
         fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
   }
 
-  const auto& column_memory_sizes = chunk_infos_[chunk_index].column_memory_sizes;
+  const auto& chunk_info = chunk_infos_[chunk_index];
+  const auto& column_memory_sizes = chunk_info.column_memory_sizes;
+  if (!chunk_info.memory_size_available) {
+    return arrow::Status::NotImplemented("Column memory size estimate is not available");
+  }
   if (column_memory_sizes.empty()) {
     return arrow::Status::NotImplemented("Column memory size metadata is not available for this format");
   }

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -57,7 +57,8 @@ struct ChunkInfo {
   size_t number_of_rows;           // number of rows in this row group
   size_t row_group_index_in_file;  // the index of this row group in its file
   size_t global_row_end;           // the ending row offset of this row group in the whole chunk reader
-  size_t avg_memory_size;          // average memory usage of this row group
+  uint64_t avg_memory_size;        // average memory usage of this row group
+  std::vector<uint64_t> column_memory_sizes;
 
   [[nodiscard]] std::string ToString() const;
 };
@@ -85,7 +86,8 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
   [[nodiscard]] arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
       const std::vector<int64_t>& chunk_indices, size_t parallelism = 1) override;
 
-  [[nodiscard]] arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_estimated_size(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<uint64_t> get_chunk_column_estimated_size(int64_t chunk_index, int col_idx) override;
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
 
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
@@ -187,6 +189,18 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
 
         // if the overlap range is valid, create the chunk info
         if (overlap_start < overlap_end) {
+          const auto overlap_rows = overlap_end - overlap_start;
+          const auto row_group_rows = rg_end - rg_start;
+          // overlap_rows <= row_group_rows, so the quotient is at most memory_size and is safe to cast to uint64_t.
+          const auto chunk_memory_size = static_cast<uint64_t>(
+              static_cast<unsigned __int128>(row_group_in_file[j].memory_size) * overlap_rows / row_group_rows);
+          auto column_memory_sizes = row_group_in_file[j].column_memory_sizes;
+          if (!column_memory_sizes.empty()) {
+            // Use the same row-count scaling as avg_memory_size when this chunk
+            // contains only part of the row group.
+            ARROW_ASSIGN_OR_RAISE(column_memory_sizes, DistributeMemorySizes(chunk_memory_size, column_memory_sizes));
+          }
+
           rows_in_file += (overlap_end - overlap_start);
           chunk_infos_.emplace_back(ChunkInfo{
               .file_index = file_idx,
@@ -195,7 +209,8 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
               .number_of_rows = overlap_end - overlap_start,
               .row_group_index_in_file = j,
               .global_row_end = rows_in_all_files + rows_in_file,
-              .avg_memory_size = row_group_in_file[j].memory_size * (overlap_end - overlap_start) / (rg_end - rg_start),
+              .avg_memory_size = chunk_memory_size,
+              .column_memory_sizes = std::move(column_memory_sizes),
           });
         }
       }
@@ -211,6 +226,7 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::open() {
             .row_group_index_in_file = j,
             .global_row_end = rows_in_all_files + rows_in_file,
             .avg_memory_size = row_group_in_file[j].memory_size,
+            .column_memory_sizes = row_group_in_file[j].column_memory_sizes,
         });
       }
     }
@@ -503,13 +519,33 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> ColumnGroupReade
 }
 
 template <typename ReaderT>
-arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_size(int64_t chunk_index) {
+arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_estimated_size(int64_t chunk_index) {
   assert(opened_);
   if (UNLIKELY(chunk_index < 0 || chunk_index >= chunk_infos_.size())) {
     return arrow::Status::Invalid(
         fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
   }
   return chunk_infos_[chunk_index].avg_memory_size;
+}
+
+template <typename ReaderT>
+arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_estimated_size(int64_t chunk_index,
+                                                                                        int col_idx) {
+  assert(opened_);
+  if (UNLIKELY(chunk_index < 0 || chunk_index >= chunk_infos_.size())) {
+    return arrow::Status::Invalid(
+        fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
+  }
+
+  const auto& column_memory_sizes = chunk_infos_[chunk_index].column_memory_sizes;
+  if (column_memory_sizes.empty()) {
+    return arrow::Status::NotImplemented("Column memory size metadata is not available for this format");
+  }
+  if (UNLIKELY(col_idx < 0 || static_cast<size_t>(col_idx) >= column_memory_sizes.size())) {
+    return arrow::Status::Invalid(
+        fmt::format("Column index out of range: {} out of {}", col_idx, column_memory_sizes.size()));
+  }
+  return column_memory_sizes[col_idx];
 }
 
 template <typename ReaderT>

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -14,11 +14,43 @@
 
 #include "milvus-storage/format/format_reader.h"
 
+#include <limits>
 #include <sstream>
 
 #include "milvus-storage/format/format.h"
 
 namespace milvus_storage {
+
+arrow::Result<std::vector<uint64_t>> DistributeMemorySizes(uint64_t total_size, const std::vector<uint64_t>& weights) {
+  if (weights.empty()) {
+    return std::vector<uint64_t>{};
+  }
+
+  std::vector<uint64_t> result(weights.size(), 0);
+  if (total_size == 0) {
+    return result;
+  }
+
+  uint64_t total_weight = 0;
+  for (auto weight : weights) {
+    if (weight > std::numeric_limits<uint64_t>::max() - total_weight) {
+      return arrow::Status::Invalid("Column memory size weights exceed the uint64_t range");
+    }
+    total_weight += weight;
+  }
+  if (total_weight == 0) {
+    return arrow::Status::Invalid("Cannot distribute a non-zero memory size with zero column weights");
+  }
+
+  uint64_t allocated = 0;
+  for (size_t i = 0; i + 1 < weights.size(); ++i) {
+    // weights[i] <= total_weight, so the quotient is at most total_size and is safe to cast back to uint64_t.
+    result[i] = static_cast<uint64_t>(static_cast<unsigned __int128>(total_size) * weights[i] / total_weight);
+    allocated += result[i];
+  }
+  result.back() = total_size - allocated;
+  return result;
+}
 
 std::string RowGroupInfo::ToString() const {
   std::stringstream ss;

--- a/cpp/src/format/iceberg/iceberg_format_reader.cpp
+++ b/cpp/src/format/iceberg/iceberg_format_reader.cpp
@@ -389,10 +389,23 @@ arrow::Result<std::vector<RowGroupInfo>> IcebergFormatReader::build_logical_row_
     }
     uint64_t logical_rows = physical_rows - deletions_in_rg;
 
+    // Positional deletes do not expose the memory size of individual values, so
+    // estimate the logical row-group size by assuming deleted rows have the
+    // physical row group's average memory size.
+    uint64_t logical_memory_size = 0;
+    if (physical_rows != 0) {
+      // logical_rows <= physical_rows, so the quotient is at most prg.memory_size and is safe to cast to uint64_t.
+      logical_memory_size =
+          static_cast<uint64_t>(static_cast<unsigned __int128>(prg.memory_size) * logical_rows / physical_rows);
+    }
+    ARROW_ASSIGN_OR_RAISE(auto logical_column_memory_sizes,
+                          milvus_storage::DistributeMemorySizes(logical_memory_size, prg.column_memory_sizes));
+
     logical_row_group_infos.emplace_back(RowGroupInfo{
         .start_offset = logical_offset,
         .end_offset = logical_offset + logical_rows,
-        .memory_size = prg.memory_size,
+        .memory_size = logical_memory_size,
+        .column_memory_sizes = std::move(logical_column_memory_sizes),
     });
     logical_offset += logical_rows;
   }

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -16,8 +16,9 @@
 
 #include <algorithm>
 #include <exception>
-#include <string>
 #include <iostream>
+#include <limits>
+#include <string>
 #include <utility>
 
 #include <arrow/chunked_array.h>  // keep this line before other arrow header
@@ -60,13 +61,36 @@ LanceTableReader::LanceTableReader(const std::string& uri,
       needed_columns_(needed_columns),
       fragment_reader_(nullptr) {}
 
-static std::vector<RowGroupInfo> create_row_group_infos(uint64_t rows_in_file,
-                                                        uint64_t logical_chunk_rows,
-                                                        uint64_t fragment_memory_size) {
+static arrow::Result<std::vector<uint64_t>> estimate_fragment_column_memory_sizes(const BlockingDataset& dataset,
+                                                                                  uint64_t fragment_id,
+                                                                                  size_t num_columns) {
+  ARROW_ASSIGN_OR_RAISE(auto memory_sizes, dataset.EstimateFragmentColumnMemory(fragment_id));
+  if (memory_sizes.size() != num_columns) {
+    return arrow::Status::Invalid("Lance column memory estimate count does not match the file schema: ",
+                                  memory_sizes.size(), " != ", num_columns);
+  }
+
+  uint64_t total_size = 0;
+  for (auto memory_size : memory_sizes) {
+    if (memory_size > std::numeric_limits<uint64_t>::max() - total_size) {
+      return arrow::Status::Invalid("Lance column memory estimates exceed the uint64_t range");
+    }
+    total_size += memory_size;
+  }
+  return memory_sizes;
+}
+
+static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
+    uint64_t rows_in_file, uint64_t logical_chunk_rows, const std::vector<uint64_t>& fragment_column_memory_sizes) {
   if (rows_in_file == 0) {
-    return {};
+    return std::vector<RowGroupInfo>{};
   }
   assert(logical_chunk_rows > 0);
+
+  uint64_t fragment_memory_size = 0;
+  for (auto column_memory_size : fragment_column_memory_sizes) {
+    fragment_memory_size += column_memory_size;
+  }
 
   std::vector<RowGroupInfo> result;
   uint64_t last_offset = 0;
@@ -74,12 +98,16 @@ static std::vector<RowGroupInfo> create_row_group_infos(uint64_t rows_in_file,
 
   while (last_offset < rows_in_file) {
     uint64_t end_offset = std::min(last_offset + logical_chunk_rows, rows_in_file);
+    // end_offset <= rows_in_file, so the quotient is at most fragment_memory_size and is safe to cast to uint64_t.
     auto memory_offset =
-        static_cast<uint64_t>((static_cast<__uint128_t>(fragment_memory_size) * end_offset) / rows_in_file);
+        static_cast<uint64_t>((static_cast<unsigned __int128>(fragment_memory_size) * end_offset) / rows_in_file);
+    auto memory_size = memory_offset - last_memory_offset;
+    ARROW_ASSIGN_OR_RAISE(auto column_memory_sizes, DistributeMemorySizes(memory_size, fragment_column_memory_sizes));
     result.emplace_back(RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = end_offset,
-        .memory_size = memory_offset - last_memory_offset,
+        .memory_size = memory_size,
+        .column_memory_sizes = std::move(column_memory_sizes),
     });
     last_offset = end_offset;
     last_memory_offset = memory_offset;
@@ -172,14 +200,23 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
   ARROW_ASSIGN_OR_RAISE(auto logical_chunk_rows,
                         milvus_storage::api::GetValue<uint64_t>(properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
 
-  auto fragment_memory_size = dataset->EstimateFragmentMemory(fragment_id);
+  ARROW_ASSIGN_OR_RAISE(
+      auto fragment_column_memory_sizes,
+      estimate_fragment_column_memory_sizes(*dataset, fragment_id, static_cast<size_t>(file_schema->num_fields())));
+  ARROW_ASSIGN_OR_RAISE(auto row_group_infos,
+                        create_row_group_infos(logical_rows, logical_chunk_rows, fragment_column_memory_sizes));
 
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key(file);
   metadata->path = file.path;
   metadata->file_schema = std::move(file_schema);
-  metadata->row_group_infos = create_row_group_infos(logical_rows, logical_chunk_rows, fragment_memory_size);
-  auto outer_metadata_size = sizeof(Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo);
+  metadata->row_group_infos = std::move(row_group_infos);
+  size_t column_memory_sizes_size = 0;
+  for (const auto& row_group_info : metadata->row_group_infos) {
+    column_memory_sizes_size += row_group_info.column_memory_sizes.size() * sizeof(uint64_t);
+  }
+  auto outer_metadata_size =
+      sizeof(Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo) + column_memory_sizes_size;
   metadata->cache_size = outer_metadata_size + file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize);
   metadata->payload = Payload{
       .base_uri = std::move(base_uri),
@@ -239,7 +276,6 @@ arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::cr
 
 arrow::Status LanceTableReader::open() {
   assert(!fragment_reader_);
-  ArrowSchema c_arrow_schema;
 
   if (!dataset_) {
     // uri_ is in Milvus format (scheme://address/bucket/key) so extfs.<alias>.*
@@ -269,11 +305,15 @@ arrow::Status LanceTableReader::open() {
   // Build the read schema for fragment reader:
   // use user-provided schema if available, otherwise project file schema by needed_columns
   ARROW_ASSIGN_OR_RAISE(auto read_schema, build_read_schema(file_schema_, read_schema_, needed_columns_));
-  ARROW_RETURN_NOT_OK(arrow::ExportSchema(*read_schema, &c_arrow_schema));
 
   ARROW_ASSIGN_OR_RAISE(logical_chunk_rows_, api::GetValue<uint64_t>(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
 
-  auto fragment_memory_size = dataset_->EstimateFragmentMemory(fragment_id_);
+  ARROW_ASSIGN_OR_RAISE(
+      auto fragment_column_memory_sizes,
+      estimate_fragment_column_memory_sizes(*dataset_, fragment_id_, static_cast<size_t>(file_schema_->num_fields())));
+
+  ArrowSchema c_arrow_schema;
+  ARROW_RETURN_NOT_OK(arrow::ExportSchema(*read_schema, &c_arrow_schema));
 
   fragment_reader_ = BlockingFragmentReader::Open(*dataset_, fragment_id_, c_arrow_schema);
 
@@ -293,7 +333,8 @@ arrow::Status LanceTableReader::open() {
   } catch (const lance::LanceException& e) {
     return arrow::Status::IOError("Failed to get physical row count for fragment ", fragment_id_, ": ", e.what());
   }
-  row_group_infos_ = create_row_group_infos(logical_rows, logical_chunk_rows_, fragment_memory_size);
+  ARROW_ASSIGN_OR_RAISE(row_group_infos_,
+                        create_row_group_infos(logical_rows, logical_chunk_rows_, fragment_column_memory_sizes));
 
   return arrow::Status::OK();
 }

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -31,6 +31,7 @@
 #include <arrow/result.h>
 #include <fmt/format.h>
 
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/lance/lance_common.h"
@@ -64,6 +65,12 @@ LanceTableReader::LanceTableReader(const std::string& uri,
 static arrow::Result<std::vector<uint64_t>> estimate_fragment_column_memory_sizes(const BlockingDataset& dataset,
                                                                                   uint64_t fragment_id,
                                                                                   size_t num_columns) {
+  FIU_RETURN_ON(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL,
+                arrow::Status::NotImplemented("Injected fault: ", FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL));
+
+  // Lance 7 returns both this estimate and FileFragment::schema() in current
+  // dataset-schema order. Fields not physically present in the fragment have a
+  // zero estimate, so schema evolution does not require positional remapping.
   ARROW_ASSIGN_OR_RAISE(auto memory_sizes, dataset.EstimateFragmentColumnMemory(fragment_id));
   if (memory_sizes.size() != num_columns) {
     return arrow::Status::Invalid("Lance column memory estimate count does not match the file schema: ",
@@ -81,15 +88,20 @@ static arrow::Result<std::vector<uint64_t>> estimate_fragment_column_memory_size
 }
 
 static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
-    uint64_t rows_in_file, uint64_t logical_chunk_rows, const std::vector<uint64_t>& fragment_column_memory_sizes) {
+    uint64_t rows_in_file,
+    uint64_t logical_chunk_rows,
+    const std::vector<uint64_t>& fragment_column_memory_sizes,
+    bool memory_size_available) {
   if (rows_in_file == 0) {
     return std::vector<RowGroupInfo>{};
   }
   assert(logical_chunk_rows > 0);
 
   uint64_t fragment_memory_size = 0;
-  for (auto column_memory_size : fragment_column_memory_sizes) {
-    fragment_memory_size += column_memory_size;
+  if (memory_size_available) {
+    for (auto column_memory_size : fragment_column_memory_sizes) {
+      fragment_memory_size += column_memory_size;
+    }
   }
 
   std::vector<RowGroupInfo> result;
@@ -102,12 +114,16 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
     auto memory_offset =
         static_cast<uint64_t>((static_cast<unsigned __int128>(fragment_memory_size) * end_offset) / rows_in_file);
     auto memory_size = memory_offset - last_memory_offset;
-    ARROW_ASSIGN_OR_RAISE(auto column_memory_sizes, DistributeMemorySizes(memory_size, fragment_column_memory_sizes));
+    std::vector<uint64_t> column_memory_sizes;
+    if (memory_size_available) {
+      ARROW_ASSIGN_OR_RAISE(column_memory_sizes, DistributeMemorySizes(memory_size, fragment_column_memory_sizes));
+    }
     result.emplace_back(RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = end_offset,
         .memory_size = memory_size,
         .column_memory_sizes = std::move(column_memory_sizes),
+        .memory_size_available = memory_size_available,
     });
     last_offset = end_offset;
     last_memory_offset = memory_offset;
@@ -200,11 +216,23 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
   ARROW_ASSIGN_OR_RAISE(auto logical_chunk_rows,
                         milvus_storage::api::GetValue<uint64_t>(properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
 
+  auto column_memory_sizes_result =
+      estimate_fragment_column_memory_sizes(*dataset, fragment_id, static_cast<size_t>(file_schema->num_fields()));
+  const bool memory_size_available = column_memory_sizes_result.ok();
+  std::vector<uint64_t> fragment_column_memory_sizes;
+  if (memory_size_available) {
+    fragment_column_memory_sizes = std::move(column_memory_sizes_result).ValueOrDie();
+  } else {
+    // Memory statistics are optional. Do not retain the underlying failure in
+    // metadata: estimate APIs return a generic NotImplemented status instead.
+    // Keep the detailed reason in the debug log for diagnostics only.
+    LOG_STORAGE_DEBUG_ << "Lance column memory estimation is unavailable while loading metadata"
+                       << ", fragment_id=" << fragment_id
+                       << ", status=" << column_memory_sizes_result.status().ToString();
+  }
   ARROW_ASSIGN_OR_RAISE(
-      auto fragment_column_memory_sizes,
-      estimate_fragment_column_memory_sizes(*dataset, fragment_id, static_cast<size_t>(file_schema->num_fields())));
-  ARROW_ASSIGN_OR_RAISE(auto row_group_infos,
-                        create_row_group_infos(logical_rows, logical_chunk_rows, fragment_column_memory_sizes));
+      auto row_group_infos,
+      create_row_group_infos(logical_rows, logical_chunk_rows, fragment_column_memory_sizes, memory_size_available));
 
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key(file);
@@ -291,7 +319,7 @@ arrow::Status LanceTableReader::open() {
     dataset_ = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config));
   }
 
-  // Always derive file schema from fragment metadata
+  // Lance 7 exposes the current dataset schema through FileFragment::schema().
   {
     ArrowSchema c_fragment_schema;
     try {
@@ -307,10 +335,6 @@ arrow::Status LanceTableReader::open() {
   ARROW_ASSIGN_OR_RAISE(auto read_schema, build_read_schema(file_schema_, read_schema_, needed_columns_));
 
   ARROW_ASSIGN_OR_RAISE(logical_chunk_rows_, api::GetValue<uint64_t>(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
-
-  ARROW_ASSIGN_OR_RAISE(
-      auto fragment_column_memory_sizes,
-      estimate_fragment_column_memory_sizes(*dataset_, fragment_id_, static_cast<size_t>(file_schema_->num_fields())));
 
   ArrowSchema c_arrow_schema;
   ARROW_RETURN_NOT_OK(arrow::ExportSchema(*read_schema, &c_arrow_schema));
@@ -333,8 +357,23 @@ arrow::Status LanceTableReader::open() {
   } catch (const lance::LanceException& e) {
     return arrow::Status::IOError("Failed to get physical row count for fragment ", fragment_id_, ": ", e.what());
   }
-  ARROW_ASSIGN_OR_RAISE(row_group_infos_,
-                        create_row_group_infos(logical_rows, logical_chunk_rows_, fragment_column_memory_sizes));
+
+  auto column_memory_sizes_result =
+      estimate_fragment_column_memory_sizes(*dataset_, fragment_id_, static_cast<size_t>(file_schema_->num_fields()));
+  const bool memory_size_available = column_memory_sizes_result.ok();
+  std::vector<uint64_t> fragment_column_memory_sizes;
+  if (memory_size_available) {
+    fragment_column_memory_sizes = std::move(column_memory_sizes_result).ValueOrDie();
+  } else {
+    // Memory statistics are optional. Do not retain the underlying failure in
+    // row-group metadata: estimate APIs return a generic NotImplemented status
+    // instead. Keep the detailed reason in the debug log for diagnostics only.
+    LOG_STORAGE_DEBUG_ << "Lance column memory estimation is unavailable while opening the reader"
+                       << ", fragment_id=" << fragment_id_
+                       << ", status=" << column_memory_sizes_result.status().ToString();
+  }
+  ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(logical_rows, logical_chunk_rows_,
+                                                                 fragment_column_memory_sizes, memory_size_available));
 
   return arrow::Status::OK();
 }

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -15,6 +15,7 @@
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -47,6 +48,8 @@
 
 namespace milvus_storage::parquet {
 
+static std::vector<int> get_leaf_column_offsets_by_field(const arrow::Schema& file_schema);
+
 static arrow::Result<std::vector<RowGroupInfo>> try_build_row_group_infos(
     const std::shared_ptr<::parquet::FileMetaData>& metadata) {
   std::vector<RowGroupInfo> row_group_infos;
@@ -77,15 +80,15 @@ static arrow::Result<std::vector<RowGroupInfo>> try_build_row_group_infos(
 }
 
 static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_metadata(
-    const std::shared_ptr<::parquet::FileMetaData>& metadata, const std::string& path);
-
-arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::create_row_group_infos(
-    const std::shared_ptr<::parquet::FileMetaData>& metadata) {
-  return create_row_group_infos_from_metadata(metadata, path_);
-}
-
-static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_metadata(
-    const std::shared_ptr<::parquet::FileMetaData>& metadata, const std::string& path) {
+    const std::shared_ptr<::parquet::FileMetaData>& metadata,
+    const arrow::Schema& file_schema,
+    const std::string& path) {
+  // Keep the existing row-group memory estimate as the total-size anchor: prefer
+  // Milvus private metadata when available, otherwise fall back to the Parquet
+  // footer's total byte size. Parquet leaf-column uncompressed sizes are used only
+  // as relative weights. Leaves belonging to a nested top-level Arrow field are
+  // aggregated so column_memory_sizes follows the complete file-schema order and
+  // sums exactly to the row group's memory_size.
   assert(metadata);
   if (!metadata) {
     return arrow::Status::Invalid(fmt::format("Failed to get parquet file metadata for file: {}", path));
@@ -93,23 +96,80 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_meta
 
   // try use the private kv metas to build row group infos
   ARROW_ASSIGN_OR_RAISE(auto row_group_infos, try_build_row_group_infos(metadata));
-  if (!row_group_infos.empty()) {
-    return row_group_infos;
+  if (row_group_infos.empty()) {
+    // use the parquet file metadata to build row group infos
+    row_group_infos.reserve(metadata->num_row_groups());
+    size_t offset = 0;
+    for (int i = 0; i < metadata->num_row_groups(); ++i) {
+      auto row_group_meta = metadata->RowGroup(i);
+      auto total_byte_size = row_group_meta->total_byte_size();
+      if (total_byte_size < 0) {
+        return arrow::Status::Invalid(
+            fmt::format("Parquet row-group total byte size is negative. [path={}, row_group={}]", path, i));
+      }
+      row_group_infos.emplace_back(RowGroupInfo{
+          .start_offset = offset,
+          .end_offset = offset + static_cast<size_t>(row_group_meta->num_rows()),
+          .memory_size = static_cast<uint64_t>(total_byte_size),
+      });
+      offset += row_group_meta->num_rows();
+    }
   }
 
-  // use the parquet file metadata to build row group infos
-  row_group_infos.reserve(metadata->num_row_groups());
-  size_t offset = 0;
-  for (int i = 0; i < metadata->num_row_groups(); ++i) {
-    auto row_group_meta = metadata->RowGroup(i);
-    row_group_infos.emplace_back(RowGroupInfo{
-        .start_offset = offset,
-        .end_offset = offset + static_cast<size_t>(row_group_meta->num_rows()),
-        .memory_size = static_cast<size_t>(row_group_meta->total_byte_size()),
-    });
-    offset += row_group_meta->num_rows();
+  // Map every top-level Arrow field to a half-open range of physical Parquet
+  // leaf columns. For example, offsets [0, 1, 3] mean field 0 owns leaf [0, 1)
+  // and field 1 owns leaves [1, 3).
+  const auto leaf_column_offsets_by_field = get_leaf_column_offsets_by_field(file_schema);
+
+  // The private row-group metadata and the Parquet footer must describe the
+  // same row groups, while the Arrow schema must expand to every Parquet leaf.
+  if (row_group_infos.size() != static_cast<size_t>(metadata->num_row_groups()) ||
+      leaf_column_offsets_by_field.back() != metadata->num_columns()) {
+    return arrow::Status::Invalid(
+        fmt::format("Parquet row-group metadata does not match the file schema. [path={}]", path));
+  }
+
+  for (int row_group_index = 0; row_group_index < metadata->num_row_groups(); ++row_group_index) {
+    auto row_group_meta = metadata->RowGroup(row_group_index);
+
+    // Build one weight per top-level Arrow field. Nested fields contribute the
+    // sum of total_uncompressed_size from all physical leaves below that field.
+    std::vector<uint64_t> column_weights;
+    column_weights.reserve(file_schema.num_fields());
+    for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
+      uint64_t field_weight = 0;
+      for (int leaf_column_index = leaf_column_offsets_by_field[field_index];
+           leaf_column_index < leaf_column_offsets_by_field[field_index + 1]; ++leaf_column_index) {
+        auto uncompressed_size = row_group_meta->ColumnChunk(leaf_column_index)->total_uncompressed_size();
+        if (uncompressed_size < 0) {
+          return arrow::Status::Invalid(
+              fmt::format("Parquet column uncompressed size is negative. [path={}, row_group={}, column={}]", path,
+                          row_group_index, leaf_column_index));
+        }
+        auto column_weight = static_cast<uint64_t>(uncompressed_size);
+        if (column_weight > std::numeric_limits<uint64_t>::max() - field_weight) {
+          return arrow::Status::Invalid(
+              fmt::format("Parquet top-level column size exceeds the uint64_t range. [path={}, row_group={}, field={}]",
+                          path, row_group_index, field_index));
+        }
+        field_weight += column_weight;
+      }
+      column_weights.emplace_back(field_weight);
+    }
+
+    // The Parquet sizes above define only the relative column proportions.
+    // Normalize them against the existing row-group memory estimate so the
+    // resulting column sizes sum exactly to memory_size.
+    ARROW_ASSIGN_OR_RAISE(row_group_infos[row_group_index].column_memory_sizes,
+                          DistributeMemorySizes(row_group_infos[row_group_index].memory_size, column_weights));
   }
   return row_group_infos;
+}
+
+arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::create_row_group_infos(
+    const std::shared_ptr<::parquet::FileMetaData>& metadata) {
+  assert(schema_);
+  return create_row_group_infos_from_metadata(metadata, *schema_, path_);
 }
 
 ParquetFormatReader::ParquetFormatReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
@@ -330,7 +390,8 @@ arrow::Result<ParquetFormatReader::MetaTrait::MetadataPtr> ParquetFormatReader::
     return arrow::Status::Invalid(fmt::format("Failed to get parquet file schema. [path={}]", uri.key));
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto row_group_infos, create_row_group_infos_from_metadata(parquet_metadata, uri.key));
+  ARROW_ASSIGN_OR_RAISE(auto row_group_infos,
+                        create_row_group_infos_from_metadata(parquet_metadata, *file_schema, uri.key));
 
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key(file);
@@ -397,14 +458,15 @@ arrow::Status ParquetFormatReader::open() {
   ARROW_ASSIGN_OR_RAISE(auto file_reader, create_parquet_file_reader(fs_, path_, properties_, key_retriever_,
                                                                      nullptr /* metadata */, file_size_, footer_size_));
   file_reader_ = std::shared_ptr<::parquet::arrow::FileReader>(std::move(file_reader));
-  // create row group infos
-  assert(file_reader_->parquet_reader() && "arrow logical fault");
-  ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(file_reader_->parquet_reader()->metadata()));
 
   // get the schema and create needed column indices
   std::shared_ptr<arrow::Schema> file_schema;
   ARROW_RETURN_NOT_OK(file_reader_->GetSchema(&file_schema));
   schema_ = file_schema;
+
+  // create row group infos
+  assert(file_reader_->parquet_reader() && "arrow logical fault");
+  ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(file_reader_->parquet_reader()->metadata()));
 
   return set_needed_columns(needed_columns_);
 }
@@ -433,6 +495,17 @@ static int get_leaf_column_count(const std::shared_ptr<arrow::DataType>& type) {
   return count;
 }
 
+static std::vector<int> get_leaf_column_offsets_by_field(const arrow::Schema& file_schema) {
+  std::vector<int> leaf_column_offsets_by_field;
+  leaf_column_offsets_by_field.reserve(file_schema.num_fields() + 1);
+  leaf_column_offsets_by_field.emplace_back(0);
+  for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
+    leaf_column_offsets_by_field.emplace_back(leaf_column_offsets_by_field.back() +
+                                              get_leaf_column_count(file_schema.field(field_index)->type()));
+  }
+  return leaf_column_offsets_by_field;
+}
+
 static arrow::Result<std::vector<int>> get_leaf_column_indices(const arrow::Schema& file_schema,
                                                                const std::vector<std::string>& needed_columns,
                                                                const std::string& path) {
@@ -446,13 +519,7 @@ static arrow::Result<std::vector<int>> get_leaf_column_indices(const arrow::Sche
   //   leaf_column_offsets_by_field: [0, 1, 3, 4]
   //   needed columns: [score, user]
   //   leaf column indices: [3, 1, 2]
-  std::vector<int> leaf_column_offsets_by_field;
-  leaf_column_offsets_by_field.reserve(file_schema.num_fields() + 1);
-  leaf_column_offsets_by_field.emplace_back(0);
-  for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
-    leaf_column_offsets_by_field.emplace_back(leaf_column_offsets_by_field.back() +
-                                              get_leaf_column_count(file_schema.field(field_index)->type()));
-  }
+  const auto leaf_column_offsets_by_field = get_leaf_column_offsets_by_field(file_schema);
 
   const int leaf_column_count = leaf_column_offsets_by_field.back();
   if (needed_columns.empty()) {

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -225,11 +225,13 @@ static arrow::Result<std::vector<uint64_t>> get_vortex_splits(const VortexFile& 
   return std::move(splits).ValueOrDie();
 }
 
-static std::vector<RowGroupInfo> create_row_group_infos(uint64_t memory_usage_in_file,
-                                                        uint64_t rows_in_file,
-                                                        const std::vector<uint64_t>& row_ranges) {
+static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
+    uint64_t memory_usage_in_file,
+    uint64_t rows_in_file,
+    const std::vector<uint64_t>& row_ranges,
+    const std::vector<uint64_t>& file_column_uncompressed_sizes) {
   if (rows_in_file == 0) {
-    return {};
+    return std::vector<RowGroupInfo>{};
   }
 
   std::vector<RowGroupInfo> result;
@@ -237,10 +239,18 @@ static std::vector<RowGroupInfo> create_row_group_infos(uint64_t memory_usage_in
   uint64_t last_offset = 0;
 
   for (auto row_range : row_ranges) {
+    if (row_range > rows_in_file) {
+      return arrow::Status::Invalid("Vortex row range exceeds the file row count");
+    }
+    // row_range <= rows_in_file, so the quotient is at most memory_usage_in_file and is safe to cast to uint64_t.
+    const auto memory_size =
+        static_cast<uint64_t>(static_cast<unsigned __int128>(memory_usage_in_file) * row_range / rows_in_file);
+    ARROW_ASSIGN_OR_RAISE(auto column_memory_sizes, DistributeMemorySizes(memory_size, file_column_uncompressed_sizes));
     result.emplace_back(RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = last_offset + row_range,
-        .memory_size = memory_usage_in_file * row_range / rows_in_file,
+        .memory_size = memory_size,
+        .column_memory_sizes = std::move(column_memory_sizes),
     });
     last_offset += row_range;
   }
@@ -301,15 +311,37 @@ static std::vector<uint64_t> recalc_row_ranges(const std::vector<uint64_t>& orig
   return new_ranges;
 }
 
-static uint64_t compute_total_mem_usage(const VortexFile& vxfile) {
+static arrow::Result<std::vector<uint64_t>> get_column_uncompressed_sizes(const VortexFile& vxfile,
+                                                                          size_t column_count) {
+  if (vxfile.RowCount() == 0) {
+    return std::vector<uint64_t>(column_count, 0);
+  }
+
   auto sizes = vxfile.GetUncompressedSizes();
   if (sizes.empty()) {
-    return 0;
+    if (column_count == 0) {
+      return sizes;
+    }
+    return arrow::Status::NotImplemented("Vortex column memory size statistics are not available");
   }
-  uint64_t total_size = 0;
+  if (sizes.size() != column_count) {
+    return arrow::Status::Invalid(fmt::format(
+        "Vortex column memory estimate count does not match the file schema: {} != {}", sizes.size(), column_count));
+  }
   for (auto size : sizes) {
     if (size == UINT64_MAX) {
-      return 0;
+      return arrow::Status::NotImplemented("Vortex column memory size statistics are not available");
+    }
+  }
+
+  return sizes;
+}
+
+static arrow::Result<uint64_t> compute_total_mem_usage(const std::vector<uint64_t>& file_column_uncompressed_sizes) {
+  uint64_t total_size = 0;
+  for (auto size : file_column_uncompressed_sizes) {
+    if (size > std::numeric_limits<uint64_t>::max() - total_size) {
+      return arrow::Status::Invalid("Vortex column memory estimates exceed the uint64_t range");
     }
     total_size += size;
   }
@@ -348,9 +380,12 @@ arrow::Result<VortexFormatReader::MetaTrait::MetadataPtr> VortexFormatReader::Me
   ARROW_ASSIGN_OR_RAISE(auto file_schema, import_vortex_file_schema(*vxfile));
 
   ARROW_ASSIGN_OR_RAISE(auto row_ranges, get_vortex_splits(*vxfile));
-  const auto memory_usage = compute_total_mem_usage(*vxfile);
-  auto row_group_infos =
-      create_row_group_infos(memory_usage, vxfile->RowCount(), recalc_row_ranges(row_ranges, logical_chunk_rows));
+  ARROW_ASSIGN_OR_RAISE(auto file_column_uncompressed_sizes,
+                        get_column_uncompressed_sizes(*vxfile, static_cast<size_t>(file_schema->num_fields())));
+  ARROW_ASSIGN_OR_RAISE(auto memory_usage, compute_total_mem_usage(file_column_uncompressed_sizes));
+  ARROW_ASSIGN_OR_RAISE(auto row_group_infos, create_row_group_infos(memory_usage, vxfile->RowCount(),
+                                                                     recalc_row_ranges(row_ranges, logical_chunk_rows),
+                                                                     file_column_uncompressed_sizes));
 
   auto metadata = std::make_shared<Metadata>(Metadata{
       .cache_key = std::move(key),
@@ -459,8 +494,12 @@ arrow::Status VortexFormatReader::open() {
   ARROW_ASSIGN_OR_RAISE(file_schema_, import_vortex_file_schema(*vxfile_));
 
   ARROW_ASSIGN_OR_RAISE(auto row_ranges, get_vortex_splits(*vxfile_));
-  row_group_infos_ = create_row_group_infos(total_mem_usage(), vxfile_->RowCount(),
-                                            recalc_row_ranges(row_ranges, logical_chunk_rows_));
+  ARROW_ASSIGN_OR_RAISE(auto file_column_uncompressed_sizes,
+                        get_column_uncompressed_sizes(*vxfile_, static_cast<size_t>(file_schema_->num_fields())));
+  ARROW_ASSIGN_OR_RAISE(auto memory_usage, compute_total_mem_usage(file_column_uncompressed_sizes));
+  ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(memory_usage, vxfile_->RowCount(),
+                                                                 recalc_row_ranges(row_ranges, logical_chunk_rows_),
+                                                                 file_column_uncompressed_sizes));
 
   return arrow::Status::OK();
 }
@@ -737,6 +776,10 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> VortexFormatReader::rea
   return streaming_read(start_offset, end_offset, kLargeCoalescingWindow);
 }
 
-uint64_t VortexFormatReader::total_mem_usage() { return compute_total_mem_usage(*vxfile_); }
+arrow::Result<uint64_t> VortexFormatReader::total_mem_usage() {
+  ARROW_ASSIGN_OR_RAISE(auto column_sizes,
+                        get_column_uncompressed_sizes(*vxfile_, static_cast<size_t>(file_schema_->num_fields())));
+  return compute_total_mem_usage(column_sizes);
+}
 
 }  // namespace milvus_storage::vortex

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -31,6 +31,8 @@
 #include <arrow/result.h>
 #include <fmt/format.h>
 
+#include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/common/log.h"
 #include "milvus-storage/filesystem/fs.h"
 
 namespace milvus_storage::vortex {
@@ -39,6 +41,11 @@ extern const ffi::CoalescingWindow kSmallCoalescingWindow{1024 * 1024, 1024 * 10
 
 namespace {
 const ffi::CoalescingWindow kLargeCoalescingWindow{1024 * 1024, 8 * 1024 * 1024};
+
+struct MemorySizeEstimate {
+  uint64_t total_size;
+  std::vector<uint64_t> column_sizes;
+};
 
 static uint8_t arrow_type_to_tag(const arrow::DataType& dt) {
   switch (dt.id()) {
@@ -226,10 +233,9 @@ static arrow::Result<std::vector<uint64_t>> get_vortex_splits(const VortexFile& 
 }
 
 static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
-    uint64_t memory_usage_in_file,
     uint64_t rows_in_file,
     const std::vector<uint64_t>& row_ranges,
-    const std::vector<uint64_t>& file_column_uncompressed_sizes) {
+    const std::optional<MemorySizeEstimate>& memory_size_estimate) {
   if (rows_in_file == 0) {
     return std::vector<RowGroupInfo>{};
   }
@@ -242,15 +248,21 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
     if (row_range > rows_in_file) {
       return arrow::Status::Invalid("Vortex row range exceeds the file row count");
     }
-    // row_range <= rows_in_file, so the quotient is at most memory_usage_in_file and is safe to cast to uint64_t.
-    const auto memory_size =
-        static_cast<uint64_t>(static_cast<unsigned __int128>(memory_usage_in_file) * row_range / rows_in_file);
-    ARROW_ASSIGN_OR_RAISE(auto column_memory_sizes, DistributeMemorySizes(memory_size, file_column_uncompressed_sizes));
+    uint64_t memory_size = 0;
+    std::vector<uint64_t> column_memory_sizes;
+    if (memory_size_estimate) {
+      // row_range <= rows_in_file, so the quotient is at most the file memory size and is safe to cast to uint64_t.
+      memory_size = static_cast<uint64_t>(static_cast<unsigned __int128>(memory_size_estimate->total_size) * row_range /
+                                          rows_in_file);
+      ARROW_ASSIGN_OR_RAISE(column_memory_sizes,
+                            DistributeMemorySizes(memory_size, memory_size_estimate->column_sizes));
+    }
     result.emplace_back(RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = last_offset + row_range,
         .memory_size = memory_size,
         .column_memory_sizes = std::move(column_memory_sizes),
+        .memory_size_available = memory_size_estimate.has_value(),
     });
     last_offset += row_range;
   }
@@ -316,6 +328,8 @@ static arrow::Result<std::vector<uint64_t>> get_column_uncompressed_sizes(const 
   if (vxfile.RowCount() == 0) {
     return std::vector<uint64_t>(column_count, 0);
   }
+  FIU_RETURN_ON(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL,
+                arrow::Status::NotImplemented("Injected fault: ", FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL));
 
   auto sizes = vxfile.GetUncompressedSizes();
   if (sizes.empty()) {
@@ -346,6 +360,32 @@ static arrow::Result<uint64_t> compute_total_mem_usage(const std::vector<uint64_
     total_size += size;
   }
   return total_size;
+}
+
+static std::optional<MemorySizeEstimate> estimate_memory_sizes(const VortexFile& vxfile,
+                                                               size_t column_count,
+                                                               const std::string& path) {
+  auto column_sizes_result = get_column_uncompressed_sizes(vxfile, column_count);
+  if (!column_sizes_result.ok()) {
+    // Memory statistics are optional. Do not retain the underlying failure in
+    // row-group metadata: estimate APIs return a generic NotImplemented status
+    // instead. Keep the detailed reason in the debug log for diagnostics only.
+    LOG_STORAGE_DEBUG_ << "Vortex memory estimation is unavailable"
+                       << ", path=" << path << ", status=" << column_sizes_result.status().ToString();
+    return std::nullopt;
+  }
+
+  auto column_sizes = std::move(column_sizes_result).ValueOrDie();
+  auto total_size_result = compute_total_mem_usage(column_sizes);
+  if (!total_size_result.ok()) {
+    LOG_STORAGE_DEBUG_ << "Vortex memory estimation is unavailable"
+                       << ", path=" << path << ", status=" << total_size_result.status().ToString();
+    return std::nullopt;
+  }
+  return MemorySizeEstimate{
+      .total_size = total_size_result.ValueOrDie(),
+      .column_sizes = std::move(column_sizes),
+  };
 }
 
 }  // namespace
@@ -380,12 +420,10 @@ arrow::Result<VortexFormatReader::MetaTrait::MetadataPtr> VortexFormatReader::Me
   ARROW_ASSIGN_OR_RAISE(auto file_schema, import_vortex_file_schema(*vxfile));
 
   ARROW_ASSIGN_OR_RAISE(auto row_ranges, get_vortex_splits(*vxfile));
-  ARROW_ASSIGN_OR_RAISE(auto file_column_uncompressed_sizes,
-                        get_column_uncompressed_sizes(*vxfile, static_cast<size_t>(file_schema->num_fields())));
-  ARROW_ASSIGN_OR_RAISE(auto memory_usage, compute_total_mem_usage(file_column_uncompressed_sizes));
-  ARROW_ASSIGN_OR_RAISE(auto row_group_infos, create_row_group_infos(memory_usage, vxfile->RowCount(),
-                                                                     recalc_row_ranges(row_ranges, logical_chunk_rows),
-                                                                     file_column_uncompressed_sizes));
+  auto memory_size_estimate = estimate_memory_sizes(*vxfile, static_cast<size_t>(file_schema->num_fields()), uri.key);
+  ARROW_ASSIGN_OR_RAISE(auto row_group_infos,
+                        create_row_group_infos(vxfile->RowCount(), recalc_row_ranges(row_ranges, logical_chunk_rows),
+                                               memory_size_estimate));
 
   auto metadata = std::make_shared<Metadata>(Metadata{
       .cache_key = std::move(key),
@@ -494,12 +532,10 @@ arrow::Status VortexFormatReader::open() {
   ARROW_ASSIGN_OR_RAISE(file_schema_, import_vortex_file_schema(*vxfile_));
 
   ARROW_ASSIGN_OR_RAISE(auto row_ranges, get_vortex_splits(*vxfile_));
-  ARROW_ASSIGN_OR_RAISE(auto file_column_uncompressed_sizes,
-                        get_column_uncompressed_sizes(*vxfile_, static_cast<size_t>(file_schema_->num_fields())));
-  ARROW_ASSIGN_OR_RAISE(auto memory_usage, compute_total_mem_usage(file_column_uncompressed_sizes));
-  ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(memory_usage, vxfile_->RowCount(),
-                                                                 recalc_row_ranges(row_ranges, logical_chunk_rows_),
-                                                                 file_column_uncompressed_sizes));
+  auto memory_size_estimate = estimate_memory_sizes(*vxfile_, static_cast<size_t>(file_schema_->num_fields()), path_);
+  ARROW_ASSIGN_OR_RAISE(row_group_infos_,
+                        create_row_group_infos(vxfile_->RowCount(), recalc_row_ranges(row_ranges, logical_chunk_rows_),
+                                               memory_size_estimate));
 
   return arrow::Status::OK();
 }

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -360,7 +360,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
     // must have one more chunk to read, should checked in caller
     assert(current_cg_chunk_index < number_of_chunks_per_cg_[column_group_index]);
 
-    ARROW_ASSIGN_OR_RAISE(auto chunk_size, cg_reader->get_chunk_size(current_cg_chunk_index));
+    ARROW_ASSIGN_OR_RAISE(auto chunk_size, cg_reader->get_chunk_estimated_size(current_cg_chunk_index));
     ARROW_ASSIGN_OR_RAISE(auto chunk_rows, cg_reader->get_chunk_rows(current_cg_chunk_index));
 
     // update the states after loading column group info
@@ -525,7 +525,10 @@ class ChunkReaderImpl : public ChunkReader {
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(int64_t chunk_index) override;
   [[nodiscard]] arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
       const std::vector<int64_t>& chunk_indices, size_t parallelism) override;
-  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_size() override;
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_estimated_size() override;
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_size(
+      const std::string& field_name) override;
+  [[nodiscard]] arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_estimated_size() override;
   [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_rows() override;
 
   private:
@@ -649,15 +652,54 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> ChunkReaderImpl:
   return sliced_results;
 }
 
-arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_size() {
+arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_estimated_size() {
   const auto total_chunks = total_number_of_chunks();
   std::vector<uint64_t> result(total_chunks);
   assert(total_chunks > 0);
 
   for (size_t i = 0; i < total_chunks; ++i) {
-    ARROW_ASSIGN_OR_RAISE(result[i], chunk_reader_->get_chunk_size(i));
+    ARROW_ASSIGN_OR_RAISE(result[i], chunk_reader_->get_chunk_estimated_size(i));
   }
 
+  return result;
+}
+
+arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_column_estimated_size(const std::string& field_name) {
+  const auto file_schema = chunk_reader_->get_schema();
+  if (!file_schema) {
+    return arrow::Status::Invalid("Chunk reader file schema is not available");
+  }
+
+  auto field_status = file_schema->CanReferenceFieldByName(field_name);
+  if (!field_status.ok()) {
+    return arrow::Status::Invalid(
+        fmt::format("Cannot resolve column '{}' in chunk reader file schema: {}", field_name, field_status.ToString()));
+  }
+  const auto col_idx = file_schema->GetFieldIndex(field_name);
+  assert(col_idx >= 0);
+
+  const auto total_chunks = total_number_of_chunks();
+  std::vector<uint64_t> result(total_chunks);
+  for (size_t i = 0; i < total_chunks; ++i) {
+    ARROW_ASSIGN_OR_RAISE(result[i], chunk_reader_->get_chunk_column_estimated_size(i, col_idx));
+  }
+  return result;
+}
+
+arrow::Result<std::vector<std::vector<uint64_t>>> ChunkReaderImpl::get_chunk_column_estimated_size() {
+  const auto file_schema = chunk_reader_->get_schema();
+  if (!file_schema) {
+    return arrow::Status::Invalid("Chunk reader file schema is not available");
+  }
+
+  const auto total_chunks = total_number_of_chunks();
+  std::vector<std::vector<uint64_t>> result(file_schema->num_fields(), std::vector<uint64_t>(total_chunks));
+  for (int col_idx = 0; col_idx < file_schema->num_fields(); ++col_idx) {
+    for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
+      ARROW_ASSIGN_OR_RAISE(result[col_idx][chunk_idx],
+                            chunk_reader_->get_chunk_column_estimated_size(chunk_idx, col_idx));
+    }
+  }
   return result;
 }
 

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -351,7 +351,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
   }
 
   private:
-  arrow::Result<int64_t> preload_column_group(const size_t& column_group_index) {
+  arrow::Result<int64_t> preload_column_group(const size_t& column_group_index, bool& memory_size_unavailable) {
     assert(column_group_index < column_groups_.size());
     std::pair<int32_t, int32_t> result;
     const auto& cg_reader = chunk_readers_[column_group_index];
@@ -360,12 +360,20 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
     // must have one more chunk to read, should checked in caller
     assert(current_cg_chunk_index < number_of_chunks_per_cg_[column_group_index]);
 
-    ARROW_ASSIGN_OR_RAISE(auto chunk_size, cg_reader->get_chunk_estimated_size(current_cg_chunk_index));
+    auto chunk_size_result = cg_reader->get_chunk_estimated_size(current_cg_chunk_index);
+    if (chunk_size_result.ok()) {
+      memory_used_ += chunk_size_result.ValueOrDie();
+    } else if (chunk_size_result.status().IsNotImplemented()) {
+      // Memory estimation is optional. Keep normal scans usable, but stop
+      // scheduling extra chunks after every column group has one chunk queued.
+      memory_size_unavailable = true;
+    } else {
+      return chunk_size_result.status();
+    }
     ARROW_ASSIGN_OR_RAISE(auto chunk_rows, cg_reader->get_chunk_rows(current_cg_chunk_index));
 
     // update the states after loading column group info
     // will update current_rbs_ queue after preload
-    memory_used_ += chunk_size;
     current_cg_offsets_[column_group_index] += chunk_rows;
     current_cg_chunk_indices_[column_group_index] = current_cg_chunk_index + 1;
 
@@ -409,7 +417,9 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
       return true;
     };
 
-    while (!sorted_offsets.empty() && (memory_used_ < memory_usage_limit_ || !all_cgs_have_data())) {
+    bool memory_size_unavailable = false;
+    while (!sorted_offsets.empty() &&
+           ((!memory_size_unavailable && memory_used_ < memory_usage_limit_) || !all_cgs_have_data())) {
       auto [cg_index, cg_offset] = sorted_offsets.top();
       sorted_offsets.pop();
 
@@ -417,7 +427,7 @@ class PackedRecordBatchReader final : public arrow::RecordBatchReader {
         continue;
       }
 
-      ARROW_ASSIGN_OR_RAISE(auto loaded_chunk_idx, preload_column_group(cg_index));
+      ARROW_ASSIGN_OR_RAISE(auto loaded_chunk_idx, preload_column_group(cg_index, memory_size_unavailable));
       loaded_chunk_indices_[cg_index].emplace_back(loaded_chunk_idx);
 
       // Push back to heap if more chunks available

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -675,18 +675,14 @@ arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_estimated_size()
 }
 
 arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_column_estimated_size(const std::string& field_name) {
-  const auto file_schema = chunk_reader_->get_schema();
-  if (!file_schema) {
-    return arrow::Status::Invalid("Chunk reader file schema is not available");
+  const auto field = std::find(column_group_->columns.begin(), column_group_->columns.end(), field_name);
+  if (field == column_group_->columns.end()) {
+    return arrow::Status::Invalid(fmt::format("Column '{}' is not part of the column group", field_name));
   }
-
-  auto field_status = file_schema->CanReferenceFieldByName(field_name);
-  if (!field_status.ok()) {
-    return arrow::Status::Invalid(
-        fmt::format("Cannot resolve column '{}' in chunk reader file schema: {}", field_name, field_status.ToString()));
+  if (std::find(std::next(field), column_group_->columns.end(), field_name) != column_group_->columns.end()) {
+    return arrow::Status::Invalid(fmt::format("Column '{}' is duplicated in the column group", field_name));
   }
-  const auto col_idx = file_schema->GetFieldIndex(field_name);
-  assert(col_idx >= 0);
+  const auto col_idx = static_cast<int>(std::distance(column_group_->columns.begin(), field));
 
   const auto total_chunks = total_number_of_chunks();
   std::vector<uint64_t> result(total_chunks);
@@ -697,17 +693,12 @@ arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_column_estimated
 }
 
 arrow::Result<std::vector<std::vector<uint64_t>>> ChunkReaderImpl::get_chunk_column_estimated_size() {
-  const auto file_schema = chunk_reader_->get_schema();
-  if (!file_schema) {
-    return arrow::Status::Invalid("Chunk reader file schema is not available");
-  }
-
   const auto total_chunks = total_number_of_chunks();
-  std::vector<std::vector<uint64_t>> result(file_schema->num_fields(), std::vector<uint64_t>(total_chunks));
-  for (int col_idx = 0; col_idx < file_schema->num_fields(); ++col_idx) {
+  std::vector<std::vector<uint64_t>> result(column_group_->columns.size(), std::vector<uint64_t>(total_chunks));
+  for (size_t col_idx = 0; col_idx < column_group_->columns.size(); ++col_idx) {
     for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
       ARROW_ASSIGN_OR_RAISE(result[col_idx][chunk_idx],
-                            chunk_reader_->get_chunk_column_estimated_size(chunk_idx, col_idx));
+                            chunk_reader_->get_chunk_column_estimated_size(chunk_idx, static_cast<int>(col_idx)));
     }
   }
   return result;

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -1025,6 +1025,41 @@ TEST_P(APIWriterReaderTest, PerCallProjectionOverride) {
   }
 }
 
+TEST_P(APIWriterReaderTest, ChunkColumnEstimatedSizeMetadataIgnoresProjection) {
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  ASSERT_OK(writer->write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgs, writer->close());
+
+  auto projection = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"id"});
+  auto reader = Reader::create(cgs, schema_, projection, properties_);
+  ASSERT_NE(reader, nullptr);
+
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+  ASSERT_AND_ASSIGN(auto chunk_sizes, chunk_reader->get_chunk_estimated_size());
+  ASSERT_AND_ASSIGN(auto column_sizes, chunk_reader->get_chunk_column_estimated_size());
+
+  ASSERT_EQ(column_sizes.size(), schema_->num_fields());
+  for (const auto& sizes : column_sizes) {
+    ASSERT_EQ(sizes.size(), chunk_sizes.size());
+  }
+
+  for (size_t chunk_idx = 0; chunk_idx < chunk_sizes.size(); ++chunk_idx) {
+    uint64_t column_total = 0;
+    for (const auto& sizes : column_sizes) {
+      column_total += sizes[chunk_idx];
+    }
+    EXPECT_EQ(column_total, chunk_sizes[chunk_idx]);
+  }
+
+  for (int field_idx = 0; field_idx < schema_->num_fields(); ++field_idx) {
+    ASSERT_AND_ASSIGN(auto sizes, chunk_reader->get_chunk_column_estimated_size(schema_->field(field_idx)->name()));
+    EXPECT_EQ(sizes, column_sizes[field_idx]);
+  }
+
+  EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size("missing").status().IsInvalid());
+}
+
 TEST_P(APIWriterReaderTest, MetadataCacheWarmupDoesNotFreezePerCallProjection) {
   ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
   auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
@@ -2029,7 +2064,7 @@ TEST_P(APIWriterReaderTest, TestEmptyFiles) {
   for (size_t i = 0; i < cgs->size(); ++i) {
     ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(i));
     ASSERT_EQ(chunk_reader->total_number_of_chunks(), 0);
-    ASSERT_AND_ASSIGN(auto chunk_size, chunk_reader->get_chunk_size());
+    ASSERT_AND_ASSIGN(auto chunk_size, chunk_reader->get_chunk_estimated_size());
     ASSERT_EQ(chunk_size.size(), 0);
     ASSERT_AND_ASSIGN(auto chunk_rows, chunk_reader->get_chunk_rows());
     ASSERT_EQ(chunk_rows.size(), 0);

--- a/cpp/test/ffi/ffi_fiu_test.c
+++ b/cpp/test/ffi/ffi_fiu_test.c
@@ -51,6 +51,9 @@ static void test_fiu_key_constants(void) {
   ck_assert(loon_fiukey_reader_open_fail != NULL);
   ck_assert(strlen(loon_fiukey_reader_open_fail) > 0);
 
+  ck_assert(loon_fiukey_memory_size_estimation_fail != NULL);
+  ck_assert(strlen(loon_fiukey_memory_size_estimation_fail) > 0);
+
   // Transaction/Manifest fault points
   ck_assert(loon_fiukey_manifest_commit_fail != NULL);
   ck_assert(strlen(loon_fiukey_manifest_commit_fail) > 0);

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <numeric>
 #include <random>
 
 #include <arrow/api.h>
@@ -22,6 +23,7 @@
 #include <arrow/io/api.h>
 #include <arrow/testing/gtest_util.h>
 #include <parquet/arrow/schema.h>
+#include <parquet/metadata.h>
 #include <parquet/type_fwd.h>
 #include <parquet/arrow/writer.h>
 
@@ -155,6 +157,12 @@ class AsyncCountingFileSystem final : public arrow::fs::SubTreeFileSystem {
 
 }  // namespace
 
+TEST(FormatReaderUtilityTest, MemorySizeDistributionAvoidsIntermediateOverflow) {
+  constexpr uint64_t kGiB = uint64_t{1} << 30;
+  ASSERT_AND_ASSIGN(auto distributed, DistributeMemorySizes(8 * kGiB, {5 * kGiB, 5 * kGiB}));
+  EXPECT_EQ(distributed, (std::vector<uint64_t>{4 * kGiB, 4 * kGiB}));
+}
+
 class FormatReaderTest : public ::testing::TestWithParam<std::string> {
   protected:
   void SetUp() override {
@@ -245,6 +253,10 @@ TEST_P(FormatReaderTest, ReadParquetWithoutMeta) {
     ASSERT_EQ(row_group_infos[i].start_offset, i * test_batch_->num_rows());
     ASSERT_EQ(row_group_infos[i].end_offset, (i + 1) * test_batch_->num_rows());
     ASSERT_GT(row_group_infos[i].memory_size, 0);
+    ASSERT_EQ(row_group_infos[i].column_memory_sizes.size(), schema_->num_fields());
+    ASSERT_EQ(std::accumulate(row_group_infos[i].column_memory_sizes.begin(),
+                              row_group_infos[i].column_memory_sizes.end(), uint64_t{0}),
+              row_group_infos[i].memory_size);
     ASSERT_AND_ASSIGN(auto rb, format_reader->get_chunk(i));
     ASSERT_EQ(rb->num_rows(), test_batch_->num_rows());
   }
@@ -631,6 +643,36 @@ TEST_P(FormatReaderTest, NestedProjectionPreservesTopLevelColumns) {
   ASSERT_AND_ASSIGN(auto column_groups, writer->close());
   ASSERT_EQ(column_groups->size(), 1);
   ASSERT_EQ(column_groups->front()->files.size(), 1);
+
+  if (format == LOON_FORMAT_PARQUET) {
+    const auto& file = column_groups->front()->files.front();
+    ASSERT_AND_ASSIGN(auto metadata,
+                      parquet::ParquetFormatReader::MetaTrait::load_metadata(file, properties_, nullptr));
+    ASSERT_NE(metadata->payload.parquet_metadata, nullptr);
+    ASSERT_EQ(metadata->row_group_infos.size(), 1);
+
+    auto parquet_row_group = metadata->payload.parquet_metadata->RowGroup(0);
+    ASSERT_EQ(parquet_row_group->num_columns(), 6);
+    auto leaf_size = [&parquet_row_group](int leaf_column_index) {
+      return static_cast<uint64_t>(parquet_row_group->ColumnChunk(leaf_column_index)->total_uncompressed_size());
+    };
+    const std::vector<uint64_t> top_level_weights = {
+        leaf_size(0),
+        leaf_size(1) + leaf_size(2),
+        leaf_size(3) + leaf_size(4),
+        leaf_size(5),
+    };
+    ASSERT_AND_ASSIGN(auto expected_column_sizes,
+                      DistributeMemorySizes(metadata->row_group_infos[0].memory_size, top_level_weights));
+    ASSERT_EQ(metadata->row_group_infos[0].column_memory_sizes, expected_column_sizes);
+    ASSERT_EQ(std::accumulate(expected_column_sizes.begin(), expected_column_sizes.end(), uint64_t{0}),
+              metadata->row_group_infos[0].memory_size);
+
+    ASSERT_AND_ASSIGN(auto projected_reader, parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
+                                                 metadata, file, nested_schema, std::vector<std::string>{"note"}, ""));
+    ASSERT_AND_ASSIGN(auto projected_row_group_infos, projected_reader->get_row_group_infos());
+    ASSERT_EQ(projected_row_group_infos[0].column_memory_sizes, expected_column_sizes);
+  }
 
   auto assert_batch_equal = [](const std::shared_ptr<arrow::RecordBatch>& actual,
                                const std::shared_ptr<arrow::RecordBatch>& expected) {

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -29,10 +29,12 @@
 
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/reader.h"
 #include "milvus-storage/writer.h"
 #include "milvus-storage/filesystem/async_random_access_file.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/format_reader.h"
+#include "milvus-storage/format/lance/lance_table_writer.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 #include "milvus-storage/format/parquet/parquet_writer.h"
 #include "test_env.h"
@@ -264,6 +266,205 @@ TEST_P(FormatReaderTest, EstimatedMemorySizesAreReasonable) {
   for (int column_idx = 0; column_idx < schema_->num_fields(); ++column_idx) {
     SCOPED_TRACE(schema_->field(column_idx)->name());
     expect_reasonable_estimate(estimated_column_sizes[column_idx], actual_column_sizes[column_idx]);
+  }
+}
+
+TEST_P(FormatReaderTest, MultiFileColumnEstimatesFollowFieldNames) {
+  const auto format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  auto ordered_schema = arrow::schema({schema_->GetFieldByName("id"), schema_->GetFieldByName("name")});
+  auto ordered_batch =
+      arrow::RecordBatch::Make(ordered_schema, test_batch_->num_rows(),
+                               {test_batch_->GetColumnByName("id"), test_batch_->GetColumnByName("name")});
+  auto reordered_schema = arrow::schema({schema_->GetFieldByName("name"), schema_->GetFieldByName("id")});
+  auto reordered_batch =
+      arrow::RecordBatch::Make(reordered_schema, test_batch_->num_rows(),
+                               {test_batch_->GetColumnByName("name"), test_batch_->GetColumnByName("id")});
+  auto id_only_schema = arrow::schema({schema_->GetFieldByName("id")});
+  auto id_only_batch =
+      arrow::RecordBatch::Make(id_only_schema, test_batch_->num_rows(), {test_batch_->GetColumnByName("id")});
+  auto extra_column_schema =
+      arrow::schema({schema_->GetFieldByName("id"), schema_->GetFieldByName("name"), schema_->GetFieldByName("value")});
+  auto extra_column_batch =
+      arrow::RecordBatch::Make(extra_column_schema, test_batch_->num_rows(),
+                               {test_batch_->GetColumnByName("id"), test_batch_->GetColumnByName("name"),
+                                test_batch_->GetColumnByName("value")});
+
+  ASSERT_AND_ASSIGN(auto ordered_policy, CreateSinglePolicy(format, ordered_schema));
+  auto ordered_writer = Writer::create(base_path_ + "/ordered", ordered_schema, std::move(ordered_policy), properties_);
+  ASSERT_NE(ordered_writer, nullptr);
+  ASSERT_OK(ordered_writer->write(ordered_batch));
+  ASSERT_AND_ASSIGN(auto ordered_groups, ordered_writer->close());
+  ASSERT_EQ(ordered_groups->size(), 1);
+  ASSERT_EQ(ordered_groups->front()->files.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto reordered_policy, CreateSinglePolicy(format, reordered_schema));
+  auto reordered_writer =
+      Writer::create(base_path_ + "/reordered", reordered_schema, std::move(reordered_policy), properties_);
+  ASSERT_NE(reordered_writer, nullptr);
+  ASSERT_OK(reordered_writer->write(reordered_batch));
+  ASSERT_AND_ASSIGN(auto reordered_groups, reordered_writer->close());
+  ASSERT_EQ(reordered_groups->size(), 1);
+  ASSERT_EQ(reordered_groups->front()->files.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto id_only_policy, CreateSinglePolicy(format, id_only_schema));
+  auto id_only_writer = Writer::create(base_path_ + "/id-only", id_only_schema, std::move(id_only_policy), properties_);
+  ASSERT_NE(id_only_writer, nullptr);
+  ASSERT_OK(id_only_writer->write(id_only_batch));
+  ASSERT_AND_ASSIGN(auto id_only_groups, id_only_writer->close());
+  ASSERT_EQ(id_only_groups->size(), 1);
+  ASSERT_EQ(id_only_groups->front()->files.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto extra_column_policy, CreateSinglePolicy(format, extra_column_schema));
+  auto extra_column_writer =
+      Writer::create(base_path_ + "/extra-column", extra_column_schema, std::move(extra_column_policy), properties_);
+  ASSERT_NE(extra_column_writer, nullptr);
+  ASSERT_OK(extra_column_writer->write(extra_column_batch));
+  ASSERT_AND_ASSIGN(auto extra_column_groups, extra_column_writer->close());
+  ASSERT_EQ(extra_column_groups->size(), 1);
+  ASSERT_EQ(extra_column_groups->front()->files.size(), 1);
+
+  ASSERT_AND_ASSIGN(
+      auto ordered_format_reader,
+      FormatReader::create(ordered_schema, format, ordered_groups->front()->files.front(), properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto ordered_row_groups, ordered_format_reader->get_row_group_infos());
+  ASSERT_AND_ASSIGN(auto reordered_format_reader,
+                    FormatReader::create(reordered_schema, format, reordered_groups->front()->files.front(),
+                                         properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto reordered_row_groups, reordered_format_reader->get_row_group_infos());
+  ASSERT_AND_ASSIGN(
+      auto id_only_format_reader,
+      FormatReader::create(id_only_schema, format, id_only_groups->front()->files.front(), properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto id_only_row_groups, id_only_format_reader->get_row_group_infos());
+  ASSERT_AND_ASSIGN(auto extra_column_format_reader,
+                    FormatReader::create(extra_column_schema, format, extra_column_groups->front()->files.front(),
+                                         properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto extra_column_row_groups, extra_column_format_reader->get_row_group_infos());
+
+  std::vector<uint64_t> expected_id_sizes;
+  std::vector<uint64_t> expected_name_sizes;
+  for (const auto& row_group : ordered_row_groups) {
+    ASSERT_EQ(row_group.column_memory_sizes.size(), 2);
+    expected_id_sizes.emplace_back(row_group.column_memory_sizes[0]);
+    expected_name_sizes.emplace_back(row_group.column_memory_sizes[1]);
+  }
+  for (const auto& row_group : reordered_row_groups) {
+    ASSERT_EQ(row_group.column_memory_sizes.size(), 2);
+    expected_name_sizes.emplace_back(row_group.column_memory_sizes[0]);
+    expected_id_sizes.emplace_back(row_group.column_memory_sizes[1]);
+  }
+  for (const auto& row_group : id_only_row_groups) {
+    ASSERT_EQ(row_group.column_memory_sizes.size(), 1);
+    expected_id_sizes.emplace_back(row_group.column_memory_sizes[0]);
+    expected_name_sizes.emplace_back(0);
+  }
+  for (const auto& row_group : extra_column_row_groups) {
+    ASSERT_EQ(row_group.column_memory_sizes.size(), 3);
+    expected_id_sizes.emplace_back(row_group.column_memory_sizes[0]);
+    expected_name_sizes.emplace_back(row_group.column_memory_sizes[1]);
+    EXPECT_GT(row_group.column_memory_sizes[2], 0);
+    EXPECT_LT(row_group.column_memory_sizes[0] + row_group.column_memory_sizes[1], row_group.memory_size);
+  }
+  ASSERT_FALSE(reordered_row_groups.empty());
+  ASSERT_NE(reordered_row_groups.front().column_memory_sizes[0], reordered_row_groups.front().column_memory_sizes[1]);
+
+  auto combined_group = std::make_shared<api::ColumnGroup>(*ordered_groups->front());
+  combined_group->files.insert(combined_group->files.end(), reordered_groups->front()->files.begin(),
+                               reordered_groups->front()->files.end());
+  combined_group->files.insert(combined_group->files.end(), id_only_groups->front()->files.begin(),
+                               id_only_groups->front()->files.end());
+  combined_group->files.insert(combined_group->files.end(), extra_column_groups->front()->files.begin(),
+                               extra_column_groups->front()->files.end());
+  auto combined_groups = std::make_shared<api::ColumnGroups>();
+  combined_groups->emplace_back(std::move(combined_group));
+  auto id_projection = std::make_shared<std::vector<std::string>>(std::vector<std::string>{"id"});
+
+  for (const bool cache_enabled : {false, true}) {
+    SCOPED_TRACE(cache_enabled ? "metadata cache enabled" : "metadata cache disabled");
+    auto read_properties = properties_;
+    api::SetValue(read_properties, PROPERTY_READER_METADATA_CACHE_ENABLE, cache_enabled ? "true" : "false");
+    auto reader = api::Reader::create(combined_groups, ordered_schema, nullptr, read_properties);
+    ASSERT_NE(reader, nullptr);
+    ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0, id_projection));
+
+    ASSERT_AND_ASSIGN(auto id_sizes, chunk_reader->get_chunk_column_estimated_size("id"));
+    ASSERT_AND_ASSIGN(auto name_sizes, chunk_reader->get_chunk_column_estimated_size("name"));
+    EXPECT_EQ(id_sizes, expected_id_sizes);
+    EXPECT_EQ(name_sizes, expected_name_sizes);
+
+    ASSERT_AND_ASSIGN(auto all_sizes, chunk_reader->get_chunk_column_estimated_size());
+    ASSERT_EQ(all_sizes.size(), 2);
+    EXPECT_EQ(all_sizes[0], expected_id_sizes);
+    EXPECT_EQ(all_sizes[1], expected_name_sizes);
+
+    ASSERT_AND_ASSIGN(auto chunk_sizes, chunk_reader->get_chunk_estimated_size());
+    ASSERT_EQ(chunk_sizes.size(), expected_id_sizes.size());
+    for (size_t chunk_idx = 0; chunk_idx < chunk_sizes.size(); ++chunk_idx) {
+      EXPECT_EQ(chunk_sizes[chunk_idx], expected_id_sizes[chunk_idx] + expected_name_sizes[chunk_idx]);
+    }
+  }
+}
+
+TEST_P(FormatReaderTest, MissingPhysicalColumnEstimateIsZero) {
+  const auto format = GetParam();
+  if (format != LOON_FORMAT_LANCE_TABLE) {
+    GTEST_SKIP() << "Test Lance schema evolution only.";
+  }
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "1000");
+
+  auto id_field = schema_->GetFieldByName("id");
+  auto name_field = schema_->GetFieldByName("name")->WithNullable(true);
+  auto original_schema = arrow::schema({id_field});
+  auto evolved_schema = arrow::schema({id_field, name_field});
+  auto original_batch =
+      arrow::RecordBatch::Make(original_schema, test_batch_->num_rows(), {test_batch_->GetColumnByName("id")});
+  auto evolved_batch =
+      arrow::RecordBatch::Make(evolved_schema, test_batch_->num_rows(),
+                               {test_batch_->GetColumnByName("id"), test_batch_->GetColumnByName("name")});
+
+  const auto lance_path = base_path_ + "/missing-physical-column";
+  lance::LanceTableWriter initial_writer(lance_path, evolved_schema, properties_);
+  ASSERT_OK(initial_writer.Write(evolved_batch));
+  ASSERT_AND_ASSIGN(auto initial_file, initial_writer.Close());
+
+  // The appended fragment omits the nullable logical column. Lance fills it
+  // with nulls when reading through the evolved schema.
+  lance::LanceTableWriter append_writer(lance_path, original_schema, properties_);
+  ASSERT_OK(append_writer.Write(original_batch));
+  ASSERT_AND_ASSIGN(auto appended_file, append_writer.Close());
+
+  auto column_group = std::make_shared<api::ColumnGroup>();
+  column_group->columns = {"id", "name"};
+  column_group->format = format;
+  column_group->files = {initial_file, appended_file};
+  auto column_groups = std::make_shared<api::ColumnGroups>();
+  column_groups->emplace_back(std::move(column_group));
+
+  for (const bool cache_enabled : {false, true}) {
+    SCOPED_TRACE(cache_enabled ? "metadata cache enabled" : "metadata cache disabled");
+    auto read_properties = properties_;
+    api::SetValue(read_properties, PROPERTY_READER_METADATA_CACHE_ENABLE, cache_enabled ? "true" : "false");
+    auto reader = api::Reader::create(column_groups, evolved_schema, nullptr, read_properties);
+    ASSERT_NE(reader, nullptr);
+    ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+    ASSERT_EQ(chunk_reader->total_number_of_chunks(), 2);
+
+    ASSERT_AND_ASSIGN(auto name_sizes, chunk_reader->get_chunk_column_estimated_size("name"));
+    ASSERT_EQ(name_sizes.size(), 2);
+    EXPECT_GT(name_sizes[0], 0);
+    EXPECT_EQ(name_sizes[1], 0);
+
+    ASSERT_AND_ASSIGN(auto appended_chunk, chunk_reader->get_chunk(1));
+    ASSERT_EQ(appended_chunk->num_columns(), 2);
+    ASSERT_NE(appended_chunk->GetColumnByName("name"), nullptr);
+    EXPECT_EQ(appended_chunk->GetColumnByName("name")->null_count(), appended_chunk->num_rows());
   }
 }
 

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -27,6 +27,7 @@
 #include <parquet/type_fwd.h>
 #include <parquet/arrow/writer.h>
 
+#include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/writer.h"
 #include "milvus-storage/filesystem/async_random_access_file.h"
@@ -212,6 +213,59 @@ class FormatReaderTest : public ::testing::TestWithParam<std::string> {
   std::shared_ptr<arrow::RecordBatch> test_batch_;
   milvus_storage::api::Properties properties_;
 };
+
+TEST_P(FormatReaderTest, EstimatedMemorySizesAreReasonable) {
+  const auto format = GetParam();
+  api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "4096");
+
+  ASSERT_AND_ASSIGN(auto estimated_batch, CreateTestData(schema_, 0, false, 10000));
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  ASSERT_OK(writer->write(estimated_batch));
+  ASSERT_AND_ASSIGN(auto column_groups, writer->close());
+  ASSERT_EQ(column_groups->size(), 1);
+  ASSERT_EQ(column_groups->front()->files.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto format_reader, FormatReader::create(schema_, format, column_groups->front()->files.front(),
+                                                             properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto row_group_infos, format_reader->get_row_group_infos());
+  ASSERT_FALSE(row_group_infos.empty());
+
+  uint64_t estimated_total_size = 0;
+  uint64_t actual_total_size = 0;
+  std::vector<uint64_t> estimated_column_sizes(schema_->num_fields(), 0);
+  std::vector<uint64_t> actual_column_sizes(schema_->num_fields(), 0);
+  for (size_t chunk_idx = 0; chunk_idx < row_group_infos.size(); ++chunk_idx) {
+    const auto& row_group_info = row_group_infos[chunk_idx];
+    ASSERT_EQ(row_group_info.column_memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
+    EXPECT_EQ(std::accumulate(row_group_info.column_memory_sizes.begin(), row_group_info.column_memory_sizes.end(),
+                              uint64_t{0}),
+              row_group_info.memory_size);
+
+    ASSERT_AND_ASSIGN(auto chunk, format_reader->get_chunk(chunk_idx));
+    ASSERT_EQ(chunk->num_columns(), schema_->num_fields());
+    estimated_total_size += row_group_info.memory_size;
+    actual_total_size += GetRecordBatchMemorySize(chunk);
+    for (int column_idx = 0; column_idx < schema_->num_fields(); ++column_idx) {
+      estimated_column_sizes[column_idx] += row_group_info.column_memory_sizes[column_idx];
+      actual_column_sizes[column_idx] += GetArrowArrayMemorySize(chunk->column(column_idx));
+    }
+  }
+
+  auto expect_reasonable_estimate = [](uint64_t estimated, uint64_t actual) {
+    ASSERT_GT(actual, 0);
+    const auto ratio = static_cast<double>(estimated) / static_cast<double>(actual);
+    EXPECT_GE(ratio, 0.5) << "estimated=" << estimated << ", actual=" << actual;
+    EXPECT_LE(ratio, 2.0) << "estimated=" << estimated << ", actual=" << actual;
+  };
+
+  expect_reasonable_estimate(estimated_total_size, actual_total_size);
+  for (int column_idx = 0; column_idx < schema_->num_fields(); ++column_idx) {
+    SCOPED_TRACE(schema_->field(column_idx)->name());
+    expect_reasonable_estimate(estimated_column_sizes[column_idx], actual_column_sizes[column_idx]);
+  }
+}
 
 TEST_P(FormatReaderTest, ReadParquetWithoutMeta) {
   std::string format = GetParam();

--- a/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <numeric>
+
 #include <arrow/api.h>
 #include <arrow/io/api.h>
 #include <parquet/arrow/writer.h>
@@ -116,11 +118,21 @@ TEST_F(IcebergFormatReaderTest, NoDeletes) {
   WriteDataFile(10);
 
   ColumnGroupFile file{data_file_path_, 0, data_num_rows_, {}};
+  ASSERT_AND_ASSIGN(auto parquet_reader,
+                    FormatReader::create(nullptr, LOON_FORMAT_PARQUET, file, properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto parquet_rg_infos, parquet_reader->get_row_group_infos());
+  ASSERT_FALSE(parquet_rg_infos.empty());
   ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_,
                                                       std::vector<std::string>{"id"}, nullptr));
 
   ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
-  ASSERT_GE(rg_infos.size(), 1);
+  ASSERT_EQ(rg_infos.size(), parquet_rg_infos.size());
+  for (size_t i = 0; i < rg_infos.size(); ++i) {
+    EXPECT_EQ(rg_infos[i].start_offset, parquet_rg_infos[i].start_offset);
+    EXPECT_EQ(rg_infos[i].end_offset, parquet_rg_infos[i].end_offset);
+    EXPECT_EQ(rg_infos[i].memory_size, parquet_rg_infos[i].memory_size);
+    EXPECT_EQ(rg_infos[i].column_memory_sizes, parquet_rg_infos[i].column_memory_sizes);
+  }
 
   ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
   ASSERT_EQ(batch->num_rows(), data_num_rows_);
@@ -152,6 +164,68 @@ TEST_F(IcebergFormatReaderTest, PositionalDeleteGetChunk) {
   for (size_t i = 0; i < expected_ids.size(); ++i) {
     ASSERT_EQ(id_array->Value(i), expected_ids[i]) << "Mismatch at index " << i;
   }
+}
+
+TEST_F(IcebergFormatReaderTest, PartialDeletesScaleRowGroupMemorySizes) {
+  WriteDataFile(10);
+
+  ColumnGroupFile parquet_file{data_file_path_, 0, data_num_rows_, {}};
+  ASSERT_AND_ASSIGN(auto parquet_reader,
+                    FormatReader::create(nullptr, LOON_FORMAT_PARQUET, parquet_file, properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto physical_infos, parquet_reader->get_row_group_infos());
+  ASSERT_EQ(physical_infos.size(), 1);
+  ASSERT_FALSE(physical_infos[0].column_memory_sizes.empty());
+
+  WritePositionalDeleteFile(data_file_path_, {2, 5, 8});
+  auto metadata = MakeDeleteMetadataJson(delete_file_path_);
+  ColumnGroupFile iceberg_file{data_file_path_, 0, data_num_rows_, metadata};
+  ASSERT_AND_ASSIGN(auto iceberg_reader,
+                    FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, iceberg_file, properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto logical_infos, iceberg_reader->get_row_group_infos());
+  ASSERT_EQ(logical_infos.size(), 1);
+
+  const auto& physical = physical_infos[0];
+  const auto& logical = logical_infos[0];
+  const auto physical_rows = physical.end_offset - physical.start_offset;
+  ASSERT_EQ(physical_rows, 10);
+  const size_t logical_rows = 7;
+  const auto expected_total =
+      static_cast<uint64_t>(static_cast<unsigned __int128>(physical.memory_size) * logical_rows / physical_rows);
+  ASSERT_AND_ASSIGN(auto expected_columns,
+                    milvus_storage::DistributeMemorySizes(expected_total, physical.column_memory_sizes));
+
+  EXPECT_EQ(logical.start_offset, 0);
+  EXPECT_EQ(logical.end_offset, logical_rows);
+  EXPECT_EQ(logical.memory_size, expected_total);
+  EXPECT_EQ(logical.column_memory_sizes, expected_columns);
+  EXPECT_EQ(std::accumulate(logical.column_memory_sizes.begin(), logical.column_memory_sizes.end(), uint64_t{0}),
+            logical.memory_size);
+}
+
+TEST_F(IcebergFormatReaderTest, FullDeletesZeroRowGroupMemorySizes) {
+  WriteDataFile(10);
+
+  ColumnGroupFile parquet_file{data_file_path_, 0, data_num_rows_, {}};
+  ASSERT_AND_ASSIGN(auto parquet_reader,
+                    FormatReader::create(nullptr, LOON_FORMAT_PARQUET, parquet_file, properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto physical_infos, parquet_reader->get_row_group_infos());
+  ASSERT_EQ(physical_infos.size(), 1);
+  ASSERT_FALSE(physical_infos[0].column_memory_sizes.empty());
+
+  WritePositionalDeleteFile(data_file_path_, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  auto metadata = MakeDeleteMetadataJson(delete_file_path_);
+  ColumnGroupFile iceberg_file{data_file_path_, 0, 0, metadata};
+  ASSERT_AND_ASSIGN(auto iceberg_reader,
+                    FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, iceberg_file, properties_, {}, nullptr));
+  ASSERT_AND_ASSIGN(auto logical_infos, iceberg_reader->get_row_group_infos());
+  ASSERT_EQ(logical_infos.size(), 1);
+
+  const auto& logical = logical_infos[0];
+  EXPECT_EQ(logical.start_offset, 0);
+  EXPECT_EQ(logical.end_offset, 0);
+  EXPECT_EQ(logical.memory_size, 0);
+  EXPECT_EQ(logical.column_memory_sizes,
+            std::vector<uint64_t>(physical_infos[0].column_memory_sizes.size(), uint64_t{0}));
 }
 
 // Positional deletes — take() maps logical doc IDs to physical positions.

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -39,12 +39,14 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/lance/lance_table_writer.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/lance/lance_common.h"
+#include "milvus-storage/reader.h"
 #include "test_env.h"
 
 namespace milvus_storage {
@@ -333,6 +335,56 @@ TEST_F(LanceBasicTest, TestBasic) {
   verify_reader();
 }
 
+TEST_F(LanceBasicTest, TestReaderHandlesFragmentMissingNullableDatasetColumn) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  ASSERT_AND_ASSIGN(auto original_schema, CreateTestSchema({true, true, false, false}));
+  ASSERT_AND_ASSIGN(auto original_batch,
+                    CreateTestData(original_schema, 0, false, 100, 4, 50, {true, true, false, false}));
+
+  auto evolved_fields = original_schema->fields();
+  evolved_fields.push_back(
+      arrow::field("new_column", arrow::int32(), true, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"102"})));
+  auto evolved_schema = arrow::schema(std::move(evolved_fields));
+  ASSERT_AND_ASSIGN(auto new_column, arrow::MakeArrayOfNull(arrow::int32(), original_batch->num_rows()));
+  auto evolved_columns = original_batch->columns();
+  evolved_columns.push_back(std::move(new_column));
+  auto evolved_batch = arrow::RecordBatch::Make(evolved_schema, original_batch->num_rows(), std::move(evolved_columns));
+
+  LanceTableWriter initial_writer(base_path_, evolved_schema, properties_);
+  ASSERT_STATUS_OK(initial_writer.Write(evolved_batch));
+  ASSERT_AND_ASSIGN(auto initial_file, initial_writer.Close());
+
+  // Lance permits an appended fragment to omit nullable dataset columns. This
+  // has the same dataset-schema/physical-fragment shape as an old fragment
+  // after a nullable column is added through schema evolution.
+  LanceTableWriter append_writer(base_path_, original_schema, properties_);
+  ASSERT_STATUS_OK(append_writer.Write(original_batch));
+  ASSERT_AND_ASSIGN(auto appended_file, append_writer.Close());
+
+  ASSERT_AND_ASSIGN(auto parsed_uri, ParseLanceUri(appended_file.path));
+  ArrowFileSystemConfig fs_config;
+  ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
+  auto dataset = BlockingDataset::Open(ToStandardLanceUri(parsed_uri.first), ToStorageOptions(fs_config));
+
+  LanceTableReader reader(dataset, parsed_uri.second, nullptr, properties_);
+  ASSERT_STATUS_OK(reader.open());
+  ASSERT_EQ(reader.get_schema()->num_fields(), evolved_schema->num_fields());
+
+  ASSERT_AND_ASSIGN(auto row_groups, reader.get_row_group_infos());
+  ASSERT_FALSE(row_groups.empty());
+  for (const auto& row_group : row_groups) {
+    ASSERT_EQ(row_group.column_memory_sizes.size(), static_cast<size_t>(evolved_schema->num_fields()));
+    EXPECT_EQ(row_group.column_memory_sizes.back(), 0);
+  }
+
+  ASSERT_AND_ASSIGN(auto table, reader.take({0, 1}));
+  ASSERT_EQ(table->num_columns(), evolved_schema->num_fields());
+  ASSERT_EQ(table->column(evolved_schema->num_fields() - 1)->null_count(), 2);
+}
+
 TEST_F(LanceBasicTest, TestRead) {
   ASSERT_AND_ASSIGN(auto large_batch, CreateTestData(schema_, 0, false, 200000));
 
@@ -503,12 +555,60 @@ TEST_F(LanceBasicTest, FixedSizeListUsesExactMemoryEstimate) {
   ASSERT_EQ(estimated_memory_size, GetRecordBatchMemorySize(batch));
 }
 
-TEST_F(LanceBasicTest, LegacyFormatReturnsErrorWhenMemoryEstimateIsUnavailable) {
+#ifdef BUILD_WITH_FIU
+TEST_F(LanceBasicTest, MemorySizeEstimationFailureDoesNotBlockOpen) {
   if (IsCloudEnv()) {
     GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
   }
 
-  constexpr int64_t kRows = 10'000;
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+  ASSERT_AND_ASSIGN(auto parsed_uri, ParseLanceUri(cgfile.path));
+
+  auto assert_memory_size_unavailable = [](const std::vector<RowGroupInfo>& row_group_infos) {
+    ASSERT_FALSE(row_group_infos.empty());
+    for (const auto& row_group_info : row_group_infos) {
+      EXPECT_FALSE(row_group_info.memory_size_available);
+      EXPECT_EQ(row_group_info.memory_size, 0u);
+      EXPECT_TRUE(row_group_info.column_memory_sizes.empty());
+    }
+  };
+
+  {
+    ScopedFiuFault fault(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL);
+    ASSERT_EQ(fault.enable_result(), 0);
+
+    LanceTableReader reader(parsed_uri.first, parsed_uri.second, schema_, properties_);
+    ASSERT_STATUS_OK(reader.open());
+    ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
+    assert_memory_size_unavailable(row_group_infos);
+    ASSERT_AND_ASSIGN(auto chunk, reader.get_chunk(0));
+    EXPECT_GT(chunk->num_rows(), 0);
+  }
+
+  LanceTableReader::MetaTrait::MetadataPtr metadata;
+  {
+    ScopedFiuFault fault(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL);
+    ASSERT_EQ(fault.enable_result(), 0);
+    ASSERT_AND_ASSIGN(metadata,
+                      LanceTableReader::MetaTrait::load_metadata(cgfile, properties_, nullptr /* key_retriever */));
+  }
+  assert_memory_size_unavailable(metadata->row_group_infos);
+
+  ASSERT_AND_ASSIGN(auto cached_reader, LanceTableReader::MetaTrait::create_from_metadata(
+                                            metadata, cgfile, schema_, std::vector<std::string>{}, ""));
+  ASSERT_AND_ASSIGN(auto chunk, cached_reader->get_chunk(0));
+  EXPECT_GT(chunk->num_rows(), 0);
+}
+#endif
+
+TEST_F(LanceBasicTest, LegacyFormatReadsWhenMemoryEstimateIsUnavailable) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  constexpr int64_t kRows = 1'024;
   ASSERT_AND_ASSIGN(auto vector_schema, CreateTestSchema({false, false, false, true}));
   ASSERT_AND_ASSIGN(auto batch, CreateTestData(vector_schema, 0, false, kRows, 4, 50, {false, false, false, true}));
 
@@ -530,8 +630,38 @@ TEST_F(LanceBasicTest, LegacyFormatReturnsErrorWhenMemoryEstimateIsUnavailable) 
   ASSERT_TRUE(estimate_result.status().IsNotImplemented()) << estimate_result.status().ToString();
 
   LanceTableReader reader(dataset, fragment_ids[0], vector_schema, properties_);
-  auto status = reader.open();
-  ASSERT_TRUE(status.IsNotImplemented()) << status.ToString();
+  ASSERT_STATUS_OK(reader.open());
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
+  ASSERT_FALSE(row_group_infos.empty());
+  for (const auto& row_group_info : row_group_infos) {
+    EXPECT_FALSE(row_group_info.memory_size_available);
+    EXPECT_EQ(row_group_info.memory_size, 0);
+    EXPECT_TRUE(row_group_info.column_memory_sizes.empty());
+  }
+
+  ASSERT_AND_ASSIGN(auto rb_reader, reader.read_with_range(0, kRows));
+  ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatchReader(rb_reader.get()));
+  ASSERT_EQ(table->num_rows(), kRows);
+
+  auto column_group = std::make_shared<api::ColumnGroup>();
+  column_group->columns = {"vector"};
+  column_group->format = LOON_FORMAT_LANCE_TABLE;
+  column_group->files = {cgfile};
+  auto column_groups = std::make_shared<api::ColumnGroups>();
+  column_groups->emplace_back(std::move(column_group));
+
+  auto api_reader = api::Reader::create(column_groups, vector_schema, nullptr, properties_);
+  ASSERT_NE(api_reader, nullptr);
+  ASSERT_AND_ASSIGN(auto chunk_reader, api_reader->get_chunk_reader(0));
+  EXPECT_TRUE(chunk_reader->get_chunk_estimated_size().status().IsNotImplemented());
+  EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size().status().IsNotImplemented());
+  EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size("vector").status().IsNotImplemented());
+  ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
+  ASSERT_GT(chunk->num_rows(), 0);
+
+  ASSERT_AND_ASSIGN(auto packed_reader, api_reader->get_record_batch_reader());
+  ASSERT_AND_ASSIGN(auto packed_table, packed_reader->ToTable());
+  ASSERT_EQ(packed_table->num_rows(), kRows);
 }
 
 TEST_F(LanceBasicTest, TestCachedOpenRejectsMissingNeededColumnWithoutReadSchema) {

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -362,10 +362,19 @@ TEST_F(LanceBasicTest, TestRead) {
   ASSERT_AND_ASSIGN(auto rgs, reader.get_row_group_infos());
   ASSERT_FALSE(rgs.empty());
   ASSERT_EQ(rgs.back().end_offset, large_batch->num_rows());
+  ASSERT_AND_ASSIGN(auto fragment_column_memory_sizes, read_dataset->EstimateFragmentColumnMemory(fragment_ids[0]));
+  ASSERT_EQ(fragment_column_memory_sizes.size(), schema_->num_fields());
   auto estimated_memory_size =
       std::accumulate(rgs.begin(), rgs.end(), uint64_t{0},
                       [](uint64_t total, const RowGroupInfo& rg) { return total + rg.memory_size; });
   ASSERT_EQ(estimated_memory_size, read_dataset->EstimateFragmentMemory(fragment_ids[0]));
+  ASSERT_EQ(std::accumulate(fragment_column_memory_sizes.begin(), fragment_column_memory_sizes.end(), uint64_t{0}),
+            estimated_memory_size);
+  for (const auto& rg : rgs) {
+    ASSERT_EQ(rg.column_memory_sizes.size(), schema_->num_fields());
+    ASSERT_EQ(std::accumulate(rg.column_memory_sizes.begin(), rg.column_memory_sizes.end(), uint64_t{0}),
+              rg.memory_size);
+  }
 
   auto verify_recordbatch = [&](const std::shared_ptr<arrow::RecordBatch>& batch, auto start_ridx, auto num_of_row) {
     ASSERT_EQ(batch->num_rows(), num_of_row);
@@ -411,6 +420,7 @@ TEST_F(LanceBasicTest, TestRead) {
       ASSERT_EQ(projection_rgs[rg_idx].start_offset, rgs[rg_idx].start_offset);
       ASSERT_EQ(projection_rgs[rg_idx].end_offset, rgs[rg_idx].end_offset);
       ASSERT_EQ(projection_rgs[rg_idx].memory_size, rgs[rg_idx].memory_size);
+      ASSERT_EQ(projection_rgs[rg_idx].column_memory_sizes, rgs[rg_idx].column_memory_sizes);
     }
 
     for (size_t rg_idx = 0; rg_idx < rgs.size(); rg_idx++) {
@@ -493,7 +503,7 @@ TEST_F(LanceBasicTest, FixedSizeListUsesExactMemoryEstimate) {
   ASSERT_EQ(estimated_memory_size, GetRecordBatchMemorySize(batch));
 }
 
-TEST_F(LanceBasicTest, LegacyFormatFallsBackToZeroMemoryEstimate) {
+TEST_F(LanceBasicTest, LegacyFormatReturnsErrorWhenMemoryEstimateIsUnavailable) {
   if (IsCloudEnv()) {
     GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
   }
@@ -515,16 +525,13 @@ TEST_F(LanceBasicTest, LegacyFormatFallsBackToZeroMemoryEstimate) {
   auto dataset = BlockingDataset::Open(lance_uri, storage_options);
   auto fragment_ids = dataset->GetAllFragmentIds();
   ASSERT_EQ(fragment_ids.size(), 1);
-  LanceTableReader reader(dataset, fragment_ids[0], vector_schema, properties_);
-  ASSERT_STATUS_OK(reader.open());
-  ASSERT_AND_ASSIGN(auto rgs, reader.get_row_group_infos());
 
-  for (const auto& rg : rgs) {
-    ASSERT_EQ(rg.memory_size, 0);
-  }
-  ASSERT_AND_ASSIGN(auto rbreader, reader.read_with_range(0, kRows));
-  ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatchReader(rbreader.get()));
-  ASSERT_EQ(table->num_rows(), kRows);
+  auto estimate_result = dataset->EstimateFragmentColumnMemory(fragment_ids[0]);
+  ASSERT_TRUE(estimate_result.status().IsNotImplemented()) << estimate_result.status().ToString();
+
+  LanceTableReader reader(dataset, fragment_ids[0], vector_schema, properties_);
+  auto status = reader.open();
+  ASSERT_TRUE(status.IsNotImplemented()) << status.ToString();
 }
 
 TEST_F(LanceBasicTest, TestCachedOpenRejectsMissingNeededColumnWithoutReadSchema) {
@@ -568,6 +575,7 @@ TEST_F(LanceBasicTest, CachedCreateReaderReappliesProjection) {
   ASSERT_EQ(id_rgs.size(), metadata->row_group_infos.size());
   for (size_t rg_idx = 0; rg_idx < id_rgs.size(); ++rg_idx) {
     ASSERT_EQ(id_rgs[rg_idx].memory_size, metadata->row_group_infos[rg_idx].memory_size);
+    ASSERT_EQ(id_rgs[rg_idx].column_memory_sizes, metadata->row_group_infos[rg_idx].column_memory_sizes);
   }
   ASSERT_AND_ASSIGN(auto id_chunk, id_reader->get_chunk(0));
   ASSERT_EQ(id_chunk->num_columns(), 1);

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -535,6 +535,28 @@ TEST_P(VortexBasicTest, TestBasicWrite) {
   ASSERT_EQ(recordBatchsRows(), cgfile.end_index);
 }
 
+TEST_P(VortexBasicTest, RowGroupColumnMemorySizesUseFullFileSchema) {
+  api::SetValue(properties_, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS, "true");
+  api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "1000");
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile(test_file_name_));
+
+  auto projection_schema = arrow::schema({schema_->field(0)});
+  auto vx_reader = vortex::VortexFormatReader(
+      file_system_, projection_schema, test_file_name_, properties_, std::vector<std::string>{"id"},
+      cgfile.Get<uint64_t>(api::kPropertyFileSize), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
+  ASSERT_STATUS_OK(vx_reader.open());
+  ASSERT_AND_ASSIGN(auto row_group_infos, vx_reader.get_row_group_infos());
+
+  ASSERT_GT(row_group_infos.size(), 1u);
+  for (const auto& row_group_info : row_group_infos) {
+    ASSERT_EQ(row_group_info.column_memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
+    EXPECT_GT(row_group_info.memory_size, 0u);
+    EXPECT_EQ(std::accumulate(row_group_info.column_memory_sizes.begin(), row_group_info.column_memory_sizes.end(),
+                              uint64_t{0}),
+              row_group_info.memory_size);
+  }
+}
+
 TEST_P(VortexBasicTest, FlushAllowsSubsequentWrites) {
   ASSERT_AND_ASSIGN(auto first_batch, MakeTestData(0, 1));
   ASSERT_AND_ASSIGN(auto second_batch, MakeTestData(1, 1));

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -549,6 +549,7 @@ TEST_P(VortexBasicTest, RowGroupColumnMemorySizesUseFullFileSchema) {
 
   ASSERT_GT(row_group_infos.size(), 1u);
   for (const auto& row_group_info : row_group_infos) {
+    EXPECT_TRUE(row_group_info.memory_size_available);
     ASSERT_EQ(row_group_info.column_memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
     EXPECT_GT(row_group_info.memory_size, 0u);
     EXPECT_EQ(std::accumulate(row_group_info.column_memory_sizes.begin(), row_group_info.column_memory_sizes.end(),
@@ -556,6 +557,51 @@ TEST_P(VortexBasicTest, RowGroupColumnMemorySizesUseFullFileSchema) {
               row_group_info.memory_size);
   }
 }
+
+#ifdef BUILD_WITH_FIU
+TEST_P(VortexBasicTest, MemorySizeUnavailableDoesNotBlockOpen) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile(test_file_name_));
+  const auto file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  const auto footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+
+  auto assert_memory_size_unavailable = [](const std::vector<RowGroupInfo>& row_group_infos) {
+    ASSERT_FALSE(row_group_infos.empty());
+    for (const auto& row_group_info : row_group_infos) {
+      EXPECT_FALSE(row_group_info.memory_size_available);
+      EXPECT_EQ(row_group_info.memory_size, 0u);
+      EXPECT_TRUE(row_group_info.column_memory_sizes.empty());
+    }
+  };
+
+  {
+    ScopedFiuFault fault(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL);
+    ASSERT_EQ(fault.enable_result(), 0);
+
+    auto reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
+                                             file_size, footer_size);
+    ASSERT_STATUS_OK(reader.open());
+    ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
+    assert_memory_size_unavailable(row_group_infos);
+    ASSERT_AND_ASSIGN(auto chunked_array, reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
+    ASSERT_AND_ASSIGN(auto batch, ChunkedArrayToRecordBatch(chunked_array));
+    EXPECT_EQ(batch->num_rows(), recordBatchsRows());
+  }
+
+  vortex::VortexFormatReader::MetaTrait::MetadataPtr metadata;
+  {
+    ScopedFiuFault fault(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL);
+    ASSERT_EQ(fault.enable_result(), 0);
+    ASSERT_AND_ASSIGN(metadata, vortex::VortexFormatReader::MetaTrait::load_metadata(cgfile, properties_, nullptr));
+  }
+  assert_memory_size_unavailable(metadata->row_group_infos);
+
+  ASSERT_AND_ASSIGN(auto cached_reader, vortex::VortexFormatReader::MetaTrait::create_from_metadata(
+                                            metadata, cgfile, schema_, data_columns(), ""));
+  ASSERT_AND_ASSIGN(auto rb_reader, cached_reader->read_with_range(0, recordBatchsRows()));
+  ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatchReader(rb_reader.get()));
+  EXPECT_EQ(table->num_rows(), recordBatchsRows());
+}
+#endif
 
 TEST_P(VortexBasicTest, FlushAllowsSubsequentWrites) {
   ASSERT_AND_ASSIGN(auto first_batch, MakeTestData(0, 1));

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -545,6 +545,7 @@ _ffi.cdef(
     extern const char* loon_fiukey_take_rows_fail;
     extern const char* loon_fiukey_chunk_reader_read_fail;
     extern const char* loon_fiukey_reader_open_fail;
+    extern const char* loon_fiukey_memory_size_estimation_fail;
     extern const char* loon_fiukey_manifest_commit_fail;
     extern const char* loon_fiukey_manifest_read_fail;
     extern const char* loon_fiukey_manifest_write_fail;

--- a/python/milvus_storage/fiu.py
+++ b/python/milvus_storage/fiu.py
@@ -39,6 +39,7 @@ Available fault points (use FaultInjector class constants):
     - FaultInjector.TAKE_ROWS_FAIL: Fail during take rows operation
     - FaultInjector.CHUNK_READER_READ_FAIL: Fail during ChunkReader read (FFI layer)
     - FaultInjector.READER_OPEN_FAIL: Fail during Reader open (FFI layer)
+    - FaultInjector.MEMORY_SIZE_ESTIMATION_FAIL: Fail format reader memory size estimation
 
     Transaction/Manifest fault points:
     - FaultInjector.MANIFEST_COMMIT_FAIL: Fail during Transaction commit
@@ -94,6 +95,7 @@ class FaultInjector:
     TAKE_ROWS_FAIL: str = ""
     CHUNK_READER_READ_FAIL: str = ""
     READER_OPEN_FAIL: str = ""
+    MEMORY_SIZE_ESTIMATION_FAIL: str = ""
 
     # Transaction/Manifest fault points
     MANIFEST_COMMIT_FAIL: str = ""
@@ -132,6 +134,9 @@ class FaultInjector:
         cls.TAKE_ROWS_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_take_rows_fail")
         cls.CHUNK_READER_READ_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_chunk_reader_read_fail")
         cls.READER_OPEN_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_reader_open_fail")
+        cls.MEMORY_SIZE_ESTIMATION_FAIL = _get_fiu_key(
+            lib.lib, "loon_fiukey_memory_size_estimation_fail"
+        )
         # Transaction/Manifest fault points
         cls.MANIFEST_COMMIT_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_manifest_commit_fail")
         cls.MANIFEST_READ_FAIL = _get_fiu_key(lib.lib, "loon_fiukey_manifest_read_fail")


### PR DESCRIPTION
ChunkReader currently reports only the total estimated decoded-memory size for each chunk, which makes it difficult for callers to understand how much each top-level column contributes when planning reads and managing memory. Add metadata-only APIs that expose per-column estimates without reading data pages, and keep the results based on the complete file schema instead of the active projection.

Carry column memory sizes through RowGroupInfo, format reader metadata, ColumnGroupReader, and the public ChunkReader interface. Provide both field-name lookup and an all-column view, preserve full file-schema ordering, reject missing or ambiguous field names, and return NotImplemented when the underlying format does not provide column-level metadata. Keep every supported chunk’s column estimates consistent with its existing total memory estimate.

For Parquet, aggregate physical leaf-column sizes under each top-level Arrow field and use those values as weights against the existing row-group memory estimate, including nested fields and files that rely on standard footer metadata. For Vortex, retain the top-level uncompressed-size statistics and distribute them across logical row groups while preserving zero-size behavior when statistics are unavailable.

For Iceberg, reuse the underlying Parquet estimates and scale both total and per-column sizes according to the rows that remain after positional deletes. Also handle partially selected row groups by scaling their total size using the overlapping row count and redistributing the column estimates so partial chunks preserve the same size invariant.