### PR TITLE
enhance: add async reader reconstruction from metadata

### DIFF
--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -214,15 +214,23 @@ concept FormatReaderWithMetadata =
       { metadata->file_schema } -> std::same_as<const std::shared_ptr<arrow::Schema>&>;
     };
 
-// Identifies formats whose immutable metadata loader itself returns a future;
-// other formats use the synchronous cache fallback.
+// Identifies formats whose immutable metadata load and reader reconstruction
+// both return futures; other formats use the synchronous cache fallback.
 template <typename ReaderT>
 concept FormatReaderWithAsyncMetadata =
-    FormatReaderWithMetadata<ReaderT> &&
-    requires(const api::ColumnGroupFile& file, const api::Properties& properties, const KeyRetriever& key_retriever) {
+    FormatReaderWithMetadata<ReaderT> && requires(const api::ColumnGroupFile& file,
+                                                  const api::Properties& properties,
+                                                  const KeyRetriever& key_retriever,
+                                                  typename ReaderT::MetaTrait::MetadataPtr metadata,
+                                                  const std::shared_ptr<arrow::Schema>& read_schema,
+                                                  const std::vector<std::string>& needed_columns,
+                                                  const std::string& predicate) {
       {
         ReaderT::MetaTrait::load_metadata_async(file, properties, key_retriever)
       } -> std::same_as<folly::SemiFuture<arrow::Result<typename ReaderT::MetaTrait::MetadataPtr>>>;
+      {
+        ReaderT::MetaTrait::create_from_metadata_async(metadata, file, read_schema, needed_columns, predicate)
+      } -> std::same_as<folly::SemiFuture<arrow::Result<std::shared_ptr<ReaderT>>>>;
     };
 
 template <typename ReaderT>

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -58,6 +58,12 @@ class ParquetFormatReader final : public FormatReader, public std::enable_shared
         const std::shared_ptr<arrow::Schema>& read_schema,
         const std::vector<std::string>& needed_columns,
         const std::string& predicate);
+    static folly::SemiFuture<arrow::Result<std::shared_ptr<ParquetFormatReader>>> create_from_metadata_async(
+        MetadataPtr metadata,
+        const api::ColumnGroupFile& file,
+        const std::shared_ptr<arrow::Schema>& read_schema,
+        const std::vector<std::string>& needed_columns,
+        const std::string& predicate);
 
  private:
     // Implementation detail, not part of FormatReaderWithMetadata. This helper

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -69,6 +69,12 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
         const std::shared_ptr<arrow::Schema>& read_schema,
         const std::vector<std::string>& needed_columns,
         const std::string& predicate);
+    static folly::SemiFuture<arrow::Result<std::shared_ptr<VortexFormatReader>>> create_from_metadata_async(
+        MetadataPtr metadata,
+        const api::ColumnGroupFile& file,
+        const std::shared_ptr<arrow::Schema>& read_schema,
+        const std::vector<std::string>& needed_columns,
+        const std::string& predicate);
 
  private:
     // Implementation detail, not part of FormatReaderWithMetadata. This helper

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -210,14 +210,15 @@ ColumnGroupLazyReaderImpl<ReaderT>::open_reader_for_file_async(size_t file_index
                             })
         .deferValue([file, read_schema = schema_, needed_columns = needed_columns_](
                         arrow::Result<typename ReaderT::MetaTrait::MetadataPtr>&& metadata_result)
-                        -> arrow::Result<std::shared_ptr<ReaderT>> {
-          ARROW_ASSIGN_OR_RAISE(auto metadata, std::move(metadata_result));
-          return FormatReader::create_from_metadata<ReaderT>(std::move(metadata), file, read_schema, needed_columns,
-                                                             "");
+                        -> folly::SemiFuture<arrow::Result<std::shared_ptr<ReaderT>>> {
+          FOLLY_ARROW_ASSIGN_OR_RAISE(auto metadata, std::move(metadata_result));
+          return ReaderT::MetaTrait::create_from_metadata_async(std::move(metadata), file, read_schema, needed_columns,
+                                                                "");
         });
   }
 
-  // Synchronous metadata formats may block here before returning their ready future.
+  // Formats without a complete async metadata path may block here before
+  // returning their ready future.
   return folly::makeSemiFuture(open_reader_for_file(file_index));
 }
 

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -354,15 +354,15 @@ folly::SemiFuture<arrow::Result<std::shared_ptr<ReaderT>>> ColumnGroupReaderImpl
                             })
         .deferValue([file, read_schema = schema_, needed_columns = needed_columns_,
                      predicate = predicate_](arrow::Result<typename ReaderT::MetaTrait::MetadataPtr>&& metadata_result)
-                        -> arrow::Result<std::shared_ptr<ReaderT>> {
-          ARROW_ASSIGN_OR_RAISE(auto metadata, std::move(metadata_result));
-          return FormatReader::create_from_metadata<ReaderT>(std::move(metadata), file, read_schema, needed_columns,
-                                                             predicate);
+                        -> folly::SemiFuture<arrow::Result<std::shared_ptr<ReaderT>>> {
+          FOLLY_ARROW_ASSIGN_OR_RAISE(auto metadata, std::move(metadata_result));
+          return ReaderT::MetaTrait::create_from_metadata_async(std::move(metadata), file, read_schema, needed_columns,
+                                                                predicate);
         });
   }
 
-  // Formats without an async metadata loader keep the synchronous cache path;
-  // constructing this ready future may therefore block.
+  // Formats without a complete async metadata path keep the synchronous cache
+  // path; constructing this ready future may therefore block.
   return folly::makeSemiFuture(open_reader_for_file(file_index));
 }
 

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -475,6 +475,19 @@ arrow::Result<std::shared_ptr<ParquetFormatReader>> ParquetFormatReader::MetaTra
   return reader;
 }
 
+folly::SemiFuture<arrow::Result<std::shared_ptr<ParquetFormatReader>>>
+ParquetFormatReader::MetaTrait::create_from_metadata_async(MetadataPtr metadata,
+                                                           const api::ColumnGroupFile& file,
+                                                           const std::shared_ptr<arrow::Schema>& read_schema,
+                                                           const std::vector<std::string>& needed_columns,
+                                                           const std::string& predicate) {
+  return folly::makeSemiFuture().deferValue(
+      [metadata = std::move(metadata), file, read_schema, needed_columns,
+       predicate](folly::Unit) -> arrow::Result<std::shared_ptr<ParquetFormatReader>> {
+        return create_from_metadata(std::move(metadata), file, read_schema, needed_columns, predicate);
+      });
+}
+
 arrow::Status ParquetFormatReader::open() {
   assert(file_reader_ == nullptr);
 

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -536,6 +536,19 @@ arrow::Result<std::shared_ptr<VortexFormatReader>> VortexFormatReader::MetaTrait
   return reader;
 }
 
+folly::SemiFuture<arrow::Result<std::shared_ptr<VortexFormatReader>>>
+VortexFormatReader::MetaTrait::create_from_metadata_async(MetadataPtr metadata,
+                                                          const api::ColumnGroupFile& file,
+                                                          const std::shared_ptr<arrow::Schema>& read_schema,
+                                                          const std::vector<std::string>& needed_columns,
+                                                          const std::string& predicate) {
+  return folly::makeSemiFuture().deferValue(
+      [metadata = std::move(metadata), file, read_schema, needed_columns,
+       predicate](folly::Unit) -> arrow::Result<std::shared_ptr<VortexFormatReader>> {
+        return create_from_metadata(std::move(metadata), file, read_schema, needed_columns, predicate);
+      });
+}
+
 VortexFormatReader::VortexFormatReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                        const std::shared_ptr<arrow::Schema>& schema,
                                        const std::string& path,

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -812,6 +812,33 @@ TEST_P(FormatReaderTest, VortexLoadMetadataAsyncUsesTokioOpen) {
   EXPECT_GT(executor.add_count(), 0);
 }
 
+TEST_P(FormatReaderTest, VortexCreateFromMetadataAsyncDefersAndAppliesReadState) {
+  if (GetParam() != LOON_FORMAT_VORTEX) {
+    GTEST_SKIP() << "Test vortex only.";
+  }
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_VORTEX, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  ASSERT_STATUS_OK(writer->write(test_batch_));
+  ASSERT_AND_ASSIGN(auto column_groups, writer->close());
+  const auto& file = column_groups->front()->files.front();
+  ASSERT_AND_ASSIGN(auto metadata, FormatReader::load_metadata<vortex::VortexFormatReader>(file, properties_, nullptr));
+
+  auto id_schema = arrow::schema({schema_->field(0)});
+  auto future = vortex::VortexFormatReader::MetaTrait::create_from_metadata_async(std::move(metadata), file, id_schema,
+                                                                                  {"id"}, "id > 1000000");
+  EXPECT_FALSE(future.isReady());
+
+  CountingExecutor executor;
+  ASSERT_AND_ASSIGN(auto reader, std::move(future).via(&executor).get());
+  EXPECT_GT(executor.add_count(), 0);
+
+  ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
+  EXPECT_EQ(batch->num_rows(), 0);
+  ASSERT_EQ(batch->num_columns(), 1);
+  EXPECT_EQ(batch->schema()->field(0)->name(), "id");
+}
+
 TEST_P(FormatReaderTest, TestReadWithRange) {
   std::string format = GetParam();
   ASSERT_AND_ASSIGN(auto two_cols_schema, CreateTestSchema(std::array<bool, 4>{true, false, false, true}));


### PR DESCRIPTION
Async column group reads can load cached metadata through a future, but they still rebuild the format reader synchronously after that metadata becomes available. Reader reconstruction may reopen the underlying file and perform blocking remote I/O, so the public async API can still block the thread that starts the operation. Add `create_from_metadata_async` to the async metadata contract and use it in both eager and lazy column group readers. This keeps metadata loading and reader reconstruction in the same future chain, while formats without a complete async metadata path continue using the existing synchronous fallback.

Parquet and Vortex now provide deferred adapters around their existing metadata-based constructors. Reconstruction starts only when the SemiFuture is driven, allowing the work to follow the caller-provided executor and leaving room for each format to adopt a native asynchronous implementation later.