### PR TITLE
enhance: use adaptive rate-limited retry strategy for S3 client

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include <aws/core/Aws.h>
+#include <aws/core/client/AdaptiveRetryStrategy.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/http/HttpTypes.h>
 #include <aws/core/http/HttpResponse.h>
@@ -362,35 +363,32 @@ inline arrow::fs::TimePoint FromAwsDatetime(const Aws::Utils::DateTime& dt) {
   return std::chrono::time_point_cast<std::chrono::nanoseconds>(dt.UnderlyingTimestamp());
 }
 
-// A connect retry strategy with a controlled max duration.
-
-class ConnectRetryStrategy : public Aws::Client::RetryStrategy {
+// A connect/throttle retry strategy built on AWS SDK's AdaptiveRetryStrategy,
+// which adds client-side rate limiting (a send token bucket that auto-enables on
+// throttling responses) plus jittered exponential backoff. We keep the IsConnectError
+// gate so MinIO-specific errors (SlowDown, XMinioServerNotInitialized) stay retriable.
+class ConnectRetryStrategy : public Aws::Client::AdaptiveRetryStrategy {
   public:
-  static const int32_t kDefaultRetryInterval = 200;     /* milliseconds */
-  static const int32_t kDefaultMaxRetryDuration = 6000; /* milliseconds */
+  static const long kDefaultMaxRetries = 10;  // NOLINT runtime/int
 
-  explicit ConnectRetryStrategy(int32_t retry_interval = kDefaultRetryInterval,
-                                int32_t max_retry_duration = kDefaultMaxRetryDuration)
-      : retry_interval_(retry_interval), max_retry_duration_(max_retry_duration) {}
+  explicit ConnectRetryStrategy(long max_retries = kDefaultMaxRetries)  // NOLINT runtime/int
+      : Aws::Client::AdaptiveRetryStrategy(max_retries), max_retries_(max_retries) {}
 
   bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
                    long attempted_retries) const override {  // NOLINT runtime/int
+    // IsConnectError covers AWS standard retryable errors (via error.ShouldRetry())
+    // plus MinIO-specific SlowDown / XMinioServerNotInitialized.
     if (!IsConnectError(error)) {
-      // Not a connect error, don't retry
       return false;
     }
-    return attempted_retries * retry_interval_ < max_retry_duration_;
+    return attempted_retries < max_retries_;
   }
 
-  long CalculateDelayBeforeNextRetry(  // NOLINT runtime/int
-      const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
-      long attempted_retries) const override {  // NOLINT runtime/int
-    return retry_interval_;
-  }
+  // HasSendToken(), RequestBookkeeping(), and CalculateDelayBeforeNextRetry() are
+  // intentionally inherited from AdaptiveRetryStrategy (rate limiter + jittered backoff).
 
-  protected:
-  int32_t retry_interval_;
-  int32_t max_retry_duration_;
+  private:
+  long max_retries_;  // NOLINT runtime/int
 };
 
 }  // namespace internal


### PR DESCRIPTION
## What & Why

The S3 client's default `ConnectRetryStrategy` used a fixed 200ms retry interval (up to ~30 attempts) and had **no client-side rate limiting**. Under sustained S3 request-rate throttling (`503 SlowDown`) — e.g. a large bulk import writing many small objects to a cold bucket prefix — this hammers the throttled endpoint at a constant rate and amplifies the overload.

This replaces it with a strategy built on the AWS SDK's `AdaptiveRetryStrategy`, which adds:

- **client-side rate limiting** via a send token bucket that auto-enables on throttling responses (CUBIC/AIMD), pacing outgoing requests toward the endpoint's dynamic capacity;
- **jittered exponential backoff** (inherited from the standard strategy), replacing the fixed 200ms interval.

The `IsConnectError` gate is preserved, so both AWS-standard retryable errors and MinIO-specific ones (`SlowDown`, `XMinioServerNotInitialized`) remain retriable.

## Notes

- The rate limiter is dormant under normal load and engages only once throttling is observed, so steady-state behavior is unchanged.
- All S3 requests issued through this client (including `CompleteMultipartUpload`, which goes through the SDK's retry machinery) are paced by the limiter.
- Verified against the aws-sdk-cpp 1.11.692 retry API. Runtime rate-limiting behavior under throttling is to be validated in integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
