### PR TITLE
fix: preserve classifications across C++ exception boundaries

### DIFF
--- a/cpp/include/milvus-storage/packed/reader.h
+++ b/cpp/include/milvus-storage/packed/reader.h
@@ -57,9 +57,9 @@ class PackedRecordBatchReader : public arrow::RecordBatchReader {
       ::parquet::ReaderProperties reader_props = ::parquet::default_reader_properties(),
       ::parquet::ArrowReaderProperties arrow_reader_props = ::parquet::default_arrow_reader_properties());
 
-  /// Deprecated in favor of Make(): a failed open THROWS std::runtime_error
-  /// with the stringified status, destroying its classification. Kept only
-  /// until direct-link consumers migrate; do not add new call sites.
+  /// Deprecated in favor of Make(): a failed open throws the typed error
+  /// converted from the initialization status. Kept only until direct-link
+  /// consumers migrate; do not add new call sites.
   PackedRecordBatchReader(
       const std::shared_ptr<arrow::fs::FileSystem>& fs,
       std::vector<std::string>& paths,

--- a/cpp/src/format/vortex/vortex_translater.cpp
+++ b/cpp/src/format/vortex/vortex_translater.cpp
@@ -22,6 +22,8 @@
 #include <arrow/io/interfaces.h>
 #include <fmt/format.h>
 
+#include "milvus-storage/common/extend_status.h"
+
 namespace milvus_storage::vortex {
 
 namespace {
@@ -177,7 +179,18 @@ std::vector<std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<VortexCellGua
   }
   auto status = cell_loader_(cids);
   if (!status.ok()) {
-    throw std::runtime_error(status.ToString());
+    // Translator::get_cells returns a vector, so milvus-common's caching layer
+    // reports load failures through exceptions -- that part is the interface's
+    // contract and not ours to change. WHAT we throw is ours, though, and
+    // `std::runtime_error(status.ToString())` threw the classification away.
+    //
+    // The status arriving here is fully classified on the object-store path:
+    // S3FileSystem's ErrorToStatus attaches an ExtendStatusDetail, and both
+    // hops up (FillVortexRangeFile, the loader lambda) propagate it untouched
+    // via ARROW_*_RAISE. Stringifying it turned a retriable throttle into an
+    // untyped message that lands on the permanent bucket, so a vortex cache
+    // miss during throttling was never retried.
+    throw ToSegcoreError(status);
   }
   for (auto cid : cids) {
     cells.emplace_back(cid, std::make_unique<VortexCellGuard>(cell_metas_, static_cast<uint64_t>(cid), range_file_));

--- a/cpp/src/packed/reader.cpp
+++ b/cpp/src/packed/reader.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <algorithm>
 #include <exception>
-#include <stdexcept>
 #include <utility>
 
 #include <arrow/array/data.h>
@@ -100,9 +99,7 @@ PackedRecordBatchReader::PackedRecordBatchReader(const std::shared_ptr<arrow::fs
   auto status = init(fs, paths, schema, reader_props, arrow_reader_props);
   if (!status.ok()) {
     LOG_STORAGE_ERROR_ << "Error initializing PackedRecordBatchReader: " << status.ToString();
-    // Deprecated path (see reader.h): stringifies the status and destroys its
-    // classification. Migrate to Make().
-    throw std::runtime_error(status.ToString());
+    throw ToSegcoreError(status);
   }
 }
 

--- a/cpp/test/format/vortex/vortex_local_format_test.cpp
+++ b/cpp/test/format/vortex/vortex_local_format_test.cpp
@@ -33,8 +33,12 @@
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/filesystem/localfs.h>
 #include <arrow/io/interfaces.h>
+#include <arrow/io/memory.h>
 #include <arrow/record_batch.h>
 #include <arrow/util/io_util.h>
+
+#include "common/EasyAssert.h"
+#include "milvus-storage/common/extend_status.h"
 
 #include <boost/filesystem/operations.hpp>
 
@@ -611,6 +615,141 @@ TEST_F(VortexLocalFormatTest, TestTranslaterLoadsAndReleasesCellRanges) {
       (void)translater->cells_storage_bytes({static_cast<milvus::cachinglayer::cid_t>(translater->num_cells())}),
       std::out_of_range);
   EXPECT_THROW((void)translater->get_cells(nullptr, {-1}), std::out_of_range);
+}
+
+namespace {
+
+// A source file whose reads fail with a fully classified status, mimicking what
+// S3FileSystem's ErrorToStatus attaches on a throttle.
+//
+// Implements RandomAccessFile directly and delegates the parts we don't care
+// about, rather than deriving from BufferReader: BufferReader inherits
+// RandomAccessFileConcurrencyWrapper<BufferReader>, which declares both ReadAt
+// overloads `final` and dispatches them through CRTP to BufferReader's
+// non-virtual DoReadAt. A subclass there cannot intercept a read at all -- it
+// does not compile, and a DoReadAt override would silently never be called.
+class ThrottledReader : public arrow::io::RandomAccessFile {
+  public:
+  explicit ThrottledReader(std::shared_ptr<arrow::Buffer> contents) : contents_(std::move(contents)) {}
+
+  // The one method under test: the load path reaches the source file through
+  // ReadAt (vortex_footer_reader.cpp).
+  arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t, int64_t) override { return ThrottleError(); }
+  arrow::Result<int64_t> ReadAt(int64_t, int64_t, void*) override { return ThrottleError(); }
+  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t) override { return ThrottleError(); }
+  arrow::Result<int64_t> Read(int64_t, void*) override { return ThrottleError(); }
+
+  // Open and size must succeed, or the test would be exercising the wrong
+  // failure.
+  arrow::Result<int64_t> GetSize() override { return contents_->size(); }
+  arrow::Result<int64_t> Tell() const override { return position_; }
+  arrow::Status Seek(int64_t position) override {
+    position_ = position;
+    return arrow::Status::OK();
+  }
+  arrow::Status Close() override {
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+  bool closed() const override { return closed_; }
+
+  private:
+  static arrow::Status ThrottleError() {
+    return milvus_storage::MakeExtendError(milvus_storage::ExtendStatusCode::StorageTransientThrottling,
+                                           "SlowDown: reduce your request rate", "SlowDown");
+  }
+
+  std::shared_ptr<arrow::Buffer> contents_;
+  int64_t position_ = 0;
+  bool closed_ = false;
+};
+
+// Delegates everything to the fixture's filesystem and swaps only the opened
+// file. It has to wrap rather than subclass LocalFileSystem: the fixture's
+// filesystem is rooted at PROPERTY_FS_ROOT_PATH, so a bare LocalFileSystem
+// resolves the same relative path against the process CWD and fails with ENOENT
+// before the read under test is ever reached.
+class ThrottledFileSystem : public arrow::fs::FileSystem {
+  public:
+  explicit ThrottledFileSystem(std::shared_ptr<arrow::fs::FileSystem> inner) : inner_(std::move(inner)) {}
+
+  std::string type_name() const override { return "throttled"; }
+  bool Equals(const arrow::fs::FileSystem& other) const override { return this == &other; }
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override {
+    // Open for real so the failure under test is the read, not the open.
+    ARROW_ASSIGN_OR_RAISE(auto real, inner_->OpenInputFile(path));
+    ARROW_ASSIGN_OR_RAISE(auto size, real->GetSize());
+    ARROW_ASSIGN_OR_RAISE(auto contents, real->ReadAt(0, size));
+    return std::make_shared<ThrottledReader>(contents);
+  }
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override {
+    return OpenInputFile(info.path());
+  }
+
+  arrow::Result<arrow::fs::FileInfo> GetFileInfo(const std::string& path) override { return inner_->GetFileInfo(path); }
+  arrow::Result<arrow::fs::FileInfoVector> GetFileInfo(const arrow::fs::FileSelector& select) override {
+    return inner_->GetFileInfo(select);
+  }
+  arrow::Status CreateDir(const std::string& path, bool recursive) override {
+    return inner_->CreateDir(path, recursive);
+  }
+  arrow::Status DeleteDir(const std::string& path) override { return inner_->DeleteDir(path); }
+  arrow::Status DeleteDirContents(const std::string& path, bool missing_dir_ok) override {
+    return inner_->DeleteDirContents(path, missing_dir_ok);
+  }
+  arrow::Status DeleteRootDirContents() override { return inner_->DeleteRootDirContents(); }
+  arrow::Status DeleteFile(const std::string& path) override { return inner_->DeleteFile(path); }
+  arrow::Status Move(const std::string& src, const std::string& dest) override { return inner_->Move(src, dest); }
+  arrow::Status CopyFile(const std::string& src, const std::string& dest) override {
+    return inner_->CopyFile(src, dest);
+  }
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override {
+    return inner_->OpenInputStream(path);
+  }
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
+    return inner_->OpenOutputStream(path, metadata);
+  }
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenAppendStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
+    return inner_->OpenAppendStream(path, metadata);
+  }
+
+  private:
+  std::shared_ptr<arrow::fs::FileSystem> inner_;
+};
+
+}  // namespace
+
+// Translator::get_cells has no error channel -- milvus-common's caching layer
+// reports load failures through exceptions. That much is the interface's
+// contract. What we throw is ours, and throwing the stringified status used to
+// discard the classification the object-store layer had already attached, so a
+// throttle during a vortex cache miss was reported as a permanent failure and
+// never retried.
+TEST_F(VortexLocalFormatTest, TranslaterLoadFailureKeepsItsClassification) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+
+  auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+  auto footer_reader = MakeFooterReader(cgfile, sparse_fs);
+  ASSERT_STATUS_OK(footer_reader->Open(file_system_));
+  ASSERT_AND_ASSIGN(auto cell_metas, BuildVortexCellMetas(footer_reader, "id"));
+
+  auto throttled_fs = std::make_shared<ThrottledFileSystem>(file_system_);
+  ASSERT_AND_ASSIGN(auto translater, VortexTranslater::Make(cell_metas, throttled_fs, test_file_name_, sparse_fs,
+                                                            "throttled.vx.sparse"));
+
+  try {
+    translater->get_cells(nullptr, {0});
+    FAIL() << "expected the classified load failure to surface";
+  } catch (const milvus::SegcoreError& e) {
+    // The point of the fix: the retriable classification survives the throw.
+    EXPECT_EQ(e.get_error_code(), milvus::StorageTransientError);
+    EXPECT_NE(std::string(e.what()).find("SlowDown"), std::string::npos) << e.what();
+  } catch (const std::exception& e) {
+    FAIL() << "load failure lost its type, got: " << e.what();
+  }
 }
 
 TEST_F(VortexLocalFormatTest, TestTranslaterRejectsInvalidInputs) {

--- a/cpp/test/packed/packed_error_status_test.cpp
+++ b/cpp/test/packed/packed_error_status_test.cpp
@@ -14,9 +14,7 @@
 
 #include <gtest/gtest.h>
 
-#include <functional>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -42,15 +40,6 @@ void ExpectPackedCode(const arrow::Status& status, ExtendStatusCode code) {
   auto detail = ExtendStatusDetail::UnwrapStatus(status);
   ASSERT_NE(detail, nullptr) << status.ToString();
   EXPECT_EQ(detail->code(), code);
-}
-
-void ExpectExceptionMessageContainsCode(const std::function<void()>& fn, const std::string& code_name) {
-  try {
-    fn();
-    FAIL() << "expected runtime_error";
-  } catch (const std::runtime_error& e) {
-    EXPECT_NE(std::string(e.what()).find(code_name), std::string::npos) << e.what();
-  }
 }
 
 }  // namespace
@@ -101,11 +90,14 @@ TEST_F(PackedErrorStatusTest, ReaderMissingFileKeepsFilesystemError) {
 
   try {
     PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_);
-    FAIL() << "expected runtime_error";
-  } catch (const std::runtime_error& e) {
+    FAIL() << "expected the classified open failure to surface";
+  } catch (const milvus::SegcoreError& e) {
+    EXPECT_EQ(e.get_error_code(), milvus::ObjectNotExist);
     auto message = std::string(e.what());
     EXPECT_NE(message.find("missing.parquet"), std::string::npos) << message;
     EXPECT_EQ(message.find("PackedStorageIO"), std::string::npos) << message;
+  } catch (const std::exception& e) {
+    FAIL() << "reader open failure lost its type, got: " << e.what();
   }
 }
 
@@ -127,8 +119,15 @@ TEST_F(PackedErrorStatusTest, ReaderMissingPackedMetadataIsMetadataCorrupted) {
   ASSERT_STATUS_OK(sink->Close());
   std::vector<std::string> paths = {parquet_path};
 
-  ExpectExceptionMessageContainsCode([&]() { PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_); },
-                                     "PackedMetadataCorrupted");
+  try {
+    PackedRecordBatchReader reader(fs_, paths, schema_, reader_memory_);
+    FAIL() << "expected the classified metadata failure to surface";
+  } catch (const milvus::SegcoreError& e) {
+    EXPECT_EQ(e.get_error_code(), milvus::DataFormatBroken);
+    EXPECT_NE(std::string(e.what()).find("PackedMetadataCorrupted"), std::string::npos) << e.what();
+  } catch (const std::exception& e) {
+    FAIL() << "metadata failure lost its type, got: " << e.what();
+  }
 }
 
 TEST_F(PackedErrorStatusTest, MakeReportsMissingFileAsStatusWithClassification) {


### PR DESCRIPTION
## Problem

Two C++ exception boundaries received an `arrow::Status` with a usable storage classification and then discarded its type by throwing `std::runtime_error(status.ToString())`:

- `VortexTranslater::get_cells`, used by the cache cell-loader path.
- The deprecated direct-link `PackedRecordBatchReader` constructor.

A throttled Vortex read could therefore become an unclassified permanent failure, and Packed constructor callers could only inspect text.

## Fix

Use the existing `ToSegcoreError(status)` conversion at both boundaries. `milvus::SegcoreError` carries the consumer-facing error code, so the exception contract remains intact without parsing strings or adding another exception mechanism.

The deprecated Packed constructor is retained for source compatibility because current Milvus still calls it directly. New callers should use `PackedRecordBatchReader::Make()`; removal can happen after downstream migration.

## Verification

- Release build passed on current `main`.
- Focused Packed and Vortex tests: 41 passed, 1 existing metadata-null skip.
- Both regression tests assert the caught exception is `milvus::SegcoreError` with the expected code.
- clang-format dry run and `git diff --check` passed.

## Scope

`ColumnGroup::Table()` already preserves the original Status on current main. This PR resolves the remaining live Status-to-string exception boundaries tracked by #609 without changing the public constructor signature.

Refs #609.