### PR TITLE
enhance: add PackedRecordBatchReader::Make factory; fix abort and code-destroying paths in packed

### DIFF
--- a/cpp/include/milvus-storage/packed/column_group.h
+++ b/cpp/include/milvus-storage/packed/column_group.h
@@ -54,7 +54,10 @@ class ColumnGroup {
 
   /// Schema of the group's batches: the first batch's schema, or nullptr for
   /// an empty group. Does NOT validate that later batches match -- callers
-  /// needing validation should go through Table().
+  /// needing validation should go through Table(). Migration note: this
+  /// replaces the previous behavior of materializing the merged table (which
+  /// THREW std::runtime_error on an empty group or schema mismatch); check
+  /// for nullptr before dereferencing.
   std::shared_ptr<arrow::Schema> Schema() const;
 
   std::shared_ptr<arrow::RecordBatch> GetRecordBatch(size_t index) const;

--- a/cpp/include/milvus-storage/packed/column_group.h
+++ b/cpp/include/milvus-storage/packed/column_group.h
@@ -45,7 +45,7 @@ class ColumnGroup {
 
   arrow::Status Merge(const ColumnGroup& other);
 
-  std::shared_ptr<arrow::Table> Table() const;
+  arrow::Result<std::shared_ptr<arrow::Table>> Table() const;
 
   std::shared_ptr<arrow::Schema> Schema() const;
 

--- a/cpp/include/milvus-storage/packed/column_group.h
+++ b/cpp/include/milvus-storage/packed/column_group.h
@@ -45,8 +45,16 @@ class ColumnGroup {
 
   arrow::Status Merge(const ColumnGroup& other);
 
+  /// Merge all batches into one table. Source-compat note: this returns
+  /// arrow::Result since the abort/throw cleanup (the previous signature
+  /// threw std::runtime_error on merge failure). Schema consistency across
+  /// batches is validated here (by Table::FromRecordBatches), not in
+  /// AddRecordBatch.
   arrow::Result<std::shared_ptr<arrow::Table>> Table() const;
 
+  /// Schema of the group's batches: the first batch's schema, or nullptr for
+  /// an empty group. Does NOT validate that later batches match -- callers
+  /// needing validation should go through Table().
   std::shared_ptr<arrow::Schema> Schema() const;
 
   std::shared_ptr<arrow::RecordBatch> GetRecordBatch(size_t index) const;
@@ -71,7 +79,7 @@ class ColumnGroup {
   std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
   size_t memory_usage_;
   std::vector<int> origin_column_indices_;
-  int64_t total_rows_;
+  int64_t total_rows_ = 0;
 };
 
 struct ColumnGroupState {

--- a/cpp/include/milvus-storage/packed/reader.h
+++ b/cpp/include/milvus-storage/packed/reader.h
@@ -47,6 +47,19 @@ class PackedRecordBatchReader : public arrow::RecordBatchReader {
    * @param buffer_size The max buffer size of the packed reader.
    * @param reader_props The reader properties.
    */
+  /// Preferred entry point: reports open failures as a status (with the
+  /// classification the underlying layers attached) instead of throwing.
+  static arrow::Result<std::unique_ptr<PackedRecordBatchReader>> Make(
+      const std::shared_ptr<arrow::fs::FileSystem>& fs,
+      std::vector<std::string>& paths,
+      const std::shared_ptr<arrow::Schema>& schema,
+      int64_t buffer_size = DEFAULT_READ_BUFFER_SIZE,
+      ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties(),
+      ::parquet::ArrowReaderProperties arrow_reader_props = ::parquet::default_arrow_reader_properties());
+
+  /// Deprecated in favor of Make(): a failed open THROWS std::runtime_error
+  /// with the stringified status, destroying its classification. Kept only
+  /// until direct-link consumers migrate; do not add new call sites.
   PackedRecordBatchReader(
       const std::shared_ptr<arrow::fs::FileSystem>& fs,
       std::vector<std::string>& paths,
@@ -79,6 +92,10 @@ class PackedRecordBatchReader : public arrow::RecordBatchReader {
   arrow::Status Close() override;
 
   private:
+  /// Member-init only; used by Make() so initialization failures can be
+  /// reported as a status instead of a constructor exception.
+  explicit PackedRecordBatchReader(int64_t buffer_size);
+
   arrow::Status init(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                      std::vector<std::string>& paths,
                      const std::shared_ptr<arrow::Schema>& origin_schema,

--- a/cpp/src/common/metadata.cpp
+++ b/cpp/src/common/metadata.cpp
@@ -178,9 +178,7 @@ int64_t RowGroupMetadata::row_offset() const { return row_offset_; }
 
 std::string RowGroupMetadata::ToString() const {
   std::stringstream ss;
-  ss << "memory_size=" << memory_size_ << ","
-     << "row_num=" << row_num_ << ","
-     << "row_offset=" << row_offset_;
+  ss << "memory_size=" << memory_size_ << "," << "row_num=" << row_num_ << "," << "row_offset=" << row_offset_;
   return ss.str();
 }
 
@@ -291,6 +289,12 @@ arrow::Result<std::shared_ptr<PackedFileMetadata>> PackedFileMetadata::Make(
     const std::shared_ptr<parquet::FileMetaData>& metadata) {
   // deserialize row group metadata
   auto key_value_metadata = metadata->key_value_metadata();
+  if (key_value_metadata == nullptr) {
+    // A foreign parquet file without any key-value metadata used to crash
+    // here on the null dereference below.
+    return arrow::Status::Invalid(fmt::format(
+        "Not a packed parquet file: no key-value metadata present. [num_row_groups={}]", metadata->num_row_groups()));
+  }
   auto row_group_meta = key_value_metadata->Get(ROW_GROUP_META_KEY);
   if (!row_group_meta.ok()) {
     return arrow::Status::Invalid(

--- a/cpp/src/format/parquet/file_reader.cpp
+++ b/cpp/src/format/parquet/file_reader.cpp
@@ -99,7 +99,9 @@ arrow::Status FileRowGroupReader::init(std::shared_ptr<arrow::fs::FileSystem> fs
       return status;
     }
     schema_ = file_schema;
-    field_id_list_ = FieldIDList::Make(schema_).ValueOrDie();
+    // FieldIDList::Make fails when a field lacks PARQUET:field_id metadata;
+    // ValueOrDie here aborted the whole process on such (data-dependent) files.
+    ARROW_ASSIGN_OR_RAISE(field_id_list_, FieldIDList::Make(schema_));
     for (size_t i = 0; i < field_id_list_.size(); ++i) {
       needed_columns_.emplace_back(i);
     }

--- a/cpp/src/packed/column_group.cpp
+++ b/cpp/src/packed/column_group.cpp
@@ -56,16 +56,22 @@ arrow::Status ColumnGroup::Merge(const ColumnGroup& other) {
   return arrow::Status::OK();
 }
 
-std::shared_ptr<arrow::Table> ColumnGroup::Table() const {
+arrow::Result<std::shared_ptr<arrow::Table>> ColumnGroup::Table() const {
   auto result = arrow::Table::FromRecordBatches(batches_);
-  if (result.ok()) {
-    return result.ValueOrDie();
-  } else {
-    throw std::runtime_error(result.status().message());
+  if (!result.ok()) {
+    // The status used to be stringified into a runtime_error here, destroying
+    // its StatusCode; propagate it unchanged instead.
+    return WrapExtendError(ExtendStatusCode::PackedUnexpected, "ColumnGroup::Table: failed to merge record batches",
+                           result.status());
   }
+  return result;
 }
 
-std::shared_ptr<arrow::Schema> ColumnGroup::Schema() const { return this->Table()->schema(); }
+std::shared_ptr<arrow::Schema> ColumnGroup::Schema() const {
+  // All batches in a group share one schema; avoid materializing the merged
+  // table (which can fail) just to read it.
+  return batches_.empty() ? nullptr : batches_.front()->schema();
+}
 
 std::shared_ptr<arrow::RecordBatch> ColumnGroup::GetRecordBatch(size_t index) const { return batches_[index]; }
 

--- a/cpp/src/packed/column_group.cpp
+++ b/cpp/src/packed/column_group.cpp
@@ -28,7 +28,12 @@ ColumnGroup::ColumnGroup(GroupId group_id,
                          const std::shared_ptr<arrow::RecordBatch>& batch)
     : group_id_(group_id), origin_column_indices_(origin_column_indices), memory_usage_(0) {
   batches_.emplace_back(batch);
-  memory_usage_ += GetRecordBatchMemorySize(batch);
+  auto batch_size = GetRecordBatchMemorySize(batch);
+  memory_usage_ += batch_size;
+  // Keep the same bookkeeping as AddRecordBatch: without these, size()==1
+  // paired with empty per-batch usages / a stale row count.
+  batch_memory_usage_.push_back(batch_size);
+  total_rows_ += batch ? batch->num_rows() : 0;
 }
 
 arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBatch>& batch) {

--- a/cpp/src/packed/column_group.cpp
+++ b/cpp/src/packed/column_group.cpp
@@ -27,13 +27,19 @@ ColumnGroup::ColumnGroup(GroupId group_id,
                          const std::vector<int>& origin_column_indices,
                          const std::shared_ptr<arrow::RecordBatch>& batch)
     : group_id_(group_id), origin_column_indices_(origin_column_indices), memory_usage_(0) {
+  // A constructor has no status channel (AddRecordBatch rejects null with
+  // PackedInvalidArgs); a null batch yields an empty group instead of the
+  // previous null dereference below.
+  if (batch == nullptr) {
+    return;
+  }
   batches_.emplace_back(batch);
   auto batch_size = GetRecordBatchMemorySize(batch);
   memory_usage_ += batch_size;
   // Keep the same bookkeeping as AddRecordBatch: without these, size()==1
   // paired with empty per-batch usages / a stale row count.
   batch_memory_usage_.push_back(batch_size);
-  total_rows_ += batch ? batch->num_rows() : 0;
+  total_rows_ += batch->num_rows();
 }
 
 arrow::Status ColumnGroup::AddRecordBatch(const std::shared_ptr<arrow::RecordBatch>& batch) {
@@ -64,10 +70,13 @@ arrow::Status ColumnGroup::Merge(const ColumnGroup& other) {
 arrow::Result<std::shared_ptr<arrow::Table>> ColumnGroup::Table() const {
   auto result = arrow::Table::FromRecordBatches(batches_);
   if (!result.ok()) {
-    // The status used to be stringified into a runtime_error here, destroying
-    // its StatusCode; propagate it unchanged instead.
-    return WrapExtendError(ExtendStatusCode::PackedUnexpected, "ColumnGroup::Table: failed to merge record batches",
-                           result.status());
+    // Keep the original StatusCode and detail (FromRecordBatches reports
+    // schema mismatch / empty group as Invalid, which classifies as
+    // DataFormatBroken downstream); only the message gains context. Wrapping
+    // into PackedUnexpected here would rewrite Invalid into IOError and
+    // degrade the classification to a generic StorageError.
+    return result.status().WithMessage("ColumnGroup::Table: failed to merge record batches: ",
+                                       result.status().message());
   }
   return result;
 }

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -71,20 +71,37 @@ arrow::Result<std::shared_ptr<PackedFileMetadata>> MakePackedMetadata(
 
 }  // namespace
 
+PackedRecordBatchReader::PackedRecordBatchReader(int64_t buffer_size)
+    : memory_limit_(buffer_size <= 0 ? INT64_MAX : buffer_size),
+      memory_used_(0),
+      row_limit_(0),
+      absolute_row_position_(0),
+      read_count_(0) {}
+
+arrow::Result<std::unique_ptr<PackedRecordBatchReader>> PackedRecordBatchReader::Make(
+    const std::shared_ptr<arrow::fs::FileSystem>& fs,
+    std::vector<std::string>& paths,
+    const std::shared_ptr<arrow::Schema>& schema,
+    int64_t buffer_size,
+    parquet::ReaderProperties reader_props,
+    parquet::ArrowReaderProperties arrow_reader_props) {
+  auto reader = std::unique_ptr<PackedRecordBatchReader>(new PackedRecordBatchReader(buffer_size));
+  ARROW_RETURN_NOT_OK(reader->init(fs, paths, schema, reader_props, arrow_reader_props));
+  return reader;
+}
+
 PackedRecordBatchReader::PackedRecordBatchReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                                  std::vector<std::string>& paths,
                                                  const std::shared_ptr<arrow::Schema>& schema,
                                                  int64_t buffer_size,
                                                  parquet::ReaderProperties reader_props,
                                                  parquet::ArrowReaderProperties arrow_reader_props)
-    : memory_limit_(buffer_size <= 0 ? INT64_MAX : buffer_size),
-      memory_used_(0),
-      row_limit_(0),
-      absolute_row_position_(0),
-      read_count_(0) {
+    : PackedRecordBatchReader(buffer_size) {
   auto status = init(fs, paths, schema, reader_props, arrow_reader_props);
   if (!status.ok()) {
     LOG_STORAGE_ERROR_ << "Error initializing PackedRecordBatchReader: " << status.ToString();
+    // Deprecated path (see reader.h): stringifies the status and destroys its
+    // classification. Migrate to Make().
     throw std::runtime_error(status.ToString());
   }
 }

--- a/cpp/test/packed/column_group_test.cpp
+++ b/cpp/test/packed/column_group_test.cpp
@@ -83,7 +83,7 @@ TEST_F(ColumnGroupTest, CreateTable) {
   auto record_batch = CreateRecordBatch(3, 5);
   ASSERT_STATUS_OK(column_group.AddRecordBatch(record_batch));
 
-  auto table = column_group.Table();
+  ASSERT_AND_ASSIGN(auto table, column_group.Table());
 
   // Check the properties of the table
   ASSERT_EQ(table->num_columns(), 3);

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -27,6 +27,10 @@
 #include "milvus-storage/packed/reader.h"
 #include "milvus-storage/packed/writer.h"
 
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+
+#include "milvus-storage/format/parquet/file_reader.h"
 #include "packed_test_base.h"
 
 namespace milvus_storage {
@@ -157,6 +161,51 @@ TEST_F(PackedErrorStatusTest, MakeSucceedsOnValidFile) {
   ASSERT_STATUS_OK(reader->ReadNext(&batch));
   ASSERT_NE(batch, nullptr);
   ASSERT_STATUS_OK(reader->Close());
+}
+
+// Integration regression for the fifth unguarded ValueOrDie
+// (file_reader.cpp: FileRowGroupReader::init, schema==nullptr branch): a
+// parquet file that passes the packed key-value metadata checks but whose
+// fields lack PARQUET:field_id must surface as a status, not abort.
+TEST_F(PackedErrorStatusTest, FileRowGroupReaderMissingFieldIdsIsStatusNotAbort) {
+  SetupOneFile();
+
+  // Grab the packed key-value metadata from a genuine packed file.
+  ASSERT_AND_ASSIGN(auto source, fs_->OpenInputFile(one_file_path_));
+  std::unique_ptr<::parquet::arrow::FileReader> packed_reader;
+  ASSERT_STATUS_OK(::parquet::arrow::OpenFile(source, arrow::default_memory_pool(), &packed_reader));
+  auto packed_kv = packed_reader->parquet_reader()->metadata()->key_value_metadata();
+  ASSERT_NE(packed_kv, nullptr);
+
+  // Write a parquet file carrying the SAME packed key-value metadata but a
+  // schema whose fields have no PARQUET:field_id.
+  std::vector<std::shared_ptr<arrow::Field>> bare_fields;
+  for (const auto& f : record_batch_->schema()->fields()) {
+    bare_fields.push_back(f->WithMetadata(nullptr));
+  }
+  // Schema-level metadata is written into the parquet key-value metadata by
+  // the arrow writer, so attaching the packed KV here reproduces "packed KV
+  // present, field ids absent".
+  auto bare_schema = arrow::schema(bare_fields);
+  auto bare_batch = arrow::RecordBatch::Make(bare_schema, record_batch_->num_rows(), record_batch_->columns());
+  ASSERT_AND_ASSIGN(auto bare_table, arrow::Table::FromRecordBatches({bare_batch}));
+  auto no_fid_path = path_ + "/no_field_ids.parquet";
+  ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(no_fid_path));
+  std::unique_ptr<::parquet::arrow::FileWriter> bare_writer;
+  ASSERT_AND_ASSIGN(bare_writer, ::parquet::arrow::FileWriter::Open(*bare_schema, arrow::default_memory_pool(), sink,
+                                                                    ::parquet::default_writer_properties(),
+                                                                    ::parquet::default_arrow_writer_properties()));
+  ASSERT_STATUS_OK(bare_writer->WriteTable(*bare_table, 100));
+  ASSERT_STATUS_OK(bare_writer->AddKeyValueMetadata(packed_kv));
+  ASSERT_STATUS_OK(bare_writer->Close());
+  ASSERT_STATUS_OK(sink->Close());
+
+  // schema==nullptr entry: the reader must derive the schema from the file,
+  // hit the missing-field-id condition, and report it as a status.
+  auto result = FileRowGroupReader::Make(fs_, no_fid_path);
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+  EXPECT_NE(result.status().ToString().find("field"), std::string::npos) << result.status().ToString();
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -127,4 +127,36 @@ TEST_F(PackedErrorStatusTest, ReaderMissingPackedMetadataIsMetadataCorrupted) {
                                      "PackedMetadataCorrupted");
 }
 
+TEST_F(PackedErrorStatusTest, MakeReportsMissingFileAsStatusWithClassification) {
+  std::vector<std::string> paths = {path_ + "/missing.parquet"};
+
+  auto result = PackedRecordBatchReader::Make(fs_, paths, schema_, reader_memory_);
+  ASSERT_FALSE(result.ok());
+  const auto& status = result.status();
+  // The wrap preserves the filesystem's own not-found detail (WrapExtendError
+  // keeps the cause's detail), so consumers get the fine-grained
+  // classification the throwing constructor used to destroy.
+  EXPECT_NE(status.ToString().find("missing.parquet"), std::string::npos) << status.ToString();
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist) << status.ToString();
+}
+
+TEST_F(PackedErrorStatusTest, MakeReportsEmptyPathsAsInvalidArgs) {
+  std::vector<std::string> paths;
+
+  auto result = PackedRecordBatchReader::Make(fs_, paths, schema_, reader_memory_);
+  ASSERT_FALSE(result.ok());
+  ExpectPackedCode(result.status(), ExtendStatusCode::PackedInvalidArgs);
+}
+
+TEST_F(PackedErrorStatusTest, MakeSucceedsOnValidFile) {
+  SetupOneFile();
+  std::vector<std::string> paths = {one_file_path_};
+
+  ASSERT_AND_ASSIGN(auto reader, PackedRecordBatchReader::Make(fs_, paths, schema_, reader_memory_));
+  std::shared_ptr<arrow::RecordBatch> batch;
+  ASSERT_STATUS_OK(reader->ReadNext(&batch));
+  ASSERT_NE(batch, nullptr);
+  ASSERT_STATUS_OK(reader->Close());
+}
+
 }  // namespace milvus_storage

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -163,6 +163,34 @@ TEST_F(PackedErrorStatusTest, MakeSucceedsOnValidFile) {
   ASSERT_STATUS_OK(reader->Close());
 }
 
+TEST_F(PackedErrorStatusTest, ColumnGroupTableSchemaMismatchIsDataFormatBroken) {
+  ColumnGroup group(0, {0});
+  ASSERT_STATUS_OK(group.AddRecordBatch(record_batch_));
+  // Second batch with a different schema: Table() must surface arrow's
+  // Invalid (-> DataFormatBroken/2024), not a wrapped generic storage error.
+  auto other_schema = arrow::schema({arrow::field("other", arrow::int8())});
+  arrow::Int8Builder builder;
+  ASSERT_STATUS_OK(builder.AppendValues({1, 2, 3}));
+  ASSERT_AND_ASSIGN(auto other_array, builder.Finish());
+  auto other_batch = arrow::RecordBatch::Make(other_schema, 3, {other_array});
+  ASSERT_STATUS_OK(group.AddRecordBatch(other_batch));
+
+  auto table_result = group.Table();
+  ASSERT_FALSE(table_result.ok());
+  EXPECT_TRUE(table_result.status().IsInvalid()) << table_result.status().ToString();
+  EXPECT_EQ(ToSegcoreError(table_result.status()).get_error_code(), milvus::DataFormatBroken)
+      << table_result.status().ToString();
+}
+
+TEST_F(PackedErrorStatusTest, ColumnGroupNullBatchConstructorYieldsEmptyGroup) {
+  // The batch-taking constructor has no status channel; a null batch must not
+  // crash (previous behavior dereferenced it) and yields an empty group.
+  ColumnGroup group(0, {0}, nullptr);
+  EXPECT_EQ(group.size(), 0);
+  EXPECT_EQ(group.GetTotalRows(), 0);
+  EXPECT_EQ(group.Schema(), nullptr);
+}
+
 // Integration regression for the fifth unguarded ValueOrDie
 // (file_reader.cpp: FileRowGroupReader::init, schema==nullptr branch): a
 // parquet file that passes the packed key-value metadata checks but whose


### PR DESCRIPTION
## Problem

Three related defects in the packed (V2 API) library-mode error paths — all instances of the "stringify-and-rethrow destroys the classification" / "abort instead of status" classes:

1. **`PackedRecordBatchReader`'s constructor throws.** On a failed open it does `throw std::runtime_error(status.ToString())` — the classification the lower layers carefully attached (`PackedInvalidArgs` / `PackedStorageIO` / `PackedMetadataCorrupted` details, the filesystem's ENOENT) is flattened into a string at the very last step. Direct-link consumers are forced to `try`-wrap construction and can only parse text.
2. **`ColumnGroup::Table()` does the same** (`throw std::runtime_error(result.status().message())` — even drops `ToString()`'s code prefix).
3. **A fifth unguarded `ValueOrDie` abort path** (missed by the #575 sweep, which fixed four): `file_reader.cpp` `FileRecordBatchReader::init`'s `schema==nullptr` branch calls `FieldIDList::Make(schema_).ValueOrDie()`. A parquet file whose stored schema lacks `PARQUET:field_id` metadata **aborts the whole process** — a data-dependent abort. The sibling `schema!=nullptr` branch already used `ARROW_ASSIGN_OR_RAISE`.

## Change

- **New `PackedRecordBatchReader::Make(...) → arrow::Result<std::unique_ptr<...>>`** — same parameters, reports open failures as a status with the classification intact. The throwing constructor is **kept** (documented as deprecated, "do not add new call sites") so direct-link consumers can migrate without a lockstep bump; it can be deleted once they have.
  - milvus side: the only constructor consumer is `segcore/packed_reader_c.cpp` (3 try-wrapped sites). Migrating those to `Make()` hands them a classified status — which is exactly the input the planned "wire the packed C-API through `ToSegcoreError`" follow-up needs (it currently hardcodes FileReadFailed/FileWriteFailed). Tracked for the milvus-side PR; not part of this change.
- **`ColumnGroup::Table()` returns `arrow::Result`**, wrapping the cause without destroying it. `ColumnGroup::Schema()` now reads the schema from the first batch (all batches in a group share one schema) instead of materializing the merged table. In-tree callers updated; there are no milvus-side callers of either.
- **`file_reader.cpp` abort path** → `ARROW_ASSIGN_OR_RAISE`, matching the sibling branch.

## Verification

- Full `make build` clean.
- New tests in `packed_error_status_test.cpp`:
  - `Make()` on a missing file → the wrap preserves the filesystem's not-found detail → `ToSegcoreError` = `ObjectNotExist` (the throwing constructor destroyed exactly this);
  - `Make()` with empty paths → `PackedInvalidArgs`;
  - `Make()` success path reads a batch.
- Packed/column-group suites: 27/29 passed — the single failure is the pre-existing upstream `ColumnGroupTest.MemoryUsageCalculation` (fails 3/3 in isolation on unmodified main; not touched here), one skipped.

Not covered (honest scope): the deprecated throwing constructor still exists (one `throw` site remains by design until milvus migrates); no fault-injection e2e.

Refs: milvus-io/milvus#50903. Follows the classification taxonomy of #574/#575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
