### PR TITLE
fix: regenerate the error-handling baseline after #598

### DIFF
--- a/cpp/scripts/error_handling_baseline.tsv
+++ b/cpp/scripts/error_handling_baseline.tsv
@@ -8,6 +8,5 @@ throw	cpp/src/format/lance/lance_common.cpp	2
 throw	cpp/src/format/vortex/vortex_translater.cpp	6
 throw	cpp/src/manifest.cpp	1
 throw	cpp/src/packed/chunk_manager.cpp	2
-throw	cpp/src/packed/column_group.cpp	1
 throw	cpp/src/packed/reader.cpp	1
 throw	cpp/src/properties.cpp	1


### PR DESCRIPTION
## Problem

`main` currently fails its own error-handling ratchet, and every open PR inherits the failure once CI merges it with main.

#598 (`352d545`) removed the last `throw` from `cpp/src/packed/column_group.cpp` — `ColumnGroup::Table()` now returns `arrow::Result` — but did not regenerate `cpp/scripts/error_handling_baseline.tsv`. The committed baseline still claims one throw there, and the ratchet's first layer is an exact match:

```
-throw	cpp/src/packed/column_group.cpp	1
```

## Why it got through

#598 branched from before #596 added the gate, so there was no baseline at its base commit and the workflow took its documented bootstrap path:

```
::notice::error-handling-ratchet: no baseline at base commit (bootstrap); base-totals layer skipped
```

The exact-match layer had nothing to compare against on that PR, so the divergence only became visible after the merge. #597 is in the same position (branched pre-#596) — it regenerated its baseline on rebase, so it is fine, but the bootstrap hole is worth knowing about: a PR that predates the gate can merge a stale baseline.

## Change

Deletes the one stale line. Content taken from the diff CI printed on #604, not from a local `update` run.

**Warning for whoever touches this next on macOS:** do not run `cpp/scripts/error_handling_ratchet.sh update` there. The scan uses `gcc -fpreprocessed -dD -E -P`, which Apple clang rejects with `unknown argument`, so every file silently counts zero — `check` reports the entire baseline as removed, and `update` would erase the file. Worth a guard in the script (probe the preprocessor once and fail loudly, and refuse to write an empty baseline); I can follow up with that if wanted.

Unblocks: #597, #603, #604, and anything else merged with main after `352d545`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HDgMok3nR8ZNugKWWQQK2