### PR TITLE
enhance: make parquet open_async non-blocking asynchronous

### DIFF
--- a/cpp/include/milvus-storage/common/arrow_util.h
+++ b/cpp/include/milvus-storage/common/arrow_util.h
@@ -32,11 +32,10 @@ namespace milvus_storage {
 
 namespace detail {
 
-// Converts an Arrow status into a ready error future for any
-// folly::SemiFuture<arrow::Result<T>> return type.
+// Converts an Arrow status into a ready future whose value carries the error.
 class FollyArrowErrorFuture {
   public:
-  // Store the setup failure until the enclosing function's Result<T> is inferred.
+  // Store the setup failure until the enclosing future's value type is inferred.
   explicit FollyArrowErrorFuture(arrow::Status status) : status_(std::move(status)) {}
 
   // Materialize a ready error future without requiring callers to spell T.
@@ -44,6 +43,8 @@ class FollyArrowErrorFuture {
   operator folly::SemiFuture<arrow::Result<T>>() && {
     return folly::makeSemiFuture(arrow::Result<T>(std::move(status_)));
   }
+
+  operator folly::SemiFuture<arrow::Status>() && { return folly::makeSemiFuture(std::move(status_)); }
 
   private:
   arrow::Status status_;
@@ -92,7 +93,7 @@ arrow::Result<std::string> GetEnvVar(const std::string& name);
 }  // namespace milvus_storage
 
 // Async counterparts of Arrow's early-return helpers. They keep validation and
-// setup failures on the same Result-bearing future path as backend failures.
+// setup failures on the same Arrow Status/Result future path as backend failures.
 #define FOLLY_ARROW_RETURN_NOT_OK(status_expr)                                                \
   do {                                                                                        \
     auto _folly_arrow_status = (status_expr);                                                 \

--- a/cpp/include/milvus-storage/filesystem/async_random_access_file.h
+++ b/cpp/include/milvus-storage/filesystem/async_random_access_file.h
@@ -20,11 +20,12 @@
 
 namespace milvus_storage {
 
-class NonBlockingReadAtFile {
+class NonBlockingRandomAccessFile {
   public:
-  virtual ~NonBlockingReadAtFile() = default;
+  virtual ~NonBlockingRandomAccessFile() = default;
 
   virtual arrow::Future<int64_t> ReadAtAsyncInto(int64_t position, int64_t nbytes, uint8_t* out) = 0;
+  virtual arrow::Future<int64_t> GetSizeAsync() = 0;
 };
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -121,10 +121,18 @@ class ParquetFormatReader final : public FormatReader, public std::enable_shared
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
   private:
+  // Read the selected row groups into one Arrow table using the current
+  // Parquet leaf-column projection.
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::Table>> get_chunks_internal(
       const std::vector<int>& rg_indices_in_file);
-  [[nodiscard]] arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
-      const std::shared_ptr<::parquet::FileMetaData>& metadata);
+
+  // Validate a completed file reader, then publish its schema, row-group, and
+  // projection state only after all derived values are ready. All failures are
+  // returned as Status.
+  [[nodiscard]] arrow::Status finish_open(std::shared_ptr<::parquet::arrow::FileReader> file_reader);
+
+  // Resolve top-level column names to Parquet leaf indices and commit the
+  // projection. An empty list selects every leaf column.
   [[nodiscard]] arrow::Status set_needed_columns(const std::vector<std::string>& needed_columns);
 
   ParquetFormatReader(const ParquetFormatReader& other, std::shared_ptr<::parquet::arrow::FileReader> file_reader);
@@ -138,7 +146,7 @@ class ParquetFormatReader final : public FormatReader, public std::enable_shared
   uint64_t file_size_ = 0;    ///< Pre-known file size to skip S3 HEAD requests
   uint64_t footer_size_ = 0;  ///< Pre-known footer size for single-IO footer read
 
-  // init after open()
+  // init after open()/open_async()
   // Parquet ReadRowGroup expects leaf-column indices, not top-level Arrow field indices.
   std::vector<int> projected_leaf_column_indices_;
   std::vector<RowGroupInfo> row_group_infos_;

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -372,7 +372,7 @@ LoonFFIResult loon_filesystem_reader_supports_async(FileSystemReaderHandle handl
     }
 
     auto input_file = reinterpret_cast<RandomAccessFileWrapper*>(handle)->get();
-    *out_supported = dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get()) != nullptr;
+    *out_supported = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(input_file.get()) != nullptr;
 
     RETURN_SUCCESS();
   } catch (const std::exception& e) {
@@ -395,7 +395,7 @@ LoonFFIResult loon_filesystem_reader_readat_async(FileSystemReaderHandle handle,
     }
 
     auto input_file = reinterpret_cast<RandomAccessFileWrapper*>(handle)->get();
-    auto* async_file = dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get());
+    auto* async_file = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(input_file.get());
     if (!async_file) {
       RETURN_ERROR(LOON_NOT_SUPPORT, "Reader does not support async read-at");
     }

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -723,7 +723,7 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
 };
 
 #ifdef WITH_CRT
-class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonBlockingReadAtFile {
+class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonBlockingRandomAccessFile {
   protected:
   struct ReadState {
     explicit ReadState(int64_t size) : content_length(size) {}
@@ -796,6 +796,59 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     ARROW_RETURN_NOT_OK(CheckClosed());
     ARROW_RETURN_NOT_OK(EnsureHeadObject(/*need_metadata=*/false));
     return GetCachedContentLength();
+  }
+
+  Future<int64_t> GetSizeAsync() override {
+    auto status = CheckClosed();
+    if (!status.ok()) {
+      return FailedReadFuture(status);
+    }
+
+    const auto content_length = GetCachedContentLength();
+    if (content_length != kNoSize) {
+      return Future<int64_t>::MakeFinished(content_length);
+    }
+
+    auto maybe_client_lease = holder_->Acquire();
+    if (!maybe_client_lease.ok()) {
+      return FailedReadFuture(maybe_client_lease.status());
+    }
+
+    auto ctx = std::make_shared<AsyncHeadContext>();
+    ctx->future = Future<int64_t>::Make();
+    ctx->client_lease = std::move(maybe_client_lease).ValueOrDie();
+    ctx->read_state = read_state_;
+    ctx->path = path_;
+    ctx->request.SetBucket(ToAwsString(path_.bucket));
+    ctx->request.SetKey(ToAwsString(path_.key));
+
+    ctx->client_lease->HeadObjectAsync(
+        ctx->request, [ctx](const Aws::S3Crt::S3CrtClient*, const S3CrtModel::HeadObjectRequest&,
+                            const S3CrtModel::HeadObjectOutcome& outcome,
+                            const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) mutable {
+          if (!outcome.IsSuccess()) {
+            if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
+              ctx->future.MarkFinished(arrow::Result<int64_t>(PathNotFound(ctx->path)));
+              return;
+            }
+            ctx->future.MarkFinished(arrow::Result<int64_t>(
+                ErrorToStatus(std::forward_as_tuple("When reading information for key '", ctx->path.key,
+                                                    "' in bucket '", ctx->path.bucket, "': "),
+                              "HeadObject", outcome.GetError())));
+            return;
+          }
+
+          const auto content_length = outcome.GetResult().GetContentLength();
+          if (content_length < 0) {
+            ctx->future.MarkFinished(
+                arrow::Result<int64_t>(arrow::Status::IOError("HeadObject returned a negative Content-Length")));
+            return;
+          }
+
+          ctx->read_state->content_length.store(content_length, std::memory_order_release);
+          ctx->future.MarkFinished(content_length);
+        });
+    return ctx->future;
   }
 
   arrow::Status Seek(int64_t position) override {
@@ -1048,6 +1101,16 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     std::shared_ptr<FilesystemMetrics> metrics;
     int64_t position = 0;
     int64_t nbytes = 0;
+  };
+
+  struct AsyncHeadContext {
+    // Keep the same non-owning CRT client lifetime model as AsyncReadContext.
+    // The path and read state remain valid without owning the file or holder.
+    Future<int64_t> future;
+    S3CrtClientLease client_lease;
+    S3CrtModel::HeadObjectRequest request;
+    std::shared_ptr<ReadState> read_state;
+    S3Path path;
   };
 
   std::shared_ptr<S3CrtClientHolder> holder_;

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -15,8 +15,10 @@
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 
 #include <cstring>
+#include <exception>
 #include <limits>
 #include <memory>
+#include <new>
 #include <numeric>
 #include <optional>
 #include <unordered_map>
@@ -35,7 +37,9 @@
 #include <arrow/type.h>
 #include <arrow/util/async_generator.h>
 #include <arrow/util/key_value_metadata.h>
+#include <arrow/util/ubsan.h>
 #include <folly/futures/Promise.h>
+#include <parquet/file_reader.h>
 #include <parquet/arrow/schema.h>
 #include <parquet/metadata.h>
 #include <parquet/type_fwd.h>
@@ -51,35 +55,139 @@
 
 namespace milvus_storage::parquet {
 
+static constexpr int64_t kParquetFooterTrailerSize = 8;
+static constexpr int64_t kParquetMagicSize = 4;
+static constexpr char kParquetMagic[] = "PAR1";
+
+static arrow::Result<std::vector<RowGroupInfo>> try_build_row_group_infos(
+    const std::shared_ptr<::parquet::FileMetaData>& metadata);
+static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_metadata(
+    const std::shared_ptr<::parquet::FileMetaData>& metadata,
+    const arrow::Schema& file_schema,
+    const std::string& path);
+static ::parquet::ReaderProperties make_reader_properties(
+    const std::function<std::string(const std::string&)>& key_retriever);
+static std::shared_ptr<arrow::Buffer> try_read_footer_buffer(const std::shared_ptr<arrow::io::RandomAccessFile>& file,
+                                                             uint64_t file_size,
+                                                             uint64_t footer_size);
+static std::shared_ptr<::parquet::FileMetaData> try_parse_footer_metadata(
+    const std::shared_ptr<arrow::Buffer>& suffix, const ::parquet::ReaderProperties& reader_props);
+static arrow::Result<::parquet::ArrowReaderProperties> make_arrow_reader_properties(
+    const milvus_storage::api::Properties& properties);
+static arrow::Result<std::shared_ptr<::parquet::arrow::FileReader>> create_parquet_file_reader(
+    const std::shared_ptr<arrow::fs::FileSystem>& fs,
+    const std::string& file_path,
+    const milvus_storage::api::Properties& properties,
+    const std::function<std::string(const std::string&)>& key_retriever,
+    std::shared_ptr<::parquet::FileMetaData> metadata = nullptr,
+    uint64_t file_size = 0,
+    uint64_t footer_size = 0);
+static arrow::Future<std::shared_ptr<arrow::Buffer>> read_file_async_and_transfer(
+    const std::shared_ptr<arrow::io::RandomAccessFile>& file,
+    int64_t position,
+    int64_t nbytes,
+    const std::shared_ptr<arrow::internal::Executor>& executor);
+static std::optional<uint32_t> try_parse_footer_length(const std::shared_ptr<arrow::Buffer>& buffer,
+                                                       const int64_t expected_read_size,
+                                                       const int64_t file_size);
+static std::shared_ptr<::parquet::FileMetaData> try_parse_plain_footer_metadata(
+    const std::shared_ptr<arrow::Buffer>& metadata_buffer,
+    const uint32_t metadata_length,
+    const ::parquet::ReaderProperties& reader_props);
+static int get_leaf_column_count(const std::shared_ptr<arrow::DataType>& type);
 static std::vector<int> get_leaf_column_offsets_by_field(const arrow::Schema& file_schema);
+static arrow::Result<std::vector<int>> get_leaf_column_indices(const arrow::Schema& file_schema,
+                                                               const std::vector<std::string>& needed_columns,
+                                                               const std::string& path);
+
+template <typename ArrowFuture, typename T = typename ArrowFuture::SyncType>
+static folly::SemiFuture<T> bridge_arrow_future(
+    ArrowFuture arrow_future, std::shared_ptr<arrow::internal::Executor> executor_keep_alive = nullptr) {
+  // Arrow defines SyncType as Status for Future<> and Result<V> for Future<V>.
+  // The optional executor is retained only for callers whose Arrow work uses
+  // a short-lived adapter; it does not affect continuation scheduling here.
+  folly::Promise<T> promise;
+  auto semi_future = promise.getSemiFuture();
+  arrow_future.AddCallback(
+      [promise = std::move(promise), executor_keep_alive = std::move(executor_keep_alive)](const T& result) mutable {
+        (void)executor_keep_alive;
+        promise.setValue(result);
+      });
+  return semi_future;
+}
+
+// Arrow 17's TransferAlways drops Executor::Spawn failures after a DCHECK.
+// Keep provider callbacks limited to enqueueing and propagate rejection through
+// the transferred Future instead of leaving the open chain without a producer.
+template <typename ArrowFuture, typename T = typename ArrowFuture::SyncType>
+static ArrowFuture transfer_arrow_future(ArrowFuture arrow_future,
+                                         const std::shared_ptr<arrow::internal::Executor>& executor) {
+  auto transferred = ArrowFuture::Make();
+  try {
+    arrow_future.AddCallback([transferred, executor](const T& result) mutable {
+      arrow::Status spawn_status;
+      try {
+        spawn_status =
+            executor->Spawn([transferred, result]() mutable { transferred.MarkFinished(std::move(result)); });
+      } catch (const std::bad_alloc& e) {
+        transferred.MarkFinished(arrow::Status::OutOfMemory("Failed to transfer Arrow future: ", e.what()));
+        return;
+      } catch (const std::exception& e) {
+        transferred.MarkFinished(arrow::Status::UnknownError("Failed to transfer Arrow future: ", e.what()));
+        return;
+      } catch (...) {
+        transferred.MarkFinished(arrow::Status::UnknownError("Unknown exception while transferring Arrow future"));
+        return;
+      }
+      if (!spawn_status.ok()) {
+        transferred.MarkFinished(std::move(spawn_status));
+      }
+    });
+  } catch (const std::bad_alloc& e) {
+    transferred.MarkFinished(arrow::Status::OutOfMemory("Failed to register Arrow future transfer: ", e.what()));
+  } catch (const std::exception& e) {
+    transferred.MarkFinished(arrow::Status::UnknownError("Failed to register Arrow future transfer: ", e.what()));
+  } catch (...) {
+    transferred.MarkFinished(arrow::Status::UnknownError("Unknown exception while registering Arrow future transfer"));
+  }
+  return transferred;
+}
 
 static arrow::Result<std::vector<RowGroupInfo>> try_build_row_group_infos(
     const std::shared_ptr<::parquet::FileMetaData>& metadata) {
-  std::vector<RowGroupInfo> row_group_infos;
-  auto key_value_metadata = metadata->key_value_metadata();
-  if (!key_value_metadata) {
+  try {
+    std::vector<RowGroupInfo> row_group_infos;
+    auto key_value_metadata = metadata->key_value_metadata();
+    if (!key_value_metadata) {
+      return row_group_infos;
+    }
+
+    auto row_group_meta_result = key_value_metadata->Get(ROW_GROUP_META_KEY);
+    if (!row_group_meta_result.ok()) {
+      return row_group_infos;
+    }
+
+    auto row_group_metadatas = RowGroupMetadataVector::Deserialize(row_group_meta_result.ValueOrDie());
+    row_group_infos.reserve(row_group_metadatas.size());
+    size_t offset = 0;
+    for (size_t i = 0; i < row_group_metadatas.size(); ++i) {
+      auto row_group_metadata = row_group_metadatas.Get(i);
+      row_group_infos.emplace_back(RowGroupInfo{
+          .start_offset = offset,
+          .end_offset = offset + row_group_metadata.row_num(),
+          .memory_size = row_group_metadata.memory_size(),
+      });
+      offset += row_group_metadata.row_num();
+    }
+
     return row_group_infos;
+  } catch (const std::bad_alloc& e) {
+    return arrow::Status::OutOfMemory("Failed to build parquet row-group metadata: ", e.what());
+  } catch (const std::exception& e) {
+    return arrow::Status::Invalid("Invalid parquet row-group metadata: ", e.what());
+  } catch (...) {
+    return arrow::Status::Invalid("Unknown exception while parsing parquet row-group metadata");
   }
-
-  auto row_group_meta_result = key_value_metadata->Get(ROW_GROUP_META_KEY);
-  if (!row_group_meta_result.ok()) {
-    return row_group_infos;
-  }
-
-  auto row_group_metadatas = RowGroupMetadataVector::Deserialize(row_group_meta_result.ValueOrDie());
-  row_group_infos.reserve(row_group_metadatas.size());
-  size_t offset = 0;
-  for (size_t i = 0; i < row_group_metadatas.size(); ++i) {
-    auto row_group_metadata = row_group_metadatas.Get(i);
-    row_group_infos.emplace_back(RowGroupInfo{
-        .start_offset = offset,
-        .end_offset = offset + row_group_metadata.row_num(),
-        .memory_size = row_group_metadata.memory_size(),
-    });
-    offset += row_group_metadata.row_num();
-  }
-
-  return row_group_infos;
 }
 
 static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_metadata(
@@ -87,7 +195,6 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_meta
   // Keep the existing row-group memory estimate as the total-size anchor: prefer
   // Milvus private metadata when available, otherwise fall back to the Parquet
   // footer's total byte size.
-  assert(metadata);
   if (!metadata) {
     return arrow::Status::Invalid(fmt::format("Failed to get parquet file metadata for file: {}", path));
   }
@@ -119,11 +226,6 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_meta
         fmt::format("Parquet row-group metadata count does not match the footer. [path={}]", path));
   }
   return row_group_infos;
-}
-
-arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::create_row_group_infos(
-    const std::shared_ptr<::parquet::FileMetaData>& metadata) {
-  return create_row_group_infos_from_metadata(metadata, path_);
 }
 
 ParquetFormatReader::ParquetFormatReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
@@ -161,15 +263,11 @@ static ::parquet::ReaderProperties make_reader_properties(
 static std::shared_ptr<arrow::Buffer> try_read_footer_buffer(const std::shared_ptr<arrow::io::RandomAccessFile>& file,
                                                              uint64_t file_size,
                                                              uint64_t footer_size) {
-#define PARQUET_MAGIC "PAR1"
-#define PARQUET_MAGIC_SIZE 4
-#define PARQUET_FOOTER_TRAILER_SIZE 8  // footer_length(4B) + magic(4B)
-
   const auto offset = static_cast<int64_t>(file_size - footer_size);
   const auto size = static_cast<int64_t>(footer_size);
   std::shared_ptr<arrow::Buffer> suffix;
 #ifdef WITH_CRT
-  if (auto* async_file = dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(file.get())) {
+  if (auto* async_file = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(file.get())) {
     auto maybe_buf = arrow::AllocateResizableBuffer(size, file->io_context().pool());
     if (!maybe_buf.ok()) {
       return nullptr;
@@ -193,26 +291,21 @@ static std::shared_ptr<arrow::Buffer> try_read_footer_buffer(const std::shared_p
     }
     suffix = *suffix_result;
   }
-  if (!suffix || static_cast<uint64_t>(suffix->size()) < PARQUET_FOOTER_TRAILER_SIZE) {
+  if (!suffix || suffix->size() < kParquetFooterTrailerSize) {
     return nullptr;
   }
   const uint8_t* data = suffix->data();
 
   // Parse footer_length from the 4 bytes before the magic.
-  uint32_t footer_length = 0;
-  std::memcpy(&footer_length, data + suffix->size() - PARQUET_FOOTER_TRAILER_SIZE, sizeof(footer_length));
+  const auto footer_length = arrow::util::SafeLoadAs<uint32_t>(data + suffix->size() - kParquetFooterTrailerSize);
 
   // Validate magic bytes and ensure the suffix covers the entire Thrift metadata.
-  if (std::memcmp(data + suffix->size() - PARQUET_MAGIC_SIZE, PARQUET_MAGIC, PARQUET_MAGIC_SIZE) != 0 ||
-      footer_length + PARQUET_FOOTER_TRAILER_SIZE > static_cast<uint64_t>(suffix->size())) {
+  if (std::memcmp(data + suffix->size() - kParquetMagicSize, kParquetMagic, kParquetMagicSize) != 0 ||
+      static_cast<int64_t>(footer_length) > suffix->size() - kParquetFooterTrailerSize) {
     return nullptr;
   }
 
   return suffix;
-
-#undef PARQUET_FOOTER_TRAILER_SIZE
-#undef PARQUET_MAGIC_SIZE
-#undef PARQUET_MAGIC
 }
 
 static std::shared_ptr<::parquet::FileMetaData> try_parse_footer_metadata(
@@ -221,26 +314,22 @@ static std::shared_ptr<::parquet::FileMetaData> try_parse_footer_metadata(
     return nullptr;
   }
 
-#define PARQUET_FOOTER_TRAILER_SIZE 8  // footer_length(4B) + magic(4B)
-  if (static_cast<uint64_t>(suffix->size()) < PARQUET_FOOTER_TRAILER_SIZE) {
+  if (suffix->size() < kParquetFooterTrailerSize) {
     return nullptr;
   }
   const uint8_t* data = suffix->data();
-  uint32_t footer_length = 0;
-  std::memcpy(&footer_length, data + suffix->size() - PARQUET_FOOTER_TRAILER_SIZE, sizeof(footer_length));
-  if (footer_length + PARQUET_FOOTER_TRAILER_SIZE > static_cast<uint64_t>(suffix->size())) {
+  auto footer_length = arrow::util::SafeLoadAs<uint32_t>(data + suffix->size() - kParquetFooterTrailerSize);
+  if (static_cast<int64_t>(footer_length) > suffix->size() - kParquetFooterTrailerSize) {
     return nullptr;
   }
 
   // Deserialize the Thrift FileMetaData from the suffix buffer.
-  const uint8_t* thrift_data = data + suffix->size() - PARQUET_FOOTER_TRAILER_SIZE - footer_length;
+  const uint8_t* thrift_data = data + suffix->size() - kParquetFooterTrailerSize - footer_length;
   try {
     return ::parquet::FileMetaData::Make(thrift_data, &footer_length, reader_props);
   } catch (...) {
     return nullptr;
   }
-
-#undef PARQUET_FOOTER_TRAILER_SIZE
 }
 
 static arrow::Result<std::shared_ptr<::parquet::arrow::FileReader>> create_parquet_file_reader(
@@ -248,41 +337,20 @@ static arrow::Result<std::shared_ptr<::parquet::arrow::FileReader>> create_parqu
     const std::string& file_path,
     const milvus_storage::api::Properties& properties,
     const std::function<std::string(const std::string&)>& key_retriever,
-    std::shared_ptr<::parquet::FileMetaData> metadata = nullptr,
-    uint64_t file_size = 0,
-    uint64_t footer_size = 0) {
+    std::shared_ptr<::parquet::FileMetaData> metadata,
+    uint64_t file_size,
+    uint64_t footer_size) {
   std::unique_ptr<::parquet::arrow::FileReader> result;
 
   ::parquet::arrow::FileReaderBuilder builder;
   auto reader_props = make_reader_properties(key_retriever);
-  ::parquet::ArrowReaderProperties arrow_reader_props = ::parquet::default_arrow_reader_properties();
+  ARROW_ASSIGN_OR_RAISE(auto arrow_reader_props, make_arrow_reader_properties(properties));
   if (key_retriever) {
     // Encrypted Parquet needs the parquet reader to initialize decryptors from
     // its own footer read path. Passing caller-supplied FileMetaData can leave
     // page decryptors incomplete.
     metadata = nullptr;
   }
-
-  arrow_reader_props.set_batch_size(INT64_MAX);
-  arrow_reader_props.set_pre_buffer(true);
-  auto cache_options = arrow_reader_props.cache_options();
-  auto hole_size_limit =
-      milvus_storage::api::GetValueNoError<int64_t>(properties, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT);
-  auto range_size_limit =
-      milvus_storage::api::GetValueNoError<int64_t>(properties, PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT);
-  if (hole_size_limit > 0) {
-    cache_options.hole_size_limit = hole_size_limit;
-  }
-  if (range_size_limit > 0) {
-    cache_options.range_size_limit = range_size_limit;
-  }
-  if (cache_options.range_size_limit <= cache_options.hole_size_limit) {
-    return arrow::Status::Invalid(fmt::format(
-        "{} must be greater than {} for Arrow read-range coalescing. [range_size_limit={}, hole_size_limit={}]",
-        PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT,
-        cache_options.range_size_limit, cache_options.hole_size_limit));
-  }
-  arrow_reader_props.set_cache_options(cache_options);
 
   std::shared_ptr<arrow::io::RandomAccessFile> parquet_file;
   if (file_size > 0) {
@@ -303,6 +371,32 @@ static arrow::Result<std::shared_ptr<::parquet::arrow::FileReader>> create_parqu
   ARROW_RETURN_NOT_OK(
       builder.memory_pool(arrow::default_memory_pool())->properties(arrow_reader_props)->Build(&result));
   return std::shared_ptr<::parquet::arrow::FileReader>(std::move(result));
+}
+
+static arrow::Result<::parquet::ArrowReaderProperties> make_arrow_reader_properties(
+    const milvus_storage::api::Properties& properties) {
+  auto arrow_reader_props = ::parquet::default_arrow_reader_properties();
+  arrow_reader_props.set_batch_size(INT64_MAX);
+  arrow_reader_props.set_pre_buffer(true);
+  auto cache_options = arrow_reader_props.cache_options();
+  auto hole_size_limit =
+      milvus_storage::api::GetValueNoError<int64_t>(properties, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT);
+  auto range_size_limit =
+      milvus_storage::api::GetValueNoError<int64_t>(properties, PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT);
+  if (hole_size_limit > 0) {
+    cache_options.hole_size_limit = hole_size_limit;
+  }
+  if (range_size_limit > 0) {
+    cache_options.range_size_limit = range_size_limit;
+  }
+  if (cache_options.range_size_limit <= cache_options.hole_size_limit) {
+    return arrow::Status::Invalid(fmt::format(
+        "{} must be greater than {} for Arrow read-range coalescing. [range_size_limit={}, hole_size_limit={}]",
+        PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT,
+        cache_options.range_size_limit, cache_options.hole_size_limit));
+  }
+  arrow_reader_props.set_cache_options(cache_options);
+  return arrow_reader_props;
 }
 
 std::string ParquetFormatReader::MetaTrait::cache_key(const api::ColumnGroupFile& file) {
@@ -432,6 +526,9 @@ ParquetFormatReader::MetaTrait::create_from_metadata_async(MetadataPtr metadata,
                                                            const std::shared_ptr<arrow::Schema>& read_schema,
                                                            const std::vector<std::string>& needed_columns,
                                                            const std::string& predicate) {
+  // A non-null key retriever identifies encrypted Parquet in this codebase. Encrypted
+  // metadata reconstruction intentionally uses this deferred synchronous fallback;
+  // the non-blocking async-open guarantee applies only to unencrypted files.
   return folly::makeSemiFuture().deferValue(
       [metadata = std::move(metadata), file, read_schema, needed_columns,
        predicate](folly::Unit) -> arrow::Result<std::shared_ptr<ParquetFormatReader>> {
@@ -445,24 +542,471 @@ arrow::Status ParquetFormatReader::open() {
   // create file reader
   ARROW_ASSIGN_OR_RAISE(auto file_reader, create_parquet_file_reader(fs_, path_, properties_, key_retriever_,
                                                                      nullptr /* metadata */, file_size_, footer_size_));
-  file_reader_ = std::shared_ptr<::parquet::arrow::FileReader>(std::move(file_reader));
-
-  // get the schema and create needed column indices
-  std::shared_ptr<arrow::Schema> file_schema;
-  ARROW_RETURN_NOT_OK(file_reader_->GetSchema(&file_schema));
-  schema_ = file_schema;
-
-  // create row group infos
-  assert(file_reader_->parquet_reader() && "arrow logical fault");
-  ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(file_reader_->parquet_reader()->metadata()));
-
-  return set_needed_columns(needed_columns_);
+  return finish_open(std::move(file_reader));
 }
 
+arrow::Status ParquetFormatReader::finish_open(std::shared_ptr<::parquet::arrow::FileReader> file_reader) {
+  try {
+    if (!file_reader) {
+      return arrow::Status::Invalid(fmt::format("Invalid parquet file reader. [path={}]", path_));
+    }
+    const auto* const parquet_reader = file_reader->parquet_reader();
+    if (!parquet_reader) {
+      return arrow::Status::Invalid(fmt::format("Invalid parquet file reader. [path={}]", path_));
+    }
+
+    // Prepare every derived value locally so a failure leaves the existing
+    // reader state unchanged.
+    std::shared_ptr<arrow::Schema> file_schema;
+    ARROW_RETURN_NOT_OK(file_reader->GetSchema(&file_schema));
+    if (!file_schema) {
+      return arrow::Status::Invalid(fmt::format("Parquet file schema is null. [path={}]", path_));
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto row_group_infos,
+                          create_row_group_infos_from_metadata(parquet_reader->metadata(), path_));
+    ARROW_ASSIGN_OR_RAISE(auto projected_leaf_column_indices,
+                          get_leaf_column_indices(*file_schema, needed_columns_, path_));
+
+    // Commit only after schema, row-group metadata, and projection have all
+    // been validated successfully. These moves do not allocate.
+    file_reader_ = std::move(file_reader);
+    schema_ = std::move(file_schema);
+    row_group_infos_ = std::move(row_group_infos);
+    projected_leaf_column_indices_ = std::move(projected_leaf_column_indices);
+    return arrow::Status::OK();
+  } catch (const std::bad_alloc& e) {
+    return arrow::Status::OutOfMemory(
+        fmt::format("Failed to finalize parquet reader. [path={}, error={}]", path_, e.what()));
+  } catch (const std::exception& e) {
+    return arrow::Status::UnknownError(
+        fmt::format("Exception while finalizing parquet reader. [path={}, error={}]", path_, e.what()));
+  } catch (...) {
+    return arrow::Status::UnknownError(
+        fmt::format("Unknown exception while finalizing parquet reader. [path={}]", path_));
+  }
+}
+
+static arrow::Future<std::shared_ptr<arrow::Buffer>> read_file_async_and_transfer(
+    const std::shared_ptr<arrow::io::RandomAccessFile>& file,
+    const int64_t position,
+    const int64_t nbytes,
+    const std::shared_ptr<arrow::internal::Executor>& executor) {
+  if (position < 0 || nbytes < 0) {
+    return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(
+        arrow::Status::Invalid("Invalid async read range: position=", position, ", size=", nbytes));
+  }
+
+  if (auto* async_file = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(file.get())) {
+    auto maybe_buffer = arrow::AllocateResizableBuffer(nbytes, file->io_context().pool());
+    if (!maybe_buffer.ok()) {
+      return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(maybe_buffer.status());
+    }
+    auto buffer = std::move(maybe_buffer).ValueUnsafe();
+    return transfer_arrow_future(async_file->ReadAtAsyncInto(position, nbytes, buffer->mutable_data()), executor)
+        .Then([buffer = std::move(buffer),
+               nbytes](const int64_t bytes_read) mutable -> arrow::Result<std::shared_ptr<arrow::Buffer>> {
+          if (bytes_read < 0 || bytes_read > nbytes) {
+            return arrow::Status::IOError("Invalid async read result: requested ", nbytes, " bytes but received ",
+                                          bytes_read);
+          }
+          ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read));
+          return std::shared_ptr<arrow::Buffer>(std::move(buffer));
+        });
+  }
+
+  return transfer_arrow_future(file->ReadAsync(file->io_context(), position, nbytes), executor);
+}
+
+// During open, route Parquet's ReadAsync through the provider-native async
+// interface, then transfer completion to the caller's Folly executor before
+// Parquet attaches its CPU continuations. After open, reads are delegated
+// unchanged to the underlying file.
+class ParquetOpenFile final : public arrow::io::RandomAccessFile {
+  public:
+  ParquetOpenFile(std::shared_ptr<arrow::io::RandomAccessFile> file,
+                  std::shared_ptr<arrow::internal::Executor> executor,
+                  const int64_t file_size)
+      : file_(std::move(file)), executor_(std::move(executor)), file_size_(file_size) {}
+
+  void FinishOpen() { executor_.reset(); }
+
+  arrow::Status Close() override { return file_->Close(); }
+  arrow::Status Abort() override { return file_->Abort(); }
+  arrow::Result<int64_t> Tell() const override { return file_->Tell(); }
+  bool closed() const override { return file_->closed(); }
+  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override { return file_->Read(nbytes, out); }
+  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override { return file_->Read(nbytes); }
+  const arrow::io::IOContext& io_context() const override { return file_->io_context(); }
+  arrow::Result<std::string_view> Peek(int64_t nbytes) override { return file_->Peek(nbytes); }
+  bool supports_zero_copy() const override { return file_->supports_zero_copy(); }
+  arrow::Result<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadata() override {
+    return file_->ReadMetadata();
+  }
+  arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadataAsync(
+      const arrow::io::IOContext& io_context) override {
+    return file_->ReadMetadataAsync(io_context);
+  }
+  arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
+  arrow::Result<int64_t> GetSize() override { return file_size_; }
+  arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    return file_->ReadAt(position, nbytes, out);
+  }
+  arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
+    return file_->ReadAt(position, nbytes);
+  }
+  arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
+                                                          int64_t position,
+                                                          int64_t nbytes) override {
+    if (executor_) {
+      return read_file_async_and_transfer(file_, position, nbytes, executor_);
+    }
+    return file_->ReadAsync(io_context, position, nbytes);
+  }
+  std::vector<arrow::Future<std::shared_ptr<arrow::Buffer>>> ReadManyAsync(
+      const arrow::io::IOContext& io_context, const std::vector<arrow::io::ReadRange>& ranges) override {
+    if (executor_) {
+      std::vector<arrow::Future<std::shared_ptr<arrow::Buffer>>> futures;
+      futures.reserve(ranges.size());
+      for (const auto& range : ranges) {
+        futures.emplace_back(ReadAsync(io_context, range.offset, range.length));
+      }
+      return futures;
+    }
+    return file_->ReadManyAsync(io_context, ranges);
+  }
+  arrow::Status WillNeed(const std::vector<arrow::io::ReadRange>& ranges) override { return file_->WillNeed(ranges); }
+
+  private:
+  std::shared_ptr<arrow::io::RandomAccessFile> file_;
+  std::shared_ptr<arrow::internal::Executor> executor_;
+  int64_t file_size_;
+};
+
+static std::optional<uint32_t> try_parse_footer_length(const std::shared_ptr<arrow::Buffer>& buffer,
+                                                       const int64_t expected_read_size,
+                                                       const int64_t file_size) {
+  if (!buffer || buffer->size() != expected_read_size || expected_read_size < kParquetFooterTrailerSize) {
+    return std::nullopt;
+  }
+
+  const auto* trailer = buffer->data() + buffer->size() - kParquetFooterTrailerSize;
+  const auto* magic = trailer + sizeof(uint32_t);
+  if (std::memcmp(magic, kParquetMagic, kParquetMagicSize) != 0) {
+    return std::nullopt;
+  }
+
+  const auto metadata_length = arrow::util::SafeLoadAs<uint32_t>(trailer);
+  if (file_size < kParquetFooterTrailerSize ||
+      static_cast<uint64_t>(metadata_length) > static_cast<uint64_t>(file_size - kParquetFooterTrailerSize)) {
+    return std::nullopt;
+  }
+  return metadata_length;
+}
+
+static std::shared_ptr<::parquet::FileMetaData> try_parse_plain_footer_metadata(
+    const std::shared_ptr<arrow::Buffer>& metadata_buffer,
+    const uint32_t metadata_length,
+    const ::parquet::ReaderProperties& reader_props) {
+  if (!metadata_buffer || metadata_buffer->size() != metadata_length) {
+    return nullptr;
+  }
+
+  try {
+    auto decoded_length = metadata_length;
+    return ::parquet::FileMetaData::Make(metadata_buffer->data(), &decoded_length, reader_props);
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+// footer hint usable and unencrypted?
+//   +-- no  --> nullptr (native fallback)
+//   +-- yes --> read suffix --> valid trailer?
+//                                  +-- no  --> nullptr
+//                                  +-- yes --> full metadata?
+//                                                 +-- yes --> parse suffix
+//                                                 +-- no  --> read missing range --> parse
+// This is an optimization-only path: I/O errors fail the Future, while an
+// unusable hint or undecodable metadata returns nullptr to request fallback.
+static arrow::Future<std::shared_ptr<::parquet::FileMetaData>> read_footer_async(
+    const std::shared_ptr<arrow::io::RandomAccessFile>& file,
+    const int64_t file_size,
+    const int64_t footer_size,
+    ::parquet::ReaderProperties reader_properties,
+    const std::shared_ptr<arrow::internal::Executor>& executor) {
+  using MetadataFuture = arrow::Future<std::shared_ptr<::parquet::FileMetaData>>;
+
+  // footer_size is an optimization hint, not part of Parquet correctness.
+  // Encrypted files and unusable hints are delegated to Parquet's native
+  // open path by returning null metadata.
+  if (reader_properties.file_decryption_properties() || footer_size < kParquetFooterTrailerSize ||
+      footer_size > file_size) {
+    return MetadataFuture::MakeFinished(nullptr);
+  }
+
+  // Read exactly the hinted suffix. A correct writer-provided hint normally
+  // contains both the metadata and the 8-byte Parquet trailer in one request.
+  auto footer_future = read_file_async_and_transfer(file, file_size - footer_size, footer_size, executor);
+  return footer_future.Then([file, file_size, footer_size, reader_properties = std::move(reader_properties),
+                             executor](const std::shared_ptr<arrow::Buffer>& footer_buffer) mutable -> MetadataFuture {
+    auto maybe_metadata_length = try_parse_footer_length(footer_buffer, footer_size, file_size);
+    if (!maybe_metadata_length) {
+      // The hint is stale, the file is encrypted, or this is not a valid
+      // plaintext Parquet trailer. Let Parquet perform its native validation.
+      return MetadataFuture::MakeFinished(nullptr);
+    }
+
+    const auto metadata_length = *maybe_metadata_length;
+    const auto required_footer_size = static_cast<int64_t>(metadata_length) + kParquetFooterTrailerSize;
+    if (required_footer_size <= footer_buffer->size()) {
+      // The hinted suffix already contains the full metadata. Decode
+      // directly and preserve the single-GET optimization.
+      auto metadata_buffer =
+          arrow::SliceBuffer(footer_buffer, footer_buffer->size() - required_footer_size, metadata_length);
+      return MetadataFuture::MakeFinished(
+          try_parse_plain_footer_metadata(metadata_buffer, metadata_length, reader_properties));
+    }
+
+    // The hint contained the trailer but not the complete metadata.
+    // Read only the missing metadata range; the trailer need not be
+    // fetched again.
+    const auto metadata_offset = file_size - kParquetFooterTrailerSize - static_cast<int64_t>(metadata_length);
+    auto metadata_future = read_file_async_and_transfer(file, metadata_offset, metadata_length, executor);
+    return metadata_future.Then([reader_properties = std::move(reader_properties),
+                                 metadata_length](const std::shared_ptr<arrow::Buffer>& metadata_buffer) {
+      return try_parse_plain_footer_metadata(metadata_buffer, metadata_length, reader_properties);
+    });
+  });
+}
+
+// read_footer_async --> metadata / nullptr
+//                              |
+//                    metadata && known size?
+//                       |                  |
+//                      yes                 no
+//                       |                  |
+//                 source = file    source = ParquetOpenFile
+//                       +---------+--------+
+//                                 v
+//                  ParquetFileReader::OpenAsync
+//                                 |
+//                     move low-level reader
+//                                 v
+//                  parquet::arrow::FileReader::Make
+// The function owns every value needed by its callbacks and never accesses or
+// mutates ParquetFormatReader state.
+static arrow::Future<std::shared_ptr<::parquet::arrow::FileReader>> create_file_reader_async(
+    std::shared_ptr<arrow::io::RandomAccessFile> file,
+    const int64_t file_size,
+    const int64_t footer_size,
+    const bool has_known_file_size,
+    ::parquet::ReaderProperties reader_properties,
+    ::parquet::ArrowReaderProperties arrow_reader_properties,
+    std::shared_ptr<arrow::internal::Executor> executor) {
+  using FileReaderFuture = arrow::Future<std::shared_ptr<::parquet::arrow::FileReader>>;
+
+  if (file_size < 0) {
+    return FileReaderFuture::MakeFinished(
+        arrow::Status::Invalid(fmt::format("Parquet file size is negative. [file_size={}]", file_size)));
+  }
+
+  auto metadata_future = read_footer_async(file, file_size, footer_size, reader_properties, executor);
+  return metadata_future.Then(
+      [file = std::move(file), file_size, has_known_file_size, reader_properties = std::move(reader_properties),
+       arrow_reader_properties = std::move(arrow_reader_properties), executor = std::move(executor)](
+          const std::shared_ptr<::parquet::FileMetaData>& metadata) mutable -> FileReaderFuture {
+        try {
+          std::shared_ptr<ParquetOpenFile> open_file;
+          std::shared_ptr<arrow::io::RandomAccessFile> source = file;
+          if (!metadata || !has_known_file_size) {
+            // Native footer parsing needs provider-native ReadAsync routing.
+            // A size resolved asynchronously must also be exposed through the
+            // synchronous GetSize() called by Parquet's reader constructor.
+            open_file = std::make_shared<ParquetOpenFile>(std::move(file), executor, file_size);
+            source = open_file;
+          }
+
+          // Non-null metadata skips Parquet's native footer read. A nullptr is
+          // the explicit fallback signal from read_footer_async.
+          auto parquet_future = ::parquet::ParquetFileReader::OpenAsync(std::move(source), reader_properties, metadata);
+          // Arrow 17 exposes a const Result in callbacks even when T is
+          // move-only. Retain the sole Future for MoveResult() and explicitly
+          // submit the CPU work so executor rejection can complete with Status.
+          auto file_reader_future = FileReaderFuture::Make();
+          try {
+            parquet_future.AddCallback(
+                [parquet_future, file_reader_future, open_file = std::move(open_file),
+                 arrow_reader_properties = std::move(arrow_reader_properties),
+                 executor](const arrow::Result<std::unique_ptr<::parquet::ParquetFileReader>>&) mutable {
+                  arrow::Status spawn_status;
+                  try {
+                    spawn_status =
+                        executor->Spawn([parquet_future, file_reader_future, open_file = std::move(open_file),
+                                         arrow_reader_properties = std::move(arrow_reader_properties)]() mutable {
+                          try {
+                            const auto& parquet_result = parquet_future.result();
+                            if (open_file) {
+                              // The low-level reader now owns the source. Subsequent data
+                              // reads should use the underlying file without open-time routing.
+                              open_file->FinishOpen();
+                            }
+                            if (!parquet_result.ok()) {
+                              file_reader_future.MarkFinished(parquet_result.status());
+                              return;
+                            }
+
+                            auto parquet_reader = parquet_future.MoveResult().ValueOrDie();
+                            std::unique_ptr<::parquet::arrow::FileReader> arrow_reader;
+                            // Add Arrow schema conversion and read properties around the
+                            // fully opened low-level Parquet reader.
+                            auto status = ::parquet::arrow::FileReader::Make(arrow::default_memory_pool(),
+                                                                             std::move(parquet_reader),
+                                                                             arrow_reader_properties, &arrow_reader);
+                            if (!status.ok()) {
+                              file_reader_future.MarkFinished(std::move(status));
+                              return;
+                            }
+                            file_reader_future.MarkFinished(
+                                std::shared_ptr<::parquet::arrow::FileReader>(std::move(arrow_reader)));
+                          } catch (const std::bad_alloc& e) {
+                            file_reader_future.MarkFinished(arrow::Status::OutOfMemory(
+                                fmt::format("Failed to create async parquet reader. [error={}]", e.what())));
+                          } catch (const std::exception& e) {
+                            file_reader_future.MarkFinished(arrow::Status::UnknownError(
+                                fmt::format("Exception while creating async parquet reader. [error={}]", e.what())));
+                          } catch (...) {
+                            file_reader_future.MarkFinished(
+                                arrow::Status::UnknownError("Unknown exception while creating async parquet reader"));
+                          }
+                        });
+                  } catch (const std::bad_alloc& e) {
+                    file_reader_future.MarkFinished(
+                        arrow::Status::OutOfMemory("Failed to schedule async parquet reader creation: ", e.what()));
+                    return;
+                  } catch (const std::exception& e) {
+                    file_reader_future.MarkFinished(
+                        arrow::Status::UnknownError("Failed to schedule async parquet reader creation: ", e.what()));
+                    return;
+                  } catch (...) {
+                    file_reader_future.MarkFinished(arrow::Status::UnknownError(
+                        "Unknown exception while scheduling async parquet reader creation"));
+                    return;
+                  }
+                  if (!spawn_status.ok()) {
+                    file_reader_future.MarkFinished(std::move(spawn_status));
+                  }
+                });
+          } catch (const std::bad_alloc& e) {
+            file_reader_future.MarkFinished(
+                arrow::Status::OutOfMemory("Failed to register async parquet reader completion: ", e.what()));
+          } catch (const std::exception& e) {
+            file_reader_future.MarkFinished(
+                arrow::Status::UnknownError("Failed to register async parquet reader completion: ", e.what()));
+          } catch (...) {
+            file_reader_future.MarkFinished(
+                arrow::Status::UnknownError("Unknown exception while registering async parquet reader completion"));
+          }
+          return file_reader_future;
+        } catch (const std::exception& e) {
+          return FileReaderFuture::MakeFinished(arrow::Status::UnknownError(
+              fmt::format("Exception while starting async parquet open. [error={}]", e.what())));
+        } catch (...) {
+          return FileReaderFuture::MakeFinished(
+              arrow::Status::UnknownError("Unknown exception while starting async parquet open"));
+        }
+      });
+}
+
+// lazy SemiFuture --> open file --> file size known?
+//                                      +-- yes --> manifest size
+//                                      +-- no  --> GetSizeAsync / Submit
+//                                                       |
+//                                          create_file_reader_async [Arrow]
+//                                                       |
+//                                             bridge_arrow_future
+//                                                       |
+//                                          finish_open [Folly, owns self]
 folly::SemiFuture<arrow::Status> ParquetFormatReader::open_async() {
-  // Keep the reader alive until the deferred open() finishes.
+  // Keep filesystem setup lazy: constructing the SemiFuture only retains the
+  // reader. OpenInputFile and all I/O start when the future is consumed. The
+  // storage layer never selects an executor: deferExValue receives the one
+  // supplied by the consumer and only transfers open-time CPU continuations.
   auto self = shared_from_this();
-  return folly::makeSemiFuture().deferValue([self = std::move(self)](folly::Unit) { return self->open(); });
+  return folly::makeSemiFuture().deferExValue([self = std::move(self)](
+                                                  folly::Executor::KeepAlive<> executor,
+                                                  folly::Unit) mutable -> folly::SemiFuture<arrow::Status> {
+    assert(self->file_reader_ == nullptr);
+
+    if (self->file_size_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+        self->footer_size_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      return folly::makeSemiFuture(arrow::Status::Invalid(
+          fmt::format("Parquet file or footer size exceeds int64 range. [path={}]", self->path_)));
+    }
+
+    auto reader_properties = make_reader_properties(self->key_retriever_);
+    FOLLY_ARROW_ASSIGN_OR_RAISE(auto arrow_reader_properties, make_arrow_reader_properties(self->properties_));
+    FOLLY_ARROW_ASSIGN_OR_RAISE(auto arrow_executor, MakeFollyArrowExecutor(std::move(executor)));
+    const auto footer_size = static_cast<int64_t>(self->footer_size_);
+
+    // A manifest-provided size lets the filesystem skip its metadata
+    // request. Zero means unknown and is resolved asynchronously below.
+    std::shared_ptr<arrow::io::RandomAccessFile> file;
+    if (self->file_size_ > 0) {
+      arrow::fs::FileInfo file_info(self->path_, arrow::fs::FileType::File);
+      file_info.set_size(static_cast<int64_t>(self->file_size_));
+      FOLLY_ARROW_ASSIGN_OR_RAISE(file, self->fs_->OpenInputFile(file_info));
+    } else {
+      FOLLY_ARROW_ASSIGN_OR_RAISE(file, self->fs_->OpenInputFile(self->path_));
+    }
+
+    // The Arrow Future chain only constructs a complete file reader. It
+    // does not publish intermediate state to this ParquetFormatReader.
+    arrow::Future<std::shared_ptr<::parquet::arrow::FileReader>> file_reader_future;
+    if (self->file_size_ > 0) {
+      // The known size is already attached to the opened file.
+      file_reader_future = create_file_reader_async(
+          std::move(file), static_cast<int64_t>(self->file_size_), footer_size, /*has_known_file_size=*/true,
+          std::move(reader_properties), std::move(arrow_reader_properties), arrow_executor);
+    } else {
+      // Resolve a missing size without blocking the consuming thread. A
+      // native async file owns the request; the generic fallback submits
+      // GetSize() to the executor already owned by the file's IOContext.
+      arrow::Future<int64_t> file_size_future;
+      if (auto* async_file = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(file.get())) {
+        file_size_future = transfer_arrow_future(async_file->GetSizeAsync(), arrow_executor);
+      } else {
+        FOLLY_ARROW_ASSIGN_OR_RAISE(auto submitted_size_future,
+                                    file->io_context().executor()->Submit([file] { return file->GetSize(); }));
+        file_size_future = transfer_arrow_future(std::move(submitted_size_future), arrow_executor);
+      }
+      file_reader_future =
+          file_size_future.Then([file = std::move(file), footer_size, reader_properties = std::move(reader_properties),
+                                 arrow_reader_properties = std::move(arrow_reader_properties),
+                                 arrow_executor](const int64_t file_size) mutable {
+            // file_size is operation-local. ParquetOpenFile supplies it to
+            // Parquet without updating ParquetFormatReader::file_size_.
+            return create_file_reader_async(std::move(file), file_size, footer_size,
+                                            /*has_known_file_size=*/false, std::move(reader_properties),
+                                            std::move(arrow_reader_properties), std::move(arrow_executor));
+          });
+    }
+
+    // Cross into Folly before publishing state. The Folly continuation
+    // retains self until the provider callback has returned, so reader and
+    // filesystem destruction cannot be triggered by the CRT callback.
+    return bridge_arrow_future(std::move(file_reader_future), std::move(arrow_executor))
+        .deferValue(
+            [self](arrow::Result<std::shared_ptr<::parquet::arrow::FileReader>>&& file_reader_result) -> arrow::Status {
+              if (!file_reader_result.ok()) {
+                const auto& status = file_reader_result.status();
+                return status.WithMessage(status.message(), " [path=", self->path_, "]");
+              }
+
+              auto file_reader = std::move(file_reader_result).ValueOrDie();
+              return self->finish_open(std::move(file_reader));
+            });
+  });
 }
 
 arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::get_row_group_infos() { return row_group_infos_; }
@@ -882,25 +1426,6 @@ ParquetFormatReader::ParquetFormatReader(const ParquetFormatReader& other,
       projected_leaf_column_indices_(other.projected_leaf_column_indices_),
       row_group_infos_(other.row_group_infos_),
       file_reader_(std::move(cloned_file_reader)) {}
-
-namespace {
-
-template <typename T>
-folly::SemiFuture<arrow::Result<T>> bridge_arrow_future(
-    arrow::Future<T> arrow_future, std::shared_ptr<arrow::internal::Executor> executor_keep_alive) {
-  // Retain the executor adapter until Arrow invokes its completion callback,
-  // then bridge the Result into Folly without blocking a thread.
-  auto promise = std::make_shared<folly::Promise<arrow::Result<T>>>();
-  auto semi_future = promise->getSemiFuture();
-  arrow_future.AddCallback(
-      [promise, executor_keep_alive = std::move(executor_keep_alive)](const arrow::Result<T>& result) {
-        (void)executor_keep_alive;
-        promise->setValue(result);
-      });
-  return semi_future;
-}
-
-}  // namespace
 
 folly::SemiFuture<arrow::Result<std::shared_ptr<arrow::RecordBatchReader>>> ParquetFormatReader::read_with_range_async(
     uint64_t start_offset, uint64_t end_offset) {

--- a/cpp/test/ffi/result_internal_test.cpp
+++ b/cpp/test/ffi/result_internal_test.cpp
@@ -38,7 +38,7 @@ LoonFFIResult ReturnArrowError(const arrow::Status& status, int fallback) {
   RETURN_ARROW_ERROR(status, fallback, status.ToString());
 }
 
-class FailingAsyncRandomAccessFile final : public arrow::io::RandomAccessFile, public NonBlockingReadAtFile {
+class FailingAsyncRandomAccessFile final : public arrow::io::RandomAccessFile, public NonBlockingRandomAccessFile {
   public:
   explicit FailingAsyncRandomAccessFile(arrow::Status status)
       : file_(std::make_shared<arrow::io::BufferReader>("test payload")), status_(std::move(status)) {}
@@ -70,6 +70,7 @@ class FailingAsyncRandomAccessFile final : public arrow::io::RandomAccessFile, p
   arrow::Future<int64_t> ReadAtAsyncInto(int64_t, int64_t, uint8_t*) override {
     return arrow::Future<int64_t>::MakeFinished(status_);
   }
+  arrow::Future<int64_t> GetSizeAsync() override { return arrow::Future<int64_t>::MakeFinished(file_->GetSize()); }
   arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
                                                           int64_t position,
                                                           int64_t nbytes) override {

--- a/cpp/test/filesystem/s3_crt_build_test.cpp
+++ b/cpp/test/filesystem/s3_crt_build_test.cpp
@@ -554,7 +554,12 @@ TEST(S3CrtBuildSupportTest, OpenInputFileUsesCrtBackedAsyncFileWhenCrtEnabled) {
   ASSERT_STATUS_OK(output_stream->Close());
 
   ASSERT_AND_ASSIGN(auto input_file, fs->OpenInputFile(object_path));
-  ASSERT_NE(dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get()), nullptr);
+  auto* async_file = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(input_file.get());
+  ASSERT_NE(async_file, nullptr);
+
+  auto size_result = async_file->GetSizeAsync().result();
+  ASSERT_STATUS_OK(size_result.status());
+  ASSERT_EQ(size_result.ValueOrDie(), static_cast<int64_t>(data.size()));
 
   auto async_result = input_file->ReadAsync({}, 2, 4).result();
   ASSERT_STATUS_OK(async_result.status());
@@ -772,7 +777,7 @@ TEST(S3CrtBuildSupportTest, InFlightNativeReadCompletesDuringFinalizeS3) {
       return fail(input_result.status().ToString());
     }
     auto input = std::move(input_result).ValueOrDie();
-    if (dynamic_cast<NonBlockingReadAtFile*>(input.get()) == nullptr) {
+    if (dynamic_cast<NonBlockingRandomAccessFile*>(input.get()) == nullptr) {
       return fail("OpenInputFile did not select the CRT async read path");
     }
 
@@ -827,7 +832,7 @@ TEST(S3CrtBuildSupportTest, OpenInputFileUsesCrtBackedAsyncFileForNonGcpProvider
     ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
     ASSERT_AND_ASSIGN(auto input_file, fs->OpenInputFile("bucket/path/object.txt"));
 
-    EXPECT_NE(dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get()), nullptr);
+    EXPECT_NE(dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(input_file.get()), nullptr);
   }
 }
 
@@ -854,7 +859,7 @@ TEST(S3CrtBuildSupportTest, ZeroLengthAsyncReadsDoNotScheduleIoExecutor) {
   arrow::fs::FileInfo file_info("bucket/path/object.txt", arrow::fs::FileType::File);
   file_info.set_size(1);
   ASSERT_AND_ASSIGN(auto input_file, fs->OpenInputFile(file_info));
-  auto* async_file = dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get());
+  auto* async_file = dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(input_file.get());
   ASSERT_NE(async_file, nullptr);
 
   io_executor.drain();
@@ -884,7 +889,7 @@ TEST(S3CrtBuildSupportTest, OpenInputFileFallsBackToSdkFileForGcpProvider) {
   ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
   ASSERT_AND_ASSIGN(auto input_file, fs->OpenInputFile("bucket/path/object.txt"));
 
-  EXPECT_EQ(dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get()), nullptr);
+  EXPECT_EQ(dynamic_cast<milvus_storage::NonBlockingRandomAccessFile*>(input_file.get()), nullptr);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/format/async_tasks_test.cpp
+++ b/cpp/test/format/async_tasks_test.cpp
@@ -47,6 +47,16 @@ folly::SemiFuture<arrow::Result<int>> assign_or_raise_future(bool ok) {
   return folly::makeSemiFuture(arrow::Result<int>(value + 1));
 }
 
+folly::SemiFuture<arrow::Status> return_not_ok_status_future(bool ok) {
+  FOLLY_ARROW_RETURN_NOT_OK(ok ? arrow::Status::OK() : arrow::Status::Invalid("bad status future"));
+  return folly::makeSemiFuture(arrow::Status::OK());
+}
+
+folly::SemiFuture<arrow::Status> assign_or_raise_status_future(bool ok) {
+  FOLLY_ARROW_ASSIGN_OR_RAISE(auto value, maybe_int(ok));
+  return folly::makeSemiFuture(value == 41 ? arrow::Status::OK() : arrow::Status::UnknownError("bad value"));
+}
+
 }  // namespace
 
 TEST(AsyncTasksTest, FollyArrowReturnNotOkPropagatesStatusToSemiFutureResult) {
@@ -68,6 +78,26 @@ TEST(AsyncTasksTest, FollyArrowAssignOrRaiseExposesAssignedValueOnSuccess) {
 
   ASSERT_TRUE(result.ok()) << result.status().ToString();
   EXPECT_EQ(result.ValueUnsafe(), 42);
+}
+
+TEST(AsyncTasksTest, FollyArrowReturnNotOkPropagatesStatusToStatusSemiFuture) {
+  auto status = std::move(return_not_ok_status_future(false)).get();
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_NE(status.ToString().find("bad status future"), std::string::npos);
+}
+
+TEST(AsyncTasksTest, FollyArrowAssignOrRaisePropagatesResultStatusToStatusSemiFuture) {
+  auto status = std::move(assign_or_raise_status_future(false)).get();
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_NE(status.ToString().find("bad int"), std::string::npos);
+}
+
+TEST(AsyncTasksTest, FollyArrowAssignOrRaiseSupportsSuccessfulStatusSemiFuture) {
+  auto status = std::move(assign_or_raise_status_future(true)).get();
+
+  EXPECT_TRUE(status.ok()) << status.ToString();
 }
 
 TEST(AsyncTasksTest, ChunkTaskBuildGroupsByFileAndMergesContiguousRanges) {

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -15,9 +15,11 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <numeric>
 #include <random>
+#include <stdexcept>
 #include <thread>
 
 #include <arrow/api.h>
@@ -26,12 +28,15 @@
 #include <arrow/testing/gtest_util.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/InlineExecutor.h>
+#include <folly/executors/ThreadedExecutor.h>
+#include <folly/synchronization/Baton.h>
 #include <parquet/arrow/schema.h>
 #include <parquet/metadata.h>
 #include <parquet/type_fwd.h>
 #include <parquet/arrow/writer.h>
 
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/reader.h"
 #include "milvus-storage/writer.h"
@@ -100,6 +105,22 @@ struct FileSystemReadStats {
   std::atomic<int> open_path_count{0};
   std::atomic<int> open_info_count{0};
   std::atomic<int> async_read_into_count{0};
+  std::atomic<int> async_get_size_count{0};
+  std::atomic<int64_t> first_async_read_position{-1};
+  std::atomic<int64_t> first_async_read_size{-1};
+
+  int record_async_read(int64_t position, int64_t nbytes) {
+    const auto read_index = async_read_into_count.fetch_add(1, std::memory_order_relaxed);
+    if (read_index == 0) {
+      first_async_read_position.store(position, std::memory_order_relaxed);
+      first_async_read_size.store(nbytes, std::memory_order_relaxed);
+    }
+    {
+      std::lock_guard<std::mutex> lock(async_read_thread_mutex);
+      async_read_threads.emplace_back(std::this_thread::get_id());
+    }
+    return read_index;
+  }
 
   void record_open_thread() {
     std::lock_guard<std::mutex> lock(open_thread_mutex);
@@ -111,9 +132,57 @@ struct FileSystemReadStats {
     return open_thread;
   }
 
+  std::thread::id get_async_read_thread(size_t read_index) const {
+    std::lock_guard<std::mutex> lock(async_read_thread_mutex);
+    return async_read_threads.at(read_index);
+  }
+
   private:
   mutable std::mutex open_thread_mutex;
   std::thread::id open_thread;
+  mutable std::mutex async_read_thread_mutex;
+  std::vector<std::thread::id> async_read_threads;
+};
+
+struct PendingAsyncOpenState {
+  arrow::Future<int64_t> size_future = arrow::Future<int64_t>::Make();
+  arrow::Future<int64_t> read_future = arrow::Future<int64_t>::Make();
+  folly::Baton<> size_requested;
+  folly::Baton<> read_requested;
+  folly::Baton<> second_read_requested;
+  std::atomic<int64_t> cached_size{-1};
+  std::atomic<bool> sync_get_size_before_ready{false};
+
+  void complete_size(int64_t size) {
+    cached_size.store(size, std::memory_order_release);
+    size_future.MarkFinished(size);
+  }
+
+  void complete_read() {
+    std::shared_ptr<arrow::io::RandomAccessFile> file;
+    int64_t position = 0;
+    int64_t nbytes = 0;
+    uint8_t* out = nullptr;
+    {
+      std::lock_guard<std::mutex> lock(read_mutex);
+      file = read_file;
+      position = read_position;
+      nbytes = read_size;
+      out = read_out;
+    }
+
+    if (!file || !out) {
+      read_future.MarkFinished(arrow::Status::Invalid("Async footer read was not requested"));
+      return;
+    }
+    read_future.MarkFinished(file->ReadAt(position, nbytes, out));
+  }
+
+  std::mutex read_mutex;
+  std::shared_ptr<arrow::io::RandomAccessFile> read_file;
+  int64_t read_position = 0;
+  int64_t read_size = 0;
+  uint8_t* read_out = nullptr;
 };
 
 class CountingExecutor final : public folly::Executor {
@@ -130,12 +199,29 @@ class CountingExecutor final : public folly::Executor {
   folly::CPUThreadPoolExecutor executor_{1};
 };
 
+class RejectOnceExecutor final : public folly::Executor {
+  public:
+  void add(folly::Func func) override {
+    if (reject_next_.exchange(false, std::memory_order_acq_rel)) {
+      throw std::runtime_error("intentional executor rejection");
+    }
+    executor_.add(std::move(func));
+  }
+
+  void reject_next_add() { reject_next_.store(true, std::memory_order_release); }
+
+  private:
+  std::atomic<bool> reject_next_{false};
+  folly::CPUThreadPoolExecutor executor_{1};
+};
+
 class AsyncCountingRandomAccessFile final : public arrow::io::RandomAccessFile,
-                                            public milvus_storage::NonBlockingReadAtFile {
+                                            public milvus_storage::NonBlockingRandomAccessFile {
   public:
   AsyncCountingRandomAccessFile(std::shared_ptr<arrow::io::RandomAccessFile> file,
-                                std::shared_ptr<FileSystemReadStats> stats)
-      : file_(std::move(file)), stats_(std::move(stats)) {}
+                                std::shared_ptr<FileSystemReadStats> stats,
+                                std::shared_ptr<PendingAsyncOpenState> pending_open = nullptr)
+      : file_(std::move(file)), stats_(std::move(stats)), pending_open_(std::move(pending_open)) {}
 
   arrow::Status Close() override { return file_->Close(); }
   arrow::Status Abort() override { return file_->Abort(); }
@@ -154,7 +240,18 @@ class AsyncCountingRandomAccessFile final : public arrow::io::RandomAccessFile,
     return file_->ReadMetadataAsync(io_context);
   }
   arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
-  arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
+  arrow::Result<int64_t> GetSize() override {
+    if (!pending_open_) {
+      return file_->GetSize();
+    }
+
+    const auto size = pending_open_->cached_size.load(std::memory_order_acquire);
+    if (size < 0) {
+      pending_open_->sync_get_size_before_ready.store(true, std::memory_order_relaxed);
+      return arrow::Status::Invalid("Synchronous size lookup before GetSizeAsync completed");
+    }
+    return size;
+  }
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     return file_->ReadAt(position, nbytes, out);
   }
@@ -162,8 +259,30 @@ class AsyncCountingRandomAccessFile final : public arrow::io::RandomAccessFile,
     return file_->ReadAt(position, nbytes);
   }
   arrow::Future<int64_t> ReadAtAsyncInto(int64_t position, int64_t nbytes, uint8_t* out) override {
-    stats_->async_read_into_count.fetch_add(1, std::memory_order_relaxed);
+    const auto read_index = stats_->record_async_read(position, nbytes);
+    if (pending_open_ && read_index == 0) {
+      {
+        std::lock_guard<std::mutex> lock(pending_open_->read_mutex);
+        pending_open_->read_file = file_;
+        pending_open_->read_position = position;
+        pending_open_->read_size = nbytes;
+        pending_open_->read_out = out;
+      }
+      pending_open_->read_requested.post();
+      return pending_open_->read_future;
+    }
+    if (pending_open_) {
+      pending_open_->second_read_requested.post();
+    }
     return arrow::Future<int64_t>::MakeFinished(file_->ReadAt(position, nbytes, out));
+  }
+  arrow::Future<int64_t> GetSizeAsync() override {
+    stats_->async_get_size_count.fetch_add(1, std::memory_order_relaxed);
+    if (pending_open_) {
+      pending_open_->size_requested.post();
+      return pending_open_->size_future;
+    }
+    return arrow::Future<int64_t>::MakeFinished(file_->GetSize());
   }
   arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
                                                           int64_t position,
@@ -175,30 +294,36 @@ class AsyncCountingRandomAccessFile final : public arrow::io::RandomAccessFile,
   private:
   std::shared_ptr<arrow::io::RandomAccessFile> file_;
   std::shared_ptr<FileSystemReadStats> stats_;
+  std::shared_ptr<PendingAsyncOpenState> pending_open_;
 };
 
 class AsyncCountingFileSystem final : public arrow::fs::SubTreeFileSystem {
   public:
   using arrow::fs::SubTreeFileSystem::OpenInputFile;
 
-  AsyncCountingFileSystem(std::shared_ptr<arrow::fs::FileSystem> fs, std::shared_ptr<FileSystemReadStats> stats)
-      : arrow::fs::SubTreeFileSystem("", std::move(fs)), stats_(std::move(stats)) {}
+  AsyncCountingFileSystem(std::shared_ptr<arrow::fs::FileSystem> fs,
+                          std::shared_ptr<FileSystemReadStats> stats,
+                          std::shared_ptr<PendingAsyncOpenState> pending_open = nullptr)
+      : arrow::fs::SubTreeFileSystem("", std::move(fs)),
+        stats_(std::move(stats)),
+        pending_open_(std::move(pending_open)) {}
 
   arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override {
     ARROW_ASSIGN_OR_RAISE(auto file, arrow::fs::SubTreeFileSystem::OpenInputFile(path));
     stats_->open_path_count.fetch_add(1, std::memory_order_relaxed);
     stats_->record_open_thread();
-    return std::make_shared<AsyncCountingRandomAccessFile>(std::move(file), stats_);
+    return std::make_shared<AsyncCountingRandomAccessFile>(std::move(file), stats_, pending_open_);
   }
   arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override {
     ARROW_ASSIGN_OR_RAISE(auto file, arrow::fs::SubTreeFileSystem::OpenInputFile(info));
     stats_->open_info_count.fetch_add(1, std::memory_order_relaxed);
     stats_->record_open_thread();
-    return std::make_shared<AsyncCountingRandomAccessFile>(std::move(file), stats_);
+    return std::make_shared<AsyncCountingRandomAccessFile>(std::move(file), stats_, pending_open_);
   }
 
   private:
   std::shared_ptr<FileSystemReadStats> stats_;
+  std::shared_ptr<PendingAsyncOpenState> pending_open_;
 };
 
 }  // namespace
@@ -578,6 +703,26 @@ TEST_P(FormatReaderTest, ReadParquetWithoutMeta) {
   ASSERT_EQ(total_size, test_batch_->num_rows() * 10);
 }
 
+TEST_P(FormatReaderTest, ParquetOpenRejectsOverflowingFooterLength) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/overflowing_footer_length.parquet";
+  std::string malformed_file = "PAR1";
+  malformed_file.append(sizeof(uint32_t), static_cast<char>(0xFF));
+  malformed_file.append("PAR1");
+  ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(file_path));
+  ASSERT_STATUS_OK(sink->Write(malformed_file.data(), malformed_file.size()));
+  ASSERT_STATUS_OK(sink->Close());
+
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      fs_, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr, malformed_file.size(),
+      /*footer_size=*/8);
+  EXPECT_FALSE(reader->open().ok());
+}
+
 TEST_P(FormatReaderTest, ParquetFooterFastPathUsesCrtReadAtAsyncInto) {
   std::string format = GetParam();
   if (format != LOON_FORMAT_PARQUET) {
@@ -662,7 +807,7 @@ TEST_P(FormatReaderTest, ParquetAsyncReadRejectsInlineExecutor) {
   EXPECT_NE(take_result.status().ToString().find("non-inline"), std::string::npos);
 }
 
-TEST_P(FormatReaderTest, ParquetOpenAsyncUsesCallerExecutor) {
+TEST_P(FormatReaderTest, ParquetOpenAsyncIsLazyAndSupportsThreadedExecutor) {
   std::string format = GetParam();
   if (format != LOON_FORMAT_PARQUET) {
     GTEST_SKIP() << "Test parquet only.";
@@ -680,7 +825,7 @@ TEST_P(FormatReaderTest, ParquetOpenAsyncUsesCallerExecutor) {
       counting_fs, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
       file.Get<uint64_t>(api::kPropertyFileSize), file.Get<uint64_t>(api::kPropertyFooterSize));
 
-  CountingExecutor executor;
+  folly::ThreadedExecutor executor;
   std::weak_ptr<parquet::ParquetFormatReader> weak_reader = reader;
   auto future = reader->open_async();
   reader.reset();
@@ -690,10 +835,270 @@ TEST_P(FormatReaderTest, ParquetOpenAsyncUsesCallerExecutor) {
   ASSERT_FALSE(weak_reader.expired());
 
   ASSERT_STATUS_OK(std::move(future).via(&executor).get());
-  EXPECT_GT(executor.add_count(), 0);
   EXPECT_EQ(
       stats->open_path_count.load(std::memory_order_relaxed) + stats->open_info_count.load(std::memory_order_relaxed),
       1);
+  EXPECT_EQ(stats->async_read_into_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(stats->async_get_size_count.load(std::memory_order_relaxed), 0);
+  const auto file_size = file.Get<uint64_t>(api::kPropertyFileSize);
+  const auto footer_size = file.Get<uint64_t>(api::kPropertyFooterSize);
+  EXPECT_EQ(stats->first_async_read_position.load(std::memory_order_relaxed), file_size - footer_size);
+  EXPECT_EQ(stats->first_async_read_size.load(std::memory_order_relaxed), footer_size);
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncReadsMetadataAgainWhenFooterHintIsTooSmall) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_small_footer.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  auto stats = std::make_shared<FileSystemReadStats>();
+  auto counting_fs = std::make_shared<AsyncCountingFileSystem>(fs_, stats);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      counting_fs, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
+      file.Get<uint64_t>(api::kPropertyFileSize), /*footer_size=*/8);
+
+  CountingExecutor executor;
+  ASSERT_STATUS_OK(std::move(reader->open_async()).via(&executor).get());
+
+  EXPECT_EQ(stats->async_read_into_count.load(std::memory_order_relaxed), 2);
+  EXPECT_EQ(stats->first_async_read_position.load(std::memory_order_relaxed),
+            file.Get<uint64_t>(api::kPropertyFileSize) - 8);
+  EXPECT_EQ(stats->first_async_read_size.load(std::memory_order_relaxed), 8);
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader->get_row_group_infos());
+  EXPECT_FALSE(row_group_infos.empty());
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncWithoutFooterHintUsesNativeAsyncOpen) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_without_footer_hint.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  auto stats = std::make_shared<FileSystemReadStats>();
+  auto counting_fs = std::make_shared<AsyncCountingFileSystem>(fs_, stats);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      counting_fs, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
+      file.Get<uint64_t>(api::kPropertyFileSize), /*footer_size=*/0);
+
+  CountingExecutor executor;
+  ASSERT_STATUS_OK(std::move(reader->open_async()).via(&executor).get());
+
+  EXPECT_EQ(stats->async_read_into_count.load(std::memory_order_relaxed), 1);
+  const auto file_size = file.Get<uint64_t>(api::kPropertyFileSize);
+  const auto native_footer_read_size = std::min<uint64_t>(file_size, 64 * 1024);
+  EXPECT_EQ(stats->first_async_read_position.load(std::memory_order_relaxed), file_size - native_footer_read_size);
+  EXPECT_EQ(stats->first_async_read_size.load(std::memory_order_relaxed), native_footer_read_size);
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader->get_row_group_infos());
+  EXPECT_FALSE(row_group_infos.empty());
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncGetsMissingFileSizeAsynchronously) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_missing_file_size.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  auto stats = std::make_shared<FileSystemReadStats>();
+  auto counting_fs = std::make_shared<AsyncCountingFileSystem>(fs_, stats);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      counting_fs, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
+      /*file_size=*/0, file.Get<uint64_t>(api::kPropertyFooterSize));
+
+  CountingExecutor executor;
+  ASSERT_STATUS_OK(std::move(reader->open_async()).via(&executor).get());
+
+  EXPECT_EQ(stats->async_get_size_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(stats->async_read_into_count.load(std::memory_order_relaxed), 1);
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader->get_row_group_infos());
+  EXPECT_FALSE(row_group_infos.empty());
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncReturnsMalformedRowGroupMetadataAsStatus) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_malformed_row_group_metadata.parquet";
+  ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(file_path));
+  ASSERT_AND_ASSIGN(auto parquet_writer,
+                    ::parquet::arrow::FileWriter::Open(*schema_, arrow::default_memory_pool(), sink));
+  ASSERT_STATUS_OK(parquet_writer->NewBufferedRowGroup());
+  ASSERT_STATUS_OK(parquet_writer->WriteRecordBatch(*test_batch_));
+  ASSERT_STATUS_OK(parquet_writer->AddKeyValueMetadata(
+      arrow::key_value_metadata({ROW_GROUP_META_KEY}, {"malformed-row-group-metadata"})));
+  ASSERT_STATUS_OK(parquet_writer->Close());
+  ASSERT_STATUS_OK(sink->Close());
+
+  ASSERT_AND_ASSIGN(auto file_info, fs_->GetFileInfo(file_path));
+  ASSERT_GT(file_info.size(), 0);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      fs_, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
+      static_cast<uint64_t>(file_info.size()), /*footer_size=*/0);
+
+  CountingExecutor executor;
+  arrow::Status status;
+  EXPECT_NO_THROW(status = std::move(reader->open_async()).via(&executor).get());
+  EXPECT_FALSE(status.ok());
+  EXPECT_NE(status.ToString().find("Invalid row group metadata format"), std::string::npos);
+  EXPECT_EQ(reader->get_schema(), nullptr);
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncKeepsCallerExecutorAvailableWhileIoIsPending) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_pending_io.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  auto stats = std::make_shared<FileSystemReadStats>();
+  auto pending_open = std::make_shared<PendingAsyncOpenState>();
+  auto counting_fs = std::make_shared<AsyncCountingFileSystem>(fs_, stats, pending_open);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      counting_fs, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
+      /*file_size=*/0, file.Get<uint64_t>(api::kPropertyFooterSize));
+
+  CountingExecutor executor;
+  auto open_future = reader->open_async().via(&executor);
+  constexpr auto kWaitTimeout = std::chrono::seconds(5);
+
+  const bool size_requested = pending_open->size_requested.try_wait_for(kWaitTimeout);
+  EXPECT_FALSE(open_future.isReady()) << "open_async completed without waiting for GetSizeAsync";
+  auto size_sentinel = std::make_shared<folly::Baton<>>();
+  executor.add([size_sentinel] { size_sentinel->post(); });
+  const bool executor_available_during_size = size_sentinel->try_wait_for(kWaitTimeout);
+  pending_open->complete_size(static_cast<int64_t>(file.Get<uint64_t>(api::kPropertyFileSize)));
+
+  const bool footer_requested = pending_open->read_requested.try_wait_for(kWaitTimeout);
+  EXPECT_FALSE(open_future.isReady()) << "open_async completed without waiting for ReadAtAsyncInto";
+  auto footer_sentinel = std::make_shared<folly::Baton<>>();
+  executor.add([footer_sentinel] { footer_sentinel->post(); });
+  const bool executor_available_during_footer = footer_sentinel->try_wait_for(kWaitTimeout);
+  pending_open->complete_read();
+
+  auto status = std::move(open_future).get();
+  EXPECT_TRUE(size_requested) << "GetSizeAsync was not used";
+  EXPECT_TRUE(executor_available_during_size) << "Caller executor blocked waiting for GetSizeAsync";
+  EXPECT_TRUE(footer_requested) << "ReadAtAsyncInto was not used for the footer";
+  EXPECT_TRUE(executor_available_during_footer) << "Caller executor blocked waiting for ReadAtAsyncInto";
+  EXPECT_FALSE(pending_open->sync_get_size_before_ready.load(std::memory_order_relaxed));
+  EXPECT_EQ(stats->async_get_size_count.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(stats->async_read_into_count.load(std::memory_order_relaxed), 1);
+  ASSERT_STATUS_OK(status);
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncRunsOpenContinuationsOnCallerExecutor) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_executor_affinity.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  auto stats = std::make_shared<FileSystemReadStats>();
+  auto pending_open = std::make_shared<PendingAsyncOpenState>();
+  auto counting_fs = std::make_shared<AsyncCountingFileSystem>(fs_, stats, pending_open);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(counting_fs, file_path, properties_,
+                                                               /*needed_columns=*/std::vector<std::string>{}, nullptr,
+                                                               /*file_size=*/0, /*footer_size=*/8);
+
+  CountingExecutor executor;
+  folly::Baton<> executor_ready;
+  std::thread::id executor_thread;
+  executor.add([&executor_ready, &executor_thread] {
+    executor_thread = std::this_thread::get_id();
+    executor_ready.post();
+  });
+
+  constexpr auto kWaitTimeout = std::chrono::seconds(5);
+  ASSERT_TRUE(executor_ready.try_wait_for(kWaitTimeout));
+  ASSERT_NE(executor_thread, std::this_thread::get_id());
+
+  auto open_future = reader->open_async().via(&executor);
+  ASSERT_TRUE(pending_open->size_requested.try_wait_for(kWaitTimeout));
+  folly::Baton<> size_continuation_registered;
+  executor.add([&size_continuation_registered] { size_continuation_registered.post(); });
+  ASSERT_TRUE(size_continuation_registered.try_wait_for(kWaitTimeout));
+  pending_open->complete_size(static_cast<int64_t>(file.Get<uint64_t>(api::kPropertyFileSize)));
+
+  ASSERT_TRUE(pending_open->read_requested.try_wait_for(kWaitTimeout));
+  EXPECT_EQ(stats->get_async_read_thread(0), executor_thread)
+      << "GetSizeAsync continuation did not run on the caller executor";
+  folly::Baton<> footer_continuation_registered;
+  executor.add([&footer_continuation_registered] { footer_continuation_registered.post(); });
+  ASSERT_TRUE(footer_continuation_registered.try_wait_for(kWaitTimeout));
+  pending_open->complete_read();
+
+  ASSERT_TRUE(pending_open->second_read_requested.try_wait_for(kWaitTimeout));
+  EXPECT_EQ(stats->get_async_read_thread(1), executor_thread)
+      << "Footer continuation did not run on the caller executor";
+  ASSERT_STATUS_OK(std::move(open_future).get());
+}
+
+TEST_P(FormatReaderTest, ParquetOpenAsyncPropagatesCallerExecutorRejection) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_open_executor_rejection.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  auto stats = std::make_shared<FileSystemReadStats>();
+  auto pending_open = std::make_shared<PendingAsyncOpenState>();
+  auto counting_fs = std::make_shared<AsyncCountingFileSystem>(fs_, stats, pending_open);
+  auto reader = std::make_shared<parquet::ParquetFormatReader>(
+      counting_fs, file_path, properties_, /*needed_columns=*/std::vector<std::string>{}, nullptr,
+      /*file_size=*/0, file.Get<uint64_t>(api::kPropertyFooterSize));
+
+  RejectOnceExecutor executor;
+  auto open_future = reader->open_async().via(&executor);
+  constexpr auto kWaitTimeout = std::chrono::seconds(5);
+  ASSERT_TRUE(pending_open->size_requested.try_wait_for(kWaitTimeout));
+
+  folly::Baton<> size_continuation_registered;
+  executor.add([&size_continuation_registered] { size_continuation_registered.post(); });
+  ASSERT_TRUE(size_continuation_registered.try_wait_for(kWaitTimeout));
+
+  executor.reject_next_add();
+  pending_open->complete_size(static_cast<int64_t>(file.Get<uint64_t>(api::kPropertyFileSize)));
+
+  auto result = std::move(open_future).within(kWaitTimeout).getTry();
+  ASSERT_TRUE(result.hasValue()) << result.exception().what();
+  const auto& status = result.value();
+  EXPECT_FALSE(status.ok());
+  EXPECT_NE(status.ToString().find("intentional executor rejection"), std::string::npos);
 }
 
 TEST_P(FormatReaderTest, VortexOpenAsyncUsesTokioRuntime) {


### PR DESCRIPTION
Previously, open_async only moved the synchronous Parquet open path onto a Folly executor. Opening a remote file could still block a worker while fetching the file size and footer, so the async API did not provide a fully non-blocking open flow.

The new path uses ParquetFileReader::OpenAsync and bridges the Arrow futures back to the Folly result. When a usable footer-size hint is available, it reads that suffix directly, parses the trailer and metadata, and fetches only the missing metadata range when the hint is too small. Encrypted files and unusable hints fallback to Parquet’s native asynchronous footer handling.

The non-blocking random-access interface now also supports asynchronous size lookup, backed by S3 CRT HeadObjectAsync with cached size reuse and existing error mapping. Open-time continuations are transferred onto the executor supplied through via(), while normal data reads return to their original I/O path after the reader has finished opening.