### PR TITLE
fix: compute per-column chunk memory estimates on demand

### DIFF
--- a/cpp/include/milvus-storage/format/column_group_reader.h
+++ b/cpp/include/milvus-storage/format/column_group_reader.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 
 #include <arrow/filesystem/filesystem.h>
 
@@ -28,9 +27,6 @@
 
 namespace milvus_storage::api {
 
-using ColumnMemorySizes = std::unordered_map<std::string, uint64_t>;
-using ColumnMemorySizesPtr = std::shared_ptr<const ColumnMemorySizes>;
-
 struct ChunkInfo {
   size_t file_index;               // current chunk belong which file
   size_t row_offset_in_row_group;  // the starting row offset of this row group in its file
@@ -39,10 +35,7 @@ struct ChunkInfo {
   size_t row_group_index_in_file;  // the index of this row group in its file
   size_t global_row_end;           // the ending row offset of this row group in the whole chunk reader
   uint64_t avg_memory_size;        // average memory usage of this row group
-  // Keyed by the current file's field names so chunks from files with different
-  // physical column orders can share immutable metadata without normalization.
-  ColumnMemorySizesPtr column_memory_sizes;
-  // False means avg_memory_size is only a placeholder and column_memory_sizes is unavailable.
+  // False means avg_memory_size is only a placeholder and column estimates are unavailable.
   bool memory_size_available;
 
   // Format all logical/file offset fields for diagnostics.
@@ -65,7 +58,7 @@ class ColumnGroupReader {
       const std::vector<int64_t>& chunk_indices, size_t parallelism = 1) = 0;
 
   virtual arrow::Result<uint64_t> get_chunk_estimated_size(int64_t chunk_index) = 0;
-  virtual arrow::Result<uint64_t> get_chunk_column_estimated_size(int64_t chunk_index, int col_idx) = 0;
+  virtual arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_sizes(int64_t chunk_index) = 0;
   virtual arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) = 0;
 
   // Get chunk info by index (for async task planning and splitting).

--- a/cpp/include/milvus-storage/format/format_reader.h
+++ b/cpp/include/milvus-storage/format/format_reader.h
@@ -41,7 +41,6 @@ struct RowGroupInfo {
   size_t start_offset;
   size_t end_offset;
   uint64_t memory_size;
-  std::vector<uint64_t> column_memory_sizes;
   // `memory_size` is only a placeholder when this is false. The original
   // statistics failure is intentionally not retained; public estimate APIs
   // return a generic NotImplemented status instead.
@@ -96,6 +95,10 @@ class FormatReader {
 
   // get the row group infos
   [[nodiscard]] virtual arrow::Result<std::vector<RowGroupInfo>> get_row_group_infos() = 0;
+
+  // Get per-column memory estimates for one row group in physical file schema order.
+  // The returned values sum to RowGroupInfo::memory_size.
+  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_rg_column_memsz(int64_t row_group_index) const = 0;
 
   // get the chunk
   [[nodiscard]] virtual arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(const int& row_group_index) = 0;

--- a/cpp/include/milvus-storage/format/iceberg/iceberg_format_reader.h
+++ b/cpp/include/milvus-storage/format/iceberg/iceberg_format_reader.h
@@ -66,6 +66,7 @@ class IcebergFormatReader final : public FormatReader {
 
   [[nodiscard]] arrow::Status open() override;
   [[nodiscard]] arrow::Result<std::vector<RowGroupInfo>> get_row_group_infos() override;
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_rg_column_memsz(int64_t row_group_index) const override;
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(const int& row_group_index) override;
   [[nodiscard]] arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> get_chunks(
       const std::vector<int>& rg_indices_in_file) override;

--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -49,6 +49,7 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
       uint64_t physical_row_count = 0;
       uint64_t num_deletions = 0;
       uint64_t logical_chunk_rows = 0;
+      std::shared_ptr<const std::vector<uint64_t>> column_memory_weights;
       milvus_storage::api::Properties properties;
     };
 
@@ -73,6 +74,8 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
 
   // get the row group infos
   [[nodiscard]] arrow::Result<std::vector<RowGroupInfo>> get_row_group_infos() override;
+
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_rg_column_memsz(int64_t row_group_index) const override;
 
   // get the chunk
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(const int& row_group_index) override;
@@ -104,6 +107,7 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
 
   uint64_t logical_chunk_rows_;
   uint64_t num_deletions_ = 0;  // physical_rows - logical_rows
+  std::shared_ptr<const std::vector<uint64_t>> column_memory_weights_;
   std::vector<RowGroupInfo> row_group_infos_;
   std::unique_ptr<BlockingFragmentReader> fragment_reader_;
 };

--- a/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_format_reader.h
@@ -82,6 +82,8 @@ class ParquetFormatReader final : public FormatReader, public std::enable_shared
   // get the row group infos
   [[nodiscard]] arrow::Result<std::vector<RowGroupInfo>> get_row_group_infos() override;
 
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_rg_column_memsz(int64_t row_group_index) const override;
+
   // get the chunk
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(const int& row_group_index) override;
 

--- a/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_format_reader.h
@@ -46,6 +46,7 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
       std::shared_ptr<FileSystemWrapper> fs_holder;
       std::shared_ptr<VortexFile> vxfile;
       uint64_t logical_chunk_rows = 0;
+      std::shared_ptr<const std::vector<uint64_t>> column_memory_weights;
       api::Properties properties;
     };
 
@@ -93,6 +94,8 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
 
   // get the row group infos
   [[nodiscard]] arrow::Result<std::vector<RowGroupInfo>> get_row_group_infos() override;
+
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_rg_column_memsz(int64_t row_group_index) const override;
 
   // get the chunk
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> get_chunk(const int& row_group_index) override;
@@ -175,6 +178,7 @@ class VortexFormatReader final : public FormatReader, public std::enable_shared_
   std::shared_ptr<arrow::Schema> file_schema_;  // always derived from file in open()
 
   uint64_t logical_chunk_rows_ = 0;
+  std::shared_ptr<const std::vector<uint64_t>> column_memory_weights_;
   std::vector<RowGroupInfo> row_group_infos_;
   std::shared_ptr<VortexFile> vxfile_;
   std::unique_ptr<expr::Expr> parsed_predicate_;

--- a/cpp/include/milvus-storage/reader.h
+++ b/cpp/include/milvus-storage/reader.h
@@ -108,10 +108,9 @@ class ChunkReader {
   /**
    * @brief Returns the estimated decoded-memory size of every chunk.
    *
-   * The result is indexed by chunk. When per-column metadata is available, each
-   * estimate is the sum of the logical column group's fields, independently of
-   * the active projection; fields present only in a physical file are excluded.
-   * Formats without per-column metadata retain their aggregate estimate.
+   * The result is indexed by chunk and contains the aggregate estimate recorded
+   * for that chunk. It is independent of the active projection and may include
+   * physical-file fields that are not present in the logical column group.
    * Estimates may be zero when a chunk has no live rows or its known
    * decoded-memory size is zero. Unavailable estimates are returned as an
    * error, typically arrow::Status::NotImplemented, rather than as zero.
@@ -119,20 +118,6 @@ class ChunkReader {
    * @return One estimated size in bytes per chunk, or an error status.
    */
   [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_estimated_size() = 0;
-
-  /**
-   * @brief Returns the estimated decoded-memory size of a top-level field in every chunk.
-   *
-   * The field is resolved against the logical column group, independently of
-   * the active projection. A field absent from a particular physical file has
-   * a known zero estimate for that chunk. Unavailable statistics are returned
-   * as an error rather than as zero.
-   *
-   * @param field_name Name of a unique top-level field in the column group.
-   * @return One estimated size in bytes per chunk, or an error status.
-   */
-  [[nodiscard]] virtual arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_size(
-      const std::string& field_name) = 0;
 
   /**
    * @brief Returns estimated decoded-memory sizes for every top-level field and chunk.

--- a/cpp/scripts/error_handling_baseline.tsv
+++ b/cpp/scripts/error_handling_baseline.tsv
@@ -8,6 +8,5 @@ throw	cpp/src/format/lance/lance_common.cpp	2
 throw	cpp/src/format/vortex/vortex_translater.cpp	6
 throw	cpp/src/manifest.cpp	1
 throw	cpp/src/packed/chunk_manager.cpp	2
-throw	cpp/src/packed/column_group.cpp	1
 throw	cpp/src/packed/reader.cpp	1
 throw	cpp/src/properties.cpp	1

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -16,10 +16,8 @@
 
 #include <algorithm>
 #include <future>
-#include <limits>
 #include <numeric>
 #include <sstream>
-#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -55,30 +53,6 @@ namespace milvus_storage::api {
 using milvus_storage::RowGroupInfo;
 using ChunkRBMapResult = arrow::Result<std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>>;
 
-namespace {
-
-arrow::Result<ColumnMemorySizesPtr> BuildColumnMemorySizes(const arrow::Schema& file_schema,
-                                                           const std::vector<uint64_t>& sizes) {
-  if (sizes.empty()) {
-    return ColumnMemorySizesPtr{};
-  }
-  if (sizes.size() != static_cast<size_t>(file_schema.num_fields())) {
-    return arrow::Status::Invalid("Column memory size count does not match the file schema");
-  }
-
-  auto column_memory_sizes = std::make_shared<ColumnMemorySizes>();
-  column_memory_sizes->reserve(sizes.size());
-  for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
-    const auto& field_name = file_schema.field(field_index)->name();
-    if (!column_memory_sizes->emplace(field_name, sizes[field_index]).second) {
-      return arrow::Status::Invalid("Duplicate field name in file schema: ", field_name);
-    }
-  }
-  return std::static_pointer_cast<const ColumnMemorySizes>(column_memory_sizes);
-}
-
-}  // namespace
-
 template <typename ReaderT>
 class ColumnGroupReaderImpl : public ColumnGroupReader {
   public:
@@ -104,7 +78,7 @@ class ColumnGroupReaderImpl : public ColumnGroupReader {
       const std::vector<int64_t>& chunk_indices, size_t parallelism = 1) override;
 
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_estimated_size(int64_t chunk_index) override;
-  [[nodiscard]] arrow::Result<uint64_t> get_chunk_column_estimated_size(int64_t chunk_index, int col_idx) override;
+  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_sizes(int64_t chunk_index) override;
   [[nodiscard]] arrow::Result<uint64_t> get_chunk_rows(int64_t chunk_index) override;
 
   [[nodiscard]] const ChunkInfo& get_chunk_info(int64_t chunk_index) const override;
@@ -187,27 +161,6 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::append_file_metadata(size_t file_i
     return arrow::Status::OK();
   }
 
-  auto current_file_schema = format_readers_[file_idx] ? format_readers_[file_idx]->get_schema() : nullptr;
-  auto build_column_memory_sizes = [&](const std::vector<uint64_t>& sizes) -> ColumnMemorySizesPtr {
-    if (sizes.empty()) {
-      return nullptr;
-    }
-    if (!current_file_schema) {
-      LOG_STORAGE_DEBUG_ << "Column memory sizes are unavailable because the file schema is missing"
-                         << ", path=" << cg_file.path;
-      return nullptr;
-    }
-    auto result = BuildColumnMemorySizes(*current_file_schema, sizes);
-    if (!result.ok()) {
-      // Column estimates are optional. Preserve the total chunk estimate and
-      // normal reads; the public column-estimate API returns NotImplemented.
-      LOG_STORAGE_DEBUG_ << "Column memory sizes are unavailable"
-                         << ", path=" << cg_file.path << ", status=" << result.status().ToString();
-      return nullptr;
-    }
-    return std::move(result).ValueOrDie();
-  };
-
   size_t rows_in_file = 0;
   if ((cg_file.start_index != 0 || cg_file.end_index != row_group_in_file.back().end_offset)) {
     // A manifest file may expose only a subrange of its physical contents.
@@ -232,16 +185,6 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::append_file_metadata(size_t file_i
           chunk_memory_size = static_cast<uint64_t>(static_cast<unsigned __int128>(row_group_in_file[j].memory_size) *
                                                     overlap_rows / row_group_rows);
         }
-        ColumnMemorySizesPtr column_memory_sizes;
-        if (row_group_in_file[j].memory_size_available && !row_group_in_file[j].column_memory_sizes.empty()) {
-          auto scaled_sizes = DistributeMemorySizes(chunk_memory_size, row_group_in_file[j].column_memory_sizes);
-          if (scaled_sizes.ok()) {
-            column_memory_sizes = build_column_memory_sizes(*scaled_sizes);
-          } else {
-            LOG_STORAGE_DEBUG_ << "Column memory size scaling is unavailable"
-                               << ", path=" << cg_file.path << ", status=" << scaled_sizes.status().ToString();
-          }
-        }
 
         rows_in_file += overlap_rows;
         // global_row_end is exclusive across the whole column group and powers
@@ -254,7 +197,6 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::append_file_metadata(size_t file_i
             .row_group_index_in_file = j,
             .global_row_end = rows_in_all_files + rows_in_file,
             .avg_memory_size = chunk_memory_size,
-            .column_memory_sizes = std::move(column_memory_sizes),
             .memory_size_available = row_group_in_file[j].memory_size_available,
         });
       }
@@ -270,9 +212,6 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::append_file_metadata(size_t file_i
           .row_group_index_in_file = j,
           .global_row_end = rows_in_all_files + rows_in_file,
           .avg_memory_size = row_group_in_file[j].memory_size,
-          .column_memory_sizes = row_group_in_file[j].memory_size_available
-                                     ? build_column_memory_sizes(row_group_in_file[j].column_memory_sizes)
-                                     : nullptr,
           .memory_size_available = row_group_in_file[j].memory_size_available,
       });
     }
@@ -716,34 +655,12 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_estimated_size
   if (!chunk_info.memory_size_available) {
     return arrow::Status::NotImplemented("Chunk memory size estimate is not available");
   }
-  if (!chunk_info.column_memory_sizes) {
-    return chunk_info.avg_memory_size;
-  }
-
-  // Files in one column group may have evolved physical schemas and can retain
-  // columns removed from the logical group. Sum the logical column estimates
-  // so physical-only columns are excluded while the result remains independent
-  // of the active projection.
-  uint64_t total_size = 0;
-  std::unordered_set<std::string_view> seen_columns;
-  seen_columns.reserve(column_group_->columns.size());
-  for (size_t col_idx = 0; col_idx < column_group_->columns.size(); ++col_idx) {
-    const auto& column_name = column_group_->columns[col_idx];
-    if (!seen_columns.emplace(column_name).second) {
-      return arrow::Status::Invalid("Duplicate column in column group: ", column_name);
-    }
-    ARROW_ASSIGN_OR_RAISE(auto column_size, get_chunk_column_estimated_size(chunk_index, static_cast<int>(col_idx)));
-    if (column_size > std::numeric_limits<uint64_t>::max() - total_size) {
-      return arrow::Status::Invalid("Chunk column memory sizes exceed the uint64_t range");
-    }
-    total_size += column_size;
-  }
-  return total_size;
+  return chunk_info.avg_memory_size;
 }
 
 template <typename ReaderT>
-arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_estimated_size(int64_t chunk_index,
-                                                                                        int col_idx) {
+arrow::Result<std::vector<uint64_t>> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_estimated_sizes(
+    int64_t chunk_index) {
   assert(opened_);
   if (UNLIKELY(chunk_index < 0 || chunk_index >= chunk_infos_.size())) {
     return arrow::Status::Invalid(
@@ -751,19 +668,35 @@ arrow::Result<uint64_t> ColumnGroupReaderImpl<ReaderT>::get_chunk_column_estimat
   }
 
   const auto& chunk_info = chunk_infos_[chunk_index];
-  const auto& column_memory_sizes = chunk_info.column_memory_sizes;
   if (!chunk_info.memory_size_available) {
     return arrow::Status::NotImplemented("Column memory size estimate is not available");
   }
-  if (!column_memory_sizes) {
-    return arrow::Status::NotImplemented("Column memory size metadata is not available for this format");
+
+  assert(chunk_info.file_index < format_readers_.size());
+  const auto& format_reader = format_readers_[chunk_info.file_index];
+  assert(format_reader);
+  auto file_schema = format_reader->get_schema();
+  assert(file_schema);
+
+  ARROW_ASSIGN_OR_RAISE(auto row_group_memory_sizes,
+                        format_reader->get_rg_column_memsz(chunk_info.row_group_index_in_file));
+  assert(row_group_memory_sizes.size() == static_cast<size_t>(file_schema->num_fields()));
+
+  for (int field_index = 0; field_index < file_schema->num_fields(); ++field_index) {
+    if (file_schema->GetFieldIndex(file_schema->field(field_index)->name()) != field_index) {
+      return arrow::Status::NotImplemented("Column memory sizes are unavailable for a schema with duplicate fields");
+    }
   }
-  if (UNLIKELY(col_idx < 0 || static_cast<size_t>(col_idx) >= column_group_->columns.size())) {
-    return arrow::Status::Invalid(
-        fmt::format("Column index out of range: {} out of {}", col_idx, column_group_->columns.size()));
+
+  ARROW_ASSIGN_OR_RAISE(auto physical_sizes, DistributeMemorySizes(chunk_info.avg_memory_size, row_group_memory_sizes));
+  std::vector<uint64_t> result(column_group_->columns.size(), 0);
+  for (size_t column_index = 0; column_index < column_group_->columns.size(); ++column_index) {
+    const auto field_index = file_schema->GetFieldIndex(column_group_->columns[column_index]);
+    if (field_index >= 0) {
+      result[column_index] = physical_sizes[field_index];
+    }
   }
-  const auto it = column_memory_sizes->find(column_group_->columns[col_idx]);
-  return it == column_memory_sizes->end() ? uint64_t{0} : it->second;
+  return result;
 }
 
 template <typename ReaderT>

--- a/cpp/src/format/format_reader.cpp
+++ b/cpp/src/format/format_reader.cpp
@@ -44,12 +44,21 @@ arrow::Result<std::vector<uint64_t>> DistributeMemorySizes(uint64_t total_size, 
   }
 
   uint64_t allocated = 0;
-  for (size_t i = 0; i + 1 < weights.size(); ++i) {
+  size_t remainder_index = 0;
+  for (size_t i = 0; i < weights.size(); ++i) {
+    if (weights[i] != 0) {
+      remainder_index = i;
+    }
     // weights[i] <= total_weight, so the quotient is at most total_size and is safe to cast back to uint64_t.
     result[i] = static_cast<uint64_t>(static_cast<unsigned __int128>(total_size) * weights[i] / total_weight);
     allocated += result[i];
   }
-  result.back() = total_size - allocated;
+
+  // Integer division may leave a remainder. Assign it to the last non-zero
+  // weight so the estimates still sum exactly to total_size without charging
+  // a physically missing column solely because of rounding.
+  const auto remainder = total_size - allocated;
+  result[remainder_index] += remainder;
   return result;
 }
 

--- a/cpp/src/format/iceberg/iceberg_format_reader.cpp
+++ b/cpp/src/format/iceberg/iceberg_format_reader.cpp
@@ -393,19 +393,17 @@ arrow::Result<std::vector<RowGroupInfo>> IcebergFormatReader::build_logical_row_
     // estimate the logical row-group size by assuming deleted rows have the
     // physical row group's average memory size.
     uint64_t logical_memory_size = 0;
-    if (physical_rows != 0) {
+    if (prg.memory_size_available && physical_rows != 0) {
       // logical_rows <= physical_rows, so the quotient is at most prg.memory_size and is safe to cast to uint64_t.
       logical_memory_size =
           static_cast<uint64_t>(static_cast<unsigned __int128>(prg.memory_size) * logical_rows / physical_rows);
     }
-    ARROW_ASSIGN_OR_RAISE(auto logical_column_memory_sizes,
-                          milvus_storage::DistributeMemorySizes(logical_memory_size, prg.column_memory_sizes));
 
     logical_row_group_infos.emplace_back(RowGroupInfo{
         .start_offset = logical_offset,
         .end_offset = logical_offset + logical_rows,
         .memory_size = logical_memory_size,
-        .column_memory_sizes = std::move(logical_column_memory_sizes),
+        .memory_size_available = prg.memory_size_available,
     });
     logical_offset += logical_rows;
   }
@@ -431,6 +429,17 @@ int64_t IcebergFormatReader::logical_to_physical(int64_t logical_offset) const {
 }
 
 arrow::Result<std::vector<RowGroupInfo>> IcebergFormatReader::get_row_group_infos() { return logical_row_group_infos_; }
+
+arrow::Result<std::vector<uint64_t>> IcebergFormatReader::get_rg_column_memsz(int64_t row_group_index) const {
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= logical_row_group_infos_.size()) {
+    return arrow::Status::Invalid(fmt::format("Iceberg row group index out of range: {}", row_group_index));
+  }
+  if (!logical_row_group_infos_[row_group_index].memory_size_available) {
+    return arrow::Status::NotImplemented("Iceberg column memory size statistics are not available");
+  }
+  ARROW_ASSIGN_OR_RAISE(auto physical_sizes, inner_reader_->get_rg_column_memsz(row_group_index));
+  return DistributeMemorySizes(logical_row_group_infos_[row_group_index].memory_size, physical_sizes);
+}
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> IcebergFormatReader::get_chunk(const int& row_group_index) {
   // Check if this logical row group has zero rows (e.g. all rows deleted)

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -114,15 +114,10 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
     auto memory_offset =
         static_cast<uint64_t>((static_cast<unsigned __int128>(fragment_memory_size) * end_offset) / rows_in_file);
     auto memory_size = memory_offset - last_memory_offset;
-    std::vector<uint64_t> column_memory_sizes;
-    if (memory_size_available) {
-      ARROW_ASSIGN_OR_RAISE(column_memory_sizes, DistributeMemorySizes(memory_size, fragment_column_memory_sizes));
-    }
     result.emplace_back(RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = end_offset,
         .memory_size = memory_size,
-        .column_memory_sizes = std::move(column_memory_sizes),
         .memory_size_available = memory_size_available,
     });
     last_offset = end_offset;
@@ -239,10 +234,7 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
   metadata->path = file.path;
   metadata->file_schema = std::move(file_schema);
   metadata->row_group_infos = std::move(row_group_infos);
-  size_t column_memory_sizes_size = 0;
-  for (const auto& row_group_info : metadata->row_group_infos) {
-    column_memory_sizes_size += row_group_info.column_memory_sizes.size() * sizeof(uint64_t);
-  }
+  const auto column_memory_sizes_size = fragment_column_memory_sizes.size() * sizeof(uint64_t);
   auto outer_metadata_size =
       sizeof(Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo) + column_memory_sizes_size;
   metadata->cache_size = outer_metadata_size + file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize);
@@ -254,6 +246,9 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
       .physical_row_count = physical_rows,
       .num_deletions = physical_rows - logical_rows,
       .logical_chunk_rows = logical_chunk_rows,
+      .column_memory_weights =
+          memory_size_available ? std::make_shared<const std::vector<uint64_t>>(std::move(fragment_column_memory_sizes))
+                                : nullptr,
       .properties = properties,
   };
 
@@ -282,6 +277,7 @@ arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::cr
   reader->file_schema_ = metadata->file_schema;
   reader->logical_chunk_rows_ = metadata->payload.logical_chunk_rows;
   reader->num_deletions_ = metadata->payload.num_deletions;
+  reader->column_memory_weights_ = metadata->payload.column_memory_weights;
   reader->row_group_infos_ = metadata->row_group_infos;
 
   ARROW_ASSIGN_OR_RAISE(auto requested_schema, build_read_schema(reader->file_schema_, read_schema, needed_columns));
@@ -374,6 +370,9 @@ arrow::Status LanceTableReader::open() {
   }
   ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(logical_rows, logical_chunk_rows_,
                                                                  fragment_column_memory_sizes, memory_size_available));
+  column_memory_weights_ = memory_size_available
+                               ? std::make_shared<const std::vector<uint64_t>>(std::move(fragment_column_memory_sizes))
+                               : nullptr;
 
   return arrow::Status::OK();
 }
@@ -383,6 +382,16 @@ std::shared_ptr<arrow::Schema> LanceTableReader::get_schema() const { return fil
 arrow::Result<std::vector<RowGroupInfo>> LanceTableReader::get_row_group_infos() {
   assert(fragment_reader_);
   return row_group_infos_;
+}
+
+arrow::Result<std::vector<uint64_t>> LanceTableReader::get_rg_column_memsz(int64_t row_group_index) const {
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid("Lance row group index out of range: ", row_group_index);
+  }
+  if (!row_group_infos_[row_group_index].memory_size_available || !column_memory_weights_) {
+    return arrow::Status::NotImplemented("Lance column memory size statistics are not available");
+  }
+  return DistributeMemorySizes(row_group_infos_[row_group_index].memory_size, *column_memory_weights_);
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> LanceTableReader::get_chunk(const int& row_group_index) {

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -83,15 +83,10 @@ static arrow::Result<std::vector<RowGroupInfo>> try_build_row_group_infos(
 }
 
 static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_metadata(
-    const std::shared_ptr<::parquet::FileMetaData>& metadata,
-    const arrow::Schema& file_schema,
-    const std::string& path) {
+    const std::shared_ptr<::parquet::FileMetaData>& metadata, const std::string& path) {
   // Keep the existing row-group memory estimate as the total-size anchor: prefer
   // Milvus private metadata when available, otherwise fall back to the Parquet
-  // footer's total byte size. Parquet leaf-column uncompressed sizes are used only
-  // as relative weights. Leaves belonging to a nested top-level Arrow field are
-  // aggregated so column_memory_sizes follows the complete file-schema order and
-  // sums exactly to the row group's memory_size.
+  // footer's total byte size.
   assert(metadata);
   if (!metadata) {
     return arrow::Status::Invalid(fmt::format("Failed to get parquet file metadata for file: {}", path));
@@ -119,60 +114,16 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos_from_meta
     }
   }
 
-  // Map every top-level Arrow field to a half-open range of physical Parquet
-  // leaf columns. For example, offsets [0, 1, 3] mean field 0 owns leaf [0, 1)
-  // and field 1 owns leaves [1, 3).
-  const auto leaf_column_offsets_by_field = get_leaf_column_offsets_by_field(file_schema);
-
-  // The private row-group metadata and the Parquet footer must describe the
-  // same row groups, while the Arrow schema must expand to every Parquet leaf.
-  if (row_group_infos.size() != static_cast<size_t>(metadata->num_row_groups()) ||
-      leaf_column_offsets_by_field.back() != metadata->num_columns()) {
+  if (row_group_infos.size() != static_cast<size_t>(metadata->num_row_groups())) {
     return arrow::Status::Invalid(
-        fmt::format("Parquet row-group metadata does not match the file schema. [path={}]", path));
-  }
-
-  for (int row_group_index = 0; row_group_index < metadata->num_row_groups(); ++row_group_index) {
-    auto row_group_meta = metadata->RowGroup(row_group_index);
-
-    // Build one weight per top-level Arrow field. Nested fields contribute the
-    // sum of total_uncompressed_size from all physical leaves below that field.
-    std::vector<uint64_t> column_weights;
-    column_weights.reserve(file_schema.num_fields());
-    for (int field_index = 0; field_index < file_schema.num_fields(); ++field_index) {
-      uint64_t field_weight = 0;
-      for (int leaf_column_index = leaf_column_offsets_by_field[field_index];
-           leaf_column_index < leaf_column_offsets_by_field[field_index + 1]; ++leaf_column_index) {
-        auto uncompressed_size = row_group_meta->ColumnChunk(leaf_column_index)->total_uncompressed_size();
-        if (uncompressed_size < 0) {
-          return arrow::Status::Invalid(
-              fmt::format("Parquet column uncompressed size is negative. [path={}, row_group={}, column={}]", path,
-                          row_group_index, leaf_column_index));
-        }
-        auto column_weight = static_cast<uint64_t>(uncompressed_size);
-        if (column_weight > std::numeric_limits<uint64_t>::max() - field_weight) {
-          return arrow::Status::Invalid(
-              fmt::format("Parquet top-level column size exceeds the uint64_t range. [path={}, row_group={}, field={}]",
-                          path, row_group_index, field_index));
-        }
-        field_weight += column_weight;
-      }
-      column_weights.emplace_back(field_weight);
-    }
-
-    // The Parquet sizes above define only the relative column proportions.
-    // Normalize them against the existing row-group memory estimate so the
-    // resulting column sizes sum exactly to memory_size.
-    ARROW_ASSIGN_OR_RAISE(row_group_infos[row_group_index].column_memory_sizes,
-                          DistributeMemorySizes(row_group_infos[row_group_index].memory_size, column_weights));
+        fmt::format("Parquet row-group metadata count does not match the footer. [path={}]", path));
   }
   return row_group_infos;
 }
 
 arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::create_row_group_infos(
     const std::shared_ptr<::parquet::FileMetaData>& metadata) {
-  assert(schema_);
-  return create_row_group_infos_from_metadata(metadata, *schema_, path_);
+  return create_row_group_infos_from_metadata(metadata, path_);
 }
 
 ParquetFormatReader::ParquetFormatReader(const std::shared_ptr<arrow::fs::FileSystem>& fs,
@@ -502,6 +453,52 @@ folly::SemiFuture<arrow::Status> ParquetFormatReader::open_async() {
 }
 
 arrow::Result<std::vector<RowGroupInfo>> ParquetFormatReader::get_row_group_infos() { return row_group_infos_; }
+
+arrow::Result<std::vector<uint64_t>> ParquetFormatReader::get_rg_column_memsz(int64_t row_group_index) const {
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid(fmt::format("Parquet row group index out of range: {}", row_group_index));
+  }
+  if (!schema_ || !file_reader_ || !file_reader_->parquet_reader()) {
+    return arrow::Status::Invalid(fmt::format("Parquet reader metadata is not initialized. [path={}]", path_));
+  }
+
+  auto metadata = file_reader_->parquet_reader()->metadata();
+  if (!metadata || row_group_index >= metadata->num_row_groups()) {
+    return arrow::Status::Invalid(
+        fmt::format("Parquet row group metadata is not available. [path={}, row_group={}]", path_, row_group_index));
+  }
+
+  const auto leaf_column_offsets_by_field = get_leaf_column_offsets_by_field(*schema_);
+  if (leaf_column_offsets_by_field.back() != metadata->num_columns()) {
+    return arrow::Status::Invalid(
+        fmt::format("Parquet row-group metadata does not match the file schema. [path={}]", path_));
+  }
+
+  auto row_group_meta = metadata->RowGroup(static_cast<int>(row_group_index));
+  std::vector<uint64_t> column_weights;
+  column_weights.reserve(schema_->num_fields());
+  for (int field_index = 0; field_index < schema_->num_fields(); ++field_index) {
+    uint64_t field_weight = 0;
+    for (int leaf_column_index = leaf_column_offsets_by_field[field_index];
+         leaf_column_index < leaf_column_offsets_by_field[field_index + 1]; ++leaf_column_index) {
+      auto uncompressed_size = row_group_meta->ColumnChunk(leaf_column_index)->total_uncompressed_size();
+      if (uncompressed_size < 0) {
+        return arrow::Status::Invalid(
+            fmt::format("Parquet column uncompressed size is negative. [path={}, row_group={}, column={}]", path_,
+                        row_group_index, leaf_column_index));
+      }
+      auto column_weight = static_cast<uint64_t>(uncompressed_size);
+      if (column_weight > std::numeric_limits<uint64_t>::max() - field_weight) {
+        return arrow::Status::Invalid(
+            fmt::format("Parquet top-level column size exceeds the uint64_t range. [path={}, row_group={}, field={}]",
+                        path_, row_group_index, field_index));
+      }
+      field_weight += column_weight;
+    }
+    column_weights.emplace_back(field_weight);
+  }
+  return DistributeMemorySizes(row_group_infos_[row_group_index].memory_size, column_weights);
+}
 
 // Parquet uses a single schema_ (always derived from the file footer) rather than
 // separate read_schema_/file_schema_ like Lance/Vortex. Projection needs both

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -261,19 +261,15 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
       return arrow::Status::Invalid("Vortex row range exceeds the file row count");
     }
     uint64_t memory_size = 0;
-    std::vector<uint64_t> column_memory_sizes;
     if (memory_size_estimate) {
       // row_range <= rows_in_file, so the quotient is at most the file memory size and is safe to cast to uint64_t.
       memory_size = static_cast<uint64_t>(static_cast<unsigned __int128>(memory_size_estimate->total_size) * row_range /
                                           rows_in_file);
-      ARROW_ASSIGN_OR_RAISE(column_memory_sizes,
-                            DistributeMemorySizes(memory_size, memory_size_estimate->column_sizes));
     }
     result.emplace_back(RowGroupInfo{
         .start_offset = last_offset,
         .end_offset = last_offset + row_range,
         .memory_size = memory_size,
-        .column_memory_sizes = std::move(column_memory_sizes),
         .memory_size_available = memory_size_estimate.has_value(),
     });
     last_offset += row_range;
@@ -472,6 +468,7 @@ arrow::Result<VortexFormatReader::MetaTrait::MetadataPtr> VortexFormatReader::Me
               .fs_holder = reader->fs_holder_,
               .vxfile = reader->vxfile_,
               .logical_chunk_rows = reader->logical_chunk_rows_,
+              .column_memory_weights = reader->column_memory_weights_,
               .properties = reader->properties_,
           },
   });
@@ -581,6 +578,7 @@ VortexFormatReader::VortexFormatReader(MetaTrait::MetadataPtr metadata,
       footer_size_(footer_size),
       file_schema_(metadata->file_schema),
       logical_chunk_rows_(metadata->payload.logical_chunk_rows),
+      column_memory_weights_(metadata->payload.column_memory_weights),
       row_group_infos_(metadata->row_group_infos),
       vxfile_(metadata->payload.vxfile) {
   if (read_schema_ && read_schema_->num_fields() == 0) {
@@ -608,6 +606,10 @@ arrow::Status VortexFormatReader::open() {
   ARROW_ASSIGN_OR_RAISE(row_group_infos_,
                         create_row_group_infos(vxfile_->RowCount(), recalc_row_ranges(row_ranges, logical_chunk_rows_),
                                                memory_size_estimate));
+  column_memory_weights_ =
+      memory_size_estimate
+          ? std::make_shared<const std::vector<uint64_t>>(std::move(memory_size_estimate->column_sizes))
+          : nullptr;
 
   return arrow::Status::OK();
 }
@@ -656,8 +658,13 @@ folly::SemiFuture<arrow::Status> VortexFormatReader::open_async() {
         auto row_group_infos,
         create_row_group_infos(vxfile->RowCount(), recalc_row_ranges(row_ranges, self->logical_chunk_rows_),
                                memory_size_estimate));
+    auto column_memory_weights =
+        memory_size_estimate
+            ? std::make_shared<const std::vector<uint64_t>>(std::move(memory_size_estimate->column_sizes))
+            : nullptr;
     self->vxfile_ = std::move(vxfile);
     self->file_schema_ = std::move(file_schema);
+    self->column_memory_weights_ = std::move(column_memory_weights);
     self->row_group_infos_ = std::move(row_group_infos);
     return arrow::Status::OK();
   };
@@ -706,6 +713,17 @@ arrow::Result<std::shared_ptr<arrow::Schema>> VortexFormatReader::output_schema(
 arrow::Result<std::vector<RowGroupInfo>> VortexFormatReader::get_row_group_infos() {
   assert(vxfile_);
   return row_group_infos_;
+}
+
+arrow::Result<std::vector<uint64_t>> VortexFormatReader::get_rg_column_memsz(int64_t row_group_index) const {
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid(
+        fmt::format("Vortex row group index {} out of range {}", row_group_index, row_group_infos_.size()));
+  }
+  if (!row_group_infos_[row_group_index].memory_size_available || !column_memory_weights_) {
+    return arrow::Status::NotImplemented("Vortex column memory size statistics are not available");
+  }
+  return DistributeMemorySizes(row_group_infos_[row_group_index].memory_size, *column_memory_weights_);
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::get_chunk(const int& row_group_index) {

--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -542,8 +542,6 @@ class ChunkReaderImpl : public ChunkReader {
   [[nodiscard]] folly::SemiFuture<arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>>> get_chunks_async(
       const std::vector<int64_t>& chunk_indices, size_t parallelism) override;
   [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_estimated_size() override;
-  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_size(
-      const std::string& field_name) override;
   [[nodiscard]] arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_estimated_size() override;
   [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_rows() override;
 
@@ -792,31 +790,14 @@ arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_estimated_size()
   return result;
 }
 
-arrow::Result<std::vector<uint64_t>> ChunkReaderImpl::get_chunk_column_estimated_size(const std::string& field_name) {
-  const auto field = std::find(column_group_->columns.begin(), column_group_->columns.end(), field_name);
-  if (field == column_group_->columns.end()) {
-    return arrow::Status::Invalid(fmt::format("Column '{}' is not part of the column group", field_name));
-  }
-  if (std::find(std::next(field), column_group_->columns.end(), field_name) != column_group_->columns.end()) {
-    return arrow::Status::Invalid(fmt::format("Column '{}' is duplicated in the column group", field_name));
-  }
-  const auto col_idx = static_cast<int>(std::distance(column_group_->columns.begin(), field));
-
-  const auto total_chunks = total_number_of_chunks();
-  std::vector<uint64_t> result(total_chunks);
-  for (size_t i = 0; i < total_chunks; ++i) {
-    ARROW_ASSIGN_OR_RAISE(result[i], chunk_reader_->get_chunk_column_estimated_size(i, col_idx));
-  }
-  return result;
-}
-
 arrow::Result<std::vector<std::vector<uint64_t>>> ChunkReaderImpl::get_chunk_column_estimated_size() {
   const auto total_chunks = total_number_of_chunks();
   std::vector<std::vector<uint64_t>> result(column_group_->columns.size(), std::vector<uint64_t>(total_chunks));
-  for (size_t col_idx = 0; col_idx < column_group_->columns.size(); ++col_idx) {
-    for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
-      ARROW_ASSIGN_OR_RAISE(result[col_idx][chunk_idx],
-                            chunk_reader_->get_chunk_column_estimated_size(chunk_idx, static_cast<int>(col_idx)));
+  for (size_t chunk_idx = 0; chunk_idx < total_chunks; ++chunk_idx) {
+    ARROW_ASSIGN_OR_RAISE(auto chunk_column_sizes, chunk_reader_->get_chunk_column_estimated_sizes(chunk_idx));
+    assert(chunk_column_sizes.size() == column_group_->columns.size());
+    for (size_t col_idx = 0; col_idx < column_group_->columns.size(); ++col_idx) {
+      result[col_idx][chunk_idx] = chunk_column_sizes[col_idx];
     }
   }
   return result;

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -97,11 +97,6 @@ class SyncOnlyChunkReader final : public ChunkReader {
     return std::vector<uint64_t>{0, 0, 0};
   }
 
-  [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_chunk_column_estimated_size(
-      const std::string& /*field_name*/) override {
-    return arrow::Status::NotImplemented("Column estimates are not provided by this test reader");
-  }
-
   [[nodiscard]] arrow::Result<std::vector<std::vector<uint64_t>>> get_chunk_column_estimated_size() override {
     return arrow::Status::NotImplemented("Column estimates are not provided by this test reader");
   }
@@ -1180,13 +1175,6 @@ TEST_P(APIWriterReaderTest, ChunkColumnEstimatedSizeMetadataIgnoresProjection) {
     }
     EXPECT_EQ(column_total, chunk_sizes[chunk_idx]);
   }
-
-  for (int field_idx = 0; field_idx < schema_->num_fields(); ++field_idx) {
-    ASSERT_AND_ASSIGN(auto sizes, chunk_reader->get_chunk_column_estimated_size(schema_->field(field_idx)->name()));
-    EXPECT_EQ(sizes, column_sizes[field_idx]);
-  }
-
-  EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size("missing").status().IsInvalid());
 }
 
 TEST_P(APIWriterReaderTest, EmptyTakeHonorsProjection) {

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -208,6 +208,11 @@ TEST(FormatReaderUtilityTest, MemorySizeDistributionAvoidsIntermediateOverflow) 
   EXPECT_EQ(distributed, (std::vector<uint64_t>{4 * kGiB, 4 * kGiB}));
 }
 
+TEST(FormatReaderUtilityTest, MemorySizeDistributionKeepsZeroWeightsZero) {
+  ASSERT_AND_ASSIGN(auto distributed, DistributeMemorySizes(3, {10, 10, 0}));
+  EXPECT_EQ(distributed, (std::vector<uint64_t>{1, 2, 0}));
+}
+
 class FormatReaderTest : public ::testing::TestWithParam<std::string> {
   protected:
   void SetUp() override {
@@ -282,9 +287,9 @@ TEST_P(FormatReaderTest, EstimatedMemorySizesAreReasonable) {
   std::vector<uint64_t> actual_column_sizes(schema_->num_fields(), 0);
   for (size_t chunk_idx = 0; chunk_idx < row_group_infos.size(); ++chunk_idx) {
     const auto& row_group_info = row_group_infos[chunk_idx];
-    ASSERT_EQ(row_group_info.column_memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
-    EXPECT_EQ(std::accumulate(row_group_info.column_memory_sizes.begin(), row_group_info.column_memory_sizes.end(),
-                              uint64_t{0}),
+    ASSERT_AND_ASSIGN(auto row_group_memory_sizes, format_reader->get_rg_column_memsz(chunk_idx));
+    ASSERT_EQ(row_group_memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
+    EXPECT_EQ(std::accumulate(row_group_memory_sizes.begin(), row_group_memory_sizes.end(), uint64_t{0}),
               row_group_info.memory_size);
 
     ASSERT_AND_ASSIGN(auto chunk, format_reader->get_chunk(chunk_idx));
@@ -292,7 +297,7 @@ TEST_P(FormatReaderTest, EstimatedMemorySizesAreReasonable) {
     estimated_total_size += row_group_info.memory_size;
     actual_total_size += GetRecordBatchMemorySize(chunk);
     for (int column_idx = 0; column_idx < schema_->num_fields(); ++column_idx) {
-      estimated_column_sizes[column_idx] += row_group_info.column_memory_sizes[column_idx];
+      estimated_column_sizes[column_idx] += row_group_memory_sizes[column_idx];
       actual_column_sizes[column_idx] += GetArrowArrayMemorySize(chunk->column(column_idx));
     }
   }
@@ -388,30 +393,40 @@ TEST_P(FormatReaderTest, MultiFileColumnEstimatesFollowFieldNames) {
 
   std::vector<uint64_t> expected_id_sizes;
   std::vector<uint64_t> expected_name_sizes;
-  for (const auto& row_group : ordered_row_groups) {
-    ASSERT_EQ(row_group.column_memory_sizes.size(), 2);
-    expected_id_sizes.emplace_back(row_group.column_memory_sizes[0]);
-    expected_name_sizes.emplace_back(row_group.column_memory_sizes[1]);
+  std::vector<uint64_t> expected_chunk_sizes;
+  for (size_t row_group_index = 0; row_group_index < ordered_row_groups.size(); ++row_group_index) {
+    ASSERT_AND_ASSIGN(auto memory_sizes, ordered_format_reader->get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), 2);
+    expected_id_sizes.emplace_back(memory_sizes[0]);
+    expected_name_sizes.emplace_back(memory_sizes[1]);
+    expected_chunk_sizes.emplace_back(ordered_row_groups[row_group_index].memory_size);
   }
-  for (const auto& row_group : reordered_row_groups) {
-    ASSERT_EQ(row_group.column_memory_sizes.size(), 2);
-    expected_name_sizes.emplace_back(row_group.column_memory_sizes[0]);
-    expected_id_sizes.emplace_back(row_group.column_memory_sizes[1]);
+  for (size_t row_group_index = 0; row_group_index < reordered_row_groups.size(); ++row_group_index) {
+    ASSERT_AND_ASSIGN(auto memory_sizes, reordered_format_reader->get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), 2);
+    expected_name_sizes.emplace_back(memory_sizes[0]);
+    expected_id_sizes.emplace_back(memory_sizes[1]);
+    expected_chunk_sizes.emplace_back(reordered_row_groups[row_group_index].memory_size);
+    if (row_group_index == 0) {
+      EXPECT_NE(memory_sizes[0], memory_sizes[1]);
+    }
   }
-  for (const auto& row_group : id_only_row_groups) {
-    ASSERT_EQ(row_group.column_memory_sizes.size(), 1);
-    expected_id_sizes.emplace_back(row_group.column_memory_sizes[0]);
+  for (size_t row_group_index = 0; row_group_index < id_only_row_groups.size(); ++row_group_index) {
+    ASSERT_AND_ASSIGN(auto memory_sizes, id_only_format_reader->get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), 1);
+    expected_id_sizes.emplace_back(memory_sizes[0]);
     expected_name_sizes.emplace_back(0);
+    expected_chunk_sizes.emplace_back(id_only_row_groups[row_group_index].memory_size);
   }
-  for (const auto& row_group : extra_column_row_groups) {
-    ASSERT_EQ(row_group.column_memory_sizes.size(), 3);
-    expected_id_sizes.emplace_back(row_group.column_memory_sizes[0]);
-    expected_name_sizes.emplace_back(row_group.column_memory_sizes[1]);
-    EXPECT_GT(row_group.column_memory_sizes[2], 0);
-    EXPECT_LT(row_group.column_memory_sizes[0] + row_group.column_memory_sizes[1], row_group.memory_size);
+  for (size_t row_group_index = 0; row_group_index < extra_column_row_groups.size(); ++row_group_index) {
+    ASSERT_AND_ASSIGN(auto memory_sizes, extra_column_format_reader->get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), 3);
+    expected_id_sizes.emplace_back(memory_sizes[0]);
+    expected_name_sizes.emplace_back(memory_sizes[1]);
+    expected_chunk_sizes.emplace_back(extra_column_row_groups[row_group_index].memory_size);
+    EXPECT_GT(memory_sizes[2], 0);
+    EXPECT_LT(memory_sizes[0] + memory_sizes[1], extra_column_row_groups[row_group_index].memory_size);
   }
-  ASSERT_FALSE(reordered_row_groups.empty());
-  ASSERT_NE(reordered_row_groups.front().column_memory_sizes[0], reordered_row_groups.front().column_memory_sizes[1]);
 
   auto combined_group = std::make_shared<api::ColumnGroup>(*ordered_groups->front());
   combined_group->files.insert(combined_group->files.end(), reordered_groups->front()->files.begin(),
@@ -432,21 +447,13 @@ TEST_P(FormatReaderTest, MultiFileColumnEstimatesFollowFieldNames) {
     ASSERT_NE(reader, nullptr);
     ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0, id_projection));
 
-    ASSERT_AND_ASSIGN(auto id_sizes, chunk_reader->get_chunk_column_estimated_size("id"));
-    ASSERT_AND_ASSIGN(auto name_sizes, chunk_reader->get_chunk_column_estimated_size("name"));
-    EXPECT_EQ(id_sizes, expected_id_sizes);
-    EXPECT_EQ(name_sizes, expected_name_sizes);
-
     ASSERT_AND_ASSIGN(auto all_sizes, chunk_reader->get_chunk_column_estimated_size());
     ASSERT_EQ(all_sizes.size(), 2);
     EXPECT_EQ(all_sizes[0], expected_id_sizes);
     EXPECT_EQ(all_sizes[1], expected_name_sizes);
 
     ASSERT_AND_ASSIGN(auto chunk_sizes, chunk_reader->get_chunk_estimated_size());
-    ASSERT_EQ(chunk_sizes.size(), expected_id_sizes.size());
-    for (size_t chunk_idx = 0; chunk_idx < chunk_sizes.size(); ++chunk_idx) {
-      EXPECT_EQ(chunk_sizes[chunk_idx], expected_id_sizes[chunk_idx] + expected_name_sizes[chunk_idx]);
-    }
+    EXPECT_EQ(chunk_sizes, expected_chunk_sizes);
   }
 }
 
@@ -498,7 +505,9 @@ TEST_P(FormatReaderTest, MissingPhysicalColumnEstimateIsZero) {
     ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
     ASSERT_EQ(chunk_reader->total_number_of_chunks(), 2);
 
-    ASSERT_AND_ASSIGN(auto name_sizes, chunk_reader->get_chunk_column_estimated_size("name"));
+    ASSERT_AND_ASSIGN(auto column_sizes, chunk_reader->get_chunk_column_estimated_size());
+    ASSERT_EQ(column_sizes.size(), 2);
+    const auto& name_sizes = column_sizes[1];
     ASSERT_EQ(name_sizes.size(), 2);
     EXPECT_GT(name_sizes[0], 0);
     EXPECT_EQ(name_sizes[1], 0);
@@ -550,10 +559,9 @@ TEST_P(FormatReaderTest, ReadParquetWithoutMeta) {
     ASSERT_EQ(row_group_infos[i].start_offset, i * test_batch_->num_rows());
     ASSERT_EQ(row_group_infos[i].end_offset, (i + 1) * test_batch_->num_rows());
     ASSERT_GT(row_group_infos[i].memory_size, 0);
-    ASSERT_EQ(row_group_infos[i].column_memory_sizes.size(), schema_->num_fields());
-    ASSERT_EQ(std::accumulate(row_group_infos[i].column_memory_sizes.begin(),
-                              row_group_infos[i].column_memory_sizes.end(), uint64_t{0}),
-              row_group_infos[i].memory_size);
+    ASSERT_AND_ASSIGN(auto memory_sizes, format_reader->get_rg_column_memsz(i));
+    ASSERT_EQ(memory_sizes.size(), schema_->num_fields());
+    ASSERT_EQ(std::accumulate(memory_sizes.begin(), memory_sizes.end(), uint64_t{0}), row_group_infos[i].memory_size);
     ASSERT_AND_ASSIGN(auto rb, format_reader->get_chunk(i));
     ASSERT_EQ(rb->num_rows(), test_batch_->num_rows());
   }
@@ -1173,14 +1181,13 @@ TEST_P(FormatReaderTest, NestedProjectionPreservesTopLevelColumns) {
     };
     ASSERT_AND_ASSIGN(auto expected_column_sizes,
                       DistributeMemorySizes(metadata->row_group_infos[0].memory_size, top_level_weights));
-    ASSERT_EQ(metadata->row_group_infos[0].column_memory_sizes, expected_column_sizes);
     ASSERT_EQ(std::accumulate(expected_column_sizes.begin(), expected_column_sizes.end(), uint64_t{0}),
               metadata->row_group_infos[0].memory_size);
 
     ASSERT_AND_ASSIGN(auto projected_reader, parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
                                                  metadata, file, nested_schema, std::vector<std::string>{"note"}, ""));
-    ASSERT_AND_ASSIGN(auto projected_row_group_infos, projected_reader->get_row_group_infos());
-    ASSERT_EQ(projected_row_group_infos[0].column_memory_sizes, expected_column_sizes);
+    ASSERT_AND_ASSIGN(auto projected_memory_sizes, projected_reader->get_rg_column_memsz(0));
+    ASSERT_EQ(projected_memory_sizes, expected_column_sizes);
   }
 
   auto assert_batch_equal = [](const std::shared_ptr<arrow::RecordBatch>& actual,

--- a/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
@@ -131,7 +131,9 @@ TEST_F(IcebergFormatReaderTest, NoDeletes) {
     EXPECT_EQ(rg_infos[i].start_offset, parquet_rg_infos[i].start_offset);
     EXPECT_EQ(rg_infos[i].end_offset, parquet_rg_infos[i].end_offset);
     EXPECT_EQ(rg_infos[i].memory_size, parquet_rg_infos[i].memory_size);
-    EXPECT_EQ(rg_infos[i].column_memory_sizes, parquet_rg_infos[i].column_memory_sizes);
+    ASSERT_AND_ASSIGN(auto iceberg_memory_sizes, reader->get_rg_column_memsz(i));
+    ASSERT_AND_ASSIGN(auto parquet_memory_sizes, parquet_reader->get_rg_column_memsz(i));
+    EXPECT_EQ(iceberg_memory_sizes, parquet_memory_sizes);
   }
 
   ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
@@ -174,7 +176,8 @@ TEST_F(IcebergFormatReaderTest, PartialDeletesScaleRowGroupMemorySizes) {
                     FormatReader::create(nullptr, LOON_FORMAT_PARQUET, parquet_file, properties_, {}, nullptr));
   ASSERT_AND_ASSIGN(auto physical_infos, parquet_reader->get_row_group_infos());
   ASSERT_EQ(physical_infos.size(), 1);
-  ASSERT_FALSE(physical_infos[0].column_memory_sizes.empty());
+  ASSERT_AND_ASSIGN(auto physical_memory_sizes, parquet_reader->get_rg_column_memsz(0));
+  ASSERT_FALSE(physical_memory_sizes.empty());
 
   WritePositionalDeleteFile(data_file_path_, {2, 5, 8});
   auto metadata = MakeDeleteMetadataJson(delete_file_path_);
@@ -192,13 +195,14 @@ TEST_F(IcebergFormatReaderTest, PartialDeletesScaleRowGroupMemorySizes) {
   const auto expected_total =
       static_cast<uint64_t>(static_cast<unsigned __int128>(physical.memory_size) * logical_rows / physical_rows);
   ASSERT_AND_ASSIGN(auto expected_columns,
-                    milvus_storage::DistributeMemorySizes(expected_total, physical.column_memory_sizes));
+                    milvus_storage::DistributeMemorySizes(expected_total, physical_memory_sizes));
+  ASSERT_AND_ASSIGN(auto logical_memory_sizes, iceberg_reader->get_rg_column_memsz(0));
 
   EXPECT_EQ(logical.start_offset, 0);
   EXPECT_EQ(logical.end_offset, logical_rows);
   EXPECT_EQ(logical.memory_size, expected_total);
-  EXPECT_EQ(logical.column_memory_sizes, expected_columns);
-  EXPECT_EQ(std::accumulate(logical.column_memory_sizes.begin(), logical.column_memory_sizes.end(), uint64_t{0}),
+  EXPECT_EQ(logical_memory_sizes, expected_columns);
+  EXPECT_EQ(std::accumulate(logical_memory_sizes.begin(), logical_memory_sizes.end(), uint64_t{0}),
             logical.memory_size);
 }
 
@@ -210,7 +214,8 @@ TEST_F(IcebergFormatReaderTest, FullDeletesZeroRowGroupMemorySizes) {
                     FormatReader::create(nullptr, LOON_FORMAT_PARQUET, parquet_file, properties_, {}, nullptr));
   ASSERT_AND_ASSIGN(auto physical_infos, parquet_reader->get_row_group_infos());
   ASSERT_EQ(physical_infos.size(), 1);
-  ASSERT_FALSE(physical_infos[0].column_memory_sizes.empty());
+  ASSERT_AND_ASSIGN(auto physical_memory_sizes, parquet_reader->get_rg_column_memsz(0));
+  ASSERT_FALSE(physical_memory_sizes.empty());
 
   WritePositionalDeleteFile(data_file_path_, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   auto metadata = MakeDeleteMetadataJson(delete_file_path_);
@@ -224,8 +229,8 @@ TEST_F(IcebergFormatReaderTest, FullDeletesZeroRowGroupMemorySizes) {
   EXPECT_EQ(logical.start_offset, 0);
   EXPECT_EQ(logical.end_offset, 0);
   EXPECT_EQ(logical.memory_size, 0);
-  EXPECT_EQ(logical.column_memory_sizes,
-            std::vector<uint64_t>(physical_infos[0].column_memory_sizes.size(), uint64_t{0}));
+  ASSERT_AND_ASSIGN(auto logical_memory_sizes, iceberg_reader->get_rg_column_memsz(0));
+  EXPECT_EQ(logical_memory_sizes, std::vector<uint64_t>(physical_memory_sizes.size(), uint64_t{0}));
 }
 
 // Positional deletes — take() maps logical doc IDs to physical positions.

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -375,9 +375,10 @@ TEST_F(LanceBasicTest, TestReaderHandlesFragmentMissingNullableDatasetColumn) {
 
   ASSERT_AND_ASSIGN(auto row_groups, reader.get_row_group_infos());
   ASSERT_FALSE(row_groups.empty());
-  for (const auto& row_group : row_groups) {
-    ASSERT_EQ(row_group.column_memory_sizes.size(), static_cast<size_t>(evolved_schema->num_fields()));
-    EXPECT_EQ(row_group.column_memory_sizes.back(), 0);
+  for (size_t row_group_index = 0; row_group_index < row_groups.size(); ++row_group_index) {
+    ASSERT_AND_ASSIGN(auto memory_sizes, reader.get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), static_cast<size_t>(evolved_schema->num_fields()));
+    EXPECT_EQ(memory_sizes.back(), 0);
   }
 
   ASSERT_AND_ASSIGN(auto table, reader.take({0, 1}));
@@ -422,10 +423,10 @@ TEST_F(LanceBasicTest, TestRead) {
   ASSERT_EQ(estimated_memory_size, read_dataset->EstimateFragmentMemory(fragment_ids[0]));
   ASSERT_EQ(std::accumulate(fragment_column_memory_sizes.begin(), fragment_column_memory_sizes.end(), uint64_t{0}),
             estimated_memory_size);
-  for (const auto& rg : rgs) {
-    ASSERT_EQ(rg.column_memory_sizes.size(), schema_->num_fields());
-    ASSERT_EQ(std::accumulate(rg.column_memory_sizes.begin(), rg.column_memory_sizes.end(), uint64_t{0}),
-              rg.memory_size);
+  for (size_t row_group_index = 0; row_group_index < rgs.size(); ++row_group_index) {
+    ASSERT_AND_ASSIGN(auto memory_sizes, reader.get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), schema_->num_fields());
+    ASSERT_EQ(std::accumulate(memory_sizes.begin(), memory_sizes.end(), uint64_t{0}), rgs[row_group_index].memory_size);
   }
 
   auto verify_recordbatch = [&](const std::shared_ptr<arrow::RecordBatch>& batch, auto start_ridx, auto num_of_row) {
@@ -472,7 +473,9 @@ TEST_F(LanceBasicTest, TestRead) {
       ASSERT_EQ(projection_rgs[rg_idx].start_offset, rgs[rg_idx].start_offset);
       ASSERT_EQ(projection_rgs[rg_idx].end_offset, rgs[rg_idx].end_offset);
       ASSERT_EQ(projection_rgs[rg_idx].memory_size, rgs[rg_idx].memory_size);
-      ASSERT_EQ(projection_rgs[rg_idx].column_memory_sizes, rgs[rg_idx].column_memory_sizes);
+      ASSERT_AND_ASSIGN(auto projection_memory_sizes, projection_reader.get_rg_column_memsz(rg_idx));
+      ASSERT_AND_ASSIGN(auto memory_sizes, reader.get_rg_column_memsz(rg_idx));
+      ASSERT_EQ(projection_memory_sizes, memory_sizes);
     }
 
     for (size_t rg_idx = 0; rg_idx < rgs.size(); rg_idx++) {
@@ -571,7 +574,6 @@ TEST_F(LanceBasicTest, MemorySizeEstimationFailureDoesNotBlockOpen) {
     for (const auto& row_group_info : row_group_infos) {
       EXPECT_FALSE(row_group_info.memory_size_available);
       EXPECT_EQ(row_group_info.memory_size, 0u);
-      EXPECT_TRUE(row_group_info.column_memory_sizes.empty());
     }
   };
 
@@ -583,6 +585,7 @@ TEST_F(LanceBasicTest, MemorySizeEstimationFailureDoesNotBlockOpen) {
     ASSERT_STATUS_OK(reader.open());
     ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
     assert_memory_size_unavailable(row_group_infos);
+    EXPECT_TRUE(reader.get_rg_column_memsz(0).status().IsNotImplemented());
     ASSERT_AND_ASSIGN(auto chunk, reader.get_chunk(0));
     EXPECT_GT(chunk->num_rows(), 0);
   }
@@ -598,6 +601,7 @@ TEST_F(LanceBasicTest, MemorySizeEstimationFailureDoesNotBlockOpen) {
 
   ASSERT_AND_ASSIGN(auto cached_reader, LanceTableReader::MetaTrait::create_from_metadata(
                                             metadata, cgfile, schema_, std::vector<std::string>{}, ""));
+  EXPECT_TRUE(cached_reader->get_rg_column_memsz(0).status().IsNotImplemented());
   ASSERT_AND_ASSIGN(auto chunk, cached_reader->get_chunk(0));
   EXPECT_GT(chunk->num_rows(), 0);
 }
@@ -633,10 +637,10 @@ TEST_F(LanceBasicTest, LegacyFormatReadsWhenMemoryEstimateIsUnavailable) {
   ASSERT_STATUS_OK(reader.open());
   ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
   ASSERT_FALSE(row_group_infos.empty());
-  for (const auto& row_group_info : row_group_infos) {
-    EXPECT_FALSE(row_group_info.memory_size_available);
-    EXPECT_EQ(row_group_info.memory_size, 0);
-    EXPECT_TRUE(row_group_info.column_memory_sizes.empty());
+  for (size_t row_group_index = 0; row_group_index < row_group_infos.size(); ++row_group_index) {
+    EXPECT_FALSE(row_group_infos[row_group_index].memory_size_available);
+    EXPECT_EQ(row_group_infos[row_group_index].memory_size, 0);
+    EXPECT_TRUE(reader.get_rg_column_memsz(row_group_index).status().IsNotImplemented());
   }
 
   ASSERT_AND_ASSIGN(auto rb_reader, reader.read_with_range(0, kRows));
@@ -655,7 +659,6 @@ TEST_F(LanceBasicTest, LegacyFormatReadsWhenMemoryEstimateIsUnavailable) {
   ASSERT_AND_ASSIGN(auto chunk_reader, api_reader->get_chunk_reader(0));
   EXPECT_TRUE(chunk_reader->get_chunk_estimated_size().status().IsNotImplemented());
   EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size().status().IsNotImplemented());
-  EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size("vector").status().IsNotImplemented());
   ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
   ASSERT_GT(chunk->num_rows(), 0);
 
@@ -703,9 +706,13 @@ TEST_F(LanceBasicTest, CachedCreateReaderReappliesProjection) {
   ASSERT_AND_ASSIGN(auto id_rgs, id_reader->get_row_group_infos());
   ASSERT_FALSE(id_rgs.empty());
   ASSERT_EQ(id_rgs.size(), metadata->row_group_infos.size());
+  ASSERT_NE(metadata->payload.column_memory_weights, nullptr);
   for (size_t rg_idx = 0; rg_idx < id_rgs.size(); ++rg_idx) {
     ASSERT_EQ(id_rgs[rg_idx].memory_size, metadata->row_group_infos[rg_idx].memory_size);
-    ASSERT_EQ(id_rgs[rg_idx].column_memory_sizes, metadata->row_group_infos[rg_idx].column_memory_sizes);
+    ASSERT_AND_ASSIGN(auto expected_memory_sizes, DistributeMemorySizes(metadata->row_group_infos[rg_idx].memory_size,
+                                                                        *metadata->payload.column_memory_weights));
+    ASSERT_AND_ASSIGN(auto memory_sizes, id_reader->get_rg_column_memsz(rg_idx));
+    ASSERT_EQ(memory_sizes, expected_memory_sizes);
   }
   ASSERT_AND_ASSIGN(auto id_chunk, id_reader->get_chunk(0));
   ASSERT_EQ(id_chunk->num_columns(), 1);

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -571,13 +571,13 @@ TEST_P(VortexBasicTest, RowGroupColumnMemorySizesUseFullFileSchema) {
   ASSERT_AND_ASSIGN(auto row_group_infos, vx_reader.get_row_group_infos());
 
   ASSERT_GT(row_group_infos.size(), 1u);
-  for (const auto& row_group_info : row_group_infos) {
-    EXPECT_TRUE(row_group_info.memory_size_available);
-    ASSERT_EQ(row_group_info.column_memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
-    EXPECT_GT(row_group_info.memory_size, 0u);
-    EXPECT_EQ(std::accumulate(row_group_info.column_memory_sizes.begin(), row_group_info.column_memory_sizes.end(),
-                              uint64_t{0}),
-              row_group_info.memory_size);
+  for (size_t row_group_index = 0; row_group_index < row_group_infos.size(); ++row_group_index) {
+    EXPECT_TRUE(row_group_infos[row_group_index].memory_size_available);
+    ASSERT_AND_ASSIGN(auto memory_sizes, vx_reader.get_rg_column_memsz(row_group_index));
+    ASSERT_EQ(memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
+    EXPECT_GT(row_group_infos[row_group_index].memory_size, 0u);
+    EXPECT_EQ(std::accumulate(memory_sizes.begin(), memory_sizes.end(), uint64_t{0}),
+              row_group_infos[row_group_index].memory_size);
   }
 }
 
@@ -592,7 +592,6 @@ TEST_P(VortexBasicTest, MemorySizeUnavailableDoesNotBlockOpen) {
     for (const auto& row_group_info : row_group_infos) {
       EXPECT_FALSE(row_group_info.memory_size_available);
       EXPECT_EQ(row_group_info.memory_size, 0u);
-      EXPECT_TRUE(row_group_info.column_memory_sizes.empty());
     }
   };
 
@@ -605,6 +604,7 @@ TEST_P(VortexBasicTest, MemorySizeUnavailableDoesNotBlockOpen) {
     ASSERT_STATUS_OK(reader.open());
     ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
     assert_memory_size_unavailable(row_group_infos);
+    EXPECT_TRUE(reader.get_rg_column_memsz(0).status().IsNotImplemented());
     ASSERT_AND_ASSIGN(auto chunked_array, reader.blocking_read(0, recordBatchsRows(), kSmallCoalescingWindow));
     ASSERT_AND_ASSIGN(auto batch, ChunkedArrayToRecordBatch(chunked_array));
     EXPECT_EQ(batch->num_rows(), recordBatchsRows());
@@ -620,6 +620,7 @@ TEST_P(VortexBasicTest, MemorySizeUnavailableDoesNotBlockOpen) {
 
   ASSERT_AND_ASSIGN(auto cached_reader, vortex::VortexFormatReader::MetaTrait::create_from_metadata(
                                             metadata, cgfile, schema_, data_columns(), ""));
+  EXPECT_TRUE(cached_reader->get_rg_column_memsz(0).status().IsNotImplemented());
   ASSERT_AND_ASSIGN(auto rb_reader, cached_reader->read_with_range(0, recordBatchsRows()));
   ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatchReader(rb_reader.get()));
   EXPECT_EQ(table->num_rows(), recordBatchsRows());


### PR DESCRIPTION
The original per-column estimate path materialized and retained a full size vector for every row group, then built another field-name map for every chunk. That metadata scaled with both chunk count and column count, which is why BuildColumnMemorySizes became a major jemalloc allocation even though callers only need the values when they actually request an estimate.

This change keeps the lightweight total memory estimate in row-group and chunk metadata, but moves the column split behind FormatReader and calculates it on demand. Parquet uses the cached footer metadata, aggregates nested physical leaves into top-level Arrow fields, and normalizes them against the row-group total. Lance and Vortex retain one shared column-weight vector per fragment or file instead of copying it into every row group, while Iceberg reuses the Parquet values and rescales them for rows left after positional deletes.

ColumnGroupReader now requests all column estimates for a chunk in one call and maps the physical file schema back to the logical column-group order by field name. This keeps results stable when different files use schemas such as [a, b], [b, a], or [a, b, c], returns zero for logical columns missing from a file, excludes extra physical columns from the logical total, and rejects ambiguous duplicate field names.

The redistribution logic also keeps zero-weight columns at zero and assigns integer rounding residue to the last non-zero-weight column. This preserves the existing estimate behavior, avoids recalculating the same vector once per requested field, and reduces long-lived metadata from O(chunks × columns) allocations to row-group totals plus, where needed, a single O(columns) weight vector per file or fragment.