### PR TITLE
enhance: fix bundled JNI library resolution

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -93,7 +93,7 @@ jobs:
             exit 1
           fi
           cp "$JNI_LIB" "$MAIN_LIB" java/native/linux-x86_64/
-          cp -P cpp/build/Release/libs/*.so* java/native/linux-x86_64/ || true
+          cp -a cpp/build/Release/libs/. java/native/linux-x86_64/
           java/patch_native_runpath.sh java/native/linux-x86_64
           java/verify_native_dependencies.sh \
             java/native/linux-x86_64/libmilvus-storage-jni.so

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install C++ dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libaio-dev
+          sudo apt-get install -y cmake patchelf libaio-dev
           pip install conan==${{ env.CONAN_VERSION }}
 
       - name: Setup JDK
@@ -82,6 +82,21 @@ jobs:
           fi
           echo "Found JNI library at: $JNI_LIB"
           cp "$JNI_LIB" ./java/
+
+      - name: Verify bundled native dependency resolution
+        run: |
+          mkdir -p java/native/linux-x86_64
+          JNI_LIB=$(find cpp/build -name "libmilvus-storage-jni.so" -type f | head -1)
+          MAIN_LIB=$(find cpp/build -name "libmilvus-storage.so" -type f | head -1)
+          if [ -z "$JNI_LIB" ] || [ -z "$MAIN_LIB" ]; then
+            echo "ERROR: milvus-storage JNI libraries not found"
+            exit 1
+          fi
+          cp "$JNI_LIB" "$MAIN_LIB" java/native/linux-x86_64/
+          cp -P cpp/build/Release/libs/*.so* java/native/linux-x86_64/ || true
+          java/patch_native_runpath.sh java/native/linux-x86_64
+          java/verify_native_dependencies.sh \
+            java/native/linux-x86_64/libmilvus-storage-jni.so
 
       - name: Compile Scala code
         working-directory: ./java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake libaio-dev
+          sudo apt-get install -y cmake patchelf libaio-dev
           pip install conan==${{ env.CONAN_VERSION }}
 
       - name: Setup JDK
@@ -206,6 +206,10 @@ jobs:
           if [ -d "cpp/build/Release/libs" ]; then
             cp -P cpp/build/Release/libs/*.so* java/native/linux-x86_64/ || true
           fi
+
+          java/patch_native_runpath.sh java/native/linux-x86_64
+          java/verify_native_dependencies.sh \
+            java/native/linux-x86_64/libmilvus-storage-jni.so
 
           echo "Native libraries in java/native/linux-x86_64:"
           ls -l java/native/linux-x86_64/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
 
           # Copy all dependency libraries from conan imports output
           if [ -d "cpp/build/Release/libs" ]; then
-            cp -P cpp/build/Release/libs/*.so* java/native/linux-x86_64/ || true
+            cp -a cpp/build/Release/libs/. java/native/linux-x86_64/
           fi
 
           java/patch_native_runpath.sh java/native/linux-x86_64
@@ -244,7 +244,7 @@ jobs:
           path: |
             java/target/scala-*/milvus-storage-*.jar
             java/target/scala-*/milvus-storage-*.pom
-            java/native/linux-x86_64/*.so*
+            java/native/linux-x86_64/
 
   publish-java:
     needs: build-java-linux
@@ -277,7 +277,7 @@ jobs:
       - name: Restore Native Libs
         run: |
           mkdir -p java/native/linux-x86_64
-          cp -P java_dist_temp/native/linux-x86_64/*.so* java/native/linux-x86_64/
+          cp -a java_dist_temp/native/linux-x86_64/. java/native/linux-x86_64/
 
       - name: Set Java Version
         working-directory: ./java

--- a/java/docker/Dockerfile.ubuntu22.04
+++ b/java/docker/Dockerfile.ubuntu22.04
@@ -17,6 +17,7 @@ RUN apt-get update && \
     gdb \
     clang-format-14 \
     clang-tidy-14 \
+    patchelf \
     python3 \
     python3-pip \
     default-jdk \

--- a/java/package_fat_jar.sh
+++ b/java/package_fat_jar.sh
@@ -98,14 +98,10 @@ else
     echo "Warning: libs directory not found: $LIBS_DIR"
 fi
 
-# Patch RUNPATH to $ORIGIN so libs find each other in the same directory
-if command -v patchelf &>/dev/null; then
-    echo "patching RUNPATH to \$ORIGIN..."
-    patchelf --set-rpath '$ORIGIN' native/linux-x86_64/libmilvus-storage.so
-    patchelf --set-rpath '$ORIGIN' native/linux-x86_64/libmilvus-storage-jni.so
-else
-    echo "Warning: patchelf not found, RUNPATH not patched"
-fi
+# Patch every bundled ELF because DT_RUNPATH is not inherited by transitive
+# dependencies. Patching only the JNI and milvus-storage libraries leaves, for
+# example, Arrow unable to locate its bundled AWS SDK dependencies.
+"$SCRIPT_DIR/patch_native_runpath.sh" native/linux-x86_64
 
 echo "detect system architecture and create corresponding directory"
 ARCH=$(uname -m)

--- a/java/patch_native_runpath.sh
+++ b/java/patch_native_runpath.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <native-library-directory>" >&2
+    exit 2
+fi
+
+NATIVE_DIR="$1"
+
+if [ ! -d "$NATIVE_DIR" ]; then
+    echo "Native library directory not found: $NATIVE_DIR" >&2
+    exit 1
+fi
+
+if ! command -v patchelf >/dev/null 2>&1; then
+    echo "patchelf is required to make bundled native libraries relocatable" >&2
+    exit 1
+fi
+
+patched=0
+while IFS= read -r -d '' library; do
+    # Some packages may ship linker scripts with a .so suffix. patchelf only
+    # understands ELF files, so leave non-ELF entries untouched.
+    if ! patchelf --print-rpath "$library" >/dev/null 2>&1; then
+        echo "Skipping non-ELF shared library: $library"
+        continue
+    fi
+
+    # NativeLibraryLoader preserves subdirectories while extracting resources.
+    # Point a top-level library at $ORIGIN and a nested library back up to the
+    # native root so every bundled dependency can resolve its siblings.
+    relative_path="${library#"$NATIVE_DIR"/}"
+    relative_dir="$(dirname "$relative_path")"
+    runpath='$ORIGIN'
+    while [ "$relative_dir" != "." ]; do
+        runpath="$runpath/.."
+        relative_dir="$(dirname "$relative_dir")"
+    done
+
+    patchelf --set-rpath "$runpath" "$library"
+    patched=$((patched + 1))
+done < <(find "$NATIVE_DIR" -type f \( -name '*.so' -o -name '*.so.*' \) -print0)
+
+if [ "$patched" -eq 0 ]; then
+    echo "No ELF shared libraries found in $NATIVE_DIR" >&2
+    exit 1
+fi
+
+echo "Patched RUNPATH for $patched bundled shared libraries in $NATIVE_DIR"

--- a/java/verify_native_dependencies.sh
+++ b/java/verify_native_dependencies.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <jni-shared-library>" >&2
+    exit 2
+fi
+
+JNI_LIBRARY="$1"
+
+if [ ! -f "$JNI_LIBRARY" ]; then
+    echo "JNI shared library not found: $JNI_LIBRARY" >&2
+    exit 1
+fi
+
+if ! command -v ldd >/dev/null 2>&1; then
+    echo "ldd is required to verify bundled native dependencies" >&2
+    exit 1
+fi
+
+# Do not allow a developer shell or CI job to hide missing RUNPATH entries.
+ldd_output="$(env -u LD_LIBRARY_PATH -u LD_PRELOAD ldd "$JNI_LIBRARY")"
+missing="$(printf '%s\n' "$ldd_output" | sed -n '/not found/p' | sort -u)"
+
+if [ -n "$missing" ]; then
+    echo "Bundled JNI library has unresolved dependencies:" >&2
+    printf '%s\n' "$missing" >&2
+    exit 1
+fi
+
+echo "Verified bundled dependency resolution for $JNI_LIBRARY"


### PR DESCRIPTION
The fat JAR only set $ORIGIN on libmilvus-storage and its JNI wrapper. DT_RUNPATH is not inherited by transitive dependencies, so libraries such as Arrow could not find bundled AWS SDK libraries after extraction on a clean host.

Patch every bundled ELF with a RUNPATH relative to the native resource root. Add a dependency check that clears LD_LIBRARY_PATH and LD_PRELOAD before running ldd, and run it in Java CI and the release workflow. Install patchelf in those environments and the Java build image.