### PR TITLE
enhance: add labeled filesystem metrics observability

### DIFF
--- a/cpp/benchmark/benchmark_predicate.cpp
+++ b/cpp/benchmark/benchmark_predicate.cpp
@@ -205,8 +205,8 @@ BENCHMARK_DEFINE_F(PredicateBenchmark, ReadWithPredicate)(::benchmark::State& st
     }
 
     if (fs_metrics) {
-      total_io_bytes += fs_metrics->GetReadBytes();
-      total_io_count += fs_metrics->GetReadCount();
+      total_io_bytes += fs_metrics->TransferBytes(OpType::Read);
+      total_io_count += fs_metrics->OpCount(OpType::Read, OpStatus::Ok);
     }
   }
 

--- a/cpp/include/milvus-storage/ffi_filesystem_metrics_c.h
+++ b/cpp/include/milvus-storage/ffi_filesystem_metrics_c.h
@@ -26,25 +26,94 @@ extern "C" {
 #ifndef LOON_FILESYSTEM_METRICS_C
 #define LOON_FILESYSTEM_METRICS_C
 
+// Cardinalities of the labeled metrics registry. Mirror the C++ enums in
+// milvus-storage/filesystem/metrics/op_type.h and buckets.h.
+#define LOON_OP_TYPE_COUNT 15
+#define LOON_STATUS_COUNT 9
+#define LOON_LATENCY_BUCKETS 16
+#define LOON_SIZE_BUCKETS 14
+#define LOON_TRANSFER_COUNT 3  // Read=0, Write=1, MultipartUploadPart=2
+
+// Indices into LoonFilesystemMetricsSnapshot.ops[] (mirror milvus_storage::OpType).
+enum {
+  LOON_OP_READ = 0,
+  LOON_OP_WRITE,
+  LOON_OP_LIST,
+  LOON_OP_HEAD,
+  LOON_OP_OPEN_INPUT,
+  LOON_OP_OPEN_OUTPUT,
+  LOON_OP_CREATE_DIR,
+  LOON_OP_DELETE_DIR,
+  LOON_OP_DELETE_FILE,
+  LOON_OP_MOVE,
+  LOON_OP_COPY,
+  LOON_OP_MULTIPART_CREATE,
+  LOON_OP_MULTIPART_UPLOAD_PART,
+  LOON_OP_MULTIPART_COMPLETE,
+  LOON_OP_MULTIPART_ABORT
+};
+
+// Indices into LoonOpStats.count_by_status[] (mirror milvus_storage::OpStatus).
+enum {
+  LOON_STATUS_OK = 0,
+  LOON_STATUS_NOT_FOUND,
+  LOON_STATUS_THROTTLED,
+  LOON_STATUS_AUTH,
+  LOON_STATUS_TIMEOUT,
+  LOON_STATUS_NETWORK,
+  LOON_STATUS_SERVER_ERROR,
+  LOON_STATUS_CLIENT_ERROR,
+  LOON_STATUS_UNKNOWN
+};
+
+// Indices into LoonFilesystemMetricsSnapshot.transfers[].
+enum { LOON_XFER_READ = 0, LOON_XFER_WRITE, LOON_XFER_MULTIPART_UPLOAD_PART };
+
 /**
- * C structure representing filesystem metrics snapshot.
+ * Per-operation statistics (indexed by OpType).
+ */
+typedef struct LoonOpStats {  // NOLINT
+  int64_t count_by_status[LOON_STATUS_COUNT];
+  int64_t retry_count;
+  int64_t latency_sum_us;
+  int64_t latency_count;
+  int64_t latency_buckets[LOON_LATENCY_BUCKETS];
+} LoonOpStats;  // NOLINT
+
+/**
+ * Per-transfer-op payload statistics (Read, Write, MultipartUploadPart).
+ */
+typedef struct LoonTransferStats {  // NOLINT
+  int64_t bytes_total;
+  int64_t size_sum_bytes;
+  int64_t size_count;
+  int64_t size_buckets[LOON_SIZE_BUCKETS];
+} LoonTransferStats;  // NOLINT
+
+/**
+ * Fixed-size labeled filesystem metrics snapshot (caller allocates).
  */
 typedef struct LoonFilesystemMetricsSnapshot {  // NOLINT
-  int64_t read_count;
-  int64_t write_count;
-  int64_t read_bytes;
-  int64_t write_bytes;
-  int64_t get_file_info_count;
-  int64_t create_dir_count;
-  int64_t delete_dir_count;
-  int64_t delete_file_count;
-  int64_t move_count;
-  int64_t copy_file_count;
-  int64_t failed_count;
-  // S3-specific metrics
-  int64_t multi_part_upload_created;
-  int64_t multi_part_upload_finished;
+  LoonOpStats ops[LOON_OP_TYPE_COUNT];
+  LoonTransferStats transfers[LOON_TRANSFER_COUNT];
+  int64_t in_flight;
+  int64_t open_connections;
+  int64_t idle_connections;
+  int64_t pending_multipart_created;
+  int64_t pending_multipart_finished;
 } LoonFilesystemMetricsSnapshot;  // NOLINT
+
+/**
+ * Static latency bucket upper bounds, microseconds. The returned pointer is
+ * owned by the library; do not free. Writes the number of bounds to out_len.
+ */
+FFI_EXPORT const int64_t* loon_fs_latency_bucket_bounds_us(int32_t* out_len);
+
+/**
+ * Static size bucket upper bounds, bytes. The returned pointer is owned by the
+ * library; do not free. Writes the number of bounds to out_len.
+ */
+FFI_EXPORT const int64_t* loon_fs_size_bucket_bounds_bytes(int32_t* out_len);
 
 /**
  * Get metrics from a filesystem handle.

--- a/cpp/include/milvus-storage/filesystem/metrics/buckets.h
+++ b/cpp/include/milvus-storage/filesystem/metrics/buckets.h
@@ -1,0 +1,32 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace milvus_storage::metrics {
+
+// Latency bucket upper bounds, microseconds. 0.1ms .. 130s.
+inline constexpr std::array<int64_t, 16> kLatencyBoundsUs = {100,     250,     500,      1000,     2500,   5000,
+                                                             10000,   25000,   50000,    100000,   250000, 500000,
+                                                             1000000, 5000000, 30000000, 130000000};
+
+// Size bucket upper bounds, bytes. 256B .. 16GB.
+inline constexpr std::array<int64_t, 14> kSizeBoundsBytes = {256,       1024,       4096,       16384,      65536,
+                                                             262144,    1048576,    4194304,    16777216,   67108864,
+                                                             268435456, 1073741824, 4294967296, 17179869184};
+
+}  // namespace milvus_storage::metrics

--- a/cpp/include/milvus-storage/filesystem/metrics/error_classify.h
+++ b/cpp/include/milvus-storage/filesystem/metrics/error_classify.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "milvus-storage/filesystem/metrics/op_type.h"
+
+namespace arrow {
+class Status;
+}
+
+namespace milvus_storage {
+
+// Map an HTTP status code to an OpStatus.
+OpStatus ClassifyHttpStatus(int http_code);
+
+// Map an arrow::Status to an OpStatus (arrow's LocalFileSystem loses errno
+// detail, so most failures classify as Unknown).
+OpStatus ClassifyArrowStatus(const arrow::Status& s);
+
+// Pure S3 mapping, testable without constructing an Aws::S3::S3Error.
+// Precedence: throttle > timeout > connect > http-code mapping.
+OpStatus ClassifyS3(int http_code, bool is_throttle, bool is_timeout, bool is_connect);
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/metrics/histogram.h
+++ b/cpp/include/milvus-storage/filesystem/metrics/histogram.h
@@ -1,0 +1,67 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+namespace milvus_storage::metrics {
+
+// Fixed-bound histogram. Non-cumulative buckets: an observation v is
+// placed in the first bucket i with v <= bounds[i]; values past the last
+// bound are counted in `count`/`sum` but no bucket (overflow recoverable
+// as count - sum(buckets)). All updates memory_order_relaxed.
+class Histogram {
+  public:
+  Histogram(const int64_t* bounds, int num) : bounds_(bounds), num_(num), buckets_(num) {}
+
+  void Observe(int64_t v) {
+    sum_.fetch_add(v, std::memory_order_relaxed);
+    count_.fetch_add(1, std::memory_order_relaxed);
+    for (int i = 0; i < num_; ++i) {
+      if (v <= bounds_[i]) {
+        buckets_[i].fetch_add(1, std::memory_order_relaxed);
+        return;
+      }
+    }
+  }
+
+  int64_t sum() const { return sum_.load(std::memory_order_relaxed); }
+  int64_t count() const { return count_.load(std::memory_order_relaxed); }
+
+  void CopyBuckets(int64_t* out, int num) const {
+    for (int i = 0; i < num && i < num_; ++i) {
+      out[i] = buckets_[i].load(std::memory_order_relaxed);
+    }
+  }
+
+  void Reset() {
+    sum_.store(0, std::memory_order_relaxed);
+    count_.store(0, std::memory_order_relaxed);
+    for (auto& b : buckets_) {
+      b.store(0, std::memory_order_relaxed);
+    }
+  }
+
+  private:
+  const int64_t* bounds_;
+  int num_;
+  std::atomic<int64_t> sum_{0};
+  std::atomic<int64_t> count_{0};
+  std::vector<std::atomic<int64_t>> buckets_;
+};
+
+}  // namespace milvus_storage::metrics

--- a/cpp/include/milvus-storage/filesystem/metrics/op_type.h
+++ b/cpp/include/milvus-storage/filesystem/metrics/op_type.h
@@ -1,0 +1,63 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace milvus_storage {
+
+// Backend filesystem operations. Order is fixed and mirrored by the FFI
+// snapshot layout; do not reorder.
+enum class OpType : int {
+  Read = 0,
+  Write,
+  List,
+  Head,
+  OpenInput,
+  OpenOutput,
+  CreateDir,
+  DeleteDir,
+  DeleteFile,
+  Move,
+  Copy,
+  MultipartCreate,
+  MultipartUploadPart,
+  MultipartComplete,
+  MultipartAbort
+};
+inline constexpr int kOpTypeCount = 15;
+
+// Operation outcome classification. Order is fixed and mirrored by the FFI
+// snapshot layout; do not reorder.
+enum class OpStatus : int { Ok = 0, NotFound, Throttled, Auth, Timeout, Network, ServerError, ClientError, Unknown };
+inline constexpr int kStatusCount = 9;
+
+inline constexpr int kTransferCount = 3;  // Read, Write, MultipartUploadPart
+
+// Index into transfer arrays, or -1 for non-transfer ops.
+inline int TransferIndex(OpType op) {
+  switch (op) {
+    case OpType::Read:
+      return 0;
+    case OpType::Write:
+      return 1;
+    case OpType::MultipartUploadPart:
+      return 2;
+    default:
+      return -1;
+  }
+}
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/observable.h
+++ b/cpp/include/milvus-storage/filesystem/observable.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string_view>
@@ -26,118 +28,241 @@
 #include <arrow/status.h>
 #include <arrow/util/future.h>
 
+#include "milvus-storage/filesystem/metrics/buckets.h"
+#include "milvus-storage/filesystem/metrics/error_classify.h"
+#include "milvus-storage/filesystem/metrics/histogram.h"
+#include "milvus-storage/filesystem/metrics/op_type.h"
+
 namespace milvus_storage {
 
-/// \brief Metrics collection for filesystem operations
+class ScopedOp;
+class ScopedXfer;
+
+/// \brief Labeled metrics registry for filesystem operations.
+///
+/// Every signal is keyed by OpType (and, for outcomes, OpStatus). Latency is
+/// recorded per operation; payload size is recorded only for the three
+/// transfer ops (Read, Write, MultipartUploadPart). A ScopedOp measures
+/// exactly one backend request.
 class FilesystemMetrics {
   public:
+  struct OpStatsSnapshot {
+    int64_t count_by_status[kStatusCount] = {};
+    int64_t retry_count = 0;
+    int64_t latency_sum_us = 0;
+    int64_t latency_count = 0;
+    int64_t latency_buckets[16] = {};
+  };
+  struct TransferSnapshot {
+    int64_t bytes_total = 0;
+    int64_t size_sum_bytes = 0;
+    int64_t size_count = 0;
+    int64_t size_buckets[14] = {};
+  };
+  struct Snapshot {
+    OpStatsSnapshot ops[kOpTypeCount];
+    TransferSnapshot transfers[kTransferCount];
+    int64_t in_flight = 0;
+    int64_t open_connections = 0;
+    int64_t idle_connections = 0;
+    int64_t pending_multipart_created = 0;
+    int64_t pending_multipart_finished = 0;
+  };
+
   FilesystemMetrics() = default;
   ~FilesystemMetrics() = default;
 
-  // Counter increment methods
-  void IncrementReadCount() { read_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementWriteCount() { write_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementReadBytes(int64_t bytes) { read_bytes_.fetch_add(bytes, std::memory_order_relaxed); }
-  void IncrementWriteBytes(int64_t bytes) { write_bytes_.fetch_add(bytes, std::memory_order_relaxed); }
-  void IncrementGetFileInfoCount() { get_file_info_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementCreateDirCount() { create_dir_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementDeleteDirCount() { delete_dir_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementDeleteFileCount() { delete_file_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementMoveCount() { move_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementCopyFileCount() { copy_file_count_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementFailedCount() { failed_count_.fetch_add(1, std::memory_order_relaxed); }
+  /// \brief Begin a control/metadata operation. Records latency, status, and
+  /// retries; increments in-flight for the scope's lifetime.
+  [[nodiscard]] ScopedOp StartOp(OpType op);
 
-  // S3-specific metrics
-  void IncrementMultiPartUploadCreated() { multi_part_upload_created_.fetch_add(1, std::memory_order_relaxed); }
-  void IncrementMultiPartUploadFinished() { multi_part_upload_finished_.fetch_add(1, std::memory_order_relaxed); }
+  /// \brief Begin a data-transfer operation (Read, Write, MultipartUploadPart).
+  /// Adds RecordBytes to the returned scope.
+  [[nodiscard]] ScopedXfer StartTransfer(OpType op);
 
-  // Getter methods
-  int64_t GetReadCount() const { return read_count_.load(std::memory_order_relaxed); }
-  int64_t GetWriteCount() const { return write_count_.load(std::memory_order_relaxed); }
-  int64_t GetReadBytes() const { return read_bytes_.load(std::memory_order_relaxed); }
-  int64_t GetWriteBytes() const { return write_bytes_.load(std::memory_order_relaxed); }
-  int64_t GetGetFileInfoCount() const { return get_file_info_count_.load(std::memory_order_relaxed); }
-  int64_t GetCreateDirCount() const { return create_dir_count_.load(std::memory_order_relaxed); }
-  int64_t GetDeleteDirCount() const { return delete_dir_count_.load(std::memory_order_relaxed); }
-  int64_t GetDeleteFileCount() const { return delete_file_count_.load(std::memory_order_relaxed); }
-  int64_t GetMoveCount() const { return move_count_.load(std::memory_order_relaxed); }
-  int64_t GetCopyFileCount() const { return copy_file_count_.load(std::memory_order_relaxed); }
-  int64_t GetFailedCount() const { return failed_count_.load(std::memory_order_relaxed); }
-
-  // S3-specific getters
-  int64_t GetMultiPartUploadCreated() const { return multi_part_upload_created_.load(std::memory_order_relaxed); }
-  int64_t GetMultiPartUploadFinished() const { return multi_part_upload_finished_.load(std::memory_order_relaxed); }
-
-  /// \brief Reset all metrics to zero
-  void Reset() {
-    read_count_.store(0, std::memory_order_relaxed);
-    write_count_.store(0, std::memory_order_relaxed);
-    read_bytes_.store(0, std::memory_order_relaxed);
-    write_bytes_.store(0, std::memory_order_relaxed);
-    get_file_info_count_.store(0, std::memory_order_relaxed);
-    create_dir_count_.store(0, std::memory_order_relaxed);
-    delete_dir_count_.store(0, std::memory_order_relaxed);
-    delete_file_count_.store(0, std::memory_order_relaxed);
-    move_count_.store(0, std::memory_order_relaxed);
-    copy_file_count_.store(0, std::memory_order_relaxed);
-    failed_count_.store(0, std::memory_order_relaxed);
-    multi_part_upload_created_.store(0, std::memory_order_relaxed);
-    multi_part_upload_finished_.store(0, std::memory_order_relaxed);
+  /// \brief Best-effort connection-pool gauges, set by the backend client.
+  void SetConnectionStats(int64_t open, int64_t idle) {
+    open_connections_.store(open, std::memory_order_relaxed);
+    idle_connections_.store(idle, std::memory_order_relaxed);
   }
 
-  /// \brief Structured snapshot of all metrics
-  struct MetricsSnapshot {
-    int64_t read_count = 0;
-    int64_t write_count = 0;
-    int64_t read_bytes = 0;
-    int64_t write_bytes = 0;
-    int64_t get_file_info_count = 0;
-    int64_t create_dir_count = 0;
-    int64_t delete_dir_count = 0;
-    int64_t delete_file_count = 0;
-    int64_t move_count = 0;
-    int64_t copy_file_count = 0;
-    int64_t failed_count = 0;
-    // S3-specific metrics
-    int64_t multi_part_upload_created = 0;
-    int64_t multi_part_upload_finished = 0;
-  };
+  /// \brief Track pending multipart uploads (created - finished reveals leaks).
+  void IncrementMultipartCreated() { pending_mp_created_.fetch_add(1, std::memory_order_relaxed); }
+  void IncrementMultipartFinished() { pending_mp_finished_.fetch_add(1, std::memory_order_relaxed); }
 
-  MetricsSnapshot GetSnapshot() const {
-    MetricsSnapshot snapshot;
-    snapshot.read_count = GetReadCount();
-    snapshot.write_count = GetWriteCount();
-    snapshot.read_bytes = GetReadBytes();
-    snapshot.write_bytes = GetWriteBytes();
-    snapshot.get_file_info_count = GetGetFileInfoCount();
-    snapshot.create_dir_count = GetCreateDirCount();
-    snapshot.delete_dir_count = GetDeleteDirCount();
-    snapshot.delete_file_count = GetDeleteFileCount();
-    snapshot.move_count = GetMoveCount();
-    snapshot.copy_file_count = GetCopyFileCount();
-    snapshot.failed_count = GetFailedCount();
-    snapshot.multi_part_upload_created = GetMultiPartUploadCreated();
-    snapshot.multi_part_upload_finished = GetMultiPartUploadFinished();
-    return snapshot;
+  // ---- Live labeled queries over the registry ----
+  /// \brief Count of one (op, status) cell.
+  int64_t OpCount(OpType op, OpStatus status) const {
+    return ops_[static_cast<int>(op)].count_by_status[static_cast<int>(status)].load(std::memory_order_relaxed);
+  }
+  /// \brief Count of an op across all statuses.
+  int64_t OpCount(OpType op) const {
+    int64_t total = 0;
+    for (const auto& c : ops_[static_cast<int>(op)].count_by_status) {
+      total += c.load(std::memory_order_relaxed);
+    }
+    return total;
+  }
+  /// \brief Total bytes moved by a transfer op (0 for non-transfer ops).
+  int64_t TransferBytes(OpType op) const {
+    int idx = TransferIndex(op);
+    return idx < 0 ? 0 : transfers_[idx].bytes_total.load(std::memory_order_relaxed);
+  }
+  /// \brief Total failures (all non-Ok statuses across every op).
+  int64_t FailedCount() const {
+    int64_t failed = 0;
+    for (const auto& slot : ops_) {
+      for (int j = 0; j < kStatusCount; ++j) {
+        if (j != static_cast<int>(OpStatus::Ok)) {
+          failed += slot.count_by_status[j].load(std::memory_order_relaxed);
+        }
+      }
+    }
+    return failed;
+  }
+  int64_t InFlight() const { return in_flight_.load(std::memory_order_relaxed); }
+  int64_t MultipartCreated() const { return pending_mp_created_.load(std::memory_order_relaxed); }
+  int64_t MultipartFinished() const { return pending_mp_finished_.load(std::memory_order_relaxed); }
+
+  Snapshot GetSnapshot() const {
+    Snapshot s;
+    for (int i = 0; i < kOpTypeCount; ++i) {
+      const auto& src = ops_[i];
+      auto& dst = s.ops[i];
+      for (int j = 0; j < kStatusCount; ++j) {
+        dst.count_by_status[j] = src.count_by_status[j].load(std::memory_order_relaxed);
+      }
+      dst.retry_count = src.retry_count.load(std::memory_order_relaxed);
+      dst.latency_sum_us = src.latency.sum();
+      dst.latency_count = src.latency.count();
+      src.latency.CopyBuckets(dst.latency_buckets, 16);
+    }
+    for (int i = 0; i < kTransferCount; ++i) {
+      s.transfers[i].bytes_total = transfers_[i].bytes_total.load(std::memory_order_relaxed);
+      s.transfers[i].size_sum_bytes = transfers_[i].size.sum();
+      s.transfers[i].size_count = transfers_[i].size.count();
+      transfers_[i].size.CopyBuckets(s.transfers[i].size_buckets, 14);
+    }
+    s.in_flight = in_flight_.load(std::memory_order_relaxed);
+    s.open_connections = open_connections_.load(std::memory_order_relaxed);
+    s.idle_connections = idle_connections_.load(std::memory_order_relaxed);
+    s.pending_multipart_created = pending_mp_created_.load(std::memory_order_relaxed);
+    s.pending_multipart_finished = pending_mp_finished_.load(std::memory_order_relaxed);
+    return s;
+  }
+
+  void Reset() {
+    for (auto& slot : ops_) {
+      for (auto& c : slot.count_by_status) {
+        c.store(0, std::memory_order_relaxed);
+      }
+      slot.retry_count.store(0, std::memory_order_relaxed);
+      slot.latency.Reset();
+    }
+    for (auto& t : transfers_) {
+      t.bytes_total.store(0, std::memory_order_relaxed);
+      t.size.Reset();
+    }
+    in_flight_.store(0, std::memory_order_relaxed);
+    pending_mp_created_.store(0, std::memory_order_relaxed);
+    pending_mp_finished_.store(0, std::memory_order_relaxed);
   }
 
   private:
-  std::atomic<int64_t> read_count_{0};
-  std::atomic<int64_t> write_count_{0};
-  std::atomic<int64_t> read_bytes_{0};
-  std::atomic<int64_t> write_bytes_{0};
-  std::atomic<int64_t> get_file_info_count_{0};
-  std::atomic<int64_t> create_dir_count_{0};
-  std::atomic<int64_t> delete_dir_count_{0};
-  std::atomic<int64_t> delete_file_count_{0};
-  std::atomic<int64_t> move_count_{0};
-  std::atomic<int64_t> copy_file_count_{0};
-  std::atomic<int64_t> failed_count_{0};
+  friend class ScopedOp;
+  friend class ScopedXfer;
 
-  // S3-specific metrics (merged from S3ClientMetrics)
-  std::atomic<int64_t> multi_part_upload_created_{0};
-  std::atomic<int64_t> multi_part_upload_finished_{0};
+  struct OpSlot {
+    std::atomic<int64_t> count_by_status[kStatusCount] = {};
+    std::atomic<int64_t> retry_count{0};
+    metrics::Histogram latency{metrics::kLatencyBoundsUs.data(), static_cast<int>(metrics::kLatencyBoundsUs.size())};
+  };
+  struct XferSlot {
+    std::atomic<int64_t> bytes_total{0};
+    metrics::Histogram size{metrics::kSizeBoundsBytes.data(), static_cast<int>(metrics::kSizeBoundsBytes.size())};
+  };
+
+  void Complete(OpType op, OpStatus status, int64_t latency_us, int64_t retries) {
+    auto& slot = ops_[static_cast<int>(op)];
+    slot.count_by_status[static_cast<int>(status)].fetch_add(1, std::memory_order_relaxed);
+    slot.latency.Observe(latency_us);
+    if (retries) {
+      slot.retry_count.fetch_add(retries, std::memory_order_relaxed);
+    }
+    in_flight_.fetch_sub(1, std::memory_order_relaxed);
+  }
+
+  OpSlot ops_[kOpTypeCount];
+  XferSlot transfers_[kTransferCount];
+  std::atomic<int64_t> in_flight_{0};
+  std::atomic<int64_t> open_connections_{0};
+  std::atomic<int64_t> idle_connections_{0};
+  std::atomic<int64_t> pending_mp_created_{0};
+  std::atomic<int64_t> pending_mp_finished_{0};
 };
+
+/// \brief RAII scope measuring exactly one backend request.
+class ScopedOp {
+  public:
+  ScopedOp(FilesystemMetrics* m, OpType op) : m_(m), op_(op), start_(std::chrono::steady_clock::now()) {
+    m_->in_flight_.fetch_add(1, std::memory_order_relaxed);
+  }
+  ScopedOp(ScopedOp&& o) noexcept : m_(o.m_), op_(o.op_), start_(o.start_), status_(o.status_), retries_(o.retries_) {
+    o.m_ = nullptr;
+  }
+  ScopedOp(const ScopedOp&) = delete;
+  ScopedOp& operator=(const ScopedOp&) = delete;
+  ScopedOp& operator=(ScopedOp&&) = delete;
+
+  void RecordRetry(int n = 1) { retries_ += n; }
+  void Fail(OpStatus s) { status_ = s; }
+
+  // Abandon the scope without recording an operation (e.g. a zero-byte EOF
+  // read that should not count). Still balances the in-flight gauge.
+  void Cancel() {
+    if (m_) {
+      m_->in_flight_.fetch_sub(1, std::memory_order_relaxed);
+      m_ = nullptr;
+    }
+  }
+
+  ~ScopedOp() {
+    if (!m_) {
+      return;  // moved-from or cancelled
+    }
+    auto us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_).count();
+    m_->Complete(op_, status_, us, retries_);
+  }
+
+  protected:
+  FilesystemMetrics* m_;
+  OpType op_;
+  std::chrono::steady_clock::time_point start_;
+  OpStatus status_ = OpStatus::Ok;
+  int64_t retries_ = 0;
+};
+
+/// \brief A ScopedOp for transfer ops, adding payload size recording.
+class ScopedXfer : public ScopedOp {
+  public:
+  using ScopedOp::ScopedOp;
+
+  void RecordBytes(int64_t n) {
+    int idx = TransferIndex(op_);
+    if (idx < 0) {
+      return;
+    }
+    m_->transfers_[idx].bytes_total.fetch_add(n, std::memory_order_relaxed);
+    m_->transfers_[idx].size.Observe(n);
+  }
+};
+
+inline ScopedOp FilesystemMetrics::StartOp(OpType op) { return ScopedOp(this, op); }
+
+inline ScopedXfer FilesystemMetrics::StartTransfer(OpType op) {
+  assert(TransferIndex(op) >= 0 && "StartTransfer requires a transfer op");
+  return ScopedXfer(this, op);
+}
 
 /// \brief Interface for filesystems that expose observable metrics
 class Observable {
@@ -149,7 +274,7 @@ class Observable {
   [[nodiscard]] virtual std::shared_ptr<FilesystemMetrics> GetMetrics() const = 0;
 };
 
-/// \brief Wrapper for InputStream to track read bytes
+/// \brief Wrapper for InputStream to track read bytes and latency
 class MetricsInputStream : public arrow::io::InputStream {
   public:
   MetricsInputStream(std::shared_ptr<arrow::io::InputStream> stream, std::shared_ptr<FilesystemMetrics> metrics)
@@ -163,21 +288,33 @@ class MetricsInputStream : public arrow::io::InputStream {
 
   // Readable
   arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
-    ARROW_ASSIGN_OR_RAISE(auto bytes_read, stream_->Read(nbytes, out));
-    if (bytes_read > 0) {
-      metrics_->IncrementReadCount();
-      metrics_->IncrementReadBytes(bytes_read);
+    auto op = metrics_->StartTransfer(OpType::Read);
+    auto result = stream_->Read(nbytes, out);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
     }
-    return bytes_read;
+    if (*result > 0) {
+      op.RecordBytes(*result);
+    } else {
+      op.Cancel();
+    }
+    return result;
   }
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
-    ARROW_ASSIGN_OR_RAISE(auto buffer, stream_->Read(nbytes));
-    if (buffer && buffer->size() > 0) {
-      metrics_->IncrementReadCount();
-      metrics_->IncrementReadBytes(buffer->size());
+    auto op = metrics_->StartTransfer(OpType::Read);
+    auto result = stream_->Read(nbytes);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
     }
-    return buffer;
+    if (*result && (*result)->size() > 0) {
+      op.RecordBytes((*result)->size());
+    } else {
+      op.Cancel();
+    }
+    return result;
   }
 
   const arrow::io::IOContext& io_context() const override { return stream_->io_context(); }
@@ -200,7 +337,7 @@ class MetricsInputStream : public arrow::io::InputStream {
   std::shared_ptr<FilesystemMetrics> metrics_;
 };
 
-/// \brief Wrapper for RandomAccessFile to track read bytes
+/// \brief Wrapper for RandomAccessFile to track read bytes and latency
 class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   public:
   MetricsRandomAccessFile(std::shared_ptr<arrow::io::RandomAccessFile> file, std::shared_ptr<FilesystemMetrics> metrics)
@@ -214,21 +351,33 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
 
   // Readable
   arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
-    ARROW_ASSIGN_OR_RAISE(auto bytes_read, file_->Read(nbytes, out));
-    if (bytes_read > 0) {
-      metrics_->IncrementReadCount();
-      metrics_->IncrementReadBytes(bytes_read);
+    auto op = metrics_->StartTransfer(OpType::Read);
+    auto result = file_->Read(nbytes, out);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
     }
-    return bytes_read;
+    if (*result > 0) {
+      op.RecordBytes(*result);
+    } else {
+      op.Cancel();
+    }
+    return result;
   }
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
-    ARROW_ASSIGN_OR_RAISE(auto buffer, file_->Read(nbytes));
-    if (buffer && buffer->size() > 0) {
-      metrics_->IncrementReadCount();
-      metrics_->IncrementReadBytes(buffer->size());
+    auto op = metrics_->StartTransfer(OpType::Read);
+    auto result = file_->Read(nbytes);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
     }
-    return buffer;
+    if (*result && (*result)->size() > 0) {
+      op.RecordBytes((*result)->size());
+    } else {
+      op.Cancel();
+    }
+    return result;
   }
 
   const arrow::io::IOContext& io_context() const override { return file_->io_context(); }
@@ -253,47 +402,73 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
 
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
-    ARROW_ASSIGN_OR_RAISE(auto bytes_read, file_->ReadAt(position, nbytes, out));
-    if (bytes_read > 0) {
-      metrics_->IncrementReadCount();
-      metrics_->IncrementReadBytes(bytes_read);
+    auto op = metrics_->StartTransfer(OpType::Read);
+    auto result = file_->ReadAt(position, nbytes, out);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
     }
-    return bytes_read;
+    if (*result > 0) {
+      op.RecordBytes(*result);
+    } else {
+      op.Cancel();
+    }
+    return result;
   }
 
   arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
-    ARROW_ASSIGN_OR_RAISE(auto buffer, file_->ReadAt(position, nbytes));
-    if (buffer && buffer->size() > 0) {
-      metrics_->IncrementReadCount();
-      metrics_->IncrementReadBytes(buffer->size());
+    auto op = metrics_->StartTransfer(OpType::Read);
+    auto result = file_->ReadAt(position, nbytes);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
     }
-    return buffer;
+    if (*result && (*result)->size() > 0) {
+      op.RecordBytes((*result)->size());
+    } else {
+      op.Cancel();
+    }
+    return result;
   }
 
   arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
                                                           int64_t position,
                                                           int64_t nbytes) override {
+    auto op = std::make_shared<ScopedXfer>(metrics_->StartTransfer(OpType::Read));
     return file_->ReadAsync(io_context, position, nbytes)
-        .Then([metrics = metrics_](const std::shared_ptr<arrow::Buffer>& buffer) {
-          if (buffer && buffer->size() > 0) {
-            metrics->IncrementReadCount();
-            metrics->IncrementReadBytes(buffer->size());
-          }
-          return buffer;
-        });
+        .Then(
+            [op](const std::shared_ptr<arrow::Buffer>& buffer) {
+              if (buffer && buffer->size() > 0) {
+                op->RecordBytes(buffer->size());
+              } else {
+                op->Cancel();
+              }
+              return buffer;
+            },
+            [op](const arrow::Status& status) {
+              op->Fail(ClassifyArrowStatus(status));
+              return arrow::Result<std::shared_ptr<arrow::Buffer>>(status);
+            });
   }
 
   std::vector<arrow::Future<std::shared_ptr<arrow::Buffer>>> ReadManyAsync(
       const arrow::io::IOContext& io_context, const std::vector<arrow::io::ReadRange>& ranges) override {
     auto futures = file_->ReadManyAsync(io_context, ranges);
     for (auto& future : futures) {
-      future = future.Then([metrics = metrics_](const std::shared_ptr<arrow::Buffer>& buffer) {
-        if (buffer && buffer->size() > 0) {
-          metrics->IncrementReadCount();
-          metrics->IncrementReadBytes(buffer->size());
-        }
-        return buffer;
-      });
+      auto op = std::make_shared<ScopedXfer>(metrics_->StartTransfer(OpType::Read));
+      future = future.Then(
+          [op](const std::shared_ptr<arrow::Buffer>& buffer) {
+            if (buffer && buffer->size() > 0) {
+              op->RecordBytes(buffer->size());
+            } else {
+              op->Cancel();
+            }
+            return buffer;
+          },
+          [op](const arrow::Status& status) {
+            op->Fail(ClassifyArrowStatus(status));
+            return arrow::Result<std::shared_ptr<arrow::Buffer>>(status);
+          });
     }
     return futures;
   }
@@ -305,7 +480,7 @@ class MetricsRandomAccessFile : public arrow::io::RandomAccessFile {
   std::shared_ptr<FilesystemMetrics> metrics_;
 };
 
-/// \brief Wrapper for OutputStream to track write bytes
+/// \brief Wrapper for OutputStream to track write bytes and latency
 class MetricsOutputStream : public arrow::io::OutputStream {
   public:
   MetricsOutputStream(std::shared_ptr<arrow::io::OutputStream> stream, std::shared_ptr<FilesystemMetrics> metrics)
@@ -319,17 +494,31 @@ class MetricsOutputStream : public arrow::io::OutputStream {
 
   // Writable
   arrow::Status Write(const void* data, int64_t nbytes) override {
+    auto op = metrics_->StartTransfer(OpType::Write);
     auto status = stream_->Write(data, nbytes);
-    if (status.ok() && nbytes > 0) {
-      metrics_->IncrementWriteBytes(nbytes);
+    if (!status.ok()) {
+      op.Fail(ClassifyArrowStatus(status));
+      return status;
+    }
+    if (nbytes > 0) {
+      op.RecordBytes(nbytes);
+    } else {
+      op.Cancel();
     }
     return status;
   }
 
   arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
+    auto op = metrics_->StartTransfer(OpType::Write);
     auto status = stream_->Write(data);
-    if (status.ok() && data && data->size() > 0) {
-      metrics_->IncrementWriteBytes(data->size());
+    if (!status.ok()) {
+      op.Fail(ClassifyArrowStatus(status));
+      return status;
+    }
+    if (data && data->size() > 0) {
+      op.RecordBytes(data->size());
+    } else {
+      op.Cancel();
     }
     return status;
   }

--- a/cpp/src/ffi/filesystem_metrics_c.cpp
+++ b/cpp/src/ffi/filesystem_metrics_c.cpp
@@ -15,12 +15,27 @@
 #include "milvus-storage/ffi_filesystem_metrics_c.h"
 
 #include "milvus-storage/ffi_internal/result.h"
+#include "milvus-storage/filesystem/metrics/buckets.h"
 #include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/ffi/filesystem_internal.h"
 
 using ::FileSystemWrapper;
 using milvus_storage::Observable;
+
+const int64_t* loon_fs_latency_bucket_bounds_us(int32_t* out_len) {
+  if (out_len) {
+    *out_len = static_cast<int32_t>(milvus_storage::metrics::kLatencyBoundsUs.size());
+  }
+  return milvus_storage::metrics::kLatencyBoundsUs.data();
+}
+
+const int64_t* loon_fs_size_bucket_bounds_bytes(int32_t* out_len) {
+  if (out_len) {
+    *out_len = static_cast<int32_t>(milvus_storage::metrics::kSizeBoundsBytes.size());
+  }
+  return milvus_storage::metrics::kSizeBoundsBytes.data();
+}
 
 LoonFFIResult loon_filesystem_get_metrics(FileSystemHandle handle, LoonFilesystemMetricsSnapshot* out_metrics) {
   try {
@@ -40,20 +55,37 @@ LoonFFIResult loon_filesystem_get_metrics(FileSystemHandle handle, LoonFilesyste
       RETURN_ERROR(LOON_INVALID_ARGS, "Filesystem metrics are not enabled");
     }
 
+    static_assert(LOON_OP_TYPE_COUNT == milvus_storage::kOpTypeCount, "op type count mismatch");
+    static_assert(LOON_STATUS_COUNT == milvus_storage::kStatusCount, "status count mismatch");
+    static_assert(LOON_TRANSFER_COUNT == milvus_storage::kTransferCount, "transfer count mismatch");
+
     auto snapshot = metrics->GetSnapshot();
-    out_metrics->read_count = snapshot.read_count;
-    out_metrics->write_count = snapshot.write_count;
-    out_metrics->read_bytes = snapshot.read_bytes;
-    out_metrics->write_bytes = snapshot.write_bytes;
-    out_metrics->get_file_info_count = snapshot.get_file_info_count;
-    out_metrics->create_dir_count = snapshot.create_dir_count;
-    out_metrics->delete_dir_count = snapshot.delete_dir_count;
-    out_metrics->delete_file_count = snapshot.delete_file_count;
-    out_metrics->move_count = snapshot.move_count;
-    out_metrics->copy_file_count = snapshot.copy_file_count;
-    out_metrics->failed_count = snapshot.failed_count;
-    out_metrics->multi_part_upload_created = snapshot.multi_part_upload_created;
-    out_metrics->multi_part_upload_finished = snapshot.multi_part_upload_finished;
+    for (int i = 0; i < LOON_OP_TYPE_COUNT; ++i) {
+      const auto& src = snapshot.ops[i];
+      auto& dst = out_metrics->ops[i];
+      for (int j = 0; j < LOON_STATUS_COUNT; ++j) {
+        dst.count_by_status[j] = src.count_by_status[j];
+      }
+      dst.retry_count = src.retry_count;
+      dst.latency_sum_us = src.latency_sum_us;
+      dst.latency_count = src.latency_count;
+      for (int j = 0; j < LOON_LATENCY_BUCKETS; ++j) {
+        dst.latency_buckets[j] = src.latency_buckets[j];
+      }
+    }
+    for (int i = 0; i < LOON_TRANSFER_COUNT; ++i) {
+      out_metrics->transfers[i].bytes_total = snapshot.transfers[i].bytes_total;
+      out_metrics->transfers[i].size_sum_bytes = snapshot.transfers[i].size_sum_bytes;
+      out_metrics->transfers[i].size_count = snapshot.transfers[i].size_count;
+      for (int j = 0; j < LOON_SIZE_BUCKETS; ++j) {
+        out_metrics->transfers[i].size_buckets[j] = snapshot.transfers[i].size_buckets[j];
+      }
+    }
+    out_metrics->in_flight = snapshot.in_flight;
+    out_metrics->open_connections = snapshot.open_connections;
+    out_metrics->idle_connections = snapshot.idle_connections;
+    out_metrics->pending_multipart_created = snapshot.pending_multipart_created;
+    out_metrics->pending_multipart_finished = snapshot.pending_multipart_finished;
 
     RETURN_SUCCESS();
   } catch (const std::exception& e) {

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -49,6 +49,7 @@
 #include <arrow/util/future.h>
 #include <arrow/util/key_value_metadata.h>
 #include "milvus-storage/common/log.h"
+#include "milvus-storage/filesystem/metrics/error_classify.h"
 #include <arrow/util/logging.h>
 #include <arrow/util/string.h>
 
@@ -372,6 +373,11 @@ Status ExceptionToStatus(const Azure::Core::RequestFailedException& exception,
   }
   return Status::IOError(std::forward<PrefixArgs>(prefix_args)..., " Azure Error: [",
                          exception.ErrorCode, "] ", exception.what());
+}
+
+// Map an Azure request failure to an OpStatus for metrics classification.
+milvus_storage::OpStatus ClassifyAzureError(const Azure::Core::RequestFailedException& exception) {
+  return milvus_storage::ClassifyHttpStatus(static_cast<int>(exception.StatusCode));
 }
 }  // namespace
 
@@ -1053,14 +1059,16 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
 Status CreateEmptyBlockBlob(const Blobs::BlockBlobClient& block_blob_client,
                             const std::shared_ptr<milvus_storage::FilesystemMetrics>& metrics) {
+  std::optional<milvus_storage::ScopedOp> op;
   if (metrics) {
-    metrics->IncrementMultiPartUploadCreated();
+    op.emplace(metrics->StartOp(milvus_storage::OpType::MultipartCreate));
+    metrics->IncrementMultipartCreated();
   }
   try {
     block_blob_client.UploadFrom(nullptr, 0);
   } catch (const Storage::StorageException& exception) {
-    if (metrics) {
-      metrics->IncrementFailedCount();
+    if (op) {
+      op->Fail(ClassifyAzureError(exception));
     }
     return ExceptionToStatus(
         exception, "UploadFrom failed for '", block_blob_client.GetUrl(),
@@ -1072,8 +1080,10 @@ Status CreateEmptyBlockBlob(const Blobs::BlockBlobClient& block_blob_client,
 
 Status CreateEmptyBlockBlobConditional(Blobs::BlockBlobClient& block_blob_client,
                                        const std::shared_ptr<milvus_storage::FilesystemMetrics>& metrics) {
+  std::optional<milvus_storage::ScopedOp> op;
   if (metrics) {
-    metrics->IncrementMultiPartUploadCreated();
+    op.emplace(metrics->StartOp(milvus_storage::OpType::MultipartCreate));
+    metrics->IncrementMultipartCreated();
   }
   try {
     Blobs::UploadBlockBlobOptions options;
@@ -1081,8 +1091,8 @@ Status CreateEmptyBlockBlobConditional(Blobs::BlockBlobClient& block_blob_client
     auto body = Core::IO::MemoryBodyStream(nullptr, 0);
     block_blob_client.Upload(body, options);
   } catch (const Storage::StorageException& exception) {
-    if (metrics) {
-      metrics->IncrementFailedCount();
+    if (op) {
+      op->Fail(ClassifyAzureError(exception));
     }
     return ExceptionToStatus(
         exception, "Conditional upload failed for '", block_blob_client.GetUrl(),
@@ -1106,8 +1116,10 @@ Status CommitBlockList(std::shared_ptr<Storage::Blobs::BlockBlobClient> block_bl
                        const std::vector<std::string>& block_ids,
                        const Blobs::CommitBlockListOptions& options,
                        const std::shared_ptr<milvus_storage::FilesystemMetrics>& metrics) {
+  std::optional<milvus_storage::ScopedOp> op;
   if (metrics) {
-    metrics->IncrementMultiPartUploadFinished();
+    op.emplace(metrics->StartOp(milvus_storage::OpType::MultipartComplete));
+    metrics->IncrementMultipartFinished();
   }
   try {
     // CommitBlockList puts all block_ids in the latest element. That means in the case
@@ -1116,8 +1128,8 @@ Status CommitBlockList(std::shared_ptr<Storage::Blobs::BlockBlobClient> block_bl
     // https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list?tabs=microsoft-entra-id#request-body
     block_blob_client->CommitBlockList(block_ids, options);
   } catch (const Storage::StorageException& exception) {
-    if (metrics) {
-      metrics->IncrementFailedCount();
+    if (op) {
+      op->Fail(ClassifyAzureError(exception));
     }
     return ExceptionToStatus(
         exception, "CommitBlockList failed for '", block_blob_client->GetUrl(),
@@ -1129,22 +1141,23 @@ Status CommitBlockList(std::shared_ptr<Storage::Blobs::BlockBlobClient> block_bl
 Status StageBlock(Blobs::BlockBlobClient* block_blob_client, const std::string& id,
                   Core::IO::MemoryBodyStream& content, int64_t content_length,
                   const std::shared_ptr<milvus_storage::FilesystemMetrics>& metrics) {
+  std::optional<milvus_storage::ScopedXfer> op;
   if (metrics) {
-    metrics->IncrementWriteCount();
+    op.emplace(metrics->StartTransfer(milvus_storage::OpType::MultipartUploadPart));
   }
   try {
     block_blob_client->StageBlock(id, content);
   } catch (const Storage::StorageException& exception) {
-    if (metrics) {
-      metrics->IncrementFailedCount();
+    if (op) {
+      op->Fail(ClassifyAzureError(exception));
     }
     return ExceptionToStatus(
         exception, "StageBlock failed for '", block_blob_client->GetUrl(),
         "' new_block_id: '", id,
         "'. Staging new blocks is fundamental to streaming writes to blob storage.");
   }
-  if (metrics) {
-    metrics->IncrementWriteBytes(content_length);
+  if (op) {
+    op->RecordBytes(content_length);
   }
   return Status::OK();
 }
@@ -3442,7 +3455,8 @@ bool AzureFileSystem::Equals(const FileSystem& other) const {
 }
 
 Result<FileInfo> AzureFileSystem::GetFileInfo(const std::string& path) {
-  impl_->metrics()->IncrementGetFileInfoCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::Head);
+  auto op_result = [&]() -> Result<FileInfo> {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   if (location.container.empty()) {
     DCHECK(location.path.empty());
@@ -3456,20 +3470,28 @@ Result<FileInfo> AzureFileSystem::GetFileInfo(const std::string& path) {
     return GetContainerPropsAsFileInfo(location, container_client);
   }
   return impl_->GetFileInfoOfPathWithinContainer(location);
+  }();
+  if (!op_result.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_result.status()));
+  return op_result;
 }
 
 Result<FileInfoVector> AzureFileSystem::GetFileInfo(const FileSelector& select) {
-  impl_->metrics()->IncrementGetFileInfoCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::List);
+  auto op_result = [&]() -> Result<FileInfoVector> {
   Core::Context context;
   Azure::Nullable<int32_t> page_size_hint;  // unspecified
   FileInfoVector results;
   RETURN_NOT_OK(
       impl_->GetFileInfoWithSelector(context, page_size_hint, select, &results));
   return {std::move(results)};
+  }();
+  if (!op_result.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_result.status()));
+  return op_result;
 }
 
 Status AzureFileSystem::CreateDir(const std::string& path, bool recursive) {
-  impl_->metrics()->IncrementCreateDirCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::CreateDir);
+  auto op_status = [&]() -> Status {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   if (location.container.empty()) {
     return Status::Invalid("CreateDir requires a non-empty path.");
@@ -3510,10 +3532,14 @@ Status AzureFileSystem::CreateDir(const std::string& path, bool recursive) {
   }
   DCHECK_EQ(hns_support, HNSSupport::kDisabled);
   return impl_->CreateDirOnContainer(container_client, location, recursive);
+  }();
+  if (!op_status.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_status));
+  return op_status;
 }
 
 Status AzureFileSystem::DeleteDir(const std::string& path) {
-  impl_->metrics()->IncrementDeleteDirCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::DeleteDir);
+  auto op_status = [&]() -> Status {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   if (location.container.empty()) {
     return Status::Invalid("DeleteDir requires a non-empty path.");
@@ -3539,10 +3565,14 @@ Status AzureFileSystem::DeleteDir(const std::string& path) {
                                              /*require_dir_to_exist=*/true,
                                              /*preserve_dir_marker_blob=*/false,
                                              "DeleteDir");
+  }();
+  if (!op_status.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_status));
+  return op_status;
 }
 
 Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_dir_ok) {
-  impl_->metrics()->IncrementDeleteDirCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::DeleteDir);
+  auto op_status = [&]() -> Status {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   if (location.container.empty()) {
     return internal::InvalidDeleteDirContents(location.all);
@@ -3563,6 +3593,9 @@ Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_
                                              /*require_dir_to_exist=*/!missing_dir_ok,
                                              /*preserve_dir_marker_blob=*/true,
                                              "DeleteDirContents");
+  }();
+  if (!op_status.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_status));
+  return op_status;
 }
 
 Status AzureFileSystem::DeleteRootDirContents() {
@@ -3570,7 +3603,8 @@ Status AzureFileSystem::DeleteRootDirContents() {
 }
 
 Status AzureFileSystem::DeleteFile(const std::string& path) {
-  impl_->metrics()->IncrementDeleteFileCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::DeleteFile);
+  auto op_status = [&]() -> Status {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   if (location.container.empty()) {
     return Status::Invalid("DeleteFile requires a non-empty path.");
@@ -3595,10 +3629,14 @@ Status AzureFileSystem::DeleteFile(const std::string& path) {
   return impl_->DeleteFileOnContainer(container_client, location,
                                       /*require_file_to_exist=*/true,
                                       /*operation=*/"DeleteFile");
+  }();
+  if (!op_status.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_status));
+  return op_status;
 }
 
 Status AzureFileSystem::Move(const std::string& src, const std::string& dest) {
-  impl_->metrics()->IncrementMoveCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::Move);
+  auto op_status = [&]() -> Status {
   ARROW_ASSIGN_OR_RAISE(auto src_location, AzureLocation::FromString(src));
   ARROW_ASSIGN_OR_RAISE(auto dest_location, AzureLocation::FromString(dest));
   if (src_location.container.empty()) {
@@ -3617,13 +3655,20 @@ Status AzureFileSystem::Move(const std::string& src, const std::string& dest) {
     return impl_->CreateContainerFromPath(src_location, dest_location);
   }
   return impl_->MovePath(src_location, dest_location);
+  }();
+  if (!op_status.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_status));
+  return op_status;
 }
 
 Status AzureFileSystem::CopyFile(const std::string& src, const std::string& dest) {
-  impl_->metrics()->IncrementCopyFileCount();
+  auto metrics_op = impl_->metrics()->StartOp(milvus_storage::OpType::Copy);
+  auto op_status = [&]() -> Status {
   ARROW_ASSIGN_OR_RAISE(auto src_location, AzureLocation::FromString(src));
   ARROW_ASSIGN_OR_RAISE(auto dest_location, AzureLocation::FromString(dest));
   return impl_->CopyFile(src_location, dest_location);
+  }();
+  if (!op_status.ok()) metrics_op.Fail(milvus_storage::ClassifyArrowStatus(op_status));
+  return op_status;
 }
 
 Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(

--- a/cpp/src/filesystem/local_fs_producer.cpp
+++ b/cpp/src/filesystem/local_fs_producer.cpp
@@ -30,39 +30,6 @@ static constexpr auto local_uri_scheme = "file://";
 
 /// \brief Wrapper for LocalFileSystem that implements Observable and UploadConditional
 class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadConditional, public Observable {
-  private:
-  // Macros to simplify metrics tracking
-#define TRACK_METRICS(counter, call)    \
-  do {                                  \
-    metrics_->counter();                \
-    auto result = call;                 \
-    if (!result.ok()) {                 \
-      metrics_->IncrementFailedCount(); \
-    }                                   \
-    return result;                      \
-  } while (0)
-
-#define TRACK_METRICS_AND_WRAP(counter, call, WrapperType)                          \
-  do {                                                                              \
-    metrics_->counter();                                                            \
-    auto result = call;                                                             \
-    if (!result.ok()) {                                                             \
-      metrics_->IncrementFailedCount();                                             \
-      return result.status();                                                       \
-    }                                                                               \
-    return std::make_shared<WrapperType>(std::move(result.ValueOrDie()), metrics_); \
-  } while (0)
-
-#define WRAP_WITH_METRICS(call, WrapperType)                                        \
-  do {                                                                              \
-    auto result = call;                                                             \
-    if (!result.ok()) {                                                             \
-      metrics_->IncrementFailedCount();                                             \
-      return result.status();                                                       \
-    }                                                                               \
-    return std::make_shared<WrapperType>(std::move(result.ValueOrDie()), metrics_); \
-  } while (0)
-
   public:
   explicit LocalFileSystemWrapper(const arrow::fs::LocalFileSystemOptions& options)
       : arrow::fs::LocalFileSystem(options), metrics_(std::make_shared<FilesystemMetrics>()) {}
@@ -71,66 +38,135 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
 
   // Override methods to track metrics
   arrow::Result<arrow::fs::FileInfo> GetFileInfo(const std::string& path) override {
-    TRACK_METRICS(IncrementGetFileInfoCount, arrow::fs::LocalFileSystem::GetFileInfo(path));
+    auto op = metrics_->StartOp(OpType::Head);
+    auto result = arrow::fs::LocalFileSystem::GetFileInfo(path);
+    if (!result.ok())
+      op.Fail(ClassifyArrowStatus(result.status()));
+    return result;
   }
 
   arrow::Result<std::vector<arrow::fs::FileInfo>> GetFileInfo(const arrow::fs::FileSelector& select) override {
-    TRACK_METRICS(IncrementGetFileInfoCount, arrow::fs::LocalFileSystem::GetFileInfo(select));
+    auto op = metrics_->StartOp(OpType::List);
+    auto result = arrow::fs::LocalFileSystem::GetFileInfo(select);
+    if (!result.ok())
+      op.Fail(ClassifyArrowStatus(result.status()));
+    return result;
   }
 
   arrow::Status CreateDir(const std::string& path, bool recursive) override {
-    TRACK_METRICS(IncrementCreateDirCount, arrow::fs::LocalFileSystem::CreateDir(path, recursive));
+    auto op = metrics_->StartOp(OpType::CreateDir);
+    auto st = arrow::fs::LocalFileSystem::CreateDir(path, recursive);
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Status DeleteDir(const std::string& path) override {
-    TRACK_METRICS(IncrementDeleteDirCount, arrow::fs::LocalFileSystem::DeleteDir(path));
+    auto op = metrics_->StartOp(OpType::DeleteDir);
+    auto st = arrow::fs::LocalFileSystem::DeleteDir(path);
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Status DeleteFile(const std::string& path) override {
-    TRACK_METRICS(IncrementDeleteFileCount, arrow::fs::LocalFileSystem::DeleteFile(path));
+    auto op = metrics_->StartOp(OpType::DeleteFile);
+    auto st = arrow::fs::LocalFileSystem::DeleteFile(path);
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Status Move(const std::string& src, const std::string& dest) override {
-    TRACK_METRICS(IncrementMoveCount, arrow::fs::LocalFileSystem::Move(src, dest));
+    auto op = metrics_->StartOp(OpType::Move);
+    auto st = arrow::fs::LocalFileSystem::Move(src, dest);
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Status CopyFile(const std::string& src, const std::string& dest) override {
-    TRACK_METRICS(IncrementCopyFileCount, arrow::fs::LocalFileSystem::CopyFile(src, dest));
+    auto op = metrics_->StartOp(OpType::Copy);
+    auto st = arrow::fs::LocalFileSystem::CopyFile(src, dest);
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override {
-    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputStream(path), MetricsInputStream);
+    auto op = metrics_->StartOp(OpType::OpenInput);
+    auto result = arrow::fs::LocalFileSystem::OpenInputStream(path);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result.status();
+    }
+    return std::make_shared<MetricsInputStream>(std::move(result.ValueOrDie()), metrics_);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const arrow::fs::FileInfo& info) override {
-    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputStream(info.path()), MetricsInputStream);
+    auto op = metrics_->StartOp(OpType::OpenInput);
+    auto result = arrow::fs::LocalFileSystem::OpenInputStream(info.path());
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result.status();
+    }
+    return std::make_shared<MetricsInputStream>(std::move(result.ValueOrDie()), metrics_);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override {
-    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputFile(path), MetricsRandomAccessFile);
+    auto op = metrics_->StartOp(OpType::OpenInput);
+    auto result = arrow::fs::LocalFileSystem::OpenInputFile(path);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result.status();
+    }
+    return std::make_shared<MetricsRandomAccessFile>(std::move(result.ValueOrDie()), metrics_);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override {
-    WRAP_WITH_METRICS(arrow::fs::LocalFileSystem::OpenInputFile(info.path()), MetricsRandomAccessFile);
+    auto op = metrics_->StartOp(OpType::OpenInput);
+    auto result = arrow::fs::LocalFileSystem::OpenInputFile(info.path());
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result.status();
+    }
+    return std::make_shared<MetricsRandomAccessFile>(std::move(result.ValueOrDie()), metrics_);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
       const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
-    TRACK_METRICS_AND_WRAP(IncrementWriteCount, arrow::fs::LocalFileSystem::OpenOutputStream(path, metadata),
-                           MetricsOutputStream);
+    auto op = metrics_->StartOp(OpType::OpenOutput);
+    auto result = arrow::fs::LocalFileSystem::OpenOutputStream(path, metadata);
+    if (!result.ok()) {
+      op.Fail(ClassifyArrowStatus(result.status()));
+      return result.status();
+    }
+    return std::make_shared<MetricsOutputStream>(std::move(result.ValueOrDie()), metrics_);
   }
 
   arrow::Status DeleteDirContents(const std::string& path, bool missing_dir_ok) override {
-    TRACK_METRICS(IncrementDeleteDirCount, arrow::fs::LocalFileSystem::DeleteDirContents(path, missing_dir_ok));
+    auto op = metrics_->StartOp(OpType::DeleteDir);
+    auto st = arrow::fs::LocalFileSystem::DeleteDirContents(path, missing_dir_ok);
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Status DeleteRootDirContents() override {
-    TRACK_METRICS(IncrementDeleteDirCount, arrow::fs::LocalFileSystem::DeleteRootDirContents());
+    auto op = metrics_->StartOp(OpType::DeleteDir);
+    auto st = arrow::fs::LocalFileSystem::DeleteRootDirContents();
+    if (!st.ok())
+      op.Fail(ClassifyArrowStatus(st));
+    return st;
   }
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenAppendStream(
       const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
-    TRACK_METRICS(IncrementWriteCount, arrow::fs::LocalFileSystem::OpenAppendStream(path, metadata));
+    auto op = metrics_->StartOp(OpType::OpenOutput);
+    auto result = arrow::fs::LocalFileSystem::OpenAppendStream(path, metadata);
+    if (!result.ok())
+      op.Fail(ClassifyArrowStatus(result.status()));
+    return result;
   }
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(
@@ -139,14 +175,18 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
     static std::mutex local_conditional_write_mutex;
     std::scoped_lock lock(local_conditional_write_mutex);
 
-    auto file_info_result = arrow::fs::LocalFileSystem::GetFileInfo(path);
+    arrow::Result<arrow::fs::FileInfo> file_info_result = [&] {
+      auto op = metrics_->StartOp(OpType::Head);
+      auto result = arrow::fs::LocalFileSystem::GetFileInfo(path);
+      if (!result.ok())
+        op.Fail(ClassifyArrowStatus(result.status()));
+      return result;
+    }();
     if (!file_info_result.ok()) {
-      metrics_->IncrementFailedCount();
       return file_info_result.status();
     }
     auto file_info = file_info_result.ValueOrDie();
     if (file_info.type() == arrow::fs::FileType::File) {
-      metrics_->IncrementFailedCount();
       return MakeExtendError(ExtendStatusCode::AwsErrorConflict, "File already exists: " + path, "");
     }
     return OpenOutputStream(path, metadata);
@@ -154,10 +194,6 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
 
   private:
   std::shared_ptr<FilesystemMetrics> metrics_;
-
-#undef TRACK_METRICS
-#undef TRACK_METRICS_AND_WRAP
-#undef WRAP_WITH_METRICS
 };
 
 arrow::Result<ArrowFileSystemPtr> LocalFileSystemProducer::Make() {

--- a/cpp/src/filesystem/metrics/error_classify.cpp
+++ b/cpp/src/filesystem/metrics/error_classify.cpp
@@ -1,0 +1,68 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/metrics/error_classify.h"
+
+#include <arrow/status.h>
+
+namespace milvus_storage {
+
+OpStatus ClassifyHttpStatus(int http_code) {
+  switch (http_code) {
+    case 404:
+      return OpStatus::NotFound;
+    case 403:
+      return OpStatus::Auth;
+    case 429:
+    case 503:
+      return OpStatus::Throttled;
+    case 408:
+    case 504:
+      return OpStatus::Timeout;
+    default:
+      break;
+  }
+  if (http_code >= 500 && http_code < 600) {
+    return OpStatus::ServerError;
+  }
+  if (http_code >= 400 && http_code < 500) {
+    return OpStatus::ClientError;
+  }
+  return OpStatus::Unknown;
+}
+
+OpStatus ClassifyArrowStatus(const arrow::Status& s) {
+  if (s.ok()) {
+    return OpStatus::Ok;
+  }
+  if (s.IsInvalid() || s.IsTypeError()) {
+    return OpStatus::ClientError;
+  }
+  return OpStatus::Unknown;
+}
+
+OpStatus ClassifyS3(int http_code, bool is_throttle, bool is_timeout, bool is_connect) {
+  if (is_throttle) {
+    return OpStatus::Throttled;
+  }
+  if (is_timeout) {
+    return OpStatus::Timeout;
+  }
+  if (is_connect) {
+    return OpStatus::Network;
+  }
+  return ClassifyHttpStatus(http_code);
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -50,6 +50,7 @@
 #include <aws/s3/model/UploadPartRequest.h>
 
 #include "milvus-storage/common/path_util.h"
+#include "milvus-storage/filesystem/metrics/error_classify.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/util_internal.h"
@@ -67,6 +68,18 @@ namespace milvus_storage {
 
 namespace S3Model = Aws::S3::Model;
 static inline constexpr auto kBucketRegionHeaderName = "x-amz-bucket-region";
+
+// Map an AWS S3 error to an OpStatus for metrics classification.
+static OpStatus ClassifyS3Error(const AWSError<S3Errors>& e) {
+  const int http = static_cast<int>(e.GetResponseCode());
+  const auto type = e.GetErrorType();
+  const bool throttle = type == S3Errors::SLOW_DOWN || type == S3Errors::THROTTLING ||
+                        http == static_cast<int>(Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS) ||
+                        http == static_cast<int>(Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE);
+  const bool timeout = type == S3Errors::REQUEST_TIMEOUT || type == S3Errors::REQUEST_TIME_TOO_SKEWED;
+  const bool connect = type == S3Errors::NETWORK_CONNECTION;
+  return ClassifyS3(http, throttle, timeout, connect);
+}
 
 inline arrow::Status ErrorS3Finalized() { return arrow::Status::Invalid("S3 subsystem is finalized"); }
 
@@ -204,7 +217,8 @@ S3Model::CompleteMultipartUploadOutcome S3Client::CompleteMultipartUploadWithErr
   // which parses the XML response for embedded errors.
 
   std::optional<AWSError<Aws::Client::CoreErrors>> aws_error;
-  metrics_->IncrementMultiPartUploadFinished();
+  auto op = metrics_->StartOp(OpType::MultipartComplete);
+  metrics_->IncrementMultipartFinished();
 
   auto handler = [&](const Aws::Http::HttpRequest* http_req, Aws::Http::HttpResponse* http_resp,
                      long long) {  // NOLINT runtime/int
@@ -248,10 +262,14 @@ S3Model::CompleteMultipartUploadOutcome S3Client::CompleteMultipartUploadWithErr
   }
 
   for (int32_t retries = 0;; retries++) {
+    if (retries > 0) {
+      op.RecordRetry();
+    }
     aws_error.reset();
     auto outcome = Aws::S3::S3Client::S3Client::CompleteMultipartUpload(request);
     if (!outcome.IsSuccess()) {
       // Error returned in HTTP headers (or client failure)
+      op.Fail(ClassifyS3Error(outcome.GetError()));
       return outcome;
     }
     if (!aws_error.has_value()) {
@@ -273,51 +291,52 @@ S3Model::CompleteMultipartUploadOutcome S3Client::CompleteMultipartUploadWithErr
   }
 
   DCHECK(aws_error.has_value());
-  metrics_->IncrementFailedCount();
   auto s3_error = AWSError<S3Errors>(std::move(aws_error).value());
+  op.Fail(ClassifyS3Error(s3_error));
   return S3Model::CompleteMultipartUploadOutcome(std::move(s3_error));
 }
 
 // Metrics related functions
 S3Model::CreateMultipartUploadOutcome S3Client::CreateMultipartUpload(
     const Aws::S3::Model::CreateMultipartUploadRequest& request) const {
-  metrics_->IncrementMultiPartUploadCreated();
+  auto op = metrics_->StartOp(OpType::MultipartCreate);
+  metrics_->IncrementMultipartCreated();
   auto outcome = Aws::S3::S3Client::CreateMultipartUpload(request);
   if (!outcome.IsSuccess()) {
-    metrics_->IncrementFailedCount();
+    op.Fail(ClassifyS3Error(outcome.GetError()));
   }
   return outcome;
 }
 
 S3Model::UploadPartOutcome S3Client::UploadPart(const Aws::S3::Model::UploadPartRequest& request) const {
-  metrics_->IncrementWriteCount();
+  auto op = metrics_->StartTransfer(OpType::MultipartUploadPart);
   auto outcome = Aws::S3::S3Client::UploadPart(request);
   if (!outcome.IsSuccess()) {
-    metrics_->IncrementFailedCount();
+    op.Fail(ClassifyS3Error(outcome.GetError()));
   } else {
-    metrics_->IncrementWriteBytes(request.GetContentLength());
+    op.RecordBytes(request.GetContentLength());
   }
   return outcome;
 }
 
 S3Model::PutObjectOutcome S3Client::PutObject(const Aws::S3::Model::PutObjectRequest& request) const {
-  metrics_->IncrementWriteCount();
+  auto op = metrics_->StartTransfer(OpType::Write);
   auto outcome = Aws::S3::S3Client::PutObject(request);
   if (!outcome.IsSuccess()) {
-    metrics_->IncrementFailedCount();
+    op.Fail(ClassifyS3Error(outcome.GetError()));
   } else {
-    metrics_->IncrementWriteBytes(request.GetContentLength());
+    op.RecordBytes(request.GetContentLength());
   }
   return outcome;
 }
 
 S3Model::GetObjectOutcome S3Client::GetObject(const Aws::S3::Model::GetObjectRequest& request) const {
-  metrics_->IncrementReadCount();
+  auto op = metrics_->StartTransfer(OpType::Read);
   auto outcome = Aws::S3::S3Client::GetObject(request);
   if (!outcome.IsSuccess()) {
-    metrics_->IncrementFailedCount();
+    op.Fail(ClassifyS3Error(outcome.GetError()));
   } else {
-    metrics_->IncrementReadBytes(outcome.GetResult().GetContentLength());
+    op.RecordBytes(outcome.GetResult().GetContentLength());
   }
   return outcome;
 }

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -82,6 +82,7 @@
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/filesystem/async_random_access_file.h"
+#include "milvus-storage/filesystem/metrics/error_classify.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/util_internal.h"
@@ -832,13 +833,13 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     ctx->request.SetRange(ToAwsString(FormatRange(position, nbytes)));
     ctx->request.SetResponseStreamFactory(AwsWriteableStreamFactory(out, nbytes));
 
-    ctx->metrics->IncrementReadCount();
+    ctx->op = std::make_shared<ScopedXfer>(ctx->metrics->StartTransfer(OpType::Read));
     ctx->client_lock->GetObjectAsync(
         ctx->request,
         [ctx](const Aws::S3Crt::S3CrtClient*, const S3CrtModel::GetObjectRequest&, S3CrtModel::GetObjectOutcome outcome,
               const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) mutable {
           if (!outcome.IsSuccess()) {
-            ctx->metrics->IncrementFailedCount();
+            ctx->op->Fail(ClassifyHttpStatus(static_cast<int>(outcome.GetError().GetResponseCode())));
             ctx->future.MarkFinished(arrow::Result<int64_t>(ErrorToStatus("GetObject", outcome.GetError())));
             return;
           }
@@ -846,7 +847,7 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
           const auto& result = outcome.GetResult();
           const auto response_content_length = result.GetContentLength();
           if (response_content_length < 0 || response_content_length > ctx->nbytes) {
-            ctx->metrics->IncrementFailedCount();
+            ctx->op->Fail(OpStatus::Unknown);
             ctx->future.MarkFinished(arrow::Result<int64_t>(
                 arrow::Status::IOError("Unexpected GetObject Content-Length ", response_content_length,
                                        " for range read of ", ctx->nbytes, " bytes")));
@@ -856,7 +857,9 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
           const int64_t bytes_read = response_content_length;
           ctx->self->CacheContentLengthFromRead(result, ctx->position, bytes_read);
           if (bytes_read > 0) {
-            ctx->metrics->IncrementReadBytes(bytes_read);
+            ctx->op->RecordBytes(bytes_read);
+          } else {
+            ctx->op->Cancel();
           }
           ctx->future.MarkFinished(bytes_read);
         });
@@ -1043,6 +1046,7 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     S3CrtModel::GetObjectRequest request;
     std::shared_ptr<ObjectCrtInputFile> self;
     std::shared_ptr<FilesystemMetrics> metrics;
+    std::shared_ptr<ScopedXfer> op;
     int64_t position = 0;
     int64_t nbytes = 0;
   };

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -2704,7 +2704,7 @@ TEST_P(APIWriterReaderTest, ParquetPrebufferHoleSizeLimitReducesReadIOCount) {
       return arrow::Status::Invalid("unexpected table shape: rows=", table->num_rows(),
                                     ", columns=", table->num_columns());
     }
-    return metrics->GetReadCount();
+    return metrics->OpCount(OpType::Read, OpStatus::Ok);
   };
 
   ASSERT_AND_ASSIGN(auto small_hole_read_count, read_count_with_hole_limit(kPrebufferSmallHoleLimit));

--- a/cpp/test/ffi/ffi_filesystem_metrics_test.c
+++ b/cpp/test/ffi/ffi_filesystem_metrics_test.c
@@ -1,0 +1,58 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "milvus-storage/ffi_filesystem_metrics_c.h"
+#include "test_runner.h"
+
+static void test_bucket_bounds_are_monotonic(void) {
+  int32_t n = 0;
+  const int64_t* lat = loon_fs_latency_bucket_bounds_us(&n);
+  ck_assert_int_eq(n, LOON_LATENCY_BUCKETS);
+  for (int i = 1; i < n; ++i) {
+    ck_assert_int_gt(lat[i], lat[i - 1]);
+  }
+
+  int32_t sn = 0;
+  const int64_t* sz = loon_fs_size_bucket_bounds_bytes(&sn);
+  ck_assert_int_eq(sn, LOON_SIZE_BUCKETS);
+  for (int i = 1; i < sn; ++i) {
+    ck_assert_int_gt(sz[i], sz[i - 1]);
+  }
+}
+
+static void test_snapshot_struct_is_zeroable(void) {
+  LoonFilesystemMetricsSnapshot s = {0};
+  ck_assert_int_eq(s.ops[0].latency_count, 0);
+  ck_assert_int_eq(s.transfers[0].bytes_total, 0);
+  ck_assert_int_eq(s.in_flight, 0);
+}
+
+static void test_get_metrics_rejects_null(void) {
+  LoonFilesystemMetricsSnapshot snap = {0};
+  // rejects a null handle with LOON_INVALID_ARGS (err_code != 0)
+  LoonFFIResult r = loon_filesystem_get_metrics(NULL, &snap);
+  ck_assert(r.err_code != 0);
+  if (r.message) {
+    free(r.message);
+  }
+}
+
+void run_metrics_snapshot_suite(void) {
+  RUN_TEST(test_bucket_bounds_are_monotonic);
+  RUN_TEST(test_snapshot_struct_is_zeroable);
+  RUN_TEST(test_get_metrics_rejects_null);
+}

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -320,19 +320,18 @@ static void test_filesystem_dir_operator(void) {
 }
 
 static void verify_filesystem_metrics_all_zero(LoonFilesystemMetricsSnapshot* metrics_snapshot) {
-  ck_assert_int_eq(metrics_snapshot->read_count, 0);
-  ck_assert_int_eq(metrics_snapshot->write_count, 0);
-  ck_assert_int_eq(metrics_snapshot->read_bytes, 0);
-  ck_assert_int_eq(metrics_snapshot->write_bytes, 0);
-  ck_assert_int_eq(metrics_snapshot->get_file_info_count, 0);
-  ck_assert_int_eq(metrics_snapshot->create_dir_count, 0);
-  ck_assert_int_eq(metrics_snapshot->delete_dir_count, 0);
-  ck_assert_int_eq(metrics_snapshot->delete_file_count, 0);
-  ck_assert_int_eq(metrics_snapshot->move_count, 0);
-  ck_assert_int_eq(metrics_snapshot->copy_file_count, 0);
-  ck_assert_int_eq(metrics_snapshot->failed_count, 0);
-  ck_assert_int_eq(metrics_snapshot->multi_part_upload_created, 0);
-  ck_assert_int_eq(metrics_snapshot->multi_part_upload_finished, 0);
+  for (int i = 0; i < LOON_OP_TYPE_COUNT; ++i) {
+    ck_assert_int_eq(metrics_snapshot->ops[i].latency_count, 0);
+    for (int j = 0; j < LOON_STATUS_COUNT; ++j) {
+      ck_assert_int_eq(metrics_snapshot->ops[i].count_by_status[j], 0);
+    }
+  }
+  for (int i = 0; i < LOON_TRANSFER_COUNT; ++i) {
+    ck_assert_int_eq(metrics_snapshot->transfers[i].bytes_total, 0);
+  }
+  ck_assert_int_eq(metrics_snapshot->in_flight, 0);
+  ck_assert_int_eq(metrics_snapshot->pending_multipart_created, 0);
+  ck_assert_int_eq(metrics_snapshot->pending_multipart_finished, 0);
 }
 
 static void test_filesystem_metrics(void) {
@@ -356,10 +355,10 @@ static void test_filesystem_metrics(void) {
   rc = loon_filesystem_get_metrics(fs_handle, &metrics_snapshot);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-  ck_assert_int_gt(metrics_snapshot.write_count, 0);
-  ck_assert_int_gt(metrics_snapshot.write_bytes, 0);
-  ck_assert_int_eq(metrics_snapshot.read_count, 0);
-  ck_assert_int_eq(metrics_snapshot.read_bytes, 0);
+  ck_assert_int_gt(metrics_snapshot.ops[LOON_OP_WRITE].count_by_status[LOON_STATUS_OK], 0);
+  ck_assert_int_gt(metrics_snapshot.transfers[LOON_XFER_WRITE].bytes_total, 0);
+  ck_assert_int_eq(metrics_snapshot.ops[LOON_OP_READ].count_by_status[LOON_STATUS_OK], 0);
+  ck_assert_int_eq(metrics_snapshot.transfers[LOON_XFER_READ].bytes_total, 0);
 
   loon_filesystem_destroy(fs_handle);
 }

--- a/cpp/test/ffi/ffi_test_main.c
+++ b/cpp/test/ffi/ffi_test_main.c
@@ -30,6 +30,7 @@ void run_filesystem_suite(void);
 void run_fiu_suite(void);
 void run_segment_suite(void);
 void run_runtime_suite(void);
+void run_metrics_snapshot_suite(void);
 
 int main(void) {
   loon_thread_pool_singleton(4);
@@ -42,6 +43,7 @@ int main(void) {
   run_filesystem_suite();
   run_segment_suite();
   run_fiu_suite();
+  run_metrics_snapshot_suite();
 
   loon_reset_context();
   loon_thread_pool_singleton_release();

--- a/cpp/test/filesystem/cloud_file_system_test.cpp
+++ b/cpp/test/filesystem/cloud_file_system_test.cpp
@@ -660,9 +660,8 @@ TEST_F(CloudFsTest, OpenInputFileWithFileInfoUsesKnownSize) {
   EXPECT_EQ(eof_buf->size(), 0);
 
   if (metrics != nullptr) {
-    auto after_get_size = metrics->GetSnapshot();
-    EXPECT_EQ(after_get_size.read_count, 0);
-    EXPECT_EQ(after_get_size.read_bytes, 0);
+    EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 0);
+    EXPECT_EQ(metrics->TransferBytes(OpType::Read), 0);
   }
 }
 
@@ -687,23 +686,24 @@ TEST_F(CloudFsTest, OpenInputFileMetricsStayLazyAfterCachedRead) {
 
   metrics->Reset();
   ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path));
-  auto after_open = metrics->GetSnapshot();
-  EXPECT_EQ(after_open.read_count, 0);
-  EXPECT_EQ(after_open.read_bytes, 0);
+  int64_t open_read_count = metrics->OpCount(OpType::Read, OpStatus::Ok);
+  int64_t open_read_bytes = metrics->TransferBytes(OpType::Read);
+  EXPECT_EQ(open_read_count, 0);
+  EXPECT_EQ(open_read_bytes, 0);
 
   ASSERT_AND_ASSIGN(auto read_buf, file->ReadAt(0, content.size() + 1024));
   EXPECT_EQ(read_buf->ToString(), content);
-  auto after_read = metrics->GetSnapshot();
-  EXPECT_GT(after_read.read_count, after_open.read_count);
-  EXPECT_GT(after_read.read_bytes, after_open.read_bytes);
+  int64_t read_read_count = metrics->OpCount(OpType::Read, OpStatus::Ok);
+  int64_t read_read_bytes = metrics->TransferBytes(OpType::Read);
+  EXPECT_GT(read_read_count, open_read_count);
+  EXPECT_GT(read_read_bytes, open_read_bytes);
 
   ASSERT_STATUS_OK(fs_->DeleteFile(path));
 
   ASSERT_AND_ASSIGN(auto size, file->GetSize());
   EXPECT_EQ(size, static_cast<int64_t>(content.size()));
-  auto after_get_size = metrics->GetSnapshot();
-  EXPECT_EQ(after_get_size.read_count, after_read.read_count);
-  EXPECT_EQ(after_get_size.read_bytes, after_read.read_bytes);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), read_read_count);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), read_read_bytes);
 }
 
 TEST_F(CloudFsTest, OverwriteExistingFile) {

--- a/cpp/test/filesystem/cloud_fs_metrics_test.cpp
+++ b/cpp/test/filesystem/cloud_fs_metrics_test.cpp
@@ -71,10 +71,11 @@ TEST_F(CloudFsMetricsTest, TestMetricsAfterFileOperations) {
   ASSERT_NE(metrics, nullptr);
 
   metrics->Reset();
-  EXPECT_EQ(metrics->GetMultiPartUploadCreated(), 0);
-  EXPECT_EQ(metrics->GetMultiPartUploadFinished(), 0);
-  EXPECT_EQ(metrics->GetWriteCount(), 0);
-  EXPECT_EQ(metrics->GetReadCount(), 0);
+  EXPECT_EQ(metrics->MultipartCreated(), 0);
+  EXPECT_EQ(metrics->MultipartFinished(), 0);
+  EXPECT_EQ(
+      (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 0);
 
   // Generate a unique test file name
   std::string test_file_name = GenerateTestFileName();
@@ -98,8 +99,8 @@ TEST_F(CloudFsMetricsTest, TestMetricsAfterFileOperations) {
   // Get metrics after operations
   metrics = observable->GetMetrics();
   ASSERT_NE(metrics, nullptr);
-  EXPECT_EQ(1, metrics->GetMultiPartUploadCreated());
-  EXPECT_EQ(1, metrics->GetMultiPartUploadFinished());
+  EXPECT_EQ(1, metrics->MultipartCreated());
+  EXPECT_EQ(1, metrics->MultipartFinished());
   // S3 and Azure have different upload splitting behavior for data exceeding
   // the upload_size (10MB). S3's OutputStream splits data at part_upload_size
   // boundaries in its write loop (UploadPart with fixed part_upload_size),
@@ -109,8 +110,10 @@ TEST_F(CloudFsMetricsTest, TestMetricsAfterFileOperations) {
   // block/part counts.
   auto provider = GetEnvVar(ENV_VAR_CLOUD_PROVIDER);
   int expected_write_count = (provider.ok() && provider.ValueOrDie() == "azure") ? 1 : 2;
-  EXPECT_EQ(expected_write_count, metrics->GetWriteCount());
-  EXPECT_EQ(test_data.size(), metrics->GetWriteBytes());
+  EXPECT_EQ(expected_write_count, (metrics->OpCount(OpType::Write, OpStatus::Ok) +
+                                   metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)));
+  EXPECT_EQ(test_data.size(),
+            (metrics->TransferBytes(OpType::Write) + metrics->TransferBytes(OpType::MultipartUploadPart)));
 
   // Download the file
   auto download_result = arrowfs_->OpenInputStream(base_path_ + test_file_name);
@@ -125,8 +128,8 @@ TEST_F(CloudFsMetricsTest, TestMetricsAfterFileOperations) {
   metrics = observable->GetMetrics();
   ASSERT_NE(metrics, nullptr);
 
-  EXPECT_EQ(1, metrics->GetReadCount());
-  EXPECT_EQ(test_data.size(), metrics->GetReadBytes());
+  EXPECT_EQ(1, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(test_data.size(), metrics->TransferBytes(OpType::Read));
 }
 
 // Test that multiple small writes below upload_size are batched into a single
@@ -163,11 +166,13 @@ TEST_F(CloudFsMetricsTest, TestBatchingBelowUploadSize) {
   // so Created/Finished = 1.
   auto provider = GetEnvVar(ENV_VAR_CLOUD_PROVIDER);
   bool is_azure = provider.ok() && provider.ValueOrDie() == "azure";
-  EXPECT_EQ(is_azure ? 1 : 0, metrics->GetMultiPartUploadCreated());
-  EXPECT_EQ(is_azure ? 1 : 0, metrics->GetMultiPartUploadFinished());
+  EXPECT_EQ(is_azure ? 1 : 0, metrics->MultipartCreated());
+  EXPECT_EQ(is_azure ? 1 : 0, metrics->MultipartFinished());
   // 9 x 1MB = 9MB < 10MB upload_size, all buffered and flushed as 1 upload
-  EXPECT_EQ(1, metrics->GetWriteCount());
-  EXPECT_EQ(static_cast<int64_t>(num_chunks) * chunk_size, metrics->GetWriteBytes());
+  EXPECT_EQ(
+      1, (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)));
+  EXPECT_EQ(static_cast<int64_t>(num_chunks) * chunk_size,
+            (metrics->TransferBytes(OpType::Write) + metrics->TransferBytes(OpType::MultipartUploadPart)));
 
   // Verify content
   const int64_t total_size = static_cast<int64_t>(num_chunks) * chunk_size;
@@ -192,8 +197,8 @@ TEST_F(CloudFsMetricsTest, TestReadMetrics) {
 
   // Reset metrics before read
   metrics->Reset();
-  EXPECT_EQ(0, metrics->GetReadCount());
-  EXPECT_EQ(0, metrics->GetReadBytes());
+  EXPECT_EQ(0, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(0, metrics->TransferBytes(OpType::Read));
 
   // Read the file
   ASSERT_OK_AND_ASSIGN(auto input_stream, arrowfs_->OpenInputStream(base_path_ + test_file_name));
@@ -203,8 +208,8 @@ TEST_F(CloudFsMetricsTest, TestReadMetrics) {
 
   metrics = observable->GetMetrics();
   ASSERT_NE(metrics, nullptr);
-  EXPECT_EQ(1, metrics->GetReadCount());
-  EXPECT_EQ(static_cast<int64_t>(test_data.size()), metrics->GetReadBytes());
+  EXPECT_EQ(1, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(static_cast<int64_t>(test_data.size()), metrics->TransferBytes(OpType::Read));
 }
 
 TEST_F(CloudFsMetricsTest, TestOpenInputDoesNotIncrementReadMetrics) {
@@ -221,13 +226,13 @@ TEST_F(CloudFsMetricsTest, TestOpenInputDoesNotIncrementReadMetrics) {
 
   metrics->Reset();
   ASSERT_OK_AND_ASSIGN(auto input_stream, arrowfs_->OpenInputStream(base_path_ + test_file_name));
-  EXPECT_EQ(0, metrics->GetReadCount());
-  EXPECT_EQ(0, metrics->GetReadBytes());
+  EXPECT_EQ(0, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(0, metrics->TransferBytes(OpType::Read));
   ASSERT_STATUS_OK(input_stream->Close());
 
   ASSERT_OK_AND_ASSIGN(auto input_file, arrowfs_->OpenInputFile(base_path_ + test_file_name));
-  EXPECT_EQ(0, metrics->GetReadCount());
-  EXPECT_EQ(0, metrics->GetReadBytes());
+  EXPECT_EQ(0, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(0, metrics->TransferBytes(OpType::Read));
   ASSERT_STATUS_OK(input_file->Close());
 }
 
@@ -247,34 +252,34 @@ TEST_F(CloudFsMetricsTest, TestReadMetricsCountSuccessfulReads) {
   ASSERT_OK_AND_ASSIGN(auto input_stream, arrowfs_->OpenInputStream(base_path_ + test_file_name));
   ASSERT_OK_AND_ASSIGN(auto first, input_stream->Read(5));
   EXPECT_EQ(first->ToString(), "01234");
-  EXPECT_EQ(1, metrics->GetReadCount());
-  EXPECT_EQ(5, metrics->GetReadBytes());
+  EXPECT_EQ(1, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(5, metrics->TransferBytes(OpType::Read));
 
   ASSERT_OK_AND_ASSIGN(auto second, input_stream->Read(7));
   EXPECT_EQ(second->ToString(), "56789ab");
-  EXPECT_EQ(2, metrics->GetReadCount());
-  EXPECT_EQ(12, metrics->GetReadBytes());
+  EXPECT_EQ(2, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(12, metrics->TransferBytes(OpType::Read));
   ASSERT_STATUS_OK(input_stream->Close());
 
   metrics->Reset();
   ASSERT_OK_AND_ASSIGN(auto input_file, arrowfs_->OpenInputFile(base_path_ + test_file_name));
-  EXPECT_EQ(0, metrics->GetReadCount());
-  EXPECT_EQ(0, metrics->GetReadBytes());
+  EXPECT_EQ(0, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(0, metrics->TransferBytes(OpType::Read));
 
   ASSERT_OK_AND_ASSIGN(auto range_a, input_file->ReadAt(0, 4));
   EXPECT_EQ(range_a->ToString(), "0123");
-  EXPECT_EQ(1, metrics->GetReadCount());
-  EXPECT_EQ(4, metrics->GetReadBytes());
+  EXPECT_EQ(1, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(4, metrics->TransferBytes(OpType::Read));
 
   ASSERT_OK_AND_ASSIGN(auto range_b, input_file->ReadAt(10, 6));
   EXPECT_EQ(range_b->ToString(), "abcdef");
-  EXPECT_EQ(2, metrics->GetReadCount());
-  EXPECT_EQ(10, metrics->GetReadBytes());
+  EXPECT_EQ(2, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(10, metrics->TransferBytes(OpType::Read));
 
   ASSERT_OK_AND_ASSIGN(auto eof, input_file->ReadAt(test_data.size(), 1024));
   EXPECT_EQ(eof->size(), 0);
-  EXPECT_EQ(2, metrics->GetReadCount());
-  EXPECT_EQ(10, metrics->GetReadBytes());
+  EXPECT_EQ(2, metrics->OpCount(OpType::Read, OpStatus::Ok));
+  EXPECT_EQ(10, metrics->TransferBytes(OpType::Read));
   ASSERT_STATUS_OK(input_file->Close());
 }
 
@@ -297,19 +302,19 @@ TEST_F(CloudFsMetricsTest, TestReadMetricsCountSuccessfulAsyncReads) {
   auto read_result = input_file->ReadAsync({}, 5, 7).result();
   ASSERT_STATUS_OK(read_result.status());
   ASSERT_EQ(read_result.ValueOrDie()->size(), 7);
-  EXPECT_EQ(metrics->GetReadCount(), 1);
-  EXPECT_EQ(metrics->GetReadBytes(), 7);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 1);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 7);
 
   auto eof_result = input_file->ReadAsync({}, test_data_size, 1024).result();
   ASSERT_STATUS_OK(eof_result.status());
   ASSERT_EQ(eof_result.ValueOrDie()->size(), 0);
-  EXPECT_EQ(metrics->GetReadCount(), 1);
-  EXPECT_EQ(metrics->GetReadBytes(), 7);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 1);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 7);
 
   auto failed_result = input_file->ReadAsync({}, -1, 1).result();
   ASSERT_STATUS_NOT_OK(failed_result.status());
-  EXPECT_EQ(metrics->GetReadCount(), 1);
-  EXPECT_EQ(metrics->GetReadBytes(), 7);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 1);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 7);
 
   metrics->Reset();
   std::vector<arrow::io::ReadRange> ranges = {
@@ -337,8 +342,8 @@ TEST_F(CloudFsMetricsTest, TestReadMetricsCountSuccessfulAsyncReads) {
   ASSERT_STATUS_OK(range_3.status());
   EXPECT_EQ(range_3.ValueOrDie()->size(), 6);
 
-  EXPECT_EQ(metrics->GetReadCount(), 2);
-  EXPECT_EQ(metrics->GetReadBytes(), 10);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 2);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 10);
 
   metrics->Reset();
   std::vector<arrow::io::ReadRange> invalid_ranges = {{-1, 1}};
@@ -346,8 +351,8 @@ TEST_F(CloudFsMetricsTest, TestReadMetricsCountSuccessfulAsyncReads) {
   ASSERT_EQ(failed_futures.size(), 1);
   auto failed_range = failed_futures[0].result();
   ASSERT_STATUS_NOT_OK(failed_range.status());
-  EXPECT_EQ(metrics->GetReadCount(), 0);
-  EXPECT_EQ(metrics->GetReadBytes(), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 0);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 0);
 
   ASSERT_STATUS_OK(input_file->Close());
 }

--- a/cpp/test/filesystem/local_file_system_test.cpp
+++ b/cpp/test/filesystem/local_file_system_test.cpp
@@ -111,16 +111,18 @@ TEST_F(LocalFsTest, Observable) {
 
   metrics = observable->GetMetrics();
 
-  ASSERT_EQ(metrics->GetReadCount(), 0);
-  ASSERT_EQ(metrics->GetWriteCount(), 1);
-  ASSERT_EQ(metrics->GetWriteBytes(), content_size);
-  ASSERT_EQ(metrics->GetReadBytes(), 0);
-  ASSERT_EQ(metrics->GetGetFileInfoCount(), 0);
-  ASSERT_EQ(metrics->GetCreateDirCount(), 0);
-  ASSERT_EQ(metrics->GetDeleteDirCount(), 0);
-  ASSERT_EQ(metrics->GetDeleteFileCount(), 0);
-  ASSERT_EQ(metrics->GetMoveCount(), 0);
-  ASSERT_EQ(metrics->GetCopyFileCount(), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 0);
+  ASSERT_EQ(
+      (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)), 1);
+  ASSERT_EQ((metrics->TransferBytes(OpType::Write) + metrics->TransferBytes(OpType::MultipartUploadPart)),
+            content_size);
+  ASSERT_EQ(metrics->TransferBytes(OpType::Read), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::Head), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::CreateDir), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::DeleteDir), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::DeleteFile), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::Move), 0);
+  ASSERT_EQ(metrics->OpCount(OpType::Copy), 0);
 }
 
 TEST_F(LocalFsTest, TestRootPath) {
@@ -191,14 +193,15 @@ TEST_F(LocalFsTest, TestMetricsAfterFileOperations) {
   ASSERT_NE(metrics, nullptr);
 
   metrics->Reset();
-  EXPECT_EQ(metrics->GetWriteCount(), 0);
-  EXPECT_EQ(metrics->GetReadCount(), 0);
-  EXPECT_EQ(metrics->GetWriteBytes(), 0);
-  EXPECT_EQ(metrics->GetReadBytes(), 0);
-  EXPECT_EQ(metrics->GetGetFileInfoCount(), 0);
-  EXPECT_EQ(metrics->GetCreateDirCount(), 0);
-  EXPECT_EQ(metrics->GetDeleteFileCount(), 0);
-  EXPECT_EQ(metrics->GetFailedCount(), 0);
+  EXPECT_EQ(
+      (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 0);
+  EXPECT_EQ((metrics->TransferBytes(OpType::Write) + metrics->TransferBytes(OpType::MultipartUploadPart)), 0);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::Head), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::CreateDir), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::DeleteFile), 0);
+  EXPECT_EQ(metrics->FailedCount(), 0);
 
   // Write a file
   std::string file_path = base_path_ + "/test-metrics-write.txt";
@@ -209,28 +212,32 @@ TEST_F(LocalFsTest, TestMetricsAfterFileOperations) {
   ASSERT_STATUS_OK(output_stream->Write(content.c_str(), content_size));
   ASSERT_STATUS_OK(output_stream->Close());
 
-  EXPECT_EQ(metrics->GetWriteCount(), 1);
-  EXPECT_EQ(metrics->GetWriteBytes(), content_size);
-  EXPECT_EQ(metrics->GetReadCount(), 0);
-  EXPECT_EQ(metrics->GetReadBytes(), 0);
+  EXPECT_EQ(
+      (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)), 1);
+  EXPECT_EQ((metrics->TransferBytes(OpType::Write) + metrics->TransferBytes(OpType::MultipartUploadPart)),
+            content_size);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 0);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 0);
 
   // Read the file
   ASSERT_AND_ASSIGN(auto input_stream, fs_->OpenInputStream(file_path));
   ASSERT_AND_ASSIGN(auto read_buffer, input_stream->Read(content_size));
   ASSERT_STATUS_OK(input_stream->Close());
 
-  EXPECT_EQ(metrics->GetReadCount(), 1);
-  EXPECT_EQ(metrics->GetReadBytes(), content_size);
-  EXPECT_EQ(metrics->GetWriteCount(), 1);  // Should remain unchanged
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 1);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), content_size);
+  EXPECT_EQ(
+      (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)),
+      1);  // Should remain unchanged
 
   // GetFileInfo operations
   ASSIGN_OR_ABORT(auto file_info, fs_->GetFileInfo(file_path));
   EXPECT_EQ(file_info.type(), arrow::fs::FileType::File);
-  EXPECT_GE(metrics->GetGetFileInfoCount(), 1);
+  EXPECT_GE(metrics->OpCount(OpType::Head), 1);
 
   // Delete file
   ASSERT_STATUS_OK(fs_->DeleteFile(file_path));
-  EXPECT_EQ(metrics->GetDeleteFileCount(), 1);
+  EXPECT_EQ(metrics->OpCount(OpType::DeleteFile), 1);
 
   // Verify file doesn't exist
   ASSIGN_OR_ABORT(auto deleted_info, fs_->GetFileInfo(file_path));
@@ -244,13 +251,13 @@ TEST_F(LocalFsTest, TestMetricsForDirectoryOperations) {
   ASSERT_NE(metrics, nullptr);
 
   metrics->Reset();
-  EXPECT_EQ(metrics->GetCreateDirCount(), 0);
-  EXPECT_EQ(metrics->GetDeleteDirCount(), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::CreateDir), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::DeleteDir), 0);
 
   // Create directory
   std::string dir_path = base_path_ + "/test-dir";
   ASSERT_STATUS_OK(fs_->CreateDir(dir_path, true));
-  EXPECT_EQ(metrics->GetCreateDirCount(), 1);
+  EXPECT_EQ(metrics->OpCount(OpType::CreateDir), 1);
 
   // GetFileInfo on directory
   ASSIGN_OR_ABORT(auto dir_info, fs_->GetFileInfo(dir_path));
@@ -258,7 +265,7 @@ TEST_F(LocalFsTest, TestMetricsForDirectoryOperations) {
 
   // Delete directory
   ASSERT_STATUS_OK(fs_->DeleteDir(dir_path));
-  EXPECT_EQ(metrics->GetDeleteDirCount(), 1);
+  EXPECT_EQ(metrics->OpCount(OpType::DeleteDir), 1);
 }
 
 TEST_F(LocalFsTest, TestMetricsForMoveAndCopy) {
@@ -268,8 +275,8 @@ TEST_F(LocalFsTest, TestMetricsForMoveAndCopy) {
   ASSERT_NE(metrics, nullptr);
 
   metrics->Reset();
-  EXPECT_EQ(metrics->GetMoveCount(), 0);
-  EXPECT_EQ(metrics->GetCopyFileCount(), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::Move), 0);
+  EXPECT_EQ(metrics->OpCount(OpType::Copy), 0);
 
   // Create source file
   std::string src_path = base_path_ + "/source.txt";
@@ -281,7 +288,7 @@ TEST_F(LocalFsTest, TestMetricsForMoveAndCopy) {
   // Copy file
   std::string copy_path = base_path_ + "/copy.txt";
   ASSERT_STATUS_OK(fs_->CopyFile(src_path, copy_path));
-  EXPECT_EQ(metrics->GetCopyFileCount(), 1);
+  EXPECT_EQ(metrics->OpCount(OpType::Copy), 1);
 
   // Verify copy exists
   ASSIGN_OR_ABORT(auto copy_info, fs_->GetFileInfo(copy_path));
@@ -290,7 +297,7 @@ TEST_F(LocalFsTest, TestMetricsForMoveAndCopy) {
   // Move file
   std::string move_path = base_path_ + "/moved.txt";
   ASSERT_STATUS_OK(fs_->Move(src_path, move_path));
-  EXPECT_EQ(metrics->GetMoveCount(), 1);
+  EXPECT_EQ(metrics->OpCount(OpType::Move), 1);
 
   // Verify source doesn't exist and destination exists
   ASSIGN_OR_ABORT(auto src_info, fs_->GetFileInfo(src_path));
@@ -306,7 +313,7 @@ TEST_F(LocalFsTest, TestMetricsForFailedOperations) {
   ASSERT_NE(metrics, nullptr);
 
   metrics->Reset();
-  EXPECT_EQ(metrics->GetFailedCount(), 0);
+  EXPECT_EQ(metrics->FailedCount(), 0);
 
   // Try to delete non-existent file
   std::string non_existent = base_path_ + "/non-existent.txt";
@@ -314,13 +321,13 @@ TEST_F(LocalFsTest, TestMetricsForFailedOperations) {
   // This might succeed (no-op) or fail depending on implementation
   // But if it fails, it should increment failed count
   if (!status.ok()) {
-    EXPECT_GE(metrics->GetFailedCount(), 1);
+    EXPECT_GE(metrics->FailedCount(), 1);
   }
 
   // Try to open non-existent file for reading
   auto read_result = fs_->OpenInputStream(non_existent);
   ASSERT_STATUS_NOT_OK(read_result);
-  EXPECT_GE(metrics->GetFailedCount(), 1);
+  EXPECT_GE(metrics->FailedCount(), 1);
 }
 
 TEST_F(LocalFsTest, TestMetricsForMultipleReadsAndWrites) {
@@ -344,8 +351,10 @@ TEST_F(LocalFsTest, TestMetricsForMultipleReadsAndWrites) {
     files.push_back(file_path);
   }
 
-  EXPECT_EQ(metrics->GetWriteCount(), 5);
-  EXPECT_EQ(metrics->GetWriteBytes(), 5 * content_size);
+  EXPECT_EQ(
+      (metrics->OpCount(OpType::Write, OpStatus::Ok) + metrics->OpCount(OpType::MultipartUploadPart, OpStatus::Ok)), 5);
+  EXPECT_EQ((metrics->TransferBytes(OpType::Write) + metrics->TransferBytes(OpType::MultipartUploadPart)),
+            5 * content_size);
 
   // Read all files
   for (const auto& file_path : files) {
@@ -354,8 +363,8 @@ TEST_F(LocalFsTest, TestMetricsForMultipleReadsAndWrites) {
     ASSERT_STATUS_OK(input_stream->Close());
   }
 
-  EXPECT_EQ(metrics->GetReadCount(), 5);
-  EXPECT_EQ(metrics->GetReadBytes(), 5 * content_size);
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 5);
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 5 * content_size);
 }
 
 TEST_F(LocalFsTest, TestMetricsForRandomAccessFile) {
@@ -381,8 +390,8 @@ TEST_F(LocalFsTest, TestMetricsForRandomAccessFile) {
   ASSERT_AND_ASSIGN(auto buffer2, file->ReadAt(10, 10));
   ASSERT_STATUS_OK(file->Close());
 
-  EXPECT_EQ(metrics->GetReadCount(), 2);   // Two successful ReadAt calls
-  EXPECT_EQ(metrics->GetReadBytes(), 20);  // 10 + 10 bytes read
+  EXPECT_EQ(metrics->OpCount(OpType::Read, OpStatus::Ok), 2);  // Two successful ReadAt calls
+  EXPECT_EQ(metrics->TransferBytes(OpType::Read), 20);         // 10 + 10 bytes read
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/filesystem/metrics/error_classify_test.cpp
+++ b/cpp/test/filesystem/metrics/error_classify_test.cpp
@@ -1,0 +1,54 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <arrow/status.h>
+
+#include "milvus-storage/filesystem/metrics/error_classify.h"
+
+namespace milvus_storage::test {
+
+struct HttpCase {
+  int code;
+  OpStatus expected;
+};
+
+TEST(ErrorClassifyTest, HttpStatusMapping) {
+  const HttpCase cases[] = {
+      {404, OpStatus::NotFound},    {403, OpStatus::Auth},        {429, OpStatus::Throttled},
+      {503, OpStatus::Throttled},   {408, OpStatus::Timeout},     {504, OpStatus::Timeout},
+      {500, OpStatus::ServerError}, {400, OpStatus::ClientError}, {412, OpStatus::ClientError},
+      {200, OpStatus::Unknown},
+  };
+  for (const auto& c : cases) {
+    EXPECT_EQ(ClassifyHttpStatus(c.code), c.expected) << c.code;
+  }
+}
+
+TEST(ErrorClassifyTest, ArrowStatusMapping) {
+  EXPECT_EQ(ClassifyArrowStatus(arrow::Status::OK()), OpStatus::Ok);
+  EXPECT_EQ(ClassifyArrowStatus(arrow::Status::IOError("boom")), OpStatus::Unknown);
+  EXPECT_EQ(ClassifyArrowStatus(arrow::Status::Invalid("bad")), OpStatus::ClientError);
+}
+
+TEST(ErrorClassifyTest, S3Mapping) {
+  EXPECT_EQ(ClassifyS3(503, /*throttle=*/true, false, false), OpStatus::Throttled);
+  EXPECT_EQ(ClassifyS3(0, false, /*timeout=*/true, false), OpStatus::Timeout);
+  EXPECT_EQ(ClassifyS3(0, false, false, /*connect=*/true), OpStatus::Network);
+  EXPECT_EQ(ClassifyS3(404, false, false, false), OpStatus::NotFound);
+  // Precedence: throttle wins over timeout/connect/http.
+  EXPECT_EQ(ClassifyS3(404, true, true, true), OpStatus::Throttled);
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/filesystem/metrics/histogram_test.cpp
+++ b/cpp/test/filesystem/metrics/histogram_test.cpp
@@ -1,0 +1,56 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "milvus-storage/filesystem/metrics/buckets.h"
+#include "milvus-storage/filesystem/metrics/histogram.h"
+
+namespace milvus_storage::test {
+
+using metrics::Histogram;
+using metrics::kLatencyBoundsUs;
+
+TEST(HistogramTest, ObserveRecordsSumCountAndBucket) {
+  Histogram h(kLatencyBoundsUs.data(), static_cast<int>(kLatencyBoundsUs.size()));
+  h.Observe(100);            // <= bounds[0] (100) -> bucket 0
+  h.Observe(1000);           // -> bucket 3 (bound 1000)
+  h.Observe(1'000'000'000);  // overflow: past last bound (130s)
+
+  EXPECT_EQ(h.count(), 3);
+  EXPECT_EQ(h.sum(), 100 + 1000 + 1'000'000'000);
+
+  std::vector<int64_t> b(kLatencyBoundsUs.size(), 0);
+  h.CopyBuckets(b.data(), static_cast<int>(b.size()));
+  EXPECT_EQ(b[0], 1);
+  EXPECT_EQ(b[3], 1);
+  int64_t bucketed = 0;
+  for (auto c : b) bucketed += c;
+  EXPECT_EQ(bucketed, 2);              // overflow not in any bucket
+  EXPECT_EQ(h.count() - bucketed, 1);  // overflow recoverable
+}
+
+TEST(HistogramTest, ResetZeroesEverything) {
+  Histogram h(kLatencyBoundsUs.data(), static_cast<int>(kLatencyBoundsUs.size()));
+  h.Observe(5000);
+  h.Reset();
+  EXPECT_EQ(h.count(), 0);
+  EXPECT_EQ(h.sum(), 0);
+  std::vector<int64_t> b(kLatencyBoundsUs.size(), 0);
+  h.CopyBuckets(b.data(), static_cast<int>(b.size()));
+  for (auto c : b) EXPECT_EQ(c, 0);
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/filesystem/metrics/registry_test.cpp
+++ b/cpp/test/filesystem/metrics/registry_test.cpp
@@ -1,0 +1,112 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <thread>
+
+#include "milvus-storage/filesystem/observable.h"
+
+namespace milvus_storage::test {
+
+TEST(RegistryTest, ScopedOpRecordsLatencyStatusAndInFlight) {
+  FilesystemMetrics m;
+  {
+    auto op = m.StartOp(OpType::Head);
+    EXPECT_EQ(m.GetSnapshot().in_flight, 1);  // in-flight while scope alive
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  auto s = m.GetSnapshot();
+  EXPECT_EQ(s.in_flight, 0);  // decremented
+  auto& head = s.ops[static_cast<int>(OpType::Head)];
+  EXPECT_EQ(head.count_by_status[static_cast<int>(OpStatus::Ok)], 1);
+  EXPECT_EQ(head.latency_count, 1);
+  EXPECT_GT(head.latency_sum_us, 0);
+}
+
+TEST(RegistryTest, FailAttributesStatusToOp) {
+  FilesystemMetrics m;
+  {
+    auto op = m.StartOp(OpType::DeleteFile);
+    op.Fail(OpStatus::NotFound);
+  }
+  auto s = m.GetSnapshot();
+  auto& del = s.ops[static_cast<int>(OpType::DeleteFile)];
+  EXPECT_EQ(del.count_by_status[static_cast<int>(OpStatus::NotFound)], 1);
+  EXPECT_EQ(del.count_by_status[static_cast<int>(OpStatus::Ok)], 0);
+}
+
+TEST(RegistryTest, TransferRecordsBytesAndSizeHistogram) {
+  FilesystemMetrics m;
+  {
+    auto op = m.StartTransfer(OpType::Read);
+    op.RecordBytes(4096);
+  }
+  auto s = m.GetSnapshot();
+  auto& t = s.transfers[TransferIndex(OpType::Read)];
+  EXPECT_EQ(t.bytes_total, 4096);
+  EXPECT_EQ(t.size_count, 1);
+  EXPECT_EQ(t.size_sum_bytes, 4096);
+  EXPECT_EQ(m.TransferBytes(OpType::Read), 4096);
+  EXPECT_EQ(m.OpCount(OpType::Read, OpStatus::Ok), 1);
+}
+
+TEST(RegistryTest, CancelRecordsNothingButBalancesInFlight) {
+  FilesystemMetrics m;
+  {
+    auto op = m.StartTransfer(OpType::Read);
+    op.Cancel();
+  }
+  auto s = m.GetSnapshot();
+  EXPECT_EQ(s.in_flight, 0);
+  EXPECT_EQ(s.ops[static_cast<int>(OpType::Read)].latency_count, 0);
+  EXPECT_EQ(m.OpCount(OpType::Read, OpStatus::Ok), 0);
+}
+
+TEST(RegistryTest, RecordRetryCountsPerOp) {
+  FilesystemMetrics m;
+  {
+    auto op = m.StartTransfer(OpType::Write);
+    op.RecordRetry();
+    op.RecordRetry(2);
+  }
+  auto s = m.GetSnapshot();
+  EXPECT_EQ(s.ops[static_cast<int>(OpType::Write)].retry_count, 3);
+}
+
+TEST(RegistryTest, QueryAccessorsReflectRegistry) {
+  FilesystemMetrics m;
+  { auto op = m.StartOp(OpType::CreateDir); }
+  {
+    auto op = m.StartOp(OpType::DeleteFile);
+    op.Fail(OpStatus::Timeout);
+  }
+  m.IncrementMultipartCreated();
+  m.IncrementMultipartFinished();
+
+  EXPECT_EQ(m.OpCount(OpType::CreateDir), 1);
+  EXPECT_EQ(m.OpCount(OpType::DeleteFile), 1);  // counted regardless of outcome
+  EXPECT_EQ(m.FailedCount(), 1);                // one non-Ok status
+  EXPECT_EQ(m.MultipartCreated(), 1);
+  EXPECT_EQ(m.MultipartFinished(), 1);
+}
+
+TEST(RegistryTest, ResetClearsRegistry) {
+  FilesystemMetrics m;
+  { auto op = m.StartOp(OpType::List); }
+  m.Reset();
+  EXPECT_EQ(m.GetSnapshot().ops[static_cast<int>(OpType::List)].latency_count, 0);
+}
+
+}  // namespace milvus_storage::test

--- a/cpp/test/format/vortex/vortex_v2_test.cpp
+++ b/cpp/test/format/vortex/vortex_v2_test.cpp
@@ -387,7 +387,7 @@ TEST_F(VortexV2Test, TestInlineArrayNodeSubSegmentRead) {
 
   // Check IO: reading 1 row of 512 bytes should read far less than the full file
   // Full file is ~5MB; sub-segment read should be well under 1MB
-  auto read_bytes = metrics->GetReadBytes();
+  auto read_bytes = metrics->TransferBytes(OpType::Read);
   ASSERT_EQ(read_bytes, fsb_width) << "Sub-segment read of 1 row should be exactly " << fsb_width << " bytes, got "
                                    << read_bytes;
 }

--- a/cpp/test/packed/packed_integration_test.cpp
+++ b/cpp/test/packed/packed_integration_test.cpp
@@ -588,7 +588,7 @@ TEST_F(PackedIntegrationTest, ParquetPrebufferHoleSizeLimitReducesReadIOCountV2)
       return arrow::Status::Invalid("unexpected table shape: rows=", table->num_rows(),
                                     ", columns=", table->num_columns());
     }
-    return metrics->GetReadCount();
+    return metrics->OpCount(OpType::Read, OpStatus::Ok);
   };
 
   ASSERT_AND_ASSIGN(auto small_hole_read_count, read_count_with_hole_limit(kPrebufferSmallHoleLimit));

--- a/docs/filesystem-metrics-observability-design.md
+++ b/docs/filesystem-metrics-observability-design.md
@@ -1,0 +1,343 @@
+# Filesystem Metrics Observability Redesign
+
+## Status
+
+Design. Supersedes the flat counter-based `FilesystemMetrics`
+(`cpp/include/milvus-storage/filesystem/observable.h`) and its FFI
+snapshot (`cpp/include/milvus-storage/ffi_filesystem_metrics_c.h`).
+
+## Motivation
+
+The current `FilesystemMetrics` is 13 monotonic `atomic<int64_t>`
+counters exposed as a flat snapshot over FFI. It answers "how much
+happened" but not the questions a monitoring system actually needs:
+
+- No timing. Not a single operation duration is measured, so p50/p95/
+  p99 latency — the primary SLI for an object store — cannot be built.
+- No distributions. `read_bytes`/`write_bytes` are running sums; the
+  per-request size distribution (average object size, tail sizes) is
+  unrecoverable.
+- No dimensions. Every field is a flat global, so failures cannot be
+  attributed to an operation, and there is no per-op error rate. A
+  single `failed_count_` collapses throttling, timeouts, auth failures,
+  and not-found into one number.
+- No saturation signal. There is no point-in-time gauge (in-flight
+  requests, connections) to tell whether the client is bottlenecked.
+- Retries are invisible. A request that succeeds after five retries
+  looks identical to one that succeeded immediately.
+
+This redesign replaces the flat counters with a labeled registry keyed
+by operation type and status, adds latency and size histograms, adds
+saturation gauges, and makes error classification and retries
+first-class. The FFI exports sum + count + fixed buckets so a consumer
+(milvus) can reconstruct Prometheus histograms.
+
+## Goals
+
+- Per-operation latency histograms.
+- Per-operation error classification (throttling, timeout, auth,
+  network, not-found, server, client, unknown) and per-op error rate.
+- Retry counts per operation.
+- In-flight and connection-pool gauges (saturation).
+- Per-request size distributions for data-transfer operations.
+- First-class coverage of `List`, `OpenInput`, `OpenOutput`, and the
+  full multipart lifecycle including `MultipartAbort` (leaked-part
+  detection).
+- A self-contained FFI snapshot with no dynamic allocation.
+
+## Non-goals
+
+- Higher-layer node metrics (compaction, index, cache) — those live in
+  milvus, not the storage library.
+- Changing the milvus consumer in this repository. The milvus bridge is
+  a separate repo; it must migrate to the labeled snapshot (see
+  Migration), but that change does not land here.
+- Distributed tracing / span propagation.
+
+## Design
+
+### Core model
+
+Every signal is an observation against two enums, so any metric can be
+sliced by `op_type` and (for errors) `status`.
+
+`OpType` (15) — real backend operations, not stream-level reads:
+
+```
+Read, Write, List, Head, OpenInput, OpenOutput, CreateDir, DeleteDir,
+DeleteFile, Move, Copy, MultipartCreate, MultipartUploadPart,
+MultipartComplete, MultipartAbort
+```
+
+`OpStatus` (9) — success plus the error taxonomy:
+
+```
+Ok, NotFound, Throttled, Auth, Timeout, Network, ServerError,
+ClientError, Unknown
+```
+
+Metric primitives, all `std::atomic<int64_t>` with `memory_order_relaxed`:
+
+- `Counter` — monotonic.
+- `Gauge` — up/down; used for in-flight, open/idle connections, pending
+  multipart.
+- `Histogram` — fixed static bucket bounds plus `sum` and `count`;
+  per-bucket atomic counts. Two bucket families: latency (microseconds,
+  exponential, 16 buckets ~100us..~130s) and size (bytes, exponential,
+  14 buckets ~256B..~4GB). Bounds are compile-time constants shared by
+  both sides of the FFI.
+
+### One `ScopedOp` = one backend request
+
+Hard rule: a `ScopedOp` measures exactly one physical request/RPC. This
+removes all aggregate-versus-per-request ambiguity.
+
+- A multipart upload is not one `ScopedOp`. It is `1x MultipartCreate` +
+  `N x MultipartUploadPart` + `1x MultipartComplete`, each its own
+  scope.
+- `size` on a `MultipartUploadPart` is that part's bytes; `retry_count`
+  is the retries of that one part's request.
+- "Total upload size" is never stored; it is `sum(MultipartUploadPart
+  .size)`, recovered downstream. Same for total retries.
+- `MultipartCreate`, `MultipartComplete`, `MultipartAbort` are control
+  requests with no payload.
+
+### Size applies only to transfer operations
+
+Only three operations move a payload: `Read`, `Write`,
+`MultipartUploadPart`. Rather than carry a dead size histogram on all
+15 op types, the record is split into two shapes, and the C++ type
+encodes whether size applies:
+
+```cpp
+// Control + metadata ops. Latency + status + retries. No size.
+[[nodiscard]] ScopedOp   StartOp(OpType op);
+
+// Data-transfer ops only: Read, Write, MultipartUploadPart.
+// A ScopedOp plus RecordBytes().
+[[nodiscard]] ScopedXfer StartTransfer(OpType op);
+```
+
+`StartTransfer` must only be called with `Read`, `Write`, or
+`MultipartUploadPart` (debug-asserted). Choosing the factory answers
+"does this op have a size?" and there is no `SetBytes` sitting uselessly
+on a `DeleteFile`.
+
+### API shape
+
+```cpp
+class FilesystemMetrics {
+ public:
+  // Starts the timer, increments in_flight[op]. Records latency,
+  // status, retries, and decrements in_flight on destruction of the
+  // returned scope.
+  [[nodiscard]] ScopedOp   StartOp(OpType op);
+  [[nodiscard]] ScopedXfer StartTransfer(OpType op);
+
+  // Best-effort connection-pool gauges, set by the backend client.
+  void SetConnectionStats(int64_t open, int64_t idle);
+
+  Snapshot GetSnapshot() const;   // structured, in-process view
+  void Reset();
+};
+
+class ScopedOp {
+ public:
+  void RecordRetry(int n = 1);    // retries of THIS request -> retry_count[op]
+  void Fail(OpStatus s);          // final status; default Ok
+  ~ScopedOp();                    // latency_hist[op] << elapsed;
+                                  // count_by_status[op][status]++;
+                                  // in_flight[op]--
+ protected:
+  // ... op, start time, status, metrics back-pointer
+};
+
+class ScopedXfer : public ScopedOp {
+ public:
+  void RecordBytes(int64_t n);    // this request's payload ->
+                                  // size_hist[xfer] << n; bytes_total[xfer] += n
+};
+```
+
+Call site (S3 read):
+
+```cpp
+auto op = metrics_->StartTransfer(OpType::Read);
+auto outcome = client_->GetObject(request);
+if (!outcome.IsSuccess()) {
+  op.Fail(ClassifyS3Error(outcome.GetError()));
+  return TranslateError(outcome);
+}
+op.RecordBytes(outcome.GetResult().GetContentLength());
+```
+
+Call site (control op):
+
+```cpp
+auto op = metrics_->StartOp(OpType::DeleteFile);
+auto st = arrow::fs::LocalFileSystem::DeleteFile(path);
+if (!st.ok()) op.Fail(ClassifyArrowStatus(st));
+return st;
+```
+
+### Error classification
+
+Per-backend free functions map a native error to `OpStatus`:
+
+```cpp
+OpStatus ClassifyS3Error(const Aws::S3::S3Error& e);      // s3_client.cpp
+OpStatus ClassifyAzureError(const Azure::Core::...& e);   // azurefs.cc
+OpStatus ClassifyArrowStatus(const arrow::Status& s);     // local_fs_producer.cpp
+```
+
+Mapping intent (S3 example): HTTP 503 / `SlowDown` / 429 -> `Throttled`;
+403 / signature errors -> `Auth`; 404 / `NoSuchKey` -> `NotFound`;
+request timeout / connection timeout -> `Timeout`; connection reset /
+DNS / TLS -> `Network`; other 5xx -> `ServerError`; other 4xx ->
+`ClientError`; anything unmapped -> `Unknown`.
+
+### Retries
+
+The existing s3_client retry loop calls `op.RecordRetry()` on each retry
+attempt for the request it is driving. Retries of a part upload count
+against that part's `MultipartUploadPart` scope.
+
+### FFI shape
+
+Both enums and both bucket families are compile-time constant on each
+side, so the entire snapshot is a fixed-size, caller-allocated struct —
+no malloc/free and no length negotiation.
+
+```c
+#define LOON_OP_TYPE_COUNT    15
+#define LOON_STATUS_COUNT      9
+#define LOON_LATENCY_BUCKETS  16   /* exp, ~100us .. ~130s */
+#define LOON_SIZE_BUCKETS     14   /* exp, ~256B .. ~4GB   */
+#define LOON_TRANSFER_COUNT    3   /* Read=0, Write=1, MultipartUploadPart=2 */
+
+typedef struct LoonOpStats {          /* every op */
+  int64_t count_by_status[LOON_STATUS_COUNT];
+  int64_t retry_count;
+  int64_t latency_sum_us;
+  int64_t latency_count;
+  int64_t latency_buckets[LOON_LATENCY_BUCKETS];
+} LoonOpStats;
+
+typedef struct LoonTransferStats {    /* Read, Write, MultipartUploadPart */
+  int64_t bytes_total;
+  int64_t size_sum_bytes;
+  int64_t size_count;
+  int64_t size_buckets[LOON_SIZE_BUCKETS];
+} LoonTransferStats;
+
+typedef struct LoonFilesystemMetricsSnapshot {
+  LoonOpStats       ops[LOON_OP_TYPE_COUNT];        /* indexed by OpType */
+  LoonTransferStats transfers[LOON_TRANSFER_COUNT]; /* indexed by transfer enum */
+  int64_t in_flight;
+  int64_t open_connections;
+  int64_t idle_connections;
+  int64_t pending_multipart_created;
+  int64_t pending_multipart_finished;
+} LoonFilesystemMetricsSnapshot;
+
+/* Static bucket bounds, queried once at startup. */
+FFI_EXPORT const int64_t* loon_fs_latency_bucket_bounds_us(int32_t* out_len);
+FFI_EXPORT const int64_t* loon_fs_size_bucket_bounds_bytes(int32_t* out_len);
+
+FFI_EXPORT LoonFFIResult loon_filesystem_get_metrics(
+    FileSystemHandle handle, LoonFilesystemMetricsSnapshot* out);
+FFI_EXPORT LoonFFIResult loon_filesystem_reset_metrics(FileSystemHandle handle);
+```
+
+Snapshot size is ~476 `int64_t` (~3.8 KB). The consumer reconstructs
+Prometheus histograms from `sum` / `count` / `buckets`, and reads the
+static bounds once.
+
+### Bucket semantics
+
+`latency_buckets[i]` and `size_buckets[i]` hold the count of
+observations whose value is less than or equal to
+`bounds[i]` and greater than `bounds[i-1]` (non-cumulative, one bucket
+per interval, with an implicit `+Inf` overflow captured by
+`count - sum(buckets)`). `latency_sum_us` / `size_sum_bytes` carry the
+exact sum so means are exact regardless of bucketing.
+
+### Instrumentation points
+
+- `s3_client.cpp`: wrap Get/Put/Multipart-part with `StartTransfer`;
+  wrap CreateMultipartUpload/Complete/Abort and metadata calls with
+  `StartOp`; classify via `ClassifyS3Error`; hook `RecordRetry` in the
+  retry loop; feed `SetConnectionStats` from the AWS HTTP client where
+  available (best-effort).
+- `local_fs_producer.cpp`: replace the `TRACK_METRICS` macros with
+  `StartOp` / `StartTransfer` scopes; classify via `ClassifyArrowStatus`.
+- `azurefs.cc`: same treatment; classify via `ClassifyAzureError`;
+  connection stats best-effort.
+- `observable.h` stream wrappers (`MetricsInputStream`,
+  `MetricsRandomAccessFile`, `MetricsOutputStream`): each `Read`/`Write`
+  records a `Read`/`Write` transfer scope. This raises the volume of
+  small-latency observations; acceptable and expected.
+
+### Query API for in-repo consumers
+
+The labeled registry is the single source of truth: there are no flat
+counter members. In-repo consumers (the S3 CRT async read path, the
+`benchmark_predicate` benchmark, and the filesystem tests) read the
+registry through a small set of live, labeled query methods:
+
+- `OpCount(op, status)` / `OpCount(op)` — per-cell and per-op counts.
+- `TransferBytes(op)` — bytes moved by a transfer op.
+- `FailedCount()` — sum of all non-Ok statuses across every op.
+- `InFlight()`, `MultipartCreated()`, `MultipartFinished()` — gauges.
+
+`GetSnapshot()` returns the full labeled snapshot (ops, transfers,
+gauges, histograms) for consumers that need histograms or a consistent
+copy. Stream wrappers only record a transfer op when it moved bytes; a
+zero-byte (EOF) success calls `ScopedOp::Cancel()` (no op recorded,
+in-flight balanced), and failures are recorded with a classified non-Ok
+status.
+
+### Migration
+
+This removes the old flat `LoonFilesystemMetricsSnapshot`. The milvus
+bridge (a separate repo) must migrate `PublishFilesystemMetrics` from the
+old flat struct to the labeled `loon_filesystem_get_metrics` snapshot,
+indexing `ops[]` / `transfers[]` by the exported `LOON_OP_*` /
+`LOON_STATUS_*` / `LOON_XFER_*` enums and reconstructing histograms from
+the sum/count/bucket data. No compatibility shim is kept.
+
+## Threading
+
+All primitives are `std::atomic<int64_t>` updated with
+`memory_order_relaxed`. Histogram observation is a bucket-index compute
+(branchless / binary search over static bounds) followed by three
+relaxed increments (bucket, sum, count). `GetSnapshot` and the FFI
+export do relaxed loads; the snapshot is not a consistent instant across
+fields, which is acceptable for monitoring.
+
+## Testing
+
+- `cloud_fs_metrics_test.cpp` (extended): latency histograms populate;
+  `in_flight` returns to zero after each op completes; retries counted;
+  status attributed to the correct op; multipart part sizes recorded per
+  part and totals recoverable by summation.
+- Error-classification unit tests: table-driven, mapping representative
+  S3 / Azure / arrow errors to the expected `OpStatus`.
+- FFI test (`ffi/...`): assert the snapshot struct is zeroable, that
+  `loon_fs_*_bucket_bounds_*` return monotonically increasing bounds of
+  the declared length, and that `loon_filesystem_get_metrics` rejects a
+  null handle.
+
+## Risks and open questions
+
+- Connection-pool gauges depend on what the AWS and Azure SDKs actually
+  expose; may be partial or unavailable. Treated as best-effort — the
+  gauges exist and read zero when the backend cannot supply them.
+- Stream-level reads produce one observation per `Read` call, increasing
+  observation volume for small reads. Mitigated by relaxed atomics and
+  fixed-bucket histograms (O(1) per observation).
+- Bucket boundaries are fixed at compile time. Chosen ranges
+  (latency ~100us..~130s, size ~256B..~4GB) are expected to cover object
+  storage workloads; revisiting them is a boundary-table change plus a
+  consumer re-read of `loon_fs_*_bucket_bounds_*`.
+```


### PR DESCRIPTION
See #591

Replace the flat 13-counter FilesystemMetrics with a labeled registry
keyed by operation type and status. Adds per-op latency and payload
size histograms, error classification, retry counts, and saturation
gauges (in-flight, connections, pending multipart).

A RAII ScopedOp measures exactly one backend request; ScopedXfer adds
payload-size recording for the transfer ops (Read, Write,
MultipartUploadPart). Local, S3 (sync and CRT async), and Azure paths
are instrumented, with per-backend error classification.

The C FFI exports a fixed-size snapshot carrying sum, count, and
static bucket bounds so a consumer can rebuild Prometheus histograms,
plus a legacy shim so the milvus bridge keeps building until it
migrates. Read-only Get* accessors are retained as helpers derived
from the registry, preserving the prior counters' semantics for
in-repo consumers (benchmarks and filesystem tests).