### PR TITLE
enhance: expose per-column per-chunk size via get_chunk_column_sizes

### DIFF
--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -42,6 +42,12 @@ class ColumnGroupReader {
   virtual arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) = 0;
   virtual arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) = 0;
 
+  // Estimated per-column in-memory size of a single chunk, from footer metadata only.
+  // One entry per projected column, in projection order. The values sum exactly to
+  // get_chunk_size(chunk_index); when the backend reports no per-column weights the chunk
+  // size is split evenly. Always non-empty for a valid chunk index.
+  virtual arrow::Result<std::vector<uint64_t>> get_chunk_column_sizes(int64_t chunk_index) = 0;
+
   // get the file schema of this column group (always derived from file metadata, not projected)
   virtual std::shared_ptr<arrow::Schema> get_schema() const = 0;
 

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -108,6 +108,19 @@ class FormatReader {
   // get the file schema of this reader (always derived from file metadata, not projected)
   [[nodiscard]] virtual std::shared_ptr<arrow::Schema> get_schema() const = 0;
 
+  // Raw per-column footer WEIGHTS of a single row group (chunk), from footer metadata only.
+  //
+  // The returned vector has one entry per column this reader projects, in the reader's
+  // output-schema (projection) order — aligned with the columns get_chunk() returns. Each
+  // value is an unnormalized weight (e.g. summed uncompressed leaf size or a whole-file
+  // per-column estimate); ColumnGroupReader normalizes these to the chunk's real memory.
+  //
+  // Best-effort: the default returns an empty vector, which the caller treats as "no weights
+  // available" and falls back to an even split. Backends override this.
+  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_column_sizes(int /*row_group_index*/) {
+    return std::vector<uint64_t>{};
+  }
+
   // set a predicate string for filtering (default no-op for formats that don't support it)
   [[nodiscard]] virtual arrow::Status set_predicate(const std::string& /*predicate*/) { return arrow::Status::OK(); }
 

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -92,6 +93,12 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
 
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
+  // Per-column (projected) size weights of a single chunk, from footer/page metadata only.
+  // Lance's estimator reports per-fragment decoded (in-memory) sizes; the whole-fragment
+  // per-column estimate is returned as raw weights (no per-chunk pro-rata here) and
+  // normalized by ColumnGroupReader.
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_column_sizes(int row_group_index) override;
+
   private:
   std::shared_ptr<BlockingDataset> dataset_;
   std::string uri_;
@@ -106,6 +113,12 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
   uint64_t num_deletions_ = 0;  // physical_rows - logical_rows
   std::vector<RowGroupInfo> row_group_infos_;
   std::unique_ptr<BlockingFragmentReader> fragment_reader_;
+
+  // Cached per-top-level-column decoded (in-memory) estimate for this fragment, in file-schema
+  // field order. The Lance estimator runs a metadata scan, so we compute it at most once and
+  // reuse it across get_column_sizes() calls. An empty vector means the estimator could not
+  // run (report no weights); a nullopt means "not yet computed".
+  std::optional<std::vector<uint64_t>> fragment_column_memory_;
 };
 
 }  // namespace milvus_storage::lance

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -90,6 +90,11 @@ class ParquetFormatReader final : public FormatReader {
 
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
+  // Per-column (projected) uncompressed-size weights of a single row group, summed over each
+  // top-level field's Parquet leaf ColumnChunks from footer metadata only.
+  // See FormatReader::get_column_sizes.
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_column_sizes(int row_group_index) override;
+
   private:
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::Table>> get_chunks_internal(
       const std::vector<int>& rg_indices_in_file);

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -99,6 +99,11 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
 
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
+  // Per-column (projected) size weights of a single chunk (row group), from footer statistics
+  // only. Vortex exposes whole-file per-column uncompressed sizes; these are returned as raw
+  // weights (no per-chunk pro-rata here) and normalized by ColumnGroupReader.
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_column_sizes(int row_group_index) override;
+
   [[nodiscard]] arrow::Status set_predicate(const std::string& predicate) override;
 
   // get the row ranges(splits) of the file

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/record_batch.h>
 #include <arrow/type.h>
@@ -25,6 +27,7 @@
 #include "milvus-storage/thread_pool.h"
 
 namespace milvus_storage::api {
+
 /**
  * @brief Interface for reading individual column groups in packed storage format
  *
@@ -92,6 +95,22 @@ class ChunkReader {
    */
   [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_size() = 0;
   [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_rows() = 0;
+
+  /**
+   * @brief Estimated per-column in-memory size within each chunk, from footer metadata only (no data pages read).
+   *
+   * Outer index: one entry per chunk, in the same order and length as get_chunk_size() / get_chunk_rows().
+   * Inner index: one entry per column this reader projects, in the reader's output-schema (projection) order.
+   * Each value is the estimated in-memory (materialized) byte size of that column within the chunk.
+   *
+   * For a full projection, the per-column values of a chunk sum exactly to get_chunk_size() for that chunk.
+   * The estimate is derived from footer metadata only; when a backend cannot report per-column weights the
+   * chunk size is split evenly across the projected columns, so the outer vector always has one entry per
+   * chunk (never globally empty). The non-pure-virtual default returns empty for readers that do not override.
+   */
+  [[nodiscard]] virtual arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_sizes() {
+    return std::vector<std::vector<uint64_t>>{};
+  }
 };
 
 /**

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -98,6 +98,11 @@ class BlockingDataset {
 
   uint64_t EstimateFragmentMemory(uint64_t fragment_id) const;
 
+  // Per-top-level-column decoded (in-memory) size estimate for a fragment, in dataset
+  // schema order. Each entry pairs the column's field id with its estimated memory size.
+  // Best-effort: returns an empty vector on estimation failure.
+  std::vector<ffi::LanceColumnMemoryEstimate> EstimateFragmentColumnMemory(uint64_t fragment_id) const;
+
   // Get the schema of a specific fragment, exported as Arrow C schema
   void GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const;
 

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -112,6 +112,15 @@ uint64_t BlockingDataset::EstimateFragmentMemory(uint64_t fragment_id) const {
   }
 }
 
+std::vector<ffi::LanceColumnMemoryEstimate> BlockingDataset::EstimateFragmentColumnMemory(uint64_t fragment_id) const {
+  try {
+    auto estimates = ffi::estimate_fragment_column_memory(*impl_, fragment_id);
+    return {estimates.begin(), estimates.end()};
+  } catch (const rust::cxxbridge1::Error&) {
+    return {};
+  }
+}
+
 void BlockingDataset::GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const {
   try {
     ffi::get_fragment_schema(*impl_, fragment_id, reinterpret_cast<uint8_t*>(&out_schema));

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -87,6 +87,7 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
 
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_size(int64_t chunk_index) override;
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_column_sizes(int64_t chunk_index) override;
 
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
@@ -510,6 +511,82 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_size(int64_t c
         fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
   }
   return chunk_infos_[chunk_index].avg_memory_size;
+}
+
+template <typename ReaderT>
+arrow::Result<std::vector<uint64_t>> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_sizes(int64_t chunk_index) {
+  assert(opened_);
+  if (UNLIKELY(chunk_index < 0 || chunk_index >= chunk_infos_.size())) {
+    return arrow::Status::Invalid(
+        fmt::format("Chunk index out of range: {} out of {}", chunk_index, chunk_infos_.size()));
+  }
+
+  const auto& chunk_info = chunk_infos_[chunk_index];
+  if (!format_readers_[chunk_info.file_index]) {
+    ARROW_ASSIGN_OR_RAISE(format_readers_[chunk_info.file_index], open_reader_for_file(chunk_info.file_index));
+  }
+
+  // Raw per-projected-column footer weights (unnormalized) for this chunk's row group.
+  // Empty means the backend has no weights; we then split the chunk memory evenly.
+  ARROW_ASSIGN_OR_RAISE(auto weights, format_readers_[chunk_info.file_index]->get_column_sizes(
+                                          static_cast<int>(chunk_info.row_group_index_in_file)));
+
+  // The chunk's real in-memory size (already slice-adjusted for partial row groups; this is
+  // exactly what get_chunk_size(chunk_index) returns). We distribute it across columns so the
+  // per-column values sum to M exactly, absorbing any integer-division remainder.
+  const uint64_t M = chunk_info.avg_memory_size;
+
+  // Number of projected columns: the weight vector length when available, otherwise the
+  // reader's projected column count. Projection is needed_columns_ (already filtered to the
+  // group's columns); an empty projection means all columns in this column group.
+  size_t num_cols = weights.size();
+  if (num_cols == 0) {
+    if (!needed_columns_.empty()) {
+      num_cols = needed_columns_.size();
+    } else if (column_group_) {
+      num_cols = column_group_->columns.size();
+    }
+  }
+  if (num_cols == 0) {
+    return std::vector<uint64_t>{};
+  }
+
+  std::vector<uint64_t> result(num_cols, 0);
+
+  uint64_t weight_sum = 0;
+  if (weights.size() == num_cols) {
+    for (const auto w : weights) {
+      weight_sum += w;
+    }
+  }
+
+  if (weight_sum > 0) {
+    // Proportional split by weight, then hand the floor-rounding remainder to the largest
+    // weights so the total lands exactly on M.
+    uint64_t assigned = 0;
+    for (size_t i = 0; i < num_cols; ++i) {
+      result[i] = static_cast<uint64_t>((static_cast<__uint128_t>(M) * weights[i]) / weight_sum);
+      assigned += result[i];
+    }
+    uint64_t remainder = M - assigned;  // assigned <= M since each floor(M*w/sum) <= M*w/sum
+    // Distribute the remainder 1 byte at a time to the largest-weight columns first.
+    std::vector<size_t> order(num_cols);
+    std::iota(order.begin(), order.end(), 0);
+    std::sort(order.begin(), order.end(), [&](size_t a, size_t b) { return weights[a] > weights[b]; });
+    for (size_t k = 0; remainder > 0 && !order.empty(); ++k) {
+      result[order[k % order.size()]] += 1;
+      --remainder;
+    }
+  } else {
+    // Even split: base share to every column, then spread the remainder one byte each.
+    const uint64_t base = M / num_cols;
+    uint64_t remainder = M - base * num_cols;
+    for (size_t i = 0; i < num_cols; ++i) {
+      result[i] = base + (i < remainder ? 1 : 0);
+    }
+  }
+
+  return result;
 }
 
 template <typename ReaderT>

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -305,6 +305,61 @@ arrow::Result<std::vector<RowGroupInfo>> LanceTableReader::get_row_group_infos()
   return row_group_infos_;
 }
 
+arrow::Result<std::vector<uint64_t>> LanceTableReader::get_column_sizes(int row_group_index) {
+  assert(fragment_reader_);
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid(
+        fmt::format("Lance row group index {} out of range {}", row_group_index, row_group_infos_.size()));
+  }
+  if (!file_schema_ || !dataset_) {
+    return arrow::Status::Invalid("Lance file schema or dataset is not initialized");
+  }
+
+  // The Lance estimator runs a metadata scan, so compute the per-column fragment estimate at
+  // most once and cache it (in file-schema field order). Every chunk of this fragment reuses
+  // the same whole-fragment per-column weights. An empty cache means the estimator could not
+  // produce a usable per-field vector; report no weights so ColumnGroupReader falls back.
+  if (!fragment_column_memory_.has_value()) {
+    std::vector<uint64_t> per_field;
+    // One entry per top-level column in file-schema order. We index it by the file-schema
+    // field position, which is sound only when the fragment schema matches the dataset schema
+    // (the common case, no schema evolution). Guard against a count mismatch to avoid
+    // mis-attributing sizes.
+    auto column_estimates = dataset_->EstimateFragmentColumnMemory(fragment_id_);
+    if (!column_estimates.empty() && column_estimates.size() == static_cast<size_t>(file_schema_->num_fields())) {
+      per_field.reserve(column_estimates.size());
+      for (const auto& estimate : column_estimates) {
+        per_field.emplace_back(estimate.memory_size);
+      }
+    }
+    fragment_column_memory_ = std::move(per_field);
+  }
+  const std::vector<uint64_t>& column_estimates = *fragment_column_memory_;
+  if (column_estimates.empty()) {
+    return std::vector<uint64_t>{};
+  }
+
+  // Output columns in projection order — the same order get_chunk() returns. These are
+  // whole-fragment weights; ColumnGroupReader normalizes them to the chunk's real memory
+  // (no per-chunk row pro-rata is done here).
+  ARROW_ASSIGN_OR_RAISE(auto out_schema, build_read_schema(file_schema_, read_schema_, needed_columns_));
+
+  std::vector<uint64_t> result;
+  result.reserve(out_schema->num_fields());
+  for (int i = 0; i < out_schema->num_fields(); ++i) {
+    // The estimate vector is one entry per top-level file-schema field, in file-schema order,
+    // so the file-schema field index selects this column's estimate.
+    const int file_field_index = file_schema_->GetFieldIndex(out_schema->field(i)->name());
+    if (file_field_index < 0 || static_cast<size_t>(file_field_index) >= column_estimates.size()) {
+      result.emplace_back(0);
+      continue;
+    }
+    result.emplace_back(column_estimates[file_field_index]);
+  }
+
+  return result;
+}
+
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> LanceTableReader::get_chunk(const int& row_group_index) {
   assert(fragment_reader_);
   auto start_idx = row_group_infos_[row_group_index].start_offset;

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -511,6 +511,93 @@ arrow::Status ParquetFormatReader::set_needed_columns(const std::vector<std::str
   return arrow::Status::OK();
 }
 
+arrow::Result<std::vector<uint64_t>> ParquetFormatReader::get_column_sizes(int row_group_index) {
+  assert(file_reader_);
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid(
+        fmt::format("Row group index out of range [path={}, row_group_index={}, "
+                    "row_group_infos={}]",
+                    path_, row_group_index, row_group_infos_.size()));
+  }
+  if (!schema_) {
+    return arrow::Status::Invalid(fmt::format("Parquet file schema is not initialized. [path={}]", path_));
+  }
+
+  auto* parquet_reader = file_reader_->parquet_reader();
+  if (!parquet_reader || !parquet_reader->metadata()) {
+    // Encrypted-file readers may withhold cached footer metadata here; report no weights
+    // so the caller falls back to an even split rather than fabricating sizes.
+    return std::vector<uint64_t>{};
+  }
+  const auto metadata = parquet_reader->metadata();
+  // The API's row-group index space (row_group_infos_) may differ from the physical
+  // Parquet row-group count only via private KV metadata; when they match, index directly.
+  if (row_group_index >= metadata->num_row_groups()) {
+    return std::vector<uint64_t>{};
+  }
+  auto row_group_meta = metadata->RowGroup(row_group_index);
+
+  // Rebuild the start offset of each top-level Arrow field in the Parquet leaf-column
+  // list, matching get_leaf_column_indices(). Nested top-level fields (list/struct/map)
+  // own a contiguous range of leaf columns whose sizes are summed into one entry.
+  std::vector<int> leaf_column_offsets_by_field;
+  leaf_column_offsets_by_field.reserve(schema_->num_fields() + 1);
+  leaf_column_offsets_by_field.emplace_back(0);
+  for (int field_index = 0; field_index < schema_->num_fields(); ++field_index) {
+    leaf_column_offsets_by_field.emplace_back(leaf_column_offsets_by_field.back() +
+                                              get_leaf_column_count(schema_->field(field_index)->type()));
+  }
+  const int leaf_column_count = leaf_column_offsets_by_field.back();
+
+  // If the schema-derived leaf count disagrees with the file's physical leaf columns,
+  // the Arrow->Parquet leaf mapping differs from get_leaf_column_count for some type
+  // (e.g. map / dictionary / fixed_size_list). We can no longer safely attribute leaves
+  // to top-level fields, so return no weights rather than silently undercounting.
+  if (leaf_column_count != row_group_meta->num_columns()) {
+    return std::vector<uint64_t>{};
+  }
+
+  // Determine the projected top-level fields in output-schema order. Empty projection
+  // means every top-level field, in file-schema order (mirrors get_leaf_column_indices).
+  std::vector<int> top_level_field_indices;
+  if (needed_columns_.empty()) {
+    top_level_field_indices.resize(schema_->num_fields());
+    std::iota(top_level_field_indices.begin(), top_level_field_indices.end(), 0);
+  } else {
+    top_level_field_indices.reserve(needed_columns_.size());
+    for (const auto& column_name : needed_columns_) {
+      const int top_level_field_index = schema_->GetFieldIndex(column_name);
+      if (top_level_field_index < 0) {
+        return arrow::Status::Invalid(fmt::format("Column '{}' not found in schema. [path={}]", column_name, path_));
+      }
+      top_level_field_indices.emplace_back(top_level_field_index);
+    }
+  }
+
+  // One weight per projected top-level column, in projection order. Each weight sums
+  // total_uncompressed_size() over all Parquet leaf columns owned by that top-level field.
+  // No data pages are read; ColumnGroupReader normalizes these to the chunk's real memory.
+  std::vector<uint64_t> result;
+  result.reserve(top_level_field_indices.size());
+  for (const int top_level_field_index : top_level_field_indices) {
+    uint64_t weight = 0;
+    for (int leaf_idx = leaf_column_offsets_by_field[top_level_field_index];
+         leaf_idx < leaf_column_offsets_by_field[top_level_field_index + 1]; ++leaf_idx) {
+      if (leaf_idx >= leaf_column_count || leaf_idx >= row_group_meta->num_columns()) {
+        break;
+      }
+      auto column_chunk = row_group_meta->ColumnChunk(leaf_idx);
+      const auto uncompressed = column_chunk->total_uncompressed_size();
+      if (uncompressed > 0) {
+        weight += static_cast<uint64_t>(uncompressed);
+      }
+    }
+    result.emplace_back(weight);
+  }
+
+  return result;
+}
+
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> ParquetFormatReader::get_chunk(const int& row_group_index) {
   std::shared_ptr<arrow::Table> table;
   assert(file_reader_);

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -503,6 +503,56 @@ arrow::Result<std::vector<RowGroupInfo>> VortexFormatReader::get_row_group_infos
   return row_group_infos_;
 }
 
+arrow::Result<std::vector<uint64_t>> VortexFormatReader::get_column_sizes(int row_group_index) {
+  assert(vxfile_);
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid(
+        fmt::format("Vortex row group index {} out of range {}", row_group_index, row_group_infos_.size()));
+  }
+  if (!file_schema_) {
+    return arrow::Status::Invalid(fmt::format("Vortex file schema is not initialized. [path={}]", path_));
+  }
+
+  // Whole-file per-column uncompressed sizes, in file-schema column order. Empty means no
+  // footer statistics; UINT64_MAX marks an invalid/missing column stat. In either case we
+  // report no weights so the caller falls back to an even split.
+  auto file_column_sizes = vxfile_->GetUncompressedSizes();
+  if (file_column_sizes.empty()) {
+    return std::vector<uint64_t>{};
+  }
+  // We map by top-level file-schema field index. That is only sound when the statistics
+  // vector has exactly one entry per top-level field (flat schemas). For nested schemas
+  // (struct/list producing multiple leaf stats) the alignment is ambiguous, so we report
+  // no weights rather than risk mis-attributing sizes.
+  if (file_column_sizes.size() != static_cast<size_t>(file_schema_->num_fields())) {
+    return std::vector<uint64_t>{};
+  }
+
+  // Determine the projected output columns in output-schema (projection) order — the same
+  // order get_chunk() returns — and map each back to its file-schema column index. These are
+  // whole-file weights; ColumnGroupReader normalizes them to the chunk's real memory (no
+  // per-chunk row pro-rata is done here).
+  ARROW_ASSIGN_OR_RAISE(auto out_schema, output_schema());
+
+  std::vector<uint64_t> result;
+  result.reserve(out_schema->num_fields());
+  for (int i = 0; i < out_schema->num_fields(); ++i) {
+    const int file_field_index = file_schema_->GetFieldIndex(out_schema->field(i)->name());
+    if (file_field_index < 0 || static_cast<size_t>(file_field_index) >= file_column_sizes.size()) {
+      // Column absent from footer statistics: leave this single weight unknown (0).
+      result.emplace_back(0);
+      continue;
+    }
+    const uint64_t col_total = file_column_sizes[file_field_index];
+    if (col_total == UINT64_MAX) {
+      return std::vector<uint64_t>{};
+    }
+    result.emplace_back(col_total);
+  }
+
+  return result;
+}
+
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::get_chunk(const int& row_group_index) {
   assert(vxfile_);
   if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -527,6 +527,7 @@ class ChunkReaderImpl : public ChunkReader {
       const std::vector<int64_t>& chunk_indices, size_t parallelism) override;
   [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_size() override;
   [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_rows() override;
+  [[nodiscard]] arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_sizes() override;
 
   private:
   std::shared_ptr<arrow::Schema> schema_;
@@ -668,6 +669,21 @@ arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_rows() {
 
   for (size_t i = 0; i < total_chunks; ++i) {
     ARROW_ASSIGN_OR_RAISE(result[i], chunk_reader_->get_chunk_rows(i));
+  }
+
+  return result;
+}
+
+arrow::Result<std::vector<std::vector<uint64_t>>> ChunkReaderImpl::get_chunk_column_sizes() {
+  const auto total_chunks = total_number_of_chunks();
+  std::vector<std::vector<uint64_t>> result(total_chunks);
+
+  // ColumnGroupReader always returns a per-chunk value (normalizing to the chunk's real
+  // memory, with an even-split fallback when no per-column weights are available), so the
+  // outer vector is always one entry per chunk. A real error propagates rather than
+  // silently dropping other chunks.
+  for (size_t i = 0; i < total_chunks; ++i) {
+    ARROW_ASSIGN_OR_RAISE(result[i], chunk_reader_->get_chunk_column_sizes(i));
   }
 
   return result;

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -258,6 +258,57 @@ TEST_P(APIWriterReaderTest, SchemaBasedColumnGroupWriteRead) {
   EXPECT_GT(chunk->num_rows(), 0);
 }
 
+TEST_P(APIWriterReaderTest, GetChunkColumnSizesShapeAndProportions) {
+  // Write a single column group holding all four columns, with enough rows that the
+  // variable-length "name" column clearly outweighs the fixed-width "id" column.
+  ASSERT_AND_ASSIGN(auto large_batch, CreateTestData(schema_, 0, false, 20000));
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  ASSERT_NE(writer, nullptr);
+  ASSERT_OK(writer->write(large_batch));
+  auto cgs_result = writer->close();
+  ASSERT_TRUE(cgs_result.ok()) << cgs_result.status().ToString();
+  auto cgs = std::move(cgs_result).ValueOrDie();
+  ASSERT_EQ(cgs->size(), 1);
+
+  // Full projection {id, name, value, vector} so the per-column values must sum exactly to
+  // get_chunk_size(). id is index 0 (small int), name is index 1 (large variable-length).
+  auto projection =
+      std::make_shared<std::vector<std::string>>(std::vector<std::string>{"id", "name", "value", "vector"});
+  auto reader = Reader::create(cgs, schema_, projection, properties_);
+  ASSERT_NE(reader, nullptr);
+
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+  ASSERT_NE(chunk_reader, nullptr);
+
+  ASSERT_AND_ASSIGN(auto chunk_sizes, chunk_reader->get_chunk_size());
+  ASSERT_AND_ASSIGN(auto column_sizes, chunk_reader->get_chunk_column_sizes());
+
+  // Outer index: always one entry per chunk (never globally empty), same length as get_chunk_size().
+  ASSERT_EQ(column_sizes.size(), chunk_sizes.size());
+
+  for (size_t chunk_idx = 0; chunk_idx < column_sizes.size(); ++chunk_idx) {
+    const auto& per_column = column_sizes[chunk_idx];
+    // Inner index: one entry per projected column, in projection (id, name, value, vector) order.
+    ASSERT_EQ(per_column.size(), 4u);
+
+    const uint64_t id_size = per_column[0];
+    const uint64_t name_size = per_column[1];
+
+    // The variable-length string column estimates larger than the 8-byte int column.
+    EXPECT_GT(name_size, id_size);
+    EXPECT_GT(name_size, 0u);
+
+    // Full projection: the per-column values sum exactly to the chunk's memory size.
+    uint64_t per_column_sum = 0;
+    for (const uint64_t s : per_column) {
+      per_column_sum += s;
+    }
+    EXPECT_EQ(per_column_sum, chunk_sizes[chunk_idx]);
+  }
+}
+
 TEST_P(APIWriterReaderTest, SizeBasedColumnGroupPolicy) {
   // Test SizeBasedColumnGroupPolicy
   int64_t max_avg_column_size = 1000;  // bytes

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -426,6 +426,53 @@ TEST_F(LanceBasicTest, TestRead) {
   }
 }
 
+TEST_F(LanceBasicTest, GetColumnSizesShapeAndProportions) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  // Enough rows that the variable-length string column ("name") dwarfs the fixed-width
+  // int64 column ("id"), so we can assert the per-column ordering is meaningful.
+  ASSERT_AND_ASSIGN(auto large_batch, CreateTestData(schema_, 0, false, 200000));
+
+  ArrowFileSystemConfig fs_config;
+  ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
+  ASSERT_AND_ASSIGN(auto lance_uri, BuildLanceBaseUri(fs_config, base_path_));
+  auto storage_options = milvus_storage::lance::ToStorageOptions(fs_config);
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(large_batch));
+  ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+
+  auto read_dataset = BlockingDataset::Open(lance_uri, storage_options);
+  const std::vector<uint64_t> fragment_ids = read_dataset->GetAllFragmentIds();
+  ASSERT_EQ(fragment_ids.size(), 1);
+
+  // Project id (small, index 0) and name (large, index 1) in that order.
+  ASSERT_AND_ASSIGN(auto projection_schema, CreateTestSchema({true, true, false, false}));
+  LanceTableReader reader(read_dataset, fragment_ids[0], projection_schema, properties_);
+  ASSERT_STATUS_OK(reader.open());
+  ASSERT_AND_ASSIGN(auto rgs, reader.get_row_group_infos());
+  ASSERT_FALSE(rgs.empty());
+
+  for (size_t rg_idx = 0; rg_idx < rgs.size(); ++rg_idx) {
+    // get_column_sizes returns raw whole-fragment per-column weights (not chunk-normalized);
+    // ColumnGroupReader normalizes them to the chunk's real memory.
+    ASSERT_AND_ASSIGN(auto column_sizes, reader.get_column_sizes(static_cast<int>(rg_idx)));
+    // Inner index: one weight per projected column, in projection (id, name) order.
+    ASSERT_EQ(column_sizes.size(), 2u);
+
+    const uint64_t id_size = column_sizes[0];
+    const uint64_t name_size = column_sizes[1];
+    // Both projected columns must carry a positive weight. We do NOT assert an
+    // ordering between them: Lance reports the accurate decoded in-memory size, and
+    // for short strings the string column can weigh about the same as (or slightly
+    // less than) an 8-byte int64 column, so name > id is not a reliable invariant.
+    ASSERT_GT(id_size, 0u);
+    ASSERT_GT(name_size, 0u);
+  }
+}
+
 TEST_F(LanceBasicTest, EstimatedMemoryAccountsForDeletions) {
   if (IsCloudEnv()) {
     GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";

--- a/cpp/test/format/parquet/parquet_column_sizes_test.cpp
+++ b/cpp/test/format/parquet/parquet_column_sizes_test.cpp
@@ -1,0 +1,156 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/api.h>
+#include <arrow/testing/gtest_util.h>
+
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/writer.h"
+#include "milvus-storage/format/format_reader.h"
+#include "test_env.h"
+
+namespace milvus_storage::test {
+
+using namespace milvus_storage::api;
+
+// Validates ParquetFormatReader::get_column_sizes(): the per-column footer sizes must be
+// keyed by projected TOP-LEVEL column (in projection order), with nested columns summing
+// their Parquet leaf ColumnChunk sizes into a single entry.
+class ParquetColumnSizesTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+    base_path_ = GetTestBasePath("parquet-column-sizes-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_));
+  }
+
+  void TearDown() override {
+    if (!IsCloudEnv()) {
+      ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_));
+    }
+  }
+
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::string base_path_;
+  Properties properties_;
+};
+
+TEST_F(ParquetColumnSizesTest, NestedLeafGroupingAndProjectionOrder) {
+  auto field_metadata = [](const std::string& field_id) {
+    return arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {field_id});
+  };
+
+  // profile (struct)  -> 2 Parquet leaf columns (score, label)
+  // events  (list<struct>) -> 2 Parquet leaf columns (code, message)
+  // id, note -> 1 leaf column each. Total leaves = 6, top-level columns = 4.
+  auto profile_type =
+      arrow::struct_({arrow::field("score", arrow::int32(), false), arrow::field("label", arrow::utf8(), false)});
+  auto event_type =
+      arrow::struct_({arrow::field("code", arrow::int32(), false), arrow::field("message", arrow::utf8(), false)});
+  auto events_type = arrow::list(arrow::field("item", event_type, false));
+  auto nested_schema = arrow::schema({
+      arrow::field("id", arrow::int64(), false, field_metadata("0")),
+      arrow::field("profile", profile_type, false, field_metadata("1")),
+      arrow::field("events", events_type, false, field_metadata("2")),
+      arrow::field("note", arrow::utf8(), false, field_metadata("3")),
+  });
+
+  arrow::Int64Builder id_builder;
+  ASSERT_STATUS_OK(id_builder.AppendValues({0, 1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto ids, id_builder.Finish());
+
+  arrow::Int32Builder score_builder;
+  ASSERT_STATUS_OK(score_builder.AppendValues({10, 20, 30, 40}));
+  ASSERT_AND_ASSIGN(auto scores, score_builder.Finish());
+  arrow::StringBuilder label_builder;
+  ASSERT_STATUS_OK(label_builder.AppendValues({"cold", "warm", "hot", "peak"}));
+  ASSERT_AND_ASSIGN(auto labels, label_builder.Finish());
+  auto profiles =
+      std::make_shared<arrow::StructArray>(profile_type, 4, std::vector<std::shared_ptr<arrow::Array>>{scores, labels});
+
+  arrow::Int32Builder event_code_builder;
+  ASSERT_STATUS_OK(event_code_builder.AppendValues({1, 2, 3, 4, 5}));
+  ASSERT_AND_ASSIGN(auto event_codes, event_code_builder.Finish());
+  arrow::StringBuilder event_message_builder;
+  ASSERT_STATUS_OK(event_message_builder.AppendValues({"created", "queued", "running", "done", "archived"}));
+  ASSERT_AND_ASSIGN(auto event_messages, event_message_builder.Finish());
+  auto event_values = std::make_shared<arrow::StructArray>(
+      event_type, 5, std::vector<std::shared_ptr<arrow::Array>>{event_codes, event_messages});
+  arrow::Int32Builder event_offsets_builder;
+  ASSERT_STATUS_OK(event_offsets_builder.AppendValues({0, 2, 3, 3, 5}));
+  ASSERT_AND_ASSIGN(auto event_offsets, event_offsets_builder.Finish());
+  ASSERT_AND_ASSIGN(auto events, arrow::ListArray::FromArrays(events_type, *event_offsets, *event_values));
+
+  arrow::StringBuilder note_builder;
+  ASSERT_STATUS_OK(note_builder.AppendValues({"note-a", "note-b", "note-c", "note-d"}));
+  ASSERT_AND_ASSIGN(auto notes, note_builder.Finish());
+
+  auto record_batch = arrow::RecordBatch::Make(nested_schema, 4, {ids, profiles, events, notes});
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, nested_schema));
+  auto writer = Writer::create(base_path_, nested_schema, std::move(policy), properties_);
+  ASSERT_OK(writer->write(record_batch));
+  ASSERT_AND_ASSIGN(auto column_groups, writer->close());
+  ASSERT_EQ(column_groups->size(), 1);
+  ASSERT_EQ(column_groups->front()->files.size(), 1);
+  const auto& cg_file = column_groups->front()->files.front();
+
+  // Case 1: full projection. Four top-level columns, so four inner entries -- NOT six
+  // (the number of Parquet leaf columns).
+  {
+    std::vector<std::string> needed_columns = {"id", "profile", "events", "note"};
+    ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nested_schema, LOON_FORMAT_PARQUET, cg_file, properties_,
+                                                        needed_columns, nullptr));
+    ASSERT_AND_ASSIGN(auto sizes, reader->get_column_sizes(0));
+    ASSERT_EQ(sizes.size(), 4u) << "one weight per top-level column, not per Parquet leaf";
+    for (const uint64_t s : sizes) {
+      EXPECT_GT(s, 0u);
+    }
+  }
+
+  // Case 2: reordered projection {note, profile, id}. Inner index follows projection order,
+  // and the nested "profile" struct sums its two leaf ColumnChunks into a single weight that
+  // matches an independently-projected "profile" read.
+  {
+    std::vector<std::string> profile_only = {"profile"};
+    ASSERT_AND_ASSIGN(auto profile_reader, FormatReader::create(nested_schema, LOON_FORMAT_PARQUET, cg_file,
+                                                                properties_, profile_only, nullptr));
+    ASSERT_AND_ASSIGN(auto profile_sizes, profile_reader->get_column_sizes(0));
+    ASSERT_EQ(profile_sizes.size(), 1u);
+    EXPECT_GT(profile_sizes[0], 0u);
+
+    std::vector<std::string> reordered = {"note", "profile", "id"};
+    ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nested_schema, LOON_FORMAT_PARQUET, cg_file, properties_,
+                                                        reordered, nullptr));
+    ASSERT_AND_ASSIGN(auto sizes, reader->get_column_sizes(0));
+    ASSERT_EQ(sizes.size(), 3u);
+    // sizes[1] corresponds to "profile" and must equal the standalone profile projection,
+    // proving the leaf->top-level grouping is projection-order-independent.
+    EXPECT_EQ(sizes[1], profile_sizes[0]);
+    for (const uint64_t s : sizes) {
+      EXPECT_GT(s, 0u);
+    }
+  }
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/format/vortex/vortex_column_sizes_test.cpp
+++ b/cpp/test/format/vortex/vortex_column_sizes_test.cpp
@@ -1,0 +1,124 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/api.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <arrow/util/key_value_metadata.h>
+
+#include <boost/filesystem/operations.hpp>
+
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/vortex/vortex_format_reader.h"
+#include "milvus-storage/format/vortex/vortex_writer.h"
+#include "test_env.h"
+
+namespace milvus_storage {
+
+using namespace vortex;
+
+// Validates VortexFormatReader::get_column_sizes(): whole-file per-column uncompressed sizes
+// (from footer statistics) mapped to the projected columns as raw weights.
+class VortexColumnSizesTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    if (IsCloudEnv()) {
+      GTEST_SKIP() << "Vortex writer/reader is local-fs only in this test.";
+    }
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    // Statistics are on by default, but be explicit: get_column_sizes relies on the
+    // per-column UncompressedSizeInBytes footer statistic.
+    api::SetValue(properties_, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS, "true");
+    ASSERT_AND_ASSIGN(file_system_, GetFileSystem(properties_));
+  }
+
+  void TearDown() override {
+    if (file_system_ != nullptr && !test_path_.empty()) {
+      (void)file_system_->DeleteFile(test_path_);
+      boost::filesystem::remove_all(test_path_);
+    }
+  }
+
+  std::shared_ptr<arrow::fs::FileSystem> file_system_;
+  api::Properties properties_;
+  std::string test_path_;
+};
+
+TEST_F(VortexColumnSizesTest, GetColumnSizesShapeAndProportions) {
+  constexpr int64_t kRows = 20000;
+  constexpr size_t kStrLen = 128;
+
+  auto schema = arrow::schema({
+      arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      arrow::field("name", arrow::utf8(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"})),
+  });
+
+  arrow::Int64Builder id_builder;
+  arrow::StringBuilder name_builder;
+  std::string value(kStrLen, 'x');
+  for (int64_t i = 0; i < kRows; ++i) {
+    ASSERT_STATUS_OK(id_builder.Append(i));
+    ASSERT_STATUS_OK(name_builder.Append(value));
+  }
+  std::shared_ptr<arrow::Array> ids;
+  std::shared_ptr<arrow::Array> names;
+  ASSERT_STATUS_OK(id_builder.Finish(&ids));
+  ASSERT_STATUS_OK(name_builder.Finish(&names));
+  auto batch = arrow::RecordBatch::Make(schema, kRows, {ids, names});
+
+  test_path_ = "vortex-column-sizes.vx";
+  (void)file_system_->DeleteFile(test_path_);
+  boost::filesystem::remove_all(test_path_);
+
+  ASSERT_AND_ASSIGN(auto vx_writer, VortexFileWriter::Open(file_system_, schema, test_path_, properties_));
+  ASSERT_STATUS_OK(vx_writer->Write(batch));
+  ASSERT_STATUS_OK(vx_writer->Flush());
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer->Close());
+  ASSERT_EQ(cgfile.end_index, kRows);
+
+  auto footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+
+  // Project id (small, index 0) then name (large, index 1) in that order.
+  VortexFormatReader reader(file_system_, schema, test_path_, properties_, std::vector<std::string>{"id", "name"},
+                            file_size, footer_size);
+  ASSERT_STATUS_OK(reader.open());
+  ASSERT_AND_ASSIGN(auto rg_infos, reader.get_row_group_infos());
+  ASSERT_FALSE(rg_infos.empty());
+
+  for (size_t rg_idx = 0; rg_idx < rg_infos.size(); ++rg_idx) {
+    // get_column_sizes returns raw whole-file per-column weights (not chunk-normalized);
+    // ColumnGroupReader normalizes them to the chunk's real memory.
+    ASSERT_AND_ASSIGN(auto column_sizes, reader.get_column_sizes(static_cast<int>(rg_idx)));
+    ASSERT_FALSE(column_sizes.empty()) << "footer statistics should populate per-column weights";
+    // Inner index: one weight per projected column, in projection (id, name) order.
+    ASSERT_EQ(column_sizes.size(), 2u);
+
+    const uint64_t id_size = column_sizes[0];
+    const uint64_t name_size = column_sizes[1];
+
+    // The variable-length string column weighs more than the 8-byte int column.
+    EXPECT_GT(name_size, id_size);
+    EXPECT_GT(name_size, 0u);
+  }
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
## What

Expose the estimated **per-column in-memory size of each chunk** through the public `ChunkReader` API:

```cpp
virtual arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_sizes();
```

- The outer vector is aligned with `get_chunk_size()` and `get_chunk_rows()`: one entry per chunk.
- The inner vector contains one entry per **projected top-level column**, in the same output-schema order as `get_chunk()`.
- Values are derived from footer or page metadata only; no data pages are read.
- For a full projection, the per-column values sum exactly to that chunk's `get_chunk_size()`.
- If a backend cannot provide usable per-column weights, the chunk size is split evenly across the projected columns.

The method is non-pure virtual with an empty default implementation, so existing external `ChunkReader` implementations remain source-compatible. The built-in `ChunkReaderImpl` overrides it and returns one result for every chunk.

## Why

Milvus segcore's storage-v3 per-field cache currently approximates a field's memory usage as:

```text
row-group memory / number of fields
```

This overestimates small scalar/filter columns and underestimates large variable-length or array columns. As a result, per-field cache cells reserve and account for memory inaccurately.

This API exposes the relative per-column sizes already available in storage metadata, allowing segcore to distribute the chunk's memory estimate proportionally instead of assuming that every field has the same size.

## Design

The implementation is layered as follows:

```text
FormatReader::get_column_sizes
    -> raw per-column metadata weights

ColumnGroupReader::get_chunk_column_sizes
    -> maps chunk to file/row group
    -> normalizes the weights to the chunk's actual get_chunk_size()
    -> falls back to an even split when weights are unavailable

ChunkReaderImpl::get_chunk_column_sizes
    -> returns the values for all chunks
```

`FormatReader::get_column_sizes()` intentionally returns raw weights rather than claiming they are exact per-chunk byte counts. This lets formats with row-group-level, file-level, or fragment-level statistics use the same normalization path.

## Backend implementations

- **Parquet**
  - Uses `ColumnChunkMetaData::total_uncompressed_size()` for each physical leaf column in the requested row group.
  - Sums all leaf-column sizes belonging to the same top-level Arrow field, so nested `struct`, `list`, and similar fields produce one result entry.
  - Returns no weights when the schema-derived leaf layout cannot be safely matched to the physical Parquet columns.

- **Vortex**
  - Uses the existing whole-file per-column `UncompressedSizeInBytes` footer statistics.
  - Maps the statistics into projection order and uses them as relative weights for each chunk.
  - Falls back to an even split when statistics are missing or cannot be mapped safely, including ambiguous nested-schema layouts.

- **Lance**
  - Reuses the per-column decoded-memory estimator introduced in #585.
  - Fetches and caches one set of per-column weights per fragment, maps them into projection order, and normalizes them for each chunk.
  - Adds only a thin C++ wrapper over the existing FFI; no Rust implementation changes are required.

This API reports estimated **in-memory sizes only**. It does not expose compressed/on-disk column sizes.

## Tests

- `api_writer_reader_test.cpp`
  - Exercises the public `Reader` / `ChunkReader` path for Parquet and Vortex.
  - Verifies the outer/inner shapes, projection order, proportional sizing, and that a full projection sums exactly to `get_chunk_size()`.

- `parquet/parquet_column_sizes_test.cpp`
  - Verifies nested-field grouping: six Parquet leaves are mapped to four top-level Arrow fields.
  - Verifies reordered projections still return sizes in projection order.

- `vortex/vortex_column_sizes_test.cpp`
  - Verifies footer-statistic shape and relative column weights.

- `lance/lance_table_test.cpp`
  - Verifies projected per-column estimates are available and positive through `LanceTableReader`.
