### PR TITLE
enhance: prevent deadlocks during S3 CRT client finalization

### DIFF
--- a/cpp/include/milvus-storage/filesystem/s3/s3_crt_client.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_crt_client.h
@@ -16,10 +16,13 @@
 
 #ifdef WITH_CRT
 
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <shared_mutex>
 #include <vector>
 
 #include <arrow/result.h>
@@ -43,50 +46,226 @@ template <>
 arrow::Result<std::shared_ptr<S3CrtClientHolder>> ClientBuilder<Aws::S3Crt::S3CrtClient>::BuildClient(
     std::optional<arrow::io::IOContext> io_context, std::shared_ptr<FilesystemMetrics> metrics);
 
-class S3CrtClientLock {
+class S3CrtClientOperationState;
+class S3CrtClientFinalizer;
+
+/// CRT client ownership and shutdown model
+/// ---------------------------------------
+///
+/// Motivation: why this cannot reuse the regular S3Client lifetime model
+/// ----------------------------------------------------------------------
+///
+/// Aws::S3::S3Client has no CRT-native release-and-wait stage in its
+/// destructor:
+///
+///   S3Client::~S3Client()
+///     -> ShutdownSdkClient()
+///     -> return
+///
+/// Aws::S3Crt::S3CrtClient owns an additional asynchronous native client. Its
+/// destructor releases that native client and then waits for the native
+/// shutdown callback to signal completion:
+///
+///   S3CrtClient::~S3CrtClient()
+///     -> aws_s3_client_release()
+///     -> wait on m_clientShutdownSem
+///          ^
+///          | native shutdown completes only after outstanding meta requests
+///          | and their native callbacks have finished
+///
+/// Consequently, allowing an operation guard to share ownership of the CRT
+/// client can make the operation thread decide where the client is destroyed.
+/// If a native callback releases the last owner, the resulting wait is cyclic:
+///
+///   native callback
+///     -> release last client owner
+///     -> S3CrtClient destructor waits for native shutdown
+///     -> native shutdown waits for this callback to return
+///
+/// The regular S3ClientLock model permits an operation guard to own a client
+/// shared_ptr. This CRT-specific model instead requires that:
+///
+///   * the holder remains the sole shared owner of the CRT client;
+///   * operations borrow the client without owning it;
+///   * holder finalization waits for all borrowed operations to finish;
+///   * every CRT client destructor returns before Aws::ShutdownAPI() begins.
+///
+/// The construction, operation, and live-client counters below form that
+/// shutdown barrier. They close the gaps between building a client, registering
+/// it, draining its operations, and completing its native destructor.
+///
+/// Each holder is the sole shared owner of one S3CrtClient. Operations borrow
+/// the client through move-only leases; a lease shares only the small
+/// per-holder operation state and never shares ownership of the client or its
+/// holder.
+///
+///   S3CrtClientFinalizer
+///            ^       |
+///     shared |       | weak registry
+///            |       v
+///   S3CrtClientHolder -------- sole shared owner ------> S3CrtClient
+///            |                                                  ^
+///            | shared                                           | raw borrow
+///            v                                                  |
+///   S3CrtClientOperationState <--------- shared -------- S3CrtClientLease
+///
+/// The finalizer-to-holder edge is weak while the holder-to-finalizer edge is
+/// strong. This avoids an ownership cycle, yet keeps the global finalizer alive
+/// until every registered client has reported the completion of its destructor.
+///
+/// A holder follows this state machine:
+///
+///   OPEN
+///     |  Acquire(): active_operations++
+///     |  Lease release: active_operations--
+///     |
+///     +-- Finalize() --> CLOSING
+///                           | reject every new Acquire()
+///                           | wait until active_operations == 0
+///                           v
+///                      destroy client
+///                           |
+///                           v
+///                    report ClientDestroyed()
+///
+/// S3CrtClientHolder::Finalize() may be entered by global S3 shutdown or by
+/// holder destruction.
+/// The last holder reference must therefore be released on a thread from which
+/// waiting for outstanding native callbacks is safe, never from one of those
+/// callbacks itself.
+
+/// Per-holder synchronization block shared by the holder and all outstanding
+/// leases. Keeping this state separate from the holder lets a lease decrement
+/// the active-operation count after holder finalization has started without
+/// owning the holder or the CRT client. The definition remains in the .cpp
+/// because callers only need to carry it indirectly through S3CrtClientLease.
+
+/// A move-only lease for one CRT client operation.
+///
+/// The lease deliberately contains only a non-owning client pointer and
+/// operation state. In particular, it must never own S3CrtClient,
+/// S3CrtClientHolder, or ObjectCrtInputFile. This makes it safe to release the
+/// lease on a CRT callback thread without running the CRT client destructor
+/// there. Acquire() increments the shared active-operation count; destroying or
+/// overwriting the lease decrements it exactly once and wakes a waiting holder
+/// when the count reaches zero.
+class S3CrtClientLease {
   public:
-  Aws::S3Crt::S3CrtClient* get();
-  Aws::S3Crt::S3CrtClient* operator->();
-  S3CrtClientLock Move();
+  S3CrtClientLease() = default;
+  S3CrtClientLease(const S3CrtClientLease&) = delete;
+  S3CrtClientLease& operator=(const S3CrtClientLease&) = delete;
+  S3CrtClientLease(S3CrtClientLease&& other) noexcept;
+  S3CrtClientLease& operator=(S3CrtClientLease&& other) noexcept;
+  ~S3CrtClientLease();
+
+  Aws::S3Crt::S3CrtClient* operator->() const;
 
   protected:
   friend class S3CrtClientHolder;
-  std::shared_lock<std::shared_mutex> lock_;
-  std::shared_ptr<Aws::S3Crt::S3CrtClient> client_;
+  void Release();
+
+  Aws::S3Crt::S3CrtClient* client_ = nullptr;
+  // Acquire() copies this shared_ptr from the owning holder. The two
+  // shared_ptr instances refer to the same per-holder operation-state object,
+  // allowing this lease to decrement and notify the state observed by Holder.
+  std::shared_ptr<S3CrtClientOperationState> operation_state_;
 };
 
-class S3CrtClientFinalizer;
-
+/// Owns one CRT client and gates its destruction on outstanding leases.
+///
+/// The holder never lends shared ownership of client_. A raw client pointer is
+/// valid through a lease because Finalize() cannot move or destroy client_
+/// before that lease has decremented active_operations.
 class S3CrtClientHolder {
   public:
-  arrow::Result<S3CrtClientLock> Lock();
-  S3CrtClientHolder(std::weak_ptr<S3CrtClientFinalizer> finalizer,
-                    std::shared_ptr<Aws::S3Crt::S3CrtClient> client,
-                    std::shared_ptr<FilesystemMetrics> metrics);
-  void Finalize();
+  S3CrtClientHolder(const S3CrtClientHolder&) = delete;
+  S3CrtClientHolder& operator=(const S3CrtClientHolder&) = delete;
+  S3CrtClientHolder(S3CrtClientHolder&&) = delete;
+  S3CrtClientHolder& operator=(S3CrtClientHolder&&) = delete;
+
+  /// Acquire a non-owning client pointer protected by an operation lease.
+  /// No lock is held while the caller uses the client.
+  arrow::Result<S3CrtClientLease> Acquire();
+  /// The last holder reference must not be released from a native CRT callback.
+  ~S3CrtClientHolder();
   std::shared_ptr<FilesystemMetrics> GetMetrics() const;
 
   protected:
-  std::mutex mutex_;
-  std::weak_ptr<S3CrtClientFinalizer> finalizer_;
+  friend class S3CrtClientFinalizer;
+  S3CrtClientHolder(std::shared_ptr<S3CrtClientFinalizer> finalizer, std::shared_ptr<FilesystemMetrics> metrics);
+  void Finalize();
+
+  std::shared_ptr<S3CrtClientFinalizer> finalizer_;
+  // Created once for this holder and copied into every successful lease.
+  // Holder and all outstanding leases therefore coordinate through the same
+  // operation-state object, not through separate counters.
+  std::shared_ptr<S3CrtClientOperationState> operation_state_;
+  // The holder is the sole shared owner of the client. Operation leases must
+  // never copy this shared_ptr.
   std::shared_ptr<Aws::S3Crt::S3CrtClient> client_;
   std::shared_ptr<FilesystemMetrics> metrics_;
 };
 
+/// Coordinates construction and destruction of every CRT client in the process.
+///
+/// Shutdown has three phases:
+///
+///   1. Set finalized_ and wait for every reserved construction to finish.
+///   2. Promote registered weak holders, then finalize them without mutex_ held.
+///   3. Wait for live_clients_ to reach zero, including holder destructors that
+///      started before their weak registry entries were collected.
+///
+///   AddClient                                  Finalize
+///   ---------                                  --------
+///   reserve constructing_clients_              finalized_ = true
+///   run factory without mutex_ held             wait constructing_clients_ == 0
+///   register holder and client                  collect live weak holders
+///   increment live_clients_                     holder->Finalize() without mutex_
+///   release construction reservation           wait live_clients_ == 0
+///
+/// Concurrent Finalize() calls are allowed: only the first caller consumes the
+/// weak registry, while every caller waits for the same construction and live
+/// client counters to drain.
 class S3CrtClientFinalizer : public std::enable_shared_from_this<S3CrtClientFinalizer> {
   using ClientHolderList = std::vector<std::weak_ptr<S3CrtClientHolder>>;
 
   public:
-  arrow::Result<std::shared_ptr<S3CrtClientHolder>> AddClient(std::shared_ptr<Aws::S3Crt::S3CrtClient> client,
+  using ClientFactory = std::function<arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>>()>;
+
+  /// Reserve construction before invoking the factory, then register its
+  /// client. The factory is not invoked after finalization starts.
+  arrow::Result<std::shared_ptr<S3CrtClientHolder>> AddClient(ClientFactory make_client,
                                                               std::shared_ptr<FilesystemMetrics> metrics);
+  /// Wait for client construction, then close all holders and wait until every
+  /// CRT client destructor has returned.
+  /// This is an S3 lifecycle operation and must not be called from a CRT
+  /// callback.
   void Finalize();
-  std::shared_lock<std::shared_mutex> LockShared();
 
   protected:
+  friend class S3CrtClientConstructionLease;
   friend class S3CrtClientHolder;
-  std::shared_mutex mutex_;
+  void ClientDestroyed();
+
+  // Protects holders_ and both counters. It is never held while invoking a
+  // client factory, waiting on a holder, or running an S3CrtClient destructor.
+  std::mutex mutex_;
+  // Wakes finalizers when either construction reservations or live clients
+  // reach zero. Both predicates are always checked while mutex_ is held.
+  std::condition_variable cv_;
+  // Weak ownership is intentional: ordinary filesystem ownership decides when
+  // a holder dies; the registry is used only to find holders during shutdown.
   ClientHolderList holders_;
-  bool finalized_ = false;
+  // Reservations acquired before running a client factory. The RAII
+  // construction lease decrements this counter on every failure path.
+  std::size_t constructing_clients_ = 0;
+  // Clients installed into holders whose destructors have not yet returned.
+  // This is stronger than counting lockable weak holders because a weak entry
+  // may expire while its holder is still inside its destructor.
+  std::size_t live_clients_ = 0;
+  // Global admission gate read by Acquire() without taking mutex_. Counter and
+  // registry synchronization still uses mutex_.
+  std::atomic<bool> finalized_{false};
 };
 
 std::shared_ptr<S3CrtClientFinalizer> GetCrtClientFinalizer();

--- a/cpp/include/milvus-storage/format/parquet/folly_arrow_executor.h
+++ b/cpp/include/milvus-storage/format/parquet/folly_arrow_executor.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include <arrow/result.h>
 #include <arrow/util/thread_pool.h>
 #include <folly/Executor.h>
 
@@ -23,7 +24,9 @@ namespace milvus_storage::parquet {
 
 // Adapt the Folly executor inherited from the consuming future chain for
 // Arrow's async generator while retaining its KeepAlive for outstanding work.
-std::shared_ptr<arrow::internal::Executor> MakeFollyArrowExecutor(folly::Executor::KeepAlive<> executor,
-                                                                  int capacity = 1);
+// Reject InlineLikeExecutor because it may run Arrow work on the submitting
+// thread, which can be a CRT callback thread.
+arrow::Result<std::shared_ptr<arrow::internal::Executor>> MakeFollyArrowExecutor(folly::Executor::KeepAlive<> executor,
+                                                                                 int capacity = 1);
 
 }  // namespace milvus_storage::parquet

--- a/cpp/src/filesystem/s3/s3_crt_client.cpp
+++ b/cpp/src/filesystem/s3/s3_crt_client.cpp
@@ -17,10 +17,11 @@
 #ifdef WITH_CRT
 
 #include <algorithm>
+#include <condition_variable>
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <shared_mutex>
 #include <utility>
 #include <vector>
 
@@ -54,82 +55,311 @@ inline arrow::Status ErrorS3Finalized() { return arrow::Status::Invalid("S3 subs
 
 }  // namespace
 
-// ------------ Implementation of S3CrtClientHolder ------------
-Aws::S3Crt::S3CrtClient* S3CrtClientLock::get() { return client_.get(); }
-Aws::S3Crt::S3CrtClient* S3CrtClientLock::operator->() { return client_.get(); }
-S3CrtClientLock S3CrtClientLock::Move() { return std::move(*this); }
+// Per-holder operation gate shared with every outstanding lease.
+//
+// Separating this block from S3CrtClientHolder is the core ownership rule:
+//
+//   holder --shared--> operation state <--shared-- lease
+//      |                                         |
+//      | sole shared owner                       | raw borrow
+//      v                                         v
+//   S3CrtClient <--------------------------------+
+//
+// A lease may outlive the point at which holder destruction starts, so it must
+// keep the synchronization block alive. It must not keep the holder or client
+// alive: releasing the last such owner on a native CRT callback thread could
+// run S3CrtClient::~S3CrtClient there, and that destructor waits for CRT
+// shutdown callbacks.
+//
+// Locking rules:
+//   * mutex protects both fields below.
+//   * no S3 operation executes while mutex is held.
+//   * the CRT client destructor executes only after mutex is released.
+class S3CrtClientOperationState {
+  public:
+  std::mutex mutex;
+  std::condition_variable cv;
+  // Number of leases that may currently dereference their raw client pointer.
+  std::size_t active_operations = 0;
+  // One-way admission gate: false -> true when holder finalization starts.
+  bool closing = false;
+};
 
-S3CrtClientHolder::S3CrtClientHolder(std::weak_ptr<S3CrtClientFinalizer> finalizer,
-                                     std::shared_ptr<Aws::S3Crt::S3CrtClient> client,
-                                     std::shared_ptr<FilesystemMetrics> metrics)
-    : finalizer_(std::move(finalizer)), client_(std::move(client)), metrics_(std::move(metrics)) {}
+// ------------ Implementation of S3CrtClientConstructionLease ------------
+// RAII reservation covering the entire client factory call, including factory
+// cleanup on success and every early-return/error path.
+//
+//   AddClient                       Finalize
+//   ---------                       --------
+//   constructing_clients_++         finalized_ = true
+//   create guard                    wait constructing_clients_ == 0
+//   unlock finalizer mutex                    ^
+//   run factory                               |
+//   destroy factory captures                  |
+//   register or return error         guard/manual decrement + notify
+//
+// The factory is deliberately invoked without the finalizer mutex held. The
+// reservation, rather than that mutex, prevents global shutdown from passing
+// client construction.
+class S3CrtClientConstructionLease {
+  public:
+  S3CrtClientConstructionLease(const S3CrtClientConstructionLease&) = delete;
+  S3CrtClientConstructionLease& operator=(const S3CrtClientConstructionLease&) = delete;
+  S3CrtClientConstructionLease(S3CrtClientConstructionLease&&) = delete;
+  S3CrtClientConstructionLease& operator=(S3CrtClientConstructionLease&&) = delete;
+  ~S3CrtClientConstructionLease();
 
-arrow::Result<S3CrtClientLock> S3CrtClientHolder::Lock() {
-  std::shared_ptr<S3CrtClientFinalizer> finalizer;
-  std::shared_ptr<Aws::S3Crt::S3CrtClient> client;
-  {
-    std::unique_lock lock(mutex_);
-    finalizer = finalizer_.lock();
-    client = client_;
-  }
+  private:
+  friend class S3CrtClientFinalizer;
+  explicit S3CrtClientConstructionLease(std::shared_ptr<S3CrtClientFinalizer> finalizer)
+      : finalizer_(std::move(finalizer)) {}
+
+  std::shared_ptr<S3CrtClientFinalizer> finalizer_;
+};
+
+// On a failed construction path finalizer_ is still set, so this destructor
+// releases the reservation. Successful registration disarms the guard and
+// decrements the same counter atomically with publishing the new live client.
+S3CrtClientConstructionLease::~S3CrtClientConstructionLease() {
+  auto finalizer = std::move(finalizer_);
   if (!finalizer) {
-    return ErrorS3Finalized();
+    return;
   }
 
-  S3CrtClientLock client_lock;
-  client_lock.lock_ = finalizer->LockShared();
-  if (finalizer->finalized_) {
-    return ErrorS3Finalized();
+  bool notify = false;
+  {
+    std::lock_guard lock(finalizer->mutex_);
+    DCHECK_GT(finalizer->constructing_clients_, 0);
+    notify = --finalizer->constructing_clients_ == 0;
   }
-  DCHECK(client) << "inconsistent S3CrtClientHolder";
-  client_lock.client_ = std::move(client);
-  return client_lock;
+  if (notify) {
+    finalizer->cv_.notify_all();
+  }
 }
 
+// ------------ Implementation of S3CrtClientHolder ------------
+S3CrtClientLease::S3CrtClientLease(S3CrtClientLease&& other) noexcept
+    : client_(std::exchange(other.client_, nullptr)), operation_state_(std::move(other.operation_state_)) {}
+
+S3CrtClientLease& S3CrtClientLease::operator=(S3CrtClientLease&& other) noexcept {
+  if (this != &other) {
+    Release();
+    client_ = std::exchange(other.client_, nullptr);
+    operation_state_ = std::move(other.operation_state_);
+  }
+  return *this;
+}
+
+S3CrtClientLease::~S3CrtClientLease() { Release(); }
+
+Aws::S3Crt::S3CrtClient* S3CrtClientLease::operator->() const { return client_; }
+
+void S3CrtClientLease::Release() {
+  // Clear the borrowed pointer before publishing that this operation is done.
+  // Moving operation_state_ out also makes repeated Release() calls harmless,
+  // which is required by move assignment and moved-from destruction.
+  client_ = nullptr;
+  auto operation_state = std::move(operation_state_);
+  if (!operation_state) {
+    return;
+  }
+
+  bool notify = false;
+  {
+    std::lock_guard lock(operation_state->mutex);
+    DCHECK_GT(operation_state->active_operations, 0);
+    notify = --operation_state->active_operations == 0;
+  }
+  if (notify) {
+    operation_state->cv.notify_all();
+  }
+}
+
+S3CrtClientHolder::S3CrtClientHolder(std::shared_ptr<S3CrtClientFinalizer> finalizer,
+                                     std::shared_ptr<FilesystemMetrics> metrics)
+    : finalizer_(std::move(finalizer)),
+      operation_state_(std::make_shared<S3CrtClientOperationState>()),
+      metrics_(std::move(metrics)) {}
+
+S3CrtClientHolder::~S3CrtClientHolder() { Finalize(); }
+
+// Holder state transition guarded by operation_state_->mutex:
+//
+//   OPEN, active=N -- Acquire() --> OPEN, active=N+1
+//   OPEN           -- Finalize() --> CLOSING -- active=0 --> client destroy
+//   CLOSING        -- Acquire() --> rejected
+//
+// finalized_ is also checked because global shutdown closes admission before
+// it has collected and finalized every individual holder.
+arrow::Result<S3CrtClientLease> S3CrtClientHolder::Acquire() {
+  S3CrtClientLease lease;
+  {
+    std::lock_guard operation_lock(operation_state_->mutex);
+    if (operation_state_->closing || finalizer_->finalized_.load(std::memory_order_acquire)) {
+      return ErrorS3Finalized();
+    }
+    DCHECK(client_) << "inconsistent S3CrtClientHolder";
+    ++operation_state_->active_operations;
+    lease.client_ = client_.get();
+    lease.operation_state_ = operation_state_;
+  }
+  return lease;
+}
+
+// Finalization deliberately separates waiting, ownership transfer, and native
+// destruction:
+//
+//   finalizing/destructor thread             operation/CRT callback threads
+//   ----------------------------             ------------------------------
+//   closing = true
+//   wait(active_operations == 0)   <-------  lease Release(): active--, notify
+//   move client_ out
+//   unlock operation mutex
+//   client.reset()
+//   ClientDestroyed()
+//
+// No new lease can start after closing is set. Existing leases keep only the
+// operation state alive and eventually wake this waiter. client.reset() is
+// outside the operation mutex because the SDK destructor may block while CRT
+// completes its own shutdown callbacks.
 void S3CrtClientHolder::Finalize() {
   std::shared_ptr<Aws::S3Crt::S3CrtClient> client;
   {
-    std::unique_lock lock(mutex_);
+    std::unique_lock lock(operation_state_->mutex);
+    operation_state_->closing = true;
+    operation_state_->cv.wait(lock, [this] { return operation_state_->active_operations == 0; });
     client = std::move(client_);
   }
+  if (!client) {
+    return;
+  }
+
+  // S3CrtClient::~S3CrtClient waits for the native CRT client shutdown
+  // callback. This runs only after every operation lease has left its callback
+  // and always on the thread finalizing/destroying the holder.
+  client.reset();
+  finalizer_->ClientDestroyed();
 }
 
 std::shared_ptr<FilesystemMetrics> S3CrtClientHolder::GetMetrics() const { return metrics_; }
 
-using CrtClientHolderList = std::vector<std::weak_ptr<S3CrtClientHolder>>;
-
+// Construction is published as one transaction under mutex_:
+//
+//   before factory:  constructing_clients_++
+//   after success:   holders_ += holder
+//                    holder->client_ = client
+//                    live_clients_++
+//                    constructing_clients_--
+//
+// Finalize() cannot observe a client between construction and registration. On
+// failure the construction guard performs only the final decrement, so a null
+// or multiply-owned client is never counted as live.
 arrow::Result<std::shared_ptr<S3CrtClientHolder>> S3CrtClientFinalizer::AddClient(
-    std::shared_ptr<Aws::S3Crt::S3CrtClient> client, std::shared_ptr<FilesystemMetrics> metrics) {
-  std::unique_lock lock(mutex_);
-  if (finalized_) {
-    return ErrorS3Finalized();
+    ClientFactory make_client, std::shared_ptr<FilesystemMetrics> metrics) {
+  auto finalizer = shared_from_this();
+  {
+    std::lock_guard lock(mutex_);
+    if (finalized_.load(std::memory_order_acquire)) {
+      return ErrorS3Finalized();
+    }
+    ++constructing_clients_;
   }
+  S3CrtClientConstructionLease construction(finalizer);
 
-  auto holder = std::make_shared<S3CrtClientHolder>(shared_from_this(), std::move(client), std::move(metrics));
+  // Destroy the std::function and all of its captures outside mutex_. Captures
+  // may perform arbitrary cleanup; that cleanup remains inside the construction
+  // reservation but never blocks other finalizer state transitions.
+  ClientFactory factory = std::move(make_client);
+  make_client = nullptr;
+  ARROW_ASSIGN_OR_RAISE(auto client, factory());
+  factory = nullptr;
+  if (!client) {
+    return arrow::Status::Invalid("S3 CRT client factory returned a null client");
+  }
+  if (client.use_count() != 1) {
+    return arrow::Status::Invalid("S3CrtClientHolder must be the sole shared owner");
+  }
+  auto holder = std::shared_ptr<S3CrtClientHolder>(new S3CrtClientHolder(finalizer, std::move(metrics)));
 
-  auto end = std::remove_if(holders_.begin(), holders_.end(),
-                            [](const std::weak_ptr<S3CrtClientHolder>& holder) { return holder.expired(); });
-  holders_.erase(end, holders_.end());
-  holders_.emplace_back(holder);
+  bool notify = false;
+  {
+    std::lock_guard lock(mutex_);
+    auto end = std::remove_if(holders_.begin(), holders_.end(),
+                              [](const std::weak_ptr<S3CrtClientHolder>& item) { return item.expired(); });
+    holders_.erase(end, holders_.end());
+    holders_.emplace_back(holder);
+
+    holder->client_ = std::move(client);
+    ++live_clients_;
+    construction.finalizer_.reset();
+    notify = --constructing_clients_ == 0;
+  }
+  if (notify) {
+    cv_.notify_all();
+  }
   return holder;
 }
 
+// Global finalization has three phases and never holds mutex_ while waiting on
+// a holder or destroying a native client:
+//
+//   Phase 1: close admission and stabilize the registry
+//     finalized_ = true
+//     wait constructing_clients_ == 0
+//     weak holder registry --lock()--> local strong holder list
+//
+//   Phase 2: drain each holder without mutex_
+//     closing = true -> wait leases -> destroy client -> ClientDestroyed()
+//
+//   Phase 3: wait live_clients_ == 0
+//
+// The final counter wait is required even after every lockable weak holder has
+// been drained. A weak entry can already be expired while its holder destructor
+// is blocked on an operation lease or inside the native client destructor; that
+// client remains live until ClientDestroyed() runs.
+//
+// Concurrent callers share the same drain. Only the caller that changes
+// finalized_ from false to true consumes holders_; all callers still wait for
+// both counters to reach zero.
 void S3CrtClientFinalizer::Finalize() {
-  std::unique_lock lock(mutex_);
-  finalized_ = true;
-
-  CrtClientHolderList finalizing = std::move(holders_);
-  lock.unlock();
-
-  for (auto&& weak_holder : finalizing) {
-    auto holder = weak_holder.lock();
-    if (holder) {
-      holder->Finalize();
+  std::vector<std::shared_ptr<S3CrtClientHolder>> finalizing;
+  {
+    std::unique_lock lock(mutex_);
+    const bool first_finalizer = !finalized_.exchange(true, std::memory_order_acq_rel);
+    cv_.wait(lock, [this] { return constructing_clients_ == 0; });
+    if (first_finalizer) {
+      finalizing.reserve(holders_.size());
+      for (auto&& weak_holder : holders_) {
+        if (auto holder = weak_holder.lock()) {
+          finalizing.emplace_back(std::move(holder));
+        }
+      }
+      holders_.clear();
     }
   }
+
+  for (auto&& holder : finalizing) {
+    holder->Finalize();
+  }
+
+  std::unique_lock lock(mutex_);
+  cv_.wait(lock, [this] { return live_clients_ == 0; });
 }
 
-std::shared_lock<std::shared_mutex> S3CrtClientFinalizer::LockShared() { return std::shared_lock(mutex_); }
+void S3CrtClientFinalizer::ClientDestroyed() {
+  // This callback runs after S3CrtClient::~S3CrtClient has returned, so zero
+  // means every registered native client is fully gone and Aws::ShutdownAPI()
+  // may proceed.
+  bool notify = false;
+  {
+    std::lock_guard lock(mutex_);
+    DCHECK_GT(live_clients_, 0);
+    notify = --live_clients_ == 0;
+  }
+  if (notify) {
+    cv_.notify_all();
+  }
+}
 
 std::shared_ptr<S3CrtClientFinalizer> GetCrtClientFinalizer() {
   static auto finalizer = std::make_shared<S3CrtClientFinalizer>();
@@ -139,27 +369,34 @@ std::shared_ptr<S3CrtClientFinalizer> GetCrtClientFinalizer() {
 template <>
 arrow::Result<std::shared_ptr<S3CrtClientHolder>> ClientBuilder<Aws::S3Crt::S3CrtClient>::BuildClient(
     std::optional<arrow::io::IOContext> io_context, std::shared_ptr<FilesystemMetrics> metrics) {
-  ARROW_RETURN_NOT_OK(PrepareClientConfig(io_context));
-
-  if (options_.retry_strategy) {
-    client_config_.retryStrategy = fs::internal::MakeWrappedRetryStrategy(options_.retry_strategy);
-  } else {
-    client_config_.retryStrategy = std::make_shared<fs::internal::ConnectRetryStrategy>();
-  }
-
-  const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
-  client_config_.useVirtualAddressing = use_virtual_addressing;
-  // Raise the CRT target from its SDK default so small concurrent range reads
-  // get enough connection budget for the Vortex reader workload.
-  // TODO: make this configurable instead of using a fixed workload-specific default.
-  client_config_.throughputTargetGbps = 50.0;
-
   if (!metrics) {
     metrics = std::make_shared<FilesystemMetrics>();
   }
-  auto client = std::make_shared<Aws::S3Crt::S3CrtClient>(
-      credentials_provider_, client_config_, client_config_.payloadSigningPolicy, client_config_.useVirtualAddressing);
-  return GetCrtClientFinalizer()->AddClient(std::move(client), std::move(metrics));
+  // Configuration and native client construction stay inside AddClient's
+  // reserved factory window. Global finalization therefore cannot reach
+  // Aws::ShutdownAPI() while either step is still using AWS runtime state.
+  return GetCrtClientFinalizer()->AddClient(
+      [this, io_context = std::move(io_context)]() mutable -> arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> {
+        ARROW_RETURN_NOT_OK(PrepareClientConfig(std::move(io_context)));
+
+        if (options_.retry_strategy) {
+          client_config_.retryStrategy = fs::internal::MakeWrappedRetryStrategy(options_.retry_strategy);
+        } else {
+          client_config_.retryStrategy = std::make_shared<fs::internal::ConnectRetryStrategy>();
+        }
+
+        const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
+        client_config_.useVirtualAddressing = use_virtual_addressing;
+        // Raise the CRT target from its SDK default so small concurrent range reads
+        // get enough connection budget for the Vortex reader workload.
+        // TODO: make this configurable instead of using a fixed workload-specific default.
+        client_config_.throughputTargetGbps = 50.0;
+
+        return std::make_shared<Aws::S3Crt::S3CrtClient>(credentials_provider_, client_config_,
+                                                         client_config_.payloadSigningPolicy,
+                                                         client_config_.useVirtualAddressing);
+      },
+      std::move(metrics));
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -724,12 +724,22 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
 
 #ifdef WITH_CRT
 class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonBlockingReadAtFile {
+  protected:
+  struct ReadState {
+    explicit ReadState(int64_t size) : content_length(size) {}
+
+    std::atomic<int64_t> content_length;
+  };
+
   public:
   ObjectCrtInputFile(std::shared_ptr<S3CrtClientHolder> holder,
                      const arrow::io::IOContext& io_context,
                      const S3Path& path,
                      int64_t size = kNoSize)
-      : holder_(std::move(holder)), io_context_(io_context), path_(path), content_length_(size) {}
+      : holder_(std::move(holder)),
+        io_context_(io_context),
+        path_(path),
+        read_state_(std::make_shared<ReadState>(size)) {}
 
   arrow::Status Init() {
     const auto content_length = GetCachedContentLength();
@@ -815,15 +825,15 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
       return Future<int64_t>::MakeFinished(0);
     }
 
-    auto maybe_client_lock = holder_->Lock();
-    if (!maybe_client_lock.ok()) {
-      return FailedReadFuture(maybe_client_lock.status());
+    auto maybe_client_lease = holder_->Acquire();
+    if (!maybe_client_lease.ok()) {
+      return FailedReadFuture(maybe_client_lease.status());
     }
 
     auto ctx = std::make_shared<AsyncReadContext>();
     ctx->future = Future<int64_t>::Make();
-    ctx->client_lock = std::move(maybe_client_lock).ValueOrDie().Move();
-    ctx->self = std::dynamic_pointer_cast<ObjectCrtInputFile>(shared_from_this());
+    ctx->client_lease = std::move(maybe_client_lease).ValueOrDie();
+    ctx->read_state = read_state_;
     ctx->metrics = holder_->GetMetrics();
     ctx->position = position;
     ctx->nbytes = nbytes;
@@ -833,7 +843,7 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     ctx->request.SetResponseStreamFactory(AwsWriteableStreamFactory(out, nbytes));
 
     ctx->metrics->IncrementReadCount();
-    ctx->client_lock->GetObjectAsync(
+    ctx->client_lease->GetObjectAsync(
         ctx->request,
         [ctx](const Aws::S3Crt::S3CrtClient*, const S3CrtModel::GetObjectRequest&, S3CrtModel::GetObjectOutcome outcome,
               const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) mutable {
@@ -854,12 +864,19 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
           }
 
           const int64_t bytes_read = response_content_length;
-          ctx->self->CacheContentLengthFromRead(result, ctx->position, bytes_read);
+          auto content_length = GetObjectSizeFromReadResult(result, ctx->position);
+          if (content_length) {
+            DCHECK_LE(ctx->position + bytes_read, *content_length);
+            int64_t expected = kNoSize;
+            ctx->read_state->content_length.compare_exchange_strong(
+                expected, *content_length, std::memory_order_acq_rel, std::memory_order_acquire);
+          }
           if (bytes_read > 0) {
             ctx->metrics->IncrementReadBytes(bytes_read);
           }
           ctx->future.MarkFinished(bytes_read);
         });
+    // Keep executor selection at the caller-owned continuation boundary.
     return ctx->future;
   }
 
@@ -978,8 +995,8 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     req.SetBucket(ToAwsString(path_.bucket));
     req.SetKey(ToAwsString(path_.key));
 
-    ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
-    auto outcome = client_lock.Move()->HeadObject(req);
+    ARROW_ASSIGN_OR_RAISE(auto client_lease, holder_->Acquire());
+    auto outcome = client_lease->HeadObject(req);
     if (!outcome.IsSuccess()) {
       if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
         return PathNotFound(path_);
@@ -1000,27 +1017,10 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     return arrow::Status::OK();
   }
 
-  template <typename ObjectResult>
-  void CacheContentLengthFromRead(const ObjectResult& result, int64_t position, int64_t bytes_read) {
-    auto content_length = GetObjectSizeFromReadResult(result, position);
-    if (!content_length) {
-      return;
-    }
-
-    DCHECK_LE(position + bytes_read, *content_length);
-    SetCachedContentLengthIfAbsent(*content_length);
-  }
-
-  int64_t GetCachedContentLength() const { return content_length_.load(std::memory_order_acquire); }
+  int64_t GetCachedContentLength() const { return read_state_->content_length.load(std::memory_order_acquire); }
 
   void SetCachedContentLength(int64_t content_length) {
-    content_length_.store(content_length, std::memory_order_release);
-  }
-
-  void SetCachedContentLengthIfAbsent(int64_t content_length) {
-    int64_t expected = kNoSize;
-    content_length_.compare_exchange_strong(expected, content_length, std::memory_order_acq_rel,
-                                            std::memory_order_acquire);
+    read_state_->content_length.store(content_length, std::memory_order_release);
   }
 
   bool HasCachedMetadata() const {
@@ -1038,10 +1038,13 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
   }
 
   struct AsyncReadContext {
+    // AWS CRT retains this context through the callback. Never add owning
+    // references to S3CrtClient, S3CrtClientHolder, or ObjectCrtInputFile here.
+    // The lease owns only operation state and a non-owning client pointer.
     Future<int64_t> future;
-    S3CrtClientLock client_lock;
+    S3CrtClientLease client_lease;
     S3CrtModel::GetObjectRequest request;
-    std::shared_ptr<ObjectCrtInputFile> self;
+    std::shared_ptr<ReadState> read_state;
     std::shared_ptr<FilesystemMetrics> metrics;
     int64_t position = 0;
     int64_t nbytes = 0;
@@ -1054,7 +1057,7 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
   bool closed_ = false;
   int64_t pos_ = 0;
   mutable std::mutex metadata_mutex_;
-  std::atomic<int64_t> content_length_{kNoSize};
+  std::shared_ptr<ReadState> read_state_;
   std::shared_ptr<const arrow::KeyValueMetadata> metadata_;
 };
 #endif  // WITH_CRT

--- a/cpp/src/filesystem/s3/s3_global.cpp
+++ b/cpp/src/filesystem/s3/s3_global.cpp
@@ -134,6 +134,8 @@ struct AwsInstance {
         return;
       }
 #ifdef WITH_CRT
+      // This waits until every holder-owned CRT client has finished its
+      // synchronous destructor. No CRT client may outlive ShutdownAPI().
       crt_client_finalizer->Finalize();
 #endif
       client_finalizer->Finalize();

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -358,7 +358,6 @@ type AsyncReadResult = Result<ByteBuffer, VortexError>;
 #[cfg(feature = "s3-crt-async")]
 struct AsyncReadCallbackState {
     sender: Option<oneshot::Sender<AsyncReadResult>>,
-    reader: Arc<ReaderHandle>,
     buffer: ByteBufferMut,
     start: u64,
     expected_len: u64,
@@ -380,7 +379,6 @@ unsafe extern "C" fn async_read_callback(
 
     let AsyncReadCallbackState {
         mut sender,
-        reader: _reader,
         mut buffer,
         start,
         expected_len,
@@ -438,7 +436,6 @@ async fn read_async_via_ffi(
     let (sender, receiver) = oneshot::channel();
     let state = Box::new(AsyncReadCallbackState {
         sender: Some(sender),
-        reader: reader.clone(),
         buffer,
         start,
         expected_len: len,
@@ -464,11 +461,13 @@ async fn read_async_via_ffi(
             check_loon_ffi_result(&mut result, "Failed to submit async readat")?;
         }
     }
-    drop(reader);
 
     let read_result = receiver
         .await
         .map_err(|_| vortex_err!("Async readat completion channel closed"))?;
+    // Keep the reader in the async task, not in AsyncReadCallbackState, so its
+    // last reference is released on the task executor rather than in the callback.
+    drop(reader);
     read_result
 }
 

--- a/cpp/src/format/parquet/folly_arrow_executor.cpp
+++ b/cpp/src/format/parquet/folly_arrow_executor.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include <arrow/status.h>
+#include <folly/executors/InlineExecutor.h>
 
 namespace milvus_storage::parquet {
 namespace {
@@ -29,7 +30,8 @@ class FollyArrowExecutor final : public arrow::internal::Executor {
   FollyArrowExecutor(folly::Executor::KeepAlive<> executor, int capacity)
       : executor_(std::move(executor)), capacity_(capacity) {}
 
-  // Capacity is an Arrow scheduling hint; it does not create additional workers.
+  // Folly's base Executor has no worker-count API. Capacity is a caller-provided
+  // Arrow scheduling hint; it does not create additional workers.
   int GetCapacity() override { return capacity_; }
 
   protected:
@@ -72,7 +74,19 @@ class FollyArrowExecutor final : public arrow::internal::Executor {
 
 }  // namespace
 
-std::shared_ptr<arrow::internal::Executor> MakeFollyArrowExecutor(folly::Executor::KeepAlive<> executor, int capacity) {
+arrow::Result<std::shared_ptr<arrow::internal::Executor>> MakeFollyArrowExecutor(folly::Executor::KeepAlive<> executor,
+                                                                                 int capacity) {
+  if (!executor) {
+    return arrow::Status::Invalid("Parquet async reads require a Folly executor");
+  }
+  // InlineLikeExecutor::add() runs work on the submitting thread. Arrow may
+  // submit Parquet decode work while an S3 future is completing on a CRT event
+  // loop, so accepting an inline executor could move that decode onto the CRT
+  // thread. Do not choose a fallback here; require the storage caller to bind a
+  // non-inline executor.
+  if (dynamic_cast<folly::InlineLikeExecutor*>(executor.get()) != nullptr) {
+    return arrow::Status::Invalid("Parquet async reads require a non-inline Folly executor");
+  }
   return std::make_shared<FollyArrowExecutor>(std::move(executor), capacity);
 }
 

--- a/cpp/src/format/parquet/parquet_format_reader.cpp
+++ b/cpp/src/format/parquet/parquet_format_reader.cpp
@@ -957,7 +957,7 @@ folly::SemiFuture<arrow::Result<std::shared_ptr<arrow::RecordBatchReader>>> Parq
         // The callback now receives a concrete KeepAlive token for the consumer's
         // executor. The Arrow adapter only retains that token and forwards work;
         // it does not create an executor or worker thread.
-        auto arrow_executor = MakeFollyArrowExecutor(std::move(executor));
+        FOLLY_ARROW_ASSIGN_OR_RAISE(auto arrow_executor, MakeFollyArrowExecutor(std::move(executor)));
         // file_reader is captured by shared ownership because Arrow may use it
         // after this continuation returns.
         FOLLY_ARROW_ASSIGN_OR_RAISE(
@@ -1021,7 +1021,7 @@ folly::SemiFuture<arrow::Result<std::shared_ptr<arrow::Table>>> ParquetFormatRea
           folly::Unit) mutable -> folly::SemiFuture<arrow::Result<std::shared_ptr<arrow::Table>>> {
         // KeepAlive is now the concrete consumer executor token. This adapter
         // forwards Arrow work to it without creating a separate thread pool.
-        auto arrow_executor = MakeFollyArrowExecutor(std::move(executor));
+        FOLLY_ARROW_ASSIGN_OR_RAISE(auto arrow_executor, MakeFollyArrowExecutor(std::move(executor)));
         // Read complete row groups once. Exact row selection happens after the
         // generator output is concatenated below.
         FOLLY_ARROW_ASSIGN_OR_RAISE(

--- a/cpp/test/filesystem/s3_crt_build_test.cpp
+++ b/cpp/test/filesystem/s3_crt_build_test.cpp
@@ -14,20 +14,37 @@
 
 #ifdef WITH_CRT
 
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdlib>
+#include <future>
+#include <iostream>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <type_traits>
+#include <vector>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 
 #include <aws/s3-crt/S3CrtClient.h>
 #include <aws/s3-crt/S3CrtClientConfiguration.h>
+#include <folly/executors/ManualExecutor.h>
 
 #include "milvus-storage/filesystem/async_random_access_file.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/s3/s3_crt_client.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
+#include "milvus-storage/format/parquet/folly_arrow_executor.h"
 #include "test_env.h"
 
 namespace milvus_storage::test {
@@ -44,15 +61,473 @@ arrow::Status EnsureS3InitializedForTest() {
   return arrow::Status::OK();
 }
 
+std::shared_ptr<Aws::S3Crt::S3CrtClient> MakeTestS3CrtClient() {
+  // The client is never dereferenced. The alias lets lifecycle tests exercise
+  // holder/finalizer behavior without constructing a native CRT client.
+  auto storage = std::make_shared<char>();
+  return {storage, reinterpret_cast<Aws::S3Crt::S3CrtClient*>(storage.get())};
+}
+
+bool WaitUntilAcquireRejected(const std::shared_ptr<S3CrtClientHolder>& holder) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (!holder->Acquire().ok()) {
+      return true;
+    }
+    std::this_thread::yield();
+  }
+  return false;
+}
+
+bool WaitUntilConstructionRejected(const std::shared_ptr<S3CrtClientFinalizer>& finalizer) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    bool factory_called = false;
+    auto result = finalizer->AddClient(
+        [&factory_called]() -> arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> {
+          factory_called = true;
+          return MakeTestS3CrtClient();
+        },
+        nullptr);
+    if (!result.ok() && !factory_called) {
+      return true;
+    }
+    std::this_thread::yield();
+  }
+  return false;
+}
+
+constexpr std::size_t kConcurrentOperations = 100;
+
 }  // namespace
 
 TEST(S3CrtBuildSupportTest, HeadersAndStaticClientSymbolsAreAvailable) {
   static_assert(std::is_class_v<Aws::S3Crt::S3CrtClient>);
   static_assert(std::is_default_constructible_v<Aws::S3Crt::S3CrtClientConfiguration>);
+  static_assert(!std::is_copy_constructible_v<S3CrtClientLease>);
+  static_assert(std::is_move_constructible_v<S3CrtClientLease>);
 
   const char* service_name = Aws::S3Crt::S3CrtClient::GetServiceName();
   ASSERT_NE(service_name, nullptr);
   EXPECT_FALSE(std::string(service_name).empty());
+}
+
+TEST(S3CrtClientFinalizerTest, RejectsSuccessfulNullClientConstruction) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  auto result = finalizer->AddClient(
+      []() -> arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> {
+        return std::shared_ptr<Aws::S3Crt::S3CrtClient>(nullptr, [](Aws::S3Crt::S3CrtClient*) {});
+      },
+      nullptr);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+}
+
+TEST(S3CrtClientFinalizerTest, RejectsClientWithAnotherSharedOwner) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  auto retained_client = MakeTestS3CrtClient();
+  auto result = finalizer->AddClient([retained_client] { return retained_client; }, nullptr);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+}
+
+TEST(S3CrtClientFinalizerTest, FinalizationWaitsForClientConstructionToRegister) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  std::promise<void> construction_entered_promise;
+  auto construction_entered = construction_entered_promise.get_future();
+  std::promise<void> release_construction_promise;
+  auto release_construction = release_construction_promise.get_future().share();
+  std::promise<std::weak_ptr<Aws::S3Crt::S3CrtClient>> client_created_promise;
+  auto client_created = client_created_promise.get_future();
+  auto constructing = std::async(
+      std::launch::async, [finalizer, &construction_entered_promise, release_construction, &client_created_promise] {
+        return finalizer->AddClient(
+            [&construction_entered_promise, release_construction,
+             &client_created_promise]() -> arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> {
+              construction_entered_promise.set_value();
+              release_construction.wait();
+              auto client = MakeTestS3CrtClient();
+              client_created_promise.set_value(std::weak_ptr<Aws::S3Crt::S3CrtClient>(client));
+              return client;
+            },
+            nullptr);
+      });
+  if (construction_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    release_construction_promise.set_value();
+    constructing.wait();
+    FAIL() << "Client construction did not start";
+  }
+
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+
+  if (!WaitUntilConstructionRejected(finalizer)) {
+    release_construction_promise.set_value();
+    constructing.wait();
+    finalized.wait();
+    FAIL() << "Finalize did not reject new client construction";
+  }
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  release_construction_promise.set_value();
+  ASSERT_EQ(constructing.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  ASSERT_AND_ASSIGN(auto holder, constructing.get());
+  const auto weak_client = client_created.get();
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+
+  EXPECT_TRUE(weak_client.expired());
+  EXPECT_FALSE(holder->Acquire().ok());
+}
+
+TEST(S3CrtClientFinalizerTest, FinalizationWaitsForEveryFailedClientConstruction) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  auto start_failed_construction = [finalizer](std::promise<void>* entered, std::shared_future<void> release) {
+    return std::async(std::launch::async, [finalizer, entered, release] {
+      return finalizer->AddClient(
+          [entered, release]() -> arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> {
+            entered->set_value();
+            release.wait();
+            return arrow::Status::IOError("Injected CRT client construction failure");
+          },
+          nullptr);
+    });
+  };
+
+  std::promise<void> first_entered_promise;
+  auto first_entered = first_entered_promise.get_future();
+  std::promise<void> first_release_promise;
+  auto first = start_failed_construction(&first_entered_promise, first_release_promise.get_future().share());
+  std::promise<void> second_entered_promise;
+  auto second_entered = second_entered_promise.get_future();
+  std::promise<void> second_release_promise;
+  auto second = start_failed_construction(&second_entered_promise, second_release_promise.get_future().share());
+
+  if (first_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready ||
+      second_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    first_release_promise.set_value();
+    second_release_promise.set_value();
+    first.wait();
+    second.wait();
+    FAIL() << "Client construction did not start";
+  }
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+
+  if (!WaitUntilConstructionRejected(finalizer)) {
+    first_release_promise.set_value();
+    second_release_promise.set_value();
+    first.wait();
+    second.wait();
+    finalized.wait();
+    FAIL() << "Finalize did not reject new client construction";
+  }
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  first_release_promise.set_value();
+  ASSERT_EQ(first.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_FALSE(first.get().ok());
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  second_release_promise.set_value();
+  ASSERT_EQ(second.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_FALSE(second.get().ok());
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+}
+
+TEST(S3CrtClientFinalizerTest, FinalizationWaitsForClientFactoryCleanup) {
+  struct BlockingFactoryCleanup {
+    BlockingFactoryCleanup(std::promise<void>* entered, std::shared_future<void> release)
+        : entered(entered), release(std::move(release)) {}
+    BlockingFactoryCleanup(const BlockingFactoryCleanup& other) : entered(other.entered), release(other.release) {}
+    BlockingFactoryCleanup(BlockingFactoryCleanup&& other) noexcept
+        : entered(other.entered), release(std::move(other.release)), armed(other.armed) {
+      other.armed = false;
+    }
+    ~BlockingFactoryCleanup() {
+      if (armed) {
+        entered->set_value();
+        release.wait();
+      }
+    }
+
+    arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> operator()() {
+      armed = true;
+      return MakeTestS3CrtClient();
+    }
+
+    std::promise<void>* entered;
+    std::shared_future<void> release;
+    bool armed = false;
+  };
+
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  std::promise<void> factory_cleanup_entered_promise;
+  auto factory_cleanup_entered = factory_cleanup_entered_promise.get_future();
+  std::promise<void> release_factory_cleanup_promise;
+  auto release_factory_cleanup = release_factory_cleanup_promise.get_future().share();
+  S3CrtClientFinalizer::ClientFactory factory(
+      BlockingFactoryCleanup(&factory_cleanup_entered_promise, release_factory_cleanup));
+
+  auto adding = std::async(std::launch::async, [finalizer, factory = std::move(factory)]() mutable {
+    return finalizer->AddClient(std::move(factory), nullptr);
+  });
+  if (factory_cleanup_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    release_factory_cleanup_promise.set_value();
+    adding.wait();
+    FAIL() << "Client factory cleanup did not start";
+  }
+
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  release_factory_cleanup_promise.set_value();
+  ASSERT_EQ(adding.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  ASSERT_AND_ASSIGN(auto holder, adding.get());
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+  EXPECT_FALSE(holder->Acquire().ok());
+}
+
+TEST(S3CrtClientFinalizerTest, LeaseIsReentrantAndClientDestructionStaysOnHolderThread) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+
+  std::promise<std::thread::id> client_destroyed_promise;
+  auto client_destroyed = client_destroyed_promise.get_future();
+  auto storage = std::shared_ptr<char>(new char, [&client_destroyed_promise](char* ptr) {
+    client_destroyed_promise.set_value(std::this_thread::get_id());
+    delete ptr;
+  });
+  auto* client_ptr = reinterpret_cast<Aws::S3Crt::S3CrtClient*>(storage.get());
+  std::shared_ptr<Aws::S3Crt::S3CrtClient> client(storage, client_ptr);
+  storage.reset();
+
+  ASSERT_AND_ASSIGN(
+      auto holder, finalizer->AddClient([client = std::move(client)]() mutable { return std::move(client); }, nullptr));
+  ASSERT_AND_ASSIGN(auto first_lease, holder->Acquire());
+  ASSERT_AND_ASSIGN(auto second_lease, holder->Acquire());
+
+  std::promise<void> holder_destruction_started_promise;
+  auto holder_destruction_started = holder_destruction_started_promise.get_future();
+  auto holder_destroyed =
+      std::async(std::launch::async,
+                 [holder = std::move(holder), &holder_destruction_started_promise]() mutable -> std::thread::id {
+                   auto thread_id = std::this_thread::get_id();
+                   holder_destruction_started_promise.set_value();
+                   holder.reset();
+                   return thread_id;
+                 });
+
+  holder_destruction_started.wait();
+  EXPECT_EQ(holder_destroyed.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  auto leases_released = std::async(
+      std::launch::async,
+      [first_lease = std::move(first_lease), second_lease = std::move(second_lease)]() mutable -> std::thread::id {
+        return std::this_thread::get_id();
+      });
+  const auto lease_release_thread = leases_released.get();
+
+  ASSERT_EQ(holder_destroyed.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  const auto holder_destruction_thread = holder_destroyed.get();
+  ASSERT_EQ(client_destroyed.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  const auto client_destruction_thread = client_destroyed.get();
+
+  EXPECT_EQ(client_destruction_thread, holder_destruction_thread);
+  EXPECT_NE(client_destruction_thread, lease_release_thread);
+}
+
+TEST(S3CrtClientFinalizerTest, LeaseMoveReleasesEachOperationOnce) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  auto client = MakeTestS3CrtClient();
+  std::weak_ptr<Aws::S3Crt::S3CrtClient> weak_client = client;
+  ASSERT_AND_ASSIGN(
+      auto holder, finalizer->AddClient([client = std::move(client)]() mutable { return std::move(client); }, nullptr));
+  ASSERT_AND_ASSIGN(auto first, holder->Acquire());
+  ASSERT_AND_ASSIGN(auto second, holder->Acquire());
+
+  auto moved = std::move(first);
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+  ASSERT_TRUE(WaitUntilAcquireRejected(holder));
+
+  moved = std::move(second);
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  moved = S3CrtClientLease{};
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+  EXPECT_TRUE(weak_client.expired());
+}
+
+TEST(S3CrtClientFinalizerTest, FinalizationWaitsForEveryActiveOperation) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  auto client = MakeTestS3CrtClient();
+  std::weak_ptr<Aws::S3Crt::S3CrtClient> weak_client = client;
+  ASSERT_AND_ASSIGN(
+      auto holder, finalizer->AddClient([client = std::move(client)]() mutable { return std::move(client); }, nullptr));
+  ASSERT_AND_ASSIGN(auto last_lease, holder->Acquire());
+
+  std::vector<S3CrtClientLease> client_leases;
+  client_leases.reserve(kConcurrentOperations);
+  for (std::size_t i = 0; i < kConcurrentOperations; ++i) {
+    ASSERT_AND_ASSIGN(auto client_lease, holder->Acquire());
+    client_leases.emplace_back(std::move(client_lease));
+  }
+
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+  if (!WaitUntilAcquireRejected(holder)) {
+    last_lease = S3CrtClientLease{};
+    client_leases.clear();
+    finalized.wait();
+    FAIL() << "Finalize did not close new client operations";
+  }
+
+  std::promise<void> release_promise;
+  auto release_signal = release_promise.get_future().share();
+  std::vector<std::future<void>> release_futures;
+  release_futures.reserve(kConcurrentOperations);
+  for (auto& client_lease : client_leases) {
+    release_futures.emplace_back(
+        std::async(std::launch::async, [release_signal, lease = std::move(client_lease)]() mutable {
+          release_signal.wait();
+          lease = S3CrtClientLease{};
+        }));
+  }
+  release_promise.set_value();
+  for (auto& release_future : release_futures) {
+    release_future.get();
+  }
+
+  EXPECT_EQ(finalized.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+  last_lease = S3CrtClientLease{};
+
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+  EXPECT_TRUE(weak_client.expired());
+  EXPECT_FALSE(holder->Acquire().ok());
+  bool factory_called = false;
+  EXPECT_FALSE(finalizer
+                   ->AddClient(
+                       [&factory_called]() -> arrow::Result<std::shared_ptr<Aws::S3Crt::S3CrtClient>> {
+                         factory_called = true;
+                         return MakeTestS3CrtClient();
+                       },
+                       nullptr)
+                   .ok());
+  EXPECT_FALSE(factory_called);
+}
+
+TEST(S3CrtClientFinalizerTest, InlineContinuationDoesNotDeadlockWithConcurrentFinalization) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  ASSERT_AND_ASSIGN(auto holder, finalizer->AddClient([] { return MakeTestS3CrtClient(); }, nullptr));
+  ASSERT_AND_ASSIGN(auto client_lease, holder->Acquire());
+
+  std::atomic<std::size_t> continuations_ran = 0;
+  std::vector<arrow::Future<int64_t>> sources;
+  std::vector<arrow::Future<int64_t>> continuations;
+  sources.reserve(kConcurrentOperations);
+  continuations.reserve(kConcurrentOperations);
+  for (std::size_t i = 0; i < kConcurrentOperations; ++i) {
+    auto source = arrow::Future<int64_t>::Make();
+    continuations.emplace_back(source.Then([holder, &continuations_ran](int64_t value) -> arrow::Result<int64_t> {
+      ++continuations_ran;
+      auto nested_lease = holder->Acquire();
+      if (!nested_lease.ok()) {
+        return nested_lease.status();
+      }
+      return value;
+    }));
+    sources.emplace_back(std::move(source));
+  }
+
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+  const bool acquire_rejected = WaitUntilAcquireRejected(holder);
+  if (!acquire_rejected) {
+    client_lease = S3CrtClientLease{};
+    finalized.wait();
+  }
+  ASSERT_TRUE(acquire_rejected);
+  EXPECT_EQ(finalized.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+
+  std::promise<void> finish_promise;
+  auto finish_signal = finish_promise.get_future().share();
+  std::vector<std::future<void>> finish_futures;
+  finish_futures.reserve(kConcurrentOperations);
+  for (auto& source : sources) {
+    finish_futures.emplace_back(std::async(std::launch::async, [finish_signal, source = &source] {
+      finish_signal.wait();
+      source->MarkFinished(1);
+    }));
+  }
+  finish_promise.set_value();
+
+  bool all_finished = true;
+  for (auto& finish_future : finish_futures) {
+    if (finish_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+      all_finished = false;
+      break;
+    }
+  }
+  if (!all_finished) {
+    client_lease = S3CrtClientLease{};
+    finalized.wait();
+    for (auto& finish_future : finish_futures) {
+      finish_future.wait();
+    }
+  }
+  ASSERT_TRUE(all_finished);
+  for (auto& finish_future : finish_futures) {
+    finish_future.get();
+  }
+
+  EXPECT_EQ(continuations_ran.load(), kConcurrentOperations);
+  for (auto& continuation : continuations) {
+    auto continuation_result = continuation.result();
+    EXPECT_FALSE(continuation_result.ok());
+    EXPECT_NE(continuation_result.status().ToString().find("S3 subsystem is finalized"), std::string::npos);
+  }
+  EXPECT_EQ(finalized.wait_for(std::chrono::seconds(0)), std::future_status::timeout);
+
+  client_lease = S3CrtClientLease{};
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+}
+
+TEST(S3CrtClientFinalizerTest, FinalizeWaitsForClientDestructorAlreadyInProgress) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+
+  std::promise<void> client_destructor_entered_promise;
+  auto client_destructor_entered = client_destructor_entered_promise.get_future();
+  std::promise<void> release_client_destructor_promise;
+  auto release_client_destructor = release_client_destructor_promise.get_future().share();
+  auto storage = std::shared_ptr<char>(new char, [&](char* ptr) {
+    client_destructor_entered_promise.set_value();
+    release_client_destructor.wait();
+    delete ptr;
+  });
+  auto* client_ptr = reinterpret_cast<Aws::S3Crt::S3CrtClient*>(storage.get());
+  std::shared_ptr<Aws::S3Crt::S3CrtClient> client(storage, client_ptr);
+  storage.reset();
+
+  ASSERT_AND_ASSIGN(
+      auto holder, finalizer->AddClient([client = std::move(client)]() mutable { return std::move(client); }, nullptr));
+  auto holder_destroyed = std::async(std::launch::async, [holder = std::move(holder)]() mutable { holder.reset(); });
+
+  if (client_destructor_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    release_client_destructor_promise.set_value();
+    holder_destroyed.wait();
+    FAIL() << "Client destructor did not start";
+  }
+
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+
+  release_client_destructor_promise.set_value();
+  ASSERT_EQ(holder_destroyed.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  holder_destroyed.get();
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
 }
 
 TEST(S3CrtBuildSupportTest, OpenInputFileUsesCrtBackedAsyncFileWhenCrtEnabled) {
@@ -92,6 +567,254 @@ TEST(S3CrtBuildSupportTest, OpenInputFileUsesCrtBackedAsyncFileWhenCrtEnabled) {
   ASSERT_STATUS_OK(DeleteTestDir(fs, base_path));
 }
 
+TEST(S3CrtBuildSupportTest, InFlightNativeReadCompletesDuringFinalizeS3) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "Test requires POSIX process and socket APIs.";
+#else
+  const auto original_death_test_style = GTEST_FLAG_GET(death_test_style);
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  const auto run_child = []() -> int {
+    class BlockingRangeGetServer final {
+      using Tcp = boost::asio::ip::tcp;
+
+   public:
+      ~BlockingRangeGetServer() { Stop(); }
+
+      bool Start() {
+        boost::system::error_code error;
+        acceptor_.open(Tcp::v4(), error);
+        if (RecordError(error)) {
+          return false;
+        }
+        acceptor_.set_option(Tcp::acceptor::reuse_address(true), error);
+        if (RecordError(error)) {
+          return false;
+        }
+        acceptor_.bind(Tcp::endpoint(boost::asio::ip::address_v4::loopback(), 0), error);
+        if (RecordError(error)) {
+          return false;
+        }
+        acceptor_.listen(1, error);
+        if (RecordError(error)) {
+          return false;
+        }
+        port_ = acceptor_.local_endpoint(error).port();
+        if (RecordError(error)) {
+          return false;
+        }
+        worker_ = std::thread([this] { Serve(); });
+        return true;
+      }
+
+      uint16_t port() const { return port_; }
+
+      bool WaitForRequest(std::chrono::milliseconds timeout) {
+        std::unique_lock lock(mutex_);
+        cv_.wait_for(lock, timeout, [this] { return request_received_ || stopped_ || !error_.empty(); });
+        return request_received_;
+      }
+
+      void ReleaseResponse() {
+        {
+          std::lock_guard lock(mutex_);
+          response_released_ = true;
+        }
+        cv_.notify_all();
+      }
+
+      std::string error() const {
+        std::lock_guard lock(mutex_);
+        return error_;
+      }
+
+      void Stop() {
+        std::shared_ptr<Tcp::socket> socket;
+        {
+          std::lock_guard lock(mutex_);
+          stopped_ = true;
+          response_released_ = true;
+          socket = socket_;
+        }
+        cv_.notify_all();
+
+        boost::system::error_code error;
+        acceptor_.close(error);
+        if (socket) {
+          socket->cancel(error);
+          socket->shutdown(Tcp::socket::shutdown_both, error);
+          socket->close(error);
+        }
+        if (worker_.joinable()) {
+          worker_.join();
+        }
+      }
+
+   private:
+      bool RecordError(const boost::system::error_code& error) {
+        if (!error) {
+          return false;
+        }
+        SetError(error.message());
+        return true;
+      }
+
+      void SetError(std::string error) {
+        {
+          std::lock_guard lock(mutex_);
+          if (error_.empty()) {
+            error_ = std::move(error);
+          }
+        }
+        cv_.notify_all();
+      }
+
+      void Serve() {
+        auto socket = std::make_shared<Tcp::socket>(io_context_);
+        {
+          std::lock_guard lock(mutex_);
+          socket_ = socket;
+        }
+        boost::system::error_code error;
+        acceptor_.accept(*socket, error);
+        if (error) {
+          std::lock_guard lock(mutex_);
+          if (!stopped_) {
+            error_ = error.message();
+            cv_.notify_all();
+          }
+          return;
+        }
+
+        boost::beast::flat_buffer buffer;
+        boost::beast::http::request<boost::beast::http::empty_body> request;
+        boost::beast::http::read(*socket, buffer, request, error);
+        if (RecordError(error)) {
+          return;
+        }
+        if (request.method() != boost::beast::http::verb::get ||
+            request[boost::beast::http::field::range] != "bytes=2-5") {
+          SetError("Unexpected CRT range GET");
+          return;
+        }
+
+        {
+          std::lock_guard lock(mutex_);
+          request_received_ = true;
+        }
+        cv_.notify_all();
+
+        {
+          std::unique_lock lock(mutex_);
+          cv_.wait(lock, [this] { return response_released_ || stopped_; });
+          if (stopped_) {
+            return;
+          }
+        }
+
+        boost::beast::http::response<boost::beast::http::string_body> response{
+            boost::beast::http::status::partial_content, request.version()};
+        response.set(boost::beast::http::field::content_range, "bytes 2-5/9");
+        response.set(boost::beast::http::field::accept_ranges, "bytes");
+        response.set(boost::beast::http::field::etag, "\"s3-crt-finalize-test\"");
+        response.keep_alive(false);
+        response.body() = "cdef";
+        response.prepare_payload();
+        boost::beast::http::write(*socket, response, error);
+        RecordError(error);
+      }
+
+      boost::asio::io_context io_context_;
+      Tcp::acceptor acceptor_{io_context_};
+      std::shared_ptr<Tcp::socket> socket_;
+      uint16_t port_ = 0;
+      std::thread worker_;
+      mutable std::mutex mutex_;
+      std::condition_variable cv_;
+      std::string error_;
+      bool request_received_ = false;
+      bool response_released_ = false;
+      bool stopped_ = false;
+    };
+
+    auto fail = [](const std::string& message) {
+      std::cerr << message << std::endl;
+      return 1;
+    };
+
+    BlockingRangeGetServer server;
+    if (!server.Start()) {
+      return fail("Failed to start the blocking S3 server: " + server.error());
+    }
+    auto initialize_status = EnsureS3Initialized();
+    if (!initialize_status.ok()) {
+      return fail(initialize_status.ToString());
+    }
+
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderAWS;
+    options.region = "us-east-1";
+    options.scheme = "http";
+    options.endpoint_override = "127.0.0.1:" + std::to_string(server.port());
+    options.connect_timeout = 5;
+    options.request_timeout = 5;
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(0);
+    options.use_crt_async_reads = true;
+
+    auto fs_result = S3FileSystem::Make(options);
+    if (!fs_result.ok()) {
+      return fail(fs_result.status().ToString());
+    }
+    auto fs = std::move(fs_result).ValueOrDie();
+    arrow::fs::FileInfo file_info("test-bucket/path/object.txt", arrow::fs::FileType::File);
+    file_info.set_size(9);
+    auto input_result = fs->OpenInputFile(file_info);
+    if (!input_result.ok()) {
+      return fail(input_result.status().ToString());
+    }
+    auto input = std::move(input_result).ValueOrDie();
+    if (dynamic_cast<NonBlockingReadAtFile*>(input.get()) == nullptr) {
+      return fail("OpenInputFile did not select the CRT async read path");
+    }
+
+    auto read = input->ReadAsync({}, 2, 4);
+    if (!server.WaitForRequest(std::chrono::seconds(5))) {
+      return fail("Timed out waiting for a real CRT range GET: " + server.error());
+    }
+
+    auto finalized = std::async(std::launch::async, [] { return FinalizeS3(); });
+    if (!WaitUntilConstructionRejected(GetCrtClientFinalizer())) {
+      server.ReleaseResponse();
+      (void)finalized.get();
+      return fail("CRT client finalization did not start");
+    }
+    if (finalized.wait_for(std::chrono::milliseconds(100)) != std::future_status::timeout) {
+      server.ReleaseResponse();
+      auto finalize_status = finalized.get();
+      return fail("FinalizeS3 did not wait for the in-flight CRT request: " + finalize_status.ToString());
+    }
+
+    server.ReleaseResponse();
+    auto read_result = read.result();
+    if (!read_result.ok()) {
+      (void)finalized.get();
+      return fail(read_result.status().ToString());
+    }
+    if (read_result.ValueOrDie()->ToString() != "cdef") {
+      (void)finalized.get();
+      return fail("CRT range read returned unexpected data");
+    }
+    auto finalize_status = finalized.get();
+    if (!finalize_status.ok()) {
+      return fail(finalize_status.ToString());
+    }
+    server.Stop();
+    return 0;
+  };
+  EXPECT_EXIT((::alarm(20), ::_exit(run_child())), ::testing::ExitedWithCode(0), "");
+  GTEST_FLAG_SET(death_test_style, original_death_test_style);
+#endif
+}
+
 TEST(S3CrtBuildSupportTest, OpenInputFileUsesCrtBackedAsyncFileForNonGcpProvider) {
   ASSERT_STATUS_OK(EnsureS3InitializedForTest());
 
@@ -106,6 +829,49 @@ TEST(S3CrtBuildSupportTest, OpenInputFileUsesCrtBackedAsyncFileForNonGcpProvider
 
     EXPECT_NE(dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get()), nullptr);
   }
+}
+
+TEST(S3CrtBuildSupportTest, ZeroLengthAsyncReadsDoNotScheduleIoExecutor) {
+  ASSERT_STATUS_OK(EnsureS3InitializedForTest());
+
+  folly::ManualExecutor io_executor;
+  ASSERT_AND_ASSIGN(auto arrow_executor,
+                    parquet::MakeFollyArrowExecutor(folly::getKeepAliveToken(io_executor), /*capacity=*/1));
+  arrow::io::IOContext io_context(arrow_executor.get());
+
+  auto options = S3Options::FromAccessKey("ak", "sk");
+  options.cloud_provider = kCloudProviderAWS;
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "127.0.0.1:1";
+  options.connect_timeout = 0.1;
+  options.request_timeout = 0.1;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(0);
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_EQ(fs->io_context().executor(), arrow_executor.get());
+
+  arrow::fs::FileInfo file_info("bucket/path/object.txt", arrow::fs::FileType::File);
+  file_info.set_size(1);
+  ASSERT_AND_ASSIGN(auto input_file, fs->OpenInputFile(file_info));
+  auto* async_file = dynamic_cast<milvus_storage::NonBlockingReadAtFile*>(input_file.get());
+  ASSERT_NE(async_file, nullptr);
+
+  io_executor.drain();
+
+  uint8_t out = 0;
+  auto read_into_future = async_file->ReadAtAsyncInto(0, 0, &out);
+  EXPECT_TRUE(read_into_future.is_finished());
+  ASSERT_AND_ASSIGN(auto bytes_read, read_into_future.result());
+  EXPECT_EQ(bytes_read, 0);
+  EXPECT_EQ(io_executor.drain(), 0);
+
+  auto read_future = input_file->ReadAsync(io_context, 0, 0);
+  EXPECT_TRUE(read_future.is_finished());
+  ASSERT_AND_ASSIGN(auto buffer, read_future.result());
+  EXPECT_EQ(buffer->size(), 0);
+  EXPECT_EQ(io_executor.drain(), 0);
+  ASSERT_STATUS_OK(input_file->Close());
 }
 
 TEST(S3CrtBuildSupportTest, OpenInputFileFallsBackToSdkFileForGcpProvider) {

--- a/cpp/test/format/format_reader_test.cpp
+++ b/cpp/test/format/format_reader_test.cpp
@@ -25,6 +25,7 @@
 #include <arrow/io/api.h>
 #include <arrow/testing/gtest_util.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/InlineExecutor.h>
 #include <parquet/arrow/schema.h>
 #include <parquet/metadata.h>
 #include <parquet/type_fwd.h>
@@ -623,6 +624,34 @@ TEST_P(FormatReaderTest, ParquetAsyncReadUsesCallerExecutorForDecode) {
   ASSERT_EQ(batches.size(), 1);
   ASSERT_EQ(batches.front()->num_rows(), test_batch_->num_rows());
   ASSERT_GT(executor.add_count(), 1);
+}
+
+TEST_P(FormatReaderTest, ParquetAsyncReadRejectsInlineExecutor) {
+  std::string format = GetParam();
+  if (format != LOON_FORMAT_PARQUET) {
+    GTEST_SKIP() << "Test parquet only.";
+  }
+
+  const auto file_path = base_path_ + "/async_inline_executor.parquet";
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(schema_, fs_, file_path, config));
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer->Close());
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(schema_, LOON_FORMAT_PARQUET, file, properties_,
+                                                      /*needed_columns=*/{}, nullptr));
+
+  auto range_result = std::move(reader->read_with_range_async(0, test_batch_->num_rows()))
+                          .via(&folly::InlineExecutor::instance())
+                          .get();
+  ASSERT_FALSE(range_result.ok());
+  EXPECT_TRUE(range_result.status().IsInvalid()) << range_result.status().ToString();
+  EXPECT_NE(range_result.status().ToString().find("non-inline"), std::string::npos);
+
+  auto take_result = std::move(reader->take_async({0})).via(&folly::InlineExecutor::instance()).get();
+  ASSERT_FALSE(take_result.ok());
+  EXPECT_TRUE(take_result.status().IsInvalid()) << take_result.status().ToString();
+  EXPECT_NE(take_result.status().ToString().find("non-inline"), std::string::npos);
 }
 
 TEST_P(FormatReaderTest, ParquetOpenAsyncUsesCallerExecutor) {

--- a/cpp/test/format/parquet/folly_arrow_executor_test.cpp
+++ b/cpp/test/format/parquet/folly_arrow_executor_test.cpp
@@ -15,10 +15,13 @@
 #include <gtest/gtest.h>
 
 #include <functional>
+#include <string>
 #include <thread>
 
 #include <arrow/util/future.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/InlineExecutor.h>
+#include <folly/executors/QueuedImmediateExecutor.h>
 #include <folly/futures/Promise.h>
 
 #include "milvus-storage/format/parquet/folly_arrow_executor.h"
@@ -30,7 +33,9 @@ size_t CurrentThreadId() { return std::hash<std::thread::id>{}(std::this_thread:
 
 TEST(FollyArrowExecutorTest, RoutesSubmittedTaskToFollyExecutor) {
   folly::CPUThreadPoolExecutor folly_executor(1);
-  auto arrow_executor = MakeFollyArrowExecutor(folly::getKeepAliveToken(folly_executor), 1);
+  auto maybe_arrow_executor = MakeFollyArrowExecutor(folly::getKeepAliveToken(folly_executor), 1);
+  ASSERT_TRUE(maybe_arrow_executor.ok()) << maybe_arrow_executor.status().ToString();
+  auto arrow_executor = std::move(maybe_arrow_executor).ValueUnsafe();
   const auto caller_thread = CurrentThreadId();
 
   auto maybe_future = arrow_executor->Submit([] { return CurrentThreadId(); });
@@ -42,7 +47,9 @@ TEST(FollyArrowExecutorTest, RoutesSubmittedTaskToFollyExecutor) {
 
 TEST(FollyArrowExecutorTest, TransferAlwaysRunsContinuationOnFollyExecutor) {
   folly::CPUThreadPoolExecutor folly_executor(1);
-  auto arrow_executor = MakeFollyArrowExecutor(folly::getKeepAliveToken(folly_executor), 1);
+  auto maybe_arrow_executor = MakeFollyArrowExecutor(folly::getKeepAliveToken(folly_executor), 1);
+  ASSERT_TRUE(maybe_arrow_executor.ok()) << maybe_arrow_executor.status().ToString();
+  auto arrow_executor = std::move(maybe_arrow_executor).ValueUnsafe();
   const auto caller_thread = CurrentThreadId();
 
   auto source = arrow::Future<>::Make();
@@ -59,7 +66,11 @@ TEST(FollyArrowExecutorTest, DeferredArrowTaskRunsOnWaitingThreadWithoutVia) {
 
   auto future = folly::makeSemiFuture().deferExValue(
       [](folly::Executor::KeepAlive<> executor, folly::Unit) -> folly::SemiFuture<arrow::Result<size_t>> {
-        auto arrow_executor = MakeFollyArrowExecutor(std::move(executor), 1);
+        auto maybe_arrow_executor = MakeFollyArrowExecutor(std::move(executor), 1);
+        if (!maybe_arrow_executor.ok()) {
+          return folly::makeSemiFuture(arrow::Result<size_t>(maybe_arrow_executor.status()));
+        }
+        auto arrow_executor = std::move(maybe_arrow_executor).ValueUnsafe();
         auto maybe_arrow_future = arrow_executor->Submit([] { return CurrentThreadId(); });
         if (!maybe_arrow_future.ok()) {
           return folly::makeSemiFuture(arrow::Result<size_t>(maybe_arrow_future.status()));
@@ -79,6 +90,26 @@ TEST(FollyArrowExecutorTest, DeferredArrowTaskRunsOnWaitingThreadWithoutVia) {
   auto result = std::move(future).get();
   ASSERT_TRUE(result.ok()) << result.status().ToString();
   EXPECT_EQ(result.ValueUnsafe(), caller_thread);
+}
+
+TEST(FollyArrowExecutorTest, RejectsEmptyExecutor) {
+  auto result = MakeFollyArrowExecutor(folly::Executor::KeepAlive<>{}, 1);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+  EXPECT_NE(result.status().ToString().find("executor"), std::string::npos);
+}
+
+TEST(FollyArrowExecutorTest, RejectsInlineLikeExecutors) {
+  auto expect_rejected = [](folly::Executor& executor) {
+    auto result = MakeFollyArrowExecutor(folly::getKeepAliveToken(executor), 1);
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+    EXPECT_NE(result.status().ToString().find("non-inline"), std::string::npos);
+  };
+
+  expect_rejected(folly::InlineExecutor::instance());
+  expect_rejected(folly::QueuedImmediateExecutor::instance());
 }
 
 }  // namespace


### PR DESCRIPTION
S3CrtClient destruction waits for native CRT shutdown callbacks. The previous operation guard shared ownership of the client, allowing the last reference to be released from a CRT callback and making that callback wait for its own completion. Global S3 shutdown could also race with client construction or destruction.

Make S3CrtClientHolder the sole owner of each CRT client and replace shared client locks with move-only, non-owning operation leases. Finalization now closes admission, waits for client construction and active operations to drain, destroys clients outside synchronization locks, and tracks live clients until every destructor has completed.

Keep asynchronous read state independent of the holder, release Rust reader ownership on its task executor, and route Arrow work through the consumer-provided Folly executor while rejecting inline-like executors. Add lifecycle, concurrency, native CRT read.