### PR TITLE
fix: upgrade azure-sdk-for-cpp to 1.16.4

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -171,7 +171,7 @@ class StorageConan(ConanFile):
         # azure-sdk-for-cpp is a transitive dep of Arrow, but must be declared
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.
-        self.requires("azure-sdk-for-cpp/1.11.3@milvus/dev#395e8e7a0c29644d41ef160088128f14")
+        self.requires("azure-sdk-for-cpp/1.16.4@milvus/dev#7c95e3df67cfea28b3cf6dbd60fbf137", force=True)
         self.requires("aws-sdk-cpp/1.11.842@milvus/dev#363556887f622db23a10168c108dd55d", force=True)
         # Force override transitive deps to align with milvus-common
         self.requires("protobuf/5.27.0@milvus/dev#42f031a96d21c230a6e05bcac4bdd633", force=True)


### PR DESCRIPTION
Milvus core declares azure-sdk-for-cpp 1.16.0 as a direct force=True requirement. When milvus-storage is built as part of Milvus, that requirement overrides the standalone storage dependency on 1.11.3 and makes 1.16.0 the effective SDK throughout the Conan graph. The 1.16.0 snapshot bundles azure-identity 1.12.0.

While opening an Azure output stream, AzureFileSystem probes Hierarchical Namespace support through GetDirectoryClient("").GetAccessControlList() on the Data Lake client. Before this request can reach the storage account, ManagedIdentityCredential must acquire a bearer token from Azure IMDS. azure-identity 1.12.0 creates the base URL http://169.254.169.254 and sets /metadata/identity/oauth2/token as the path, producing http://169.254.169.254//metadata/identity/oauth2/token.

IMDS does not route the double-slash endpoint and returns a misleading 404 ResourceNotFound response. This is a credential acquisition failure, not an indication that HNS is disabled. ARROW_ASSIGN_OR_RAISE propagates the error before HNS support can be classified, so the flat Blob fallback is never reached and the write fails.

Pin the internal package built from azure-core_1.16.4, which includes azure-identity 1.13.1 and the upstream IMDS URL fix from Azure/azure-sdk-for-cpp#6698. Also include the memory leak fix in core_1.16.1(Azure/azure-sdk-for-cpp#7153).

Related: milvus-io/milvus#52033