### PR TITLE
fix: refresh error-handling baseline after the packed burn-down

### DIFF
--- a/cpp/scripts/error_handling_baseline.tsv
+++ b/cpp/scripts/error_handling_baseline.tsv
@@ -8,6 +8,5 @@ throw	cpp/src/format/lance/lance_common.cpp	2
 throw	cpp/src/format/vortex/vortex_translater.cpp	6
 throw	cpp/src/manifest.cpp	1
 throw	cpp/src/packed/chunk_manager.cpp	2
-throw	cpp/src/packed/column_group.cpp	1
 throw	cpp/src/packed/reader.cpp	1
 throw	cpp/src/properties.cpp	1


### PR DESCRIPTION
#598 removed the last bare throw from `packed/column_group.cpp` but landed without regenerating `cpp/scripts/error_handling_baseline.tsv`, so the ratchet gate has been failing on `main` ever since.

Every PR branched off main inherits it — **#604 is red for this reason, not for anything in its own diff**:

```
error-handling ratchet: counts diverged from cpp/scripts/error_handling_baseline.tsv
-throw	cpp/src/packed/column_group.cpp	1
```

This records the burn-down (`throw` total 49 → 48), which is what `error_handling_ratchet.sh update` produces. Verified locally: `error_handling_ratchet.sh check` returns OK afterwards.

Worth considering separately: a burn-down turning CI red is easy to miss at merge time — the gate could either auto-accept a decrease, or print the exact `update` command in the failure output.