### PR TITLE
enhance: reuse AWS and Aliyun credential providers across Lance and Iceberg

### DIFF
--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -4814,6 +4814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6682,6 +6691,7 @@ dependencies = [
  "lance-index",
  "lance-io",
  "lance-table",
+ "lru",
  "object_store",
  "object_store_opendal",
  "opendal 0.56.0",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -15,6 +15,7 @@ s3-crt-async = []
 # common dependencies
 anyhow = "1.0.99"
 futures = "0.3.31"
+lru = "0.16"
 paste = "1.0.15"
 take_mut = "0.2.2"
 async-compat = "0.2.5"

--- a/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
@@ -88,7 +88,7 @@ use lance::session::Session;
 use lance::{Error as LanceError, Result as LanceResult};
 use lance_io::object_store::{
     DEFAULT_CLOUD_IO_PARALLELISM, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
-    ObjectStoreRegistry, StorageOptions,
+    ObjectStoreRegistry,
 };
 
 use iceberg::io::{
@@ -107,6 +107,10 @@ const OSS_DEFAULT_DOWNLOAD_RETRIES: usize = 3;
 const ALIYUN_OSS_STORE_NAME: &str = "aliyun_oss";
 const OSS_CREDENTIAL_REFRESH_SECS_KEY: &str = "oss_credential_refresh_secs";
 const DEFAULT_OSS_CREDENTIAL_REFRESH_SECS: u64 = 50 * 60;
+const DEFAULT_ALIYUN_STS_DURATION_SECS: u64 = 60 * 60;
+const ALIYUN_STS_MIN_SESSION_DURATION_SECS: u64 = 15 * 60;
+const ALIYUN_STS_REFRESH_GRACE_SECS: u64 = 3 * 60;
+const ALIYUN_STS_MAX_SESSION_DURATION_SECS: u64 = 12 * 60 * 60;
 const REFRESH_LOCK_RETRY_MS: u64 = 10;
 
 // ============================================================================
@@ -298,13 +302,14 @@ pub(crate) fn build_oss_config_from_iceberg_opts(
 pub(crate) async fn apply_oidc_chain_if_requested(
     config_map: &mut HashMap<String, String>,
 ) -> Result<(), String> {
-    apply_oidc_chain_if_requested_with_expiration(config_map)
+    apply_oidc_chain_if_requested_with_expiration(config_map, DEFAULT_ALIYUN_STS_DURATION_SECS)
         .await
         .map(|_| ())
 }
 
 async fn apply_oidc_chain_if_requested_with_expiration(
     config_map: &mut HashMap<String, String>,
+    duration_seconds: u64,
 ) -> Result<Option<u64>, String> {
     // RAM mode owns this config_map; do not double-resolve.
     if std::env::var(ram::AUTH_MODE_ENV).as_deref() == Ok(ram::AUTH_MODE_RAM) {
@@ -351,6 +356,7 @@ async fn apply_oidc_chain_if_requested_with_expiration(
         &target_role_arn,
         &session_name,
         &external_id,
+        duration_seconds,
     )
     .await?;
     let expires_at_ms = outer.expires_at_ms;
@@ -432,18 +438,19 @@ async fn call_assume_role_with_oidc(
 /// callers, plain AK/SK callers, and any caller without the env var flipped
 /// fall straight through. Lance `role_arn` stores wrap this one-shot swap in
 /// [`RefreshableAliyunOssStore`] so long-lived scans rebuild the opendal store
-/// on the configured refresh interval. Iceberg intentionally calls this from
-/// `create_operator()` for each I/O operation instead of keeping a cache.
+/// shortly before the server-provided expiration. Iceberg role factories own
+/// the same refreshable store shape for their configured bucket.
 pub(crate) async fn apply_ram_mode_if_requested(
     config_map: &mut HashMap<String, String>,
 ) -> Result<(), String> {
-    apply_ram_mode_if_requested_with_expiration(config_map)
+    apply_ram_mode_if_requested_with_expiration(config_map, DEFAULT_ALIYUN_STS_DURATION_SECS)
         .await
         .map(|_| ())
 }
 
 async fn apply_ram_mode_if_requested_with_expiration(
     config_map: &mut HashMap<String, String>,
+    duration_seconds: u64,
 ) -> Result<Option<u64>, String> {
     if std::env::var(ram::AUTH_MODE_ENV).as_deref() != Ok(ram::AUTH_MODE_RAM) {
         return Ok(None);
@@ -456,7 +463,9 @@ async fn apply_ram_mode_if_requested_with_expiration(
         .cloned()
         .unwrap_or_else(ram::default_session_name);
     let external_id = config_map.get("external_id").cloned().unwrap_or_default();
-    let creds = ram::fetch_assume_role_creds(&role_arn, &session_name, &external_id).await?;
+    let creds =
+        ram::fetch_assume_role_creds(&role_arn, &session_name, &external_id, duration_seconds)
+            .await?;
     let expires_at_ms = creds.expires_at_ms;
     ram::apply_credentials(config_map, creds);
     Ok(expires_at_ms)
@@ -474,7 +483,7 @@ fn parse_aliyun_expiration_to_ms(s: &str) -> Result<u64, String> {
     u64::try_from(dt.timestamp_millis()).map_err(|_| format!("pre-epoch Expiration: {s}"))
 }
 
-fn parse_oss_credential_refresh_interval(
+fn parse_oss_credential_duration(
     storage_options: &HashMap<String, String>,
 ) -> Result<Duration, String> {
     let Some(raw) = storage_options.get(OSS_CREDENTIAL_REFRESH_SECS_KEY) else {
@@ -483,40 +492,19 @@ fn parse_oss_credential_refresh_interval(
     let secs = raw.parse::<u64>().map_err(|e| {
         format!("{OSS_CREDENTIAL_REFRESH_SECS_KEY} must be a positive integer seconds value: {e}")
     })?;
-    if secs == 0 {
+    if !(ALIYUN_STS_MIN_SESSION_DURATION_SECS..=ALIYUN_STS_MAX_SESSION_DURATION_SECS)
+        .contains(&secs)
+    {
         return Err(format!(
-            "{OSS_CREDENTIAL_REFRESH_SECS_KEY} must be greater than 0"
+            "{OSS_CREDENTIAL_REFRESH_SECS_KEY} must be in [{ALIYUN_STS_MIN_SESSION_DURATION_SECS}, \
+             {ALIYUN_STS_MAX_SESSION_DURATION_SECS}], got {secs}"
         ));
     }
     Ok(Duration::from_secs(secs))
 }
 
-fn duration_millis(duration: Duration) -> u64 {
-    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
-}
-
-fn should_refresh(last_refresh_at_ms: u64, now_ms: u64, refresh_interval: Duration) -> bool {
-    now_ms >= last_refresh_at_ms.saturating_add(duration_millis(refresh_interval))
-}
-
-fn validate_refresh_interval_before_expiration(
-    refresh_interval: Duration,
-    issued_at_ms: u64,
-    expires_at_ms: u64,
-) -> Result<(), String> {
-    if expires_at_ms <= issued_at_ms {
-        return Err("Aliyun STS credentials are already expired".to_string());
-    }
-    let lifetime_ms = expires_at_ms - issued_at_ms;
-    let refresh_ms = duration_millis(refresh_interval);
-    if refresh_ms >= lifetime_ms {
-        return Err(format!(
-            "Aliyun OSS credential refresh interval {}s must be less than server credential lifetime {}s",
-            refresh_interval.as_secs(),
-            lifetime_ms / 1000
-        ));
-    }
-    Ok(())
+fn credential_is_fresh(expires_at_ms: u64, now_ms: u64) -> bool {
+    now_ms.saturating_add(ALIYUN_STS_REFRESH_GRACE_SECS * 1000) < expires_at_ms
 }
 
 fn aliyun_object_store_error(message: impl Into<String>) -> object_store::Error {
@@ -529,29 +517,44 @@ fn aliyun_object_store_error(message: impl Into<String>) -> object_store::Error 
 
 #[derive(Clone)]
 struct CachedAliyunOssStore {
+    config_map: HashMap<String, String>,
     store: Arc<dyn OSObjectStore>,
-    refreshed_at_ms: u64,
+    expires_at_ms: u64,
 }
 
 #[derive(Clone)]
-struct RefreshableAliyunOssStore {
+pub(crate) struct RefreshableAliyunOssStore {
     base_config: HashMap<String, String>,
-    refresh_interval: Duration,
+    credential_duration: Duration,
     cache: Arc<RwLock<Option<CachedAliyunOssStore>>>,
 }
 
 impl RefreshableAliyunOssStore {
-    fn new(base_config: HashMap<String, String>, refresh_interval: Duration) -> Self {
+    pub(crate) fn new(base_config: HashMap<String, String>, credential_duration: Duration) -> Self {
         Self {
             base_config,
-            refresh_interval,
+            credential_duration,
             cache: Arc::new(RwLock::new(None)),
         }
     }
 
+    fn validate_bucket(&self, requested_bucket: &str) -> Result<(), String> {
+        let configured_bucket = self
+            .base_config
+            .get("bucket")
+            .expect("Aliyun OSS base config always contains a bucket");
+        if requested_bucket != configured_bucket {
+            return Err(format!(
+                "Cross-bucket Aliyun OSS access is unsupported: configured bucket \
+                 '{configured_bucket}', requested bucket '{requested_bucket}'"
+            ));
+        }
+        Ok(())
+    }
+
     fn cached_store_is_fresh(&self, cached: &Option<CachedAliyunOssStore>) -> bool {
         match cached {
-            Some(c) => !should_refresh(c.refreshed_at_ms, now_ms(), self.refresh_interval),
+            Some(c) => credential_is_fresh(c.expires_at_ms, now_ms()),
             None => false,
         }
     }
@@ -591,43 +594,63 @@ impl RefreshableAliyunOssStore {
         Ok(Some(store))
     }
 
+    async fn current_config(&self) -> ObjectStoreResult<HashMap<String, String>> {
+        self.current_store().await?;
+        let cached = self.cache.read().await;
+        Ok(cached
+            .as_ref()
+            .expect("current_store initializes the Aliyun OSS cache")
+            .config_map
+            .clone())
+    }
+
     async fn refresh_store(&self) -> ObjectStoreResult<CachedAliyunOssStore> {
         let mut config_map = self.base_config.clone();
+        let duration_seconds = self.credential_duration.as_secs();
 
-        let ram_expires_at_ms = apply_ram_mode_if_requested_with_expiration(&mut config_map)
-            .await
-            .map_err(|e| {
-                aliyun_object_store_error(format!("Aliyun RAM-mode credential refresh failed: {e}"))
-            })?;
-        let oidc_expires_at_ms = apply_oidc_chain_if_requested_with_expiration(&mut config_map)
-            .await
-            .map_err(|e| {
-                aliyun_object_store_error(format!(
-                    "Aliyun OIDC chain credential refresh failed: {e}"
-                ))
-            })?;
+        let ram_expires_at_ms =
+            apply_ram_mode_if_requested_with_expiration(&mut config_map, duration_seconds)
+                .await
+                .map_err(|e| {
+                    aliyun_object_store_error(format!(
+                        "Aliyun RAM-mode credential refresh failed: {e}"
+                    ))
+                })?;
+        let oidc_expires_at_ms =
+            apply_oidc_chain_if_requested_with_expiration(&mut config_map, duration_seconds)
+                .await
+                .map_err(|e| {
+                    aliyun_object_store_error(format!(
+                        "Aliyun OIDC chain credential refresh failed: {e}"
+                    ))
+                })?;
         let expires_at_ms = ram_expires_at_ms.or(oidc_expires_at_ms).ok_or_else(|| {
             aliyun_object_store_error(
                 "Aliyun role_arn credential refresh did not return an Expiration",
             )
         })?;
-        let refreshed_at_ms = now_ms();
+        let received_at_ms = now_ms();
+        if expires_at_ms <= received_at_ms {
+            return Err(aliyun_object_store_error(
+                "Aliyun STS credentials are already expired",
+            ));
+        }
+        if !credential_is_fresh(expires_at_ms, received_at_ms) {
+            return Err(aliyun_object_store_error(format!(
+                "Aliyun STS credentials expire within the {}s refresh grace",
+                ALIYUN_STS_REFRESH_GRACE_SECS
+            )));
+        }
 
-        validate_refresh_interval_before_expiration(
-            self.refresh_interval,
-            refreshed_at_ms,
-            expires_at_ms,
-        )
-        .map_err(aliyun_object_store_error)?;
-
-        let operator = Operator::from_iter::<Oss>(config_map)
+        let operator = Operator::from_iter::<Oss>(config_map.clone())
             .map_err(|e| {
                 aliyun_object_store_error(format!("Failed to create OSS operator: {e:?}"))
             })?
             .finish();
         Ok(CachedAliyunOssStore {
+            config_map,
             store: Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>,
-            refreshed_at_ms,
+            expires_at_ms,
         })
     }
 }
@@ -635,7 +658,7 @@ impl RefreshableAliyunOssStore {
 impl fmt::Debug for RefreshableAliyunOssStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RefreshableAliyunOssStore")
-            .field("refresh_interval", &self.refresh_interval)
+            .field("credential_duration", &self.credential_duration)
             .field("has_role_arn", &self.base_config.contains_key("role_arn"))
             .finish_non_exhaustive()
     }
@@ -645,8 +668,8 @@ impl fmt::Display for RefreshableAliyunOssStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "RefreshableAliyunOssStore(refresh_interval={}s)",
-            self.refresh_interval.as_secs()
+            "RefreshableAliyunOssStore(credential_duration={}s)",
+            self.credential_duration.as_secs()
         )
     }
 }
@@ -755,8 +778,42 @@ impl OSObjectStore for RefreshableAliyunOssStore {
 // Lance: ObjectStoreProvider
 // ============================================================================
 
-#[derive(Default, Debug)]
-pub struct AliyunOssStoreProvider;
+#[derive(Clone, Debug)]
+pub struct AliyunOssStoreProvider {
+    store: Arc<RefreshableAliyunOssStore>,
+}
+
+impl AliyunOssStoreProvider {
+    pub(crate) async fn from_uri(
+        uri: &str,
+        storage_options: &HashMap<String, String>,
+    ) -> LanceResult<Self> {
+        let base_path = Url::parse(uri).map_err(|error| {
+            LanceError::invalid_input(format!("Invalid OSS URL {uri}: {error}"))
+        })?;
+        let bucket = base_path
+            .host_str()
+            .ok_or_else(|| LanceError::invalid_input("OSS URL must contain bucket name"))?
+            .to_string();
+        let config_map = build_oss_config_from_lance_opts(
+            bucket,
+            &base_path,
+            storage_options,
+        )
+        .map_err(LanceError::invalid_input)?;
+        let credential_duration = parse_oss_credential_duration(storage_options)
+            .map_err(LanceError::invalid_input)?;
+        let store = Arc::new(RefreshableAliyunOssStore::new(
+            config_map,
+            credential_duration,
+        ));
+        store.current_store().await.map_err(|error| LanceError::IO {
+            source: Box::new(error),
+            location: location!(),
+        })?;
+        Ok(Self { store })
+    }
+}
 
 #[async_trait::async_trait]
 impl ObjectStoreProvider for AliyunOssStoreProvider {
@@ -765,38 +822,18 @@ impl ObjectStoreProvider for AliyunOssStoreProvider {
         base_path: Url,
         params: &ObjectStoreParams,
     ) -> LanceResult<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(OSS_DEFAULT_BLOCK_SIZE);
-        let storage_options = StorageOptions(params.storage_options().cloned().unwrap_or_default());
-
-        let bucket = base_path
+        let requested_bucket = base_path
             .host_str()
-            .ok_or_else(|| LanceError::invalid_input("OSS URL must contain bucket name"))?
-            .to_string();
-
-        let config_map = build_oss_config_from_lance_opts(bucket, &base_path, &storage_options.0)
+            .ok_or_else(|| LanceError::invalid_input("OSS URL must contain bucket name"))?;
+        // The refreshable store owns an OpenDAL operator bound to its configured
+        // bucket. Reject cross-bucket reuse instead of routing the object key to
+        // that bucket silently.
+        self.store
+            .validate_bucket(requested_bucket)
             .map_err(LanceError::invalid_input)?;
 
-        let inner = if config_map.contains_key("role_arn") {
-            let refresh_interval = parse_oss_credential_refresh_interval(&storage_options.0)
-                .map_err(LanceError::invalid_input)?;
-            let refreshable =
-                Arc::new(RefreshableAliyunOssStore::new(config_map, refresh_interval));
-            refreshable
-                .current_store()
-                .await
-                .map_err(|e| LanceError::IO {
-                    source: Box::new(e),
-                    location: location!(),
-                })?;
-            refreshable as Arc<dyn OSObjectStore>
-        } else {
-            let operator = Operator::from_iter::<Oss>(config_map)
-                .map_err(|e| {
-                    LanceError::invalid_input(format!("Failed to create OSS operator: {:?}", e))
-                })?
-                .finish();
-            Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>
-        };
+        let block_size = params.block_size.unwrap_or(OSS_DEFAULT_BLOCK_SIZE);
+        let inner = self.store.clone() as Arc<dyn OSObjectStore>;
 
         let mut url = base_path;
         if !url.path().ends_with('/') {
@@ -828,9 +865,11 @@ impl ObjectStoreProvider for AliyunOssStoreProvider {
 /// prevents concurrent opens with different roles from colliding on a
 /// shared registry. Cache sizes of zero match what the FFI entry points
 /// already pass to `BlockingDataset::open`.
-pub fn build_aliyun_oss_session() -> Arc<Session> {
+pub fn build_aliyun_oss_session(
+    provider: Arc<dyn ObjectStoreProvider>,
+) -> Arc<Session> {
     let registry = ObjectStoreRegistry::default();
-    registry.insert("oss", Arc::new(AliyunOssStoreProvider::default()));
+    registry.insert("oss", provider);
     Arc::new(Session::new(0, 0, Arc::new(registry)))
 }
 
@@ -846,17 +885,61 @@ fn from_opendal_error(e: opendal::Error) -> IcebergError {
     .with_source(e)
 }
 
-/// `StorageFactory` produces an [`AliyunOssStorage`] wrapping the iceberg
-/// `StorageConfig` props. Cross-process serialization (via `typetag`) is
-/// trivial because the factory is a unit struct.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct AliyunOssStorageFactory;
+pub struct AliyunOssStorageFactory {
+    #[serde(skip)]
+    store: Option<Arc<RefreshableAliyunOssStore>>,
+}
+
+impl AliyunOssStorageFactory {
+    pub(crate) async fn from_uri(
+        uri: &str,
+        storage_options: &HashMap<String, String>,
+    ) -> IcebergResult<Self> {
+        let base_path = Url::parse(uri).map_err(|error| {
+            IcebergError::new(
+                IcebergErrorKind::DataInvalid,
+                format!("Invalid OSS URL {uri}: {error}"),
+            )
+        })?;
+        let bucket = base_path
+            .host_str()
+            .ok_or_else(|| {
+                IcebergError::new(
+                    IcebergErrorKind::DataInvalid,
+                    format!("Invalid OSS URL {uri}, missing bucket"),
+                )
+            })?
+            .to_string();
+        let config_map = build_oss_config_from_iceberg_opts(
+            bucket,
+            &base_path,
+            storage_options,
+        )
+        .map_err(|error| IcebergError::new(IcebergErrorKind::DataInvalid, error))?;
+        let credential_duration = parse_oss_credential_duration(storage_options)
+            .map_err(|error| IcebergError::new(IcebergErrorKind::DataInvalid, error))?;
+        let store = Arc::new(RefreshableAliyunOssStore::new(
+            config_map,
+            credential_duration,
+        ));
+        store.current_store().await.map_err(|error| {
+            IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                "Aliyun OSS credential resolution failed",
+            )
+            .with_source(error)
+        })?;
+        Ok(Self { store: Some(store) })
+    }
+}
 
 #[typetag::serde(name = "AliyunOssStorageFactory")]
 impl StorageFactory for AliyunOssStorageFactory {
     fn build(&self, config: &StorageConfig) -> IcebergResult<Arc<dyn IcebergStorage>> {
         Ok(Arc::new(AliyunOssStorage {
             props: Arc::new(config.props().clone()),
+            store: self.store.clone(),
         }))
     }
 }
@@ -872,13 +955,11 @@ impl StorageFactory for AliyunOssStorageFactory {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AliyunOssStorage {
     props: Arc<HashMap<String, String>>,
+    #[serde(skip)]
+    store: Option<Arc<RefreshableAliyunOssStore>>,
 }
 
 impl AliyunOssStorage {
-    /// Derive bucket from the absolute `oss://bucket/key` path, then build
-    /// and return an opendal `Operator` for that bucket along with the
-    /// relative path (the `key` part) to use with it. Mirrors
-    /// `OpenDalStorage::create_operator` + `oss_config_build`.
     async fn create_operator(&self, path: &str) -> IcebergResult<(Operator, String)> {
         let url = Url::parse(path).map_err(|e| {
             IcebergError::new(
@@ -886,35 +967,45 @@ impl AliyunOssStorage {
                 format!("Invalid oss url: {path}: {e}"),
             )
         })?;
-        let bucket = url
-            .host_str()
-            .ok_or_else(|| {
+        let requested_bucket = url.host_str().ok_or_else(|| {
+            IcebergError::new(
+                IcebergErrorKind::DataInvalid,
+                format!("Invalid oss url: {path}, missing bucket"),
+            )
+        })?;
+        let config_map = if let Some(store) = &self.store {
+            store
+                .validate_bucket(requested_bucket)
+                .map_err(|error| IcebergError::new(IcebergErrorKind::DataInvalid, error))?;
+            store.current_config().await.map_err(|error| {
                 IcebergError::new(
-                    IcebergErrorKind::DataInvalid,
-                    format!("Invalid oss url: {path}, missing bucket"),
+                    IcebergErrorKind::Unexpected,
+                    "Aliyun OSS credential resolution failed",
                 )
+                .with_source(error)
             })?
-            .to_string();
-
-        let mut config_map = build_oss_config_from_iceberg_opts(bucket, &url, &self.props)
-            .map_err(|e| IcebergError::new(IcebergErrorKind::DataInvalid, e))?;
-
-        apply_ram_mode_if_requested(&mut config_map)
-            .await
-            .map_err(|e| {
-                IcebergError::new(
-                    IcebergErrorKind::Unexpected,
-                    format!("Aliyun RAM-mode credential resolution failed: {e}"),
-                )
-            })?;
-        apply_oidc_chain_if_requested(&mut config_map)
-            .await
-            .map_err(|e| {
-                IcebergError::new(
-                    IcebergErrorKind::Unexpected,
-                    format!("Aliyun OIDC chain credential resolution failed: {e}"),
-                )
-            })?;
+        } else {
+            let mut config_map =
+                build_oss_config_from_iceberg_opts(requested_bucket.to_string(), &url, &self.props)
+                    .map_err(|e| IcebergError::new(IcebergErrorKind::DataInvalid, e))?;
+            apply_ram_mode_if_requested(&mut config_map)
+                .await
+                .map_err(|e| {
+                    IcebergError::new(
+                        IcebergErrorKind::Unexpected,
+                        format!("Aliyun RAM-mode credential resolution failed: {e}"),
+                    )
+                })?;
+            apply_oidc_chain_if_requested(&mut config_map)
+                .await
+                .map_err(|e| {
+                    IcebergError::new(
+                        IcebergErrorKind::Unexpected,
+                        format!("Aliyun OIDC chain credential resolution failed: {e}"),
+                    )
+                })?;
+            config_map
+        };
 
         let op = Operator::from_iter::<Oss>(config_map)
             .map_err(|e| {
@@ -925,7 +1016,7 @@ impl AliyunOssStorage {
             })?
             .finish();
 
-        let prefix = format!("oss://{}/", op.info().name());
+        let prefix = format!("oss://{requested_bucket}/");
         let relative = path
             .strip_prefix(&prefix)
             .ok_or_else(|| {
@@ -1112,10 +1203,19 @@ pub(crate) mod ram {
         role_arn: &str,
         role_session_name: &str,
         external_id: &str,
+        duration_seconds: u64,
     ) -> Result<AssumeRoleCreds, String> {
         let client = build_http_client()?;
         let caller = fetch_imds_credentials(&client).await?;
-        call_assume_role(&client, &caller, role_arn, role_session_name, external_id).await
+        call_assume_role(
+            &client,
+            &caller,
+            role_arn,
+            role_session_name,
+            external_id,
+            duration_seconds,
+        )
+        .await
     }
 
     /// Build a reqwest client with short timeouts tuned for IMDS + STS. IMDS
@@ -1243,6 +1343,7 @@ pub(crate) mod ram {
         role_arn: &str,
         role_session_name: &str,
         external_id: &str,
+        duration_seconds: u64,
     ) -> Result<AssumeRoleCreds, String> {
         // BTreeMap for deterministic ASCII ordering of keys (POP v1 requirement).
         let mut params = std::collections::BTreeMap::new();
@@ -1257,6 +1358,8 @@ pub(crate) mod ram {
         if !external_id.is_empty() {
             params.insert("ExternalId", external_id);
         }
+        let duration_seconds = duration_seconds.to_string();
+        params.insert("DurationSeconds", &duration_seconds);
         params.insert("Format", "JSON");
         params.insert("RoleArn", role_arn);
         params.insert("RoleSessionName", role_session_name);
@@ -1394,12 +1497,65 @@ pub(crate) mod ram {
 
 #[cfg(test)]
 mod tests {
+    use crate::cloud_provider_cache::GlobalLruCache;
+
     use super::*;
 
     fn opts(kvs: &[(&str, &str)]) -> HashMap<String, String> {
         kvs.iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    fn refreshable_store() -> Arc<RefreshableAliyunOssStore> {
+        Arc::new(RefreshableAliyunOssStore::new(
+            opts(&[("bucket", "my-bucket")]),
+            Duration::from_secs(900),
+        ))
+    }
+
+    #[test]
+    fn load_frequency_is_aliyun_sts_duration() {
+        assert_eq!(
+            parse_oss_credential_duration(&HashMap::new()).unwrap(),
+            Duration::from_secs(DEFAULT_OSS_CREDENTIAL_REFRESH_SECS)
+        );
+        for seconds in [
+            ALIYUN_STS_MIN_SESSION_DURATION_SECS,
+            3600,
+            ALIYUN_STS_MAX_SESSION_DURATION_SECS,
+        ] {
+            let value = seconds.to_string();
+            let storage_options = opts(&[(OSS_CREDENTIAL_REFRESH_SECS_KEY, &value)]);
+            assert_eq!(
+                parse_oss_credential_duration(&storage_options).unwrap(),
+                Duration::from_secs(seconds)
+            );
+        }
+
+        for seconds in [
+            ALIYUN_STS_MIN_SESSION_DURATION_SECS - 1,
+            ALIYUN_STS_MAX_SESSION_DURATION_SECS + 1,
+        ] {
+            let value = seconds.to_string();
+            let storage_options = opts(&[(OSS_CREDENTIAL_REFRESH_SECS_KEY, &value)]);
+            assert!(parse_oss_credential_duration(&storage_options).is_err());
+        }
+    }
+
+    #[test]
+    fn aliyun_credentials_refresh_within_expiration_grace() {
+        let expires_at_ms = 1_000_000;
+        let grace_ms = ALIYUN_STS_REFRESH_GRACE_SECS * 1000;
+        assert!(credential_is_fresh(
+            expires_at_ms,
+            expires_at_ms - grace_ms - 1
+        ));
+        assert!(!credential_is_fresh(
+            expires_at_ms,
+            expires_at_ms - grace_ms
+        ));
+        assert!(!credential_is_fresh(expires_at_ms, expires_at_ms));
     }
 
     #[test]
@@ -1530,5 +1686,112 @@ mod tests {
         )
         .unwrap_err();
         assert!(iceberg_err.contains("OSS endpoint is required"));
+    }
+
+    #[tokio::test]
+    async fn lance_provider_is_reused() {
+        let cache: GlobalLruCache<Arc<dyn ObjectStoreProvider>> = GlobalLruCache::new(2);
+        let first = cache
+            .get("aliyun", || async {
+                Ok::<_, ()>(Arc::new(AliyunOssStoreProvider {
+                    store: refreshable_store(),
+                })
+                    as Arc<dyn ObjectStoreProvider>)
+            })
+            .await
+            .unwrap();
+        let second = cache
+            .get("aliyun", || async {
+                Ok::<_, ()>(Arc::new(AliyunOssStoreProvider {
+                    store: refreshable_store(),
+                })
+                    as Arc<dyn ObjectStoreProvider>)
+            })
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn lance_provider_rejects_cross_bucket() {
+        let provider = AliyunOssStoreProvider {
+            store: refreshable_store(),
+        };
+        let error = provider
+            .new_store(
+                Url::parse("oss://other-bucket/path").unwrap(),
+                &ObjectStoreParams::default(),
+            )
+            .await
+            .err()
+            .expect("cross-bucket Lance store should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("configured bucket 'my-bucket', requested bucket 'other-bucket'")
+        );
+    }
+
+    #[tokio::test]
+    async fn iceberg_factory_is_reused() {
+        let cache: GlobalLruCache<Arc<dyn StorageFactory>> = GlobalLruCache::new(2);
+        let first = cache
+            .get("aliyun", || async {
+                Ok::<_, ()>(Arc::new(AliyunOssStorageFactory {
+                    store: Some(refreshable_store()),
+                }) as Arc<dyn StorageFactory>)
+            })
+            .await
+            .unwrap();
+        let second = cache
+            .get("aliyun", || async {
+                Ok::<_, ()>(Arc::new(AliyunOssStorageFactory {
+                    store: Some(refreshable_store()),
+                }) as Arc<dyn StorageFactory>)
+            })
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn iceberg_storage_preserves_raw_object_key() {
+        let storage = AliyunOssStorage {
+            props: Arc::new(opts(&[
+                ("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com"),
+                ("oss.access-key-id", "test-access-key-id"),
+                ("oss.access-key-secret", "test-access-key-secret"),
+            ])),
+            store: None,
+        };
+        let path = "oss://my-bucket/dir/a b/中文/%25/literal/../file+name.parquet";
+        let (_, relative) = storage.create_operator(path).await.unwrap();
+
+        assert_eq!(
+            relative,
+            "dir/a b/中文/%25/literal/../file+name.parquet"
+        );
+    }
+
+    #[tokio::test]
+    async fn iceberg_storage_rejects_cross_bucket() {
+        let storage = AliyunOssStorage {
+            props: Arc::new(HashMap::new()),
+            store: Some(refreshable_store()),
+        };
+        let error = storage
+            .create_operator("oss://other-bucket/path")
+            .await
+            .err()
+            .expect("cross-bucket Iceberg storage should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("configured bucket 'my-bucket', requested bucket 'other-bucket'")
+        );
     }
 }

--- a/cpp/src/format/bridge/rust/src/aws_arn_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aws_arn_provider.rs
@@ -1,0 +1,383 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use aws_config::sts::AssumeRoleProvider;
+use aws_credential_types::provider::ProvideCredentials;
+use iceberg::io::StorageFactory;
+use iceberg_storage_opendal::{
+    AwsCredential, AwsCredentialLoad, CustomAwsCredentialLoader, OpenDalStorageFactory,
+};
+use lance::session::Session;
+use lance::{Error as LanceError, Result as LanceResult};
+use lance_io::object_store::providers::aws::AwsStoreProvider;
+use lance_io::object_store::{
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, ObjectStoreRegistry,
+};
+use object_store::CredentialProvider;
+use tokio::sync::{Mutex, RwLock};
+use url::Url;
+
+#[derive(Debug)]
+struct SingleFlightAwsCredentialProvider {
+    inner: Arc<dyn ProvideCredentials>,
+    cached: RwLock<Option<aws_credential_types::Credentials>>,
+    refresh_lock: Mutex<()>,
+    refresh_offset: Duration,
+}
+
+impl SingleFlightAwsCredentialProvider {
+    fn new(inner: Arc<dyn ProvideCredentials>, refresh_offset: Duration) -> Self {
+        Self {
+            inner,
+            cached: RwLock::new(None),
+            refresh_lock: Mutex::new(()),
+            refresh_offset,
+        }
+    }
+
+    fn current_credential(
+        &self,
+        credentials: Option<&aws_credential_types::Credentials>,
+    ) -> Option<Arc<object_store::aws::AwsCredential>> {
+        let credentials = credentials?;
+        let fresh = credentials
+            .expiry()
+            .map(|expires_at| {
+                expires_at
+                    .duration_since(SystemTime::now())
+                    .is_ok_and(|remaining| remaining > self.refresh_offset)
+            })
+            .unwrap_or(true);
+        fresh.then(|| Self::to_object_store_credential(credentials))
+    }
+
+    fn to_object_store_credential(
+        credentials: &aws_credential_types::Credentials,
+    ) -> Arc<object_store::aws::AwsCredential> {
+        Arc::new(object_store::aws::AwsCredential {
+            key_id: credentials.access_key_id().to_string(),
+            secret_key: credentials.secret_access_key().to_string(),
+            token: credentials.session_token().map(ToString::to_string),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialProvider for SingleFlightAwsCredentialProvider {
+    type Credential = object_store::aws::AwsCredential;
+
+    async fn get_credential(&self) -> object_store::Result<Arc<Self::Credential>> {
+        {
+            let cached = self.cached.read().await;
+            if let Some(credential) = self.current_credential(cached.as_ref()) {
+                return Ok(credential);
+            }
+        }
+
+        let _refresh = self.refresh_lock.lock().await;
+        {
+            let cached = self.cached.read().await;
+            if let Some(credential) = self.current_credential(cached.as_ref()) {
+                return Ok(credential);
+            }
+        }
+
+        let refreshed = self
+            .inner
+            .provide_credentials()
+            .await
+            .map_err(|source| object_store::Error::Generic {
+                store: "AWS",
+                source: Box::new(source),
+            })?;
+        let credential = Self::to_object_store_credential(&refreshed);
+        *self.cached.write().await = Some(refreshed);
+        Ok(credential)
+    }
+}
+
+pub(crate) struct AssumeRoleConfig {
+    role_arn: String,
+    session_name: String,
+    external_id: String,
+    region: String,
+    credential_refresh_secs: u64,
+}
+
+impl AssumeRoleConfig {
+    pub(crate) fn parse(
+        role_arn: &str,
+        session_name: &str,
+        external_id: &str,
+        region: &str,
+        credential_refresh_secs: u64,
+    ) -> LanceResult<Option<Self>> {
+        if role_arn.is_empty() {
+            return Ok(None);
+        }
+        if credential_refresh_secs < 900 || credential_refresh_secs > 43200 {
+            return Err(LanceError::invalid_input(
+                format!(
+                    "credential_refresh_secs must be in [900, 43200], got {}",
+                    credential_refresh_secs
+                ),
+            ));
+        }
+        Ok(Some(Self {
+            role_arn: role_arn.to_string(),
+            session_name: session_name.to_string(),
+            external_id: external_id.to_string(),
+            region: region.to_string(),
+            credential_refresh_secs,
+        }))
+    }
+
+    async fn build_credentials(&self) -> LanceResult<object_store::aws::AwsCredentialProvider> {
+        const REFRESH_OFFSET_SECS: u64 = 300;
+
+        let mut builder = AssumeRoleProvider::builder(&self.role_arn)
+            .session_length(Duration::from_secs(self.credential_refresh_secs));
+
+        if !self.session_name.is_empty() {
+            builder = builder.session_name(&self.session_name);
+        }
+        if !self.external_id.is_empty() {
+            builder = builder.external_id(&self.external_id);
+        }
+        if !self.region.is_empty() {
+            builder = builder.region(aws_config::Region::new(self.region.clone()));
+        }
+
+        let assume_role_provider = builder.build().await;
+        let provider: object_store::aws::AwsCredentialProvider =
+            Arc::new(SingleFlightAwsCredentialProvider::new(
+                Arc::new(assume_role_provider),
+                Duration::from_secs(REFRESH_OFFSET_SECS),
+            ));
+        provider
+            .get_credential()
+            .await
+            .map_err(|error| LanceError::IO {
+                source: Box::new(error),
+                location: snafu::location!(),
+            })?;
+        Ok(provider)
+    }
+}
+
+#[derive(Debug)]
+struct AwsArnStoreProvider {
+    credentials: object_store::aws::AwsCredentialProvider,
+}
+
+impl AwsArnStoreProvider {
+    fn new(credentials: object_store::aws::AwsCredentialProvider) -> Self {
+        Self { credentials }
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for AwsArnStoreProvider {
+    async fn new_store(
+        &self,
+        base_path: Url,
+        params: &ObjectStoreParams,
+    ) -> LanceResult<ObjectStore> {
+        let mut params = params.clone();
+        params.aws_credentials = Some(self.credentials.clone());
+        AwsStoreProvider::default()
+            .new_store(base_path, &params)
+            .await
+    }
+}
+
+#[derive(Clone)]
+struct ObjectStoreAwsCredentialLoader {
+    provider: object_store::aws::AwsCredentialProvider,
+}
+
+#[async_trait::async_trait]
+impl AwsCredentialLoad for ObjectStoreAwsCredentialLoader {
+    async fn load_credential(
+        &self,
+        _client: reqwest::Client,
+    ) -> anyhow::Result<Option<AwsCredential>> {
+        let credential = self
+            .provider
+            .get_credential()
+            .await
+            .map_err(|error| anyhow::anyhow!("AWS credential provider failed: {error}"))?;
+        Ok(Some(AwsCredential {
+            access_key_id: credential.key_id.clone(),
+            secret_access_key: credential.secret_key.clone(),
+            session_token: credential.token.clone(),
+            expires_in: None,
+        }))
+    }
+}
+
+pub(crate) async fn build_lance_provider(
+    config: &AssumeRoleConfig,
+) -> LanceResult<Arc<dyn ObjectStoreProvider>> {
+    let credentials = config.build_credentials().await?;
+    Ok(Arc::new(AwsArnStoreProvider::new(credentials)))
+}
+
+pub(crate) fn build_lance_session(provider: Arc<dyn ObjectStoreProvider>) -> Arc<Session> {
+    let registry = ObjectStoreRegistry::default();
+    registry.insert("s3", provider.clone());
+    registry.insert("s3+ddb", provider);
+    Arc::new(Session::new(0, 0, Arc::new(registry)))
+}
+
+fn iceberg_factory(
+    scheme: &str,
+    provider: object_store::aws::AwsCredentialProvider,
+) -> Arc<dyn StorageFactory> {
+    Arc::new(OpenDalStorageFactory::S3 {
+        configured_scheme: scheme.to_string(),
+        customized_credential_load: Some(CustomAwsCredentialLoader::new(Arc::new(
+            ObjectStoreAwsCredentialLoader { provider },
+        ))),
+    })
+}
+
+pub(crate) async fn build_iceberg_factory(
+    scheme: &str,
+    config: &AssumeRoleConfig,
+) -> LanceResult<Arc<dyn StorageFactory>> {
+    Ok(iceberg_factory(scheme, config.build_credentials().await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::future::join_all;
+    use object_store::StaticCredentialProvider;
+
+    use crate::cloud_provider_cache::GlobalLruCache;
+
+    use super::*;
+
+    fn static_credentials(key_id: &str) -> object_store::aws::AwsCredentialProvider {
+        Arc::new(StaticCredentialProvider::new(
+            object_store::aws::AwsCredential {
+                key_id: key_id.to_string(),
+                secret_key: "secret".to_string(),
+                token: None,
+            },
+        ))
+    }
+
+    #[derive(Debug)]
+    struct CountingCredentialsProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ProvideCredentials for CountingCredentialsProvider {
+        fn provide_credentials<'a>(
+            &'a self,
+        ) -> aws_credential_types::provider::future::ProvideCredentials<'a>
+        where
+            Self: 'a,
+        {
+            let calls = self.calls.clone();
+            aws_credential_types::provider::future::ProvideCredentials::new(async move {
+                let call = calls.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok(aws_credential_types::Credentials::new(
+                    format!("key-{call}"),
+                    "secret",
+                    None,
+                    Some(SystemTime::now() + Duration::from_secs(3600)),
+                    "test",
+                ))
+            })
+        }
+    }
+
+    #[test]
+    fn assume_role_config_preserves_region() {
+        let config = AssumeRoleConfig::parse(
+            "arn:aws:iam::123456789012:role/test",
+            "session",
+            "external-id",
+            "cn-north-1",
+            900,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(config.region, "cn-north-1");
+    }
+
+    #[tokio::test]
+    async fn credential_refresh_is_single_flight() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = Arc::new(SingleFlightAwsCredentialProvider::new(
+            Arc::new(CountingCredentialsProvider {
+                calls: calls.clone(),
+            }),
+            Duration::from_secs(300),
+        ));
+        *provider.cached.write().await = Some(aws_credential_types::Credentials::new(
+            "stale",
+            "secret",
+            None,
+            Some(SystemTime::now() + Duration::from_secs(1)),
+            "test",
+        ));
+
+        let credentials = join_all((0..100).map(|_| {
+            let provider = provider.clone();
+            async move { provider.get_credential().await.unwrap() }
+        }))
+        .await;
+
+        assert!(credentials.iter().all(|credential| credential.key_id == "key-0"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn lance_provider_is_reused() {
+        let cache: GlobalLruCache<Arc<dyn ObjectStoreProvider>> = GlobalLruCache::new(2);
+        let first = cache
+            .get("aws", || async {
+                Ok::<_, ()>(Arc::new(AwsArnStoreProvider::new(static_credentials(
+                    "first",
+                ))) as Arc<dyn ObjectStoreProvider>)
+            })
+            .await
+            .unwrap();
+        let second = cache
+            .get("aws", || async {
+                Ok::<_, ()>(Arc::new(AwsArnStoreProvider::new(static_credentials(
+                    "second",
+                ))) as Arc<dyn ObjectStoreProvider>)
+            })
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn iceberg_factory_is_reused() {
+        let cache: GlobalLruCache<Arc<dyn StorageFactory>> = GlobalLruCache::new(2);
+        let first = cache
+            .get("aws", || async {
+                Ok::<_, ()>(iceberg_factory("s3", static_credentials("first")))
+            })
+            .await
+            .unwrap();
+        let second = cache
+            .get("aws", || async {
+                Ok::<_, ()>(iceberg_factory("s3", static_credentials("second")))
+            })
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+}

--- a/cpp/src/format/bridge/rust/src/cloud_provider_cache.rs
+++ b/cpp/src/format/bridge/rust/src/cloud_provider_cache.rs
@@ -1,0 +1,151 @@
+use std::future::Future;
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use tokio::sync::Mutex;
+
+pub(crate) const CACHE_KEY: &str = "milvus_fs_cache_key";
+pub(crate) const CACHE_CAPACITY: usize = 64;
+
+pub(crate) struct GlobalLruCache<V> {
+    entries: Mutex<LruCache<String, V>>,
+}
+
+impl<V: Clone> GlobalLruCache<V> {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            entries: Mutex::new(LruCache::new(
+                NonZeroUsize::new(capacity).expect("cloud provider cache capacity must be non-zero"),
+            )),
+        }
+    }
+
+    pub(crate) async fn get<E, F, Fut>(&self, key: &str, create: F) -> Result<V, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<V, E>>,
+    {
+        let mut entries = self.entries.lock().await;
+        if let Some(value) = entries.get(key).cloned() {
+            return Ok(value);
+        }
+
+        let value = create().await?;
+        entries.put(key.to_string(), value.clone());
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::future::join_all;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn concurrent_same_key_initializes_once() {
+        let cache = Arc::new(GlobalLruCache::new(2));
+        let initializations = Arc::new(AtomicUsize::new(0));
+        let tasks = (0..100).map(|_| {
+            let cache = cache.clone();
+            let initializations = initializations.clone();
+            async move {
+                cache
+                    .get("same", || async move {
+                        initializations.fetch_add(1, Ordering::SeqCst);
+                        tokio::task::yield_now().await;
+                        Ok::<_, ()>(Arc::new(42_u64))
+                    })
+                    .await
+                    .unwrap()
+            }
+        });
+
+        let values = join_all(tasks).await;
+        assert_eq!(initializations.load(Ordering::SeqCst), 1);
+        assert!(values.iter().all(|value| Arc::ptr_eq(value, &values[0])));
+    }
+
+    #[tokio::test]
+    async fn different_keys_initialize_serially() {
+        let cache = Arc::new(GlobalLruCache::new(32));
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let tasks = (0..16).map(|index| {
+            let cache = cache.clone();
+            let active = active.clone();
+            let max_active = max_active.clone();
+            async move {
+                cache
+                    .get(&format!("key-{index}"), || async move {
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(current, Ordering::SeqCst);
+                        tokio::task::yield_now().await;
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok::<_, ()>(Arc::new(index))
+                    })
+                    .await
+                    .unwrap()
+            }
+        });
+
+        join_all(tasks).await;
+        assert_eq!(max_active.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_initialization_is_not_cached() {
+        let cache = GlobalLruCache::new(2);
+        let initializations = AtomicUsize::new(0);
+
+        let first = cache
+            .get("key", || async {
+                initializations.fetch_add(1, Ordering::SeqCst);
+                Err::<Arc<u64>, _>("failed")
+            })
+            .await;
+        assert_eq!(first.unwrap_err(), "failed");
+
+        let second = cache
+            .get("key", || async {
+                initializations.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(Arc::new(42_u64))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(*second, 42);
+        assert_eq!(initializations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn least_recently_used_entry_is_evicted() {
+        let cache = GlobalLruCache::new(2);
+        let first = cache
+            .get("first", || async { Ok::<_, ()>(Arc::new(1)) })
+            .await
+            .unwrap();
+        cache
+            .get("second", || async { Ok::<_, ()>(Arc::new(2)) })
+            .await
+            .unwrap();
+        let first_hit = cache
+            .get("first", || async { Ok::<_, ()>(Arc::new(10)) })
+            .await
+            .unwrap();
+        cache
+            .get("third", || async { Ok::<_, ()>(Arc::new(3)) })
+            .await
+            .unwrap();
+        let second_reloaded = cache
+            .get("second", || async { Ok::<_, ()>(Arc::new(20)) })
+            .await
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &first_hit));
+        assert_eq!(*second_reloaded, 20);
+    }
+}

--- a/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
@@ -17,20 +17,26 @@ use crate::TOKIO_RT;
 use arrow_array::Array;
 use futures::TryStreamExt;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use iceberg::TableIdent;
 use iceberg::io::{FileIOBuilder, LocalFsStorageFactory, MemoryStorageFactory, StorageFactory};
 use iceberg::scan::FileScanTask;
 use iceberg::table::StaticTable;
 use iceberg_storage_opendal::OpenDalStorageFactory;
-
 use crate::aliyun_oss_provider::AliyunOssStorageFactory;
+use crate::aws_arn_provider::{AssumeRoleConfig, build_iceberg_factory};
 use crate::azure_sas_provider::{AzureBrokerClient, AzureBrokerConfig};
+use crate::cloud_provider_cache::{
+    CACHE_CAPACITY, CACHE_KEY, GlobalLruCache,
+};
 use crate::gcp_impersonation::{DEFAULT_TOKEN_LIFETIME_SECS, fetch_impersonated_bearer};
 use crate::iceberg_ffi::IcebergFileInfo;
 
 const CLOUD_PROVIDER_KEY: &str = "cloud_provider";
+
+static ICEBERG_FACTORY_CACHE: LazyLock<GlobalLruCache<Arc<dyn StorageFactory>>> =
+    LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
 
 /// Internal representation for a delete file reference, serialized to JSON.
 #[derive(serde::Serialize)]
@@ -105,10 +111,77 @@ pub(crate) async fn prepare_cloud_storage_options(
 
 /// Scheme → `iceberg-storage-opendal` variant. Hand-written because 0.9
 /// ships no `from_scheme` helper; collapse when upstream adds one.
-fn upstream_opendal_factory(scheme: &str) -> anyhow::Result<Arc<dyn StorageFactory>> {
+async fn upstream_opendal_factory(
+    uri: &str,
+    scheme: &str,
+    props: &mut HashMap<String, String>,
+) -> anyhow::Result<Arc<dyn StorageFactory>> {
+    let cache_key = props.remove(CACHE_KEY).filter(|key| !key.is_empty());
+    let cloud_provider = props.get(CLOUD_PROVIDER_KEY).cloned();
+    let assume_role = if cloud_provider.as_deref() == Some("aws") {
+        let role_arn = props
+            .remove("client.assume-role.arn")
+            .unwrap_or_default();
+        let session_name = props
+            .remove("client.assume-role.session-name")
+            .unwrap_or_default();
+        let external_id = props
+            .remove("client.assume-role.external-id")
+            .unwrap_or_default();
+        let region = props.get("s3.region").cloned().unwrap_or_default();
+        let credential_refresh_secs = props
+            .remove("aws_credential_refresh_secs")
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        AssumeRoleConfig::parse(
+            &role_arn,
+            &session_name,
+            &external_id,
+            &region,
+            credential_refresh_secs,
+        )?
+    } else {
+        None
+    };
+
     match scheme {
         // The upstream OSS factory does not carry per-tenant `oss.role-arn`.
+        "oss" if cloud_provider.as_deref() == Some("aliyun")
+            && props.contains_key("oss.role-arn") =>
+        {
+            match cache_key.as_deref() {
+                Some(cache_key) => ICEBERG_FACTORY_CACHE
+                    .get(cache_key, || async {
+                        let factory = Arc::new(
+                            AliyunOssStorageFactory::from_uri(uri, props).await?,
+                        ) as Arc<dyn StorageFactory>;
+                        eprintln!(
+                            "created cloud cache entry: consumer=iceberg, cloud=aliyun, mechanism=role"
+                        );
+                        Ok::<_, anyhow::Error>(factory)
+                    })
+                    .await,
+                None => Ok(Arc::new(
+                    AliyunOssStorageFactory::from_uri(uri, props).await?,
+                )),
+            }
+        }
         "oss" => Ok(Arc::new(AliyunOssStorageFactory::default())),
+        "s3" | "s3a" if assume_role.is_some() => {
+            let config = assume_role.as_ref().unwrap();
+            match cache_key.as_deref() {
+                Some(cache_key) => ICEBERG_FACTORY_CACHE
+                    .get(cache_key, || async {
+                        let factory = build_iceberg_factory(scheme, config).await?;
+                        eprintln!(
+                            "created cloud cache entry: consumer=iceberg, cloud=aws, mechanism=assume_role"
+                        );
+                        Ok::<_, anyhow::Error>(factory)
+                    })
+                    .await,
+                None => Ok(build_iceberg_factory(scheme, config).await?),
+            }
+        }
         "s3" | "s3a" => Ok(Arc::new(OpenDalStorageFactory::S3 {
             configured_scheme: scheme.to_string(),
             customized_credential_load: None,
@@ -136,13 +209,15 @@ fn upstream_opendal_factory(scheme: &str) -> anyhow::Result<Arc<dyn StorageFacto
     }
 }
 
-pub(crate) fn build_file_io(
+pub(crate) async fn build_file_io(
+    uri: &str,
     scheme: &str,
-    props: &HashMap<String, String>,
+    props: &mut HashMap<String, String>,
 ) -> anyhow::Result<iceberg::io::FileIO> {
-    let factory = upstream_opendal_factory(scheme)?;
+    let factory = upstream_opendal_factory(uri, scheme, props).await?;
+    prepare_cloud_storage_options(props).await?;
     let mut builder = FileIOBuilder::new(factory);
-    for (k, v) in props {
+    for (k, v) in props.iter() {
         builder = builder.with_prop(k, v);
     }
     // `FileIOBuilder::build` became infallible in iceberg 0.9 (was
@@ -317,13 +392,12 @@ pub fn iceberg_plan_files(
 
     TOKIO_RT.block_on(async {
         let mut props = vec_to_hashmap(storage_options_keys, storage_options_values);
-        prepare_cloud_storage_options(&mut props).await?;
 
         // Normalize URI for opendal and detect FileIO scheme in one pass.
         // For Azure ABFSS, expands scheme://container/path to container@endpoint format.
         let (resolved_location, scheme) = normalize_uri(metadata_location, &props);
 
-        let file_io = build_file_io(&scheme, &props)?;
+        let file_io = build_file_io(&resolved_location, &scheme, &mut props).await?;
 
         // Load table metadata directly from location (no catalog needed)
         let table_ident = TableIdent::from_strs(["default", "table"])?;

--- a/cpp/src/format/bridge/rust/src/iceberg_testutil.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_testutil.rs
@@ -35,7 +35,7 @@ use iceberg::spec::{
 
 use crate::TOKIO_RT;
 use crate::iceberg_bridgeimpl::{
-    build_file_io, denormalize_uri, normalize_uri, prepare_cloud_storage_options, vec_to_hashmap,
+    build_file_io, denormalize_uri, normalize_uri, vec_to_hashmap,
 };
 use crate::iceberg_test_ffi::IcebergTestTableInfo;
 
@@ -84,7 +84,6 @@ pub fn iceberg_create_test_table(
 
     TOKIO_RT.block_on(async {
         let mut props = vec_to_hashmap(storage_options_keys, storage_options_values);
-        prepare_cloud_storage_options(&mut props).await?;
 
         // Normalize URI for opendal and detect FileIO scheme in one pass.
         let (resolved_dir, scheme) = normalize_uri(table_dir, &props);
@@ -95,7 +94,7 @@ pub fn iceberg_create_test_table(
 
         // Build FileIO with storage options via the shared scheme-dispatch
         // helper; iceberg 0.9 no longer accepts a bare scheme string.
-        let file_io = build_file_io(&scheme, &props)?;
+        let file_io = build_file_io(&resolved_dir, &scheme, &mut props).await?;
 
         // Create directories for local filesystem only (S3 has no directories)
         if is_local {

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -8,7 +8,7 @@ use futures::stream::StreamExt;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::result::Result as RustResult;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use tokio::runtime::Handle;
 
 use arrow_array58::Array;
@@ -40,13 +40,26 @@ use lance_table::utils::stream::ReadBatchFutStream;
 
 use lance::io::ObjectStoreParams;
 use lance::session::Session;
-use lance_io::object_store::{ObjectStoreRegistry, StorageOptionsAccessor};
+use lance_io::object_store::{
+    ObjectStoreProvider, ObjectStoreRegistry, StorageOptionsAccessor,
+};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 
+use crate::aliyun_oss_provider::{AliyunOssStoreProvider, build_aliyun_oss_session};
+use crate::aws_arn_provider::{
+    AssumeRoleConfig, build_lance_provider as build_aws_arn_provider,
+    build_lance_session as build_aws_arn_session,
+};
 use crate::azure_sas_provider::{AzureBrokerConfig, AzureSasStorageOptionsProvider};
+use crate::cloud_provider_cache::{
+    CACHE_CAPACITY, CACHE_KEY, GlobalLruCache,
+};
 use crate::gcp_impersonation::{ImpersonatingGcsStoreProvider, REFRESH_OFFSET_SECS};
 
 const CLOUD_PROVIDER_KEY: &str = "cloud_provider";
+
+static LANCE_PROVIDER_CACHE: LazyLock<GlobalLruCache<Arc<dyn ObjectStoreProvider>>> =
+    LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
 
 #[derive(Clone)]
 pub struct BlockingDataset {
@@ -329,78 +342,6 @@ impl BlockingDataset {
 
 use crate::iceberg_bridgeimpl::vec_to_hashmap;
 
-/// Configuration for AWS STS AssumeRole credentials.
-struct AssumeRoleConfig {
-    role_arn: String,
-    session_name: String,
-    external_id: String,
-    credential_refresh_secs: u64,
-}
-
-impl AssumeRoleConfig {
-    /// Parse from raw parameters. Returns None if role_arn is empty.
-    /// Returns Err if credential_refresh_secs is out of range [900, 43200].
-    /// 43200s (12h) is AWS STS `AssumeRole`'s hard upper bound on
-    /// `DurationSeconds`, reachable only when the target IAM role's
-    /// `MaxSessionDuration` is raised from the 3600s default.
-    fn parse(
-        role_arn: &str,
-        session_name: &str,
-        external_id: &str,
-        credential_refresh_secs: u64,
-    ) -> Result<Option<Self>> {
-        if role_arn.is_empty() {
-            return Ok(None);
-        }
-        if credential_refresh_secs < 900 || credential_refresh_secs > 43200 {
-            return Err(LanceError::invalid_input(
-                format!(
-                    "credential_refresh_secs must be in [900, 43200], got {}",
-                    credential_refresh_secs
-                ),
-            ));
-        }
-        Ok(Some(Self {
-            role_arn: role_arn.to_string(),
-            session_name: session_name.to_string(),
-            external_id: external_id.to_string(),
-            credential_refresh_secs,
-        }))
-    }
-
-    /// Build AWS credentials by calling STS AssumeRole.
-    async fn build_credentials(&self) -> Result<object_store::aws::AwsCredentialProvider> {
-        use aws_config::sts::AssumeRoleProvider;
-        use lance_io::object_store::providers::aws::AwsCredentialAdapter;
-
-        // session_length = STS token TTL (credential_refresh_secs, e.g. 900s).
-        // refresh_offset = how early before expiry AwsCredentialAdapter triggers a
-        //   refresh.  Must be strictly less than session_length, otherwise the cache
-        //   is considered expired immediately after issuance and every credential
-        //   check triggers a new STS call (credential thrashing).
-        //   Use a fixed 300s offset to leave enough safety margin.
-        const REFRESH_OFFSET_SECS: u64 = 300;
-
-        let mut builder = AssumeRoleProvider::builder(&self.role_arn)
-            .session_length(std::time::Duration::from_secs(self.credential_refresh_secs));
-
-        if !self.session_name.is_empty() {
-            builder = builder.session_name(&self.session_name);
-        }
-        if !self.external_id.is_empty() {
-            builder = builder.external_id(&self.external_id);
-        }
-
-        // build() auto-loads base credentials from the default chain (IAM / IRSA / env vars)
-        let assume_role_provider = builder.build().await;
-
-        Ok(Arc::new(AwsCredentialAdapter::new(
-            Arc::new(assume_role_provider),
-            std::time::Duration::from_secs(REFRESH_OFFSET_SECS),
-        )))
-    }
-}
-
 /// GCP cross-tenant impersonation parameters extracted from `storage_options`.
 ///
 /// The C++ side (`lance::ToStorageOptions` in `lance_common.cpp`) stamps these
@@ -479,6 +420,7 @@ pub fn open_dataset(
     storage_options_values: Vec<String>,
 ) -> Result<Box<BlockingDataset>> {
     let mut storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
+    let credential_cache_key = storage_options.remove(CACHE_KEY);
     let cloud_provider = storage_options.remove(CLOUD_PROVIDER_KEY);
     if let Some(cloud_provider) = cloud_provider.as_deref()
         && !matches!(cloud_provider, "aws" | "azure" | "gcp" | "aliyun")
@@ -489,18 +431,18 @@ pub fn open_dataset(
     }
 
     // Configure each cloud provider's cross-tenant credential path in one
-    // place. AWS and Azure use ObjectStoreParams directly, while GCP and
-    // Aliyun require a per-call Session with an overridden object-store provider.
+    // place. AWS, GCP, and Aliyun use a per-call Session with an overridden
+    // object-store provider, while Azure uses ObjectStoreParams directly.
     let mut store_params = ObjectStoreParams::default();
     let mut custom_session = None;
     match cloud_provider.as_deref() {
         Some("aws") => {
-            // Lance accepts a refreshable AWS credential provider directly.
             let role_arn = storage_options.remove("aws_role_arn").unwrap_or_default();
             let session_name = storage_options
                 .remove("aws_session_name")
                 .unwrap_or_default();
             let external_id = storage_options.remove("aws_external_id").unwrap_or_default();
+            let region = storage_options.get("aws_region").cloned().unwrap_or_default();
             let refresh_secs_str = storage_options
                 .remove("aws_credential_refresh_secs")
                 .unwrap_or_default();
@@ -509,12 +451,25 @@ pub fn open_dataset(
                 &role_arn,
                 &session_name,
                 &external_id,
+                &region,
                 credential_refresh_secs,
             )?;
-            store_params.aws_credentials = match &assume_role {
-                Some(config) => Some(TOKIO_RT.block_on(config.build_credentials())?),
-                None => None,
-            };
+            if let Some(config) = &assume_role {
+                let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
+                    Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
+                        cache_key,
+                        || async {
+                            let provider = build_aws_arn_provider(config).await?;
+                            eprintln!(
+                                "created cloud cache entry: consumer=lance, cloud=aws, mechanism=assume_role"
+                            );
+                            Ok::<_, LanceError>(provider)
+                        },
+                    ))?,
+                    None => TOKIO_RT.block_on(build_aws_arn_provider(config))?,
+                };
+                custom_session = Some(build_aws_arn_session(provider));
+            }
         }
         Some("azure") => {
             // Lance refreshes Azure credentials through StorageOptionsAccessor;
@@ -554,14 +509,31 @@ pub fn open_dataset(
                 .map(|config| build_gcp_impersonation_session(&config));
         }
         Some("aliyun") if storage_options.contains_key("oss_role_arn") => {
-            // Lance's stock OSS provider does not forward the role ARN options.
-            custom_session = Some(crate::aliyun_oss_provider::build_aliyun_oss_session());
+            let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
+                Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
+                    cache_key,
+                    || async {
+                        let provider = Arc::new(
+                            AliyunOssStoreProvider::from_uri(uri, &storage_options).await?,
+                        ) as Arc<dyn ObjectStoreProvider>;
+                        eprintln!(
+                            "created cloud cache entry: consumer=lance, cloud=aliyun, mechanism=role"
+                        );
+                        Ok::<_, LanceError>(provider)
+                    },
+                ))?,
+                None => Arc::new(TOKIO_RT.block_on(AliyunOssStoreProvider::from_uri(
+                    uri,
+                    &storage_options,
+                ))?) as Arc<dyn ObjectStoreProvider>,
+            };
+            custom_session = Some(build_aliyun_oss_session(provider));
         }
         _ => {}
     }
 
     // Do not pass credential_refresh_secs as s3_credentials_refresh_offset here:
-    // AwsCredentialAdapter already handles refresh internally with REFRESH_OFFSET_SECS.
+    // The AWS ARN credential provider handles refresh internally with REFRESH_OFFSET_SECS.
     // Passing the full session TTL (e.g. 900s) as the offset would cause Lance to
     // consider credentials expired immediately after issuance (credential thrashing).
     if store_params.storage_options_accessor.is_none() {
@@ -591,6 +563,7 @@ pub unsafe fn write_dataset(
     data_storage_format: LanceDataStorageFormat,
 ) -> Result<Box<BlockingDataset>> {
     let mut storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
+    let credential_cache_key = storage_options.remove(CACHE_KEY);
     let cloud_provider = storage_options.remove(CLOUD_PROVIDER_KEY);
     if let Some(cloud_provider) = cloud_provider.as_deref()
         && !matches!(cloud_provider, "aws" | "azure" | "gcp" | "aliyun")
@@ -609,6 +582,7 @@ pub unsafe fn write_dataset(
                 .remove("aws_session_name")
                 .unwrap_or_default();
             let external_id = storage_options.remove("aws_external_id").unwrap_or_default();
+            let region = storage_options.get("aws_region").cloned().unwrap_or_default();
             let refresh_secs_str = storage_options
                 .remove("aws_credential_refresh_secs")
                 .unwrap_or_default();
@@ -617,12 +591,25 @@ pub unsafe fn write_dataset(
                 &role_arn,
                 &session_name,
                 &external_id,
+                &region,
                 credential_refresh_secs,
             )?;
-            store_params.aws_credentials = match &assume_role {
-                Some(config) => Some(TOKIO_RT.block_on(config.build_credentials())?),
-                None => None,
-            };
+            if let Some(config) = &assume_role {
+                let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
+                    Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
+                        cache_key,
+                        || async {
+                            let provider = build_aws_arn_provider(config).await?;
+                            eprintln!(
+                                "created cloud cache entry: consumer=lance, cloud=aws, mechanism=assume_role"
+                            );
+                            Ok::<_, LanceError>(provider)
+                        },
+                    ))?,
+                    None => TOKIO_RT.block_on(build_aws_arn_provider(config))?,
+                };
+                custom_session = Some(build_aws_arn_session(provider));
+            }
         }
         Some("azure") => {
             store_params.storage_options_accessor = match AzureBrokerConfig::extract(
@@ -654,7 +641,25 @@ pub unsafe fn write_dataset(
                 .map(|config| build_gcp_impersonation_session(&config));
         }
         Some("aliyun") if storage_options.contains_key("oss_role_arn") => {
-            custom_session = Some(crate::aliyun_oss_provider::build_aliyun_oss_session());
+            let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
+                Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
+                    cache_key,
+                    || async {
+                        let provider = Arc::new(
+                            AliyunOssStoreProvider::from_uri(uri, &storage_options).await?,
+                        ) as Arc<dyn ObjectStoreProvider>;
+                        eprintln!(
+                            "created cloud cache entry: consumer=lance, cloud=aliyun, mechanism=role"
+                        );
+                        Ok::<_, LanceError>(provider)
+                    },
+                ))?,
+                None => Arc::new(TOKIO_RT.block_on(AliyunOssStoreProvider::from_uri(
+                    uri,
+                    &storage_options,
+                ))?) as Arc<dyn ObjectStoreProvider>,
+            };
+            custom_session = Some(build_aliyun_oss_session(provider));
         }
         _ => {}
     }

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 mod aliyun_oss_provider;
+mod aws_arn_provider;
 mod azure_sas_provider;
+mod cloud_provider_cache;
 mod gcp_impersonation;
 mod iceberg_bridgeimpl;
 mod iceberg_testutil;

--- a/cpp/src/format/iceberg/iceberg_common.cpp
+++ b/cpp/src/format/iceberg/iceberg_common.cpp
@@ -67,6 +67,7 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
     if (endpoint.find("http://") == 0)
       options["allow_http"] = "true";
   };
+  auto set_credential_cache_key = [&]() { options["milvus_fs_cache_key"] = config.GetCacheKey(); };
 
   const auto& provider = config.cloud_provider;
   // Bridge-private dispatch key. The Rust entry point removes it before
@@ -84,6 +85,7 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
       !config.azure_credential_endpoint.empty());
   if (provider == kCloudProviderAWS) {
     if (!config.role_arn.empty()) {
+      set_credential_cache_key();
       // AssumeRole: set ARN fields + region/endpoint; do NOT set AKSK so opendal
       // uses the default credential chain (EC2 metadata / env vars) as base
       // credential for the STS AssumeRole call.
@@ -92,6 +94,9 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
       set("client.assume-role.arn", config.role_arn);
       set("client.assume-role.session-name", config.session_name);
       set("client.assume-role.external-id", config.external_id);
+      if (config.load_frequency > 0) {
+        options["aws_credential_refresh_secs"] = std::to_string(config.load_frequency);
+      }
     } else {
       // Explicit AKSK or IAM
       if (!config.use_iam) {
@@ -126,7 +131,7 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
       set("adls.account-key", config.access_key_value);
     }
   } else if (provider == kCloudProviderGCP) {
-    if (!config.gcp_target_service_account.empty()) {
+    if (config.use_iam && !config.gcp_target_service_account.empty()) {
       // Bridge-private: iceberg-rust 0.8's gcs_config_parse doesn't recognize
       // this key as an impersonation target (it would be silently dropped).
       // Instead, iceberg_bridgeimpl.rs::iceberg_plan_files intercepts it,
@@ -138,6 +143,7 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
     // Otherwise uses default credentials (VM metadata)
   } else if (provider == kCloudProviderAliyun) {
     if (!config.role_arn.empty()) {
+      set_credential_cache_key();
       // Per-tenant AssumeRoleWithOIDC. Machine identity (oidc_token_file,
       // oidc_provider_arn) stays in process env — opendal picks it up via the
       // env sweep inside `AliyunOssStorage::create_operator`. Do NOT emit
@@ -156,6 +162,9 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
       set("oss.role-arn", config.role_arn);
       set("oss.role-session-name", config.session_name);
       set("oss.external-id", config.external_id);
+      if (config.load_frequency > 0) {
+        options["oss_credential_refresh_secs"] = std::to_string(config.load_frequency);
+      }
     } else {
       // Explicit AKSK. iceberg 0.9 `OSS_*` constants in the `iceberg` crate
       // map to these three dotted keys.

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -42,6 +42,7 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
     if (endpoint.find("http://") == 0)
       options["allow_http"] = "true";
   };
+  auto set_credential_cache_key = [&]() { options["milvus_fs_cache_key"] = config.GetCacheKey(); };
 
   const auto& provider = config.cloud_provider;
   LOG_STORAGE_DEBUG_ << fmt::format(
@@ -58,6 +59,7 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
   set("cloud_provider", provider);
   if (provider == kCloudProviderAWS) {
     if (!config.role_arn.empty()) {
+      set_credential_cache_key();
       // AssumeRole: set region/endpoint + ARN fields; do NOT set AKSK so the
       // Rust layer uses the default credential chain (EC2 metadata / env vars)
       // as base credential for the STS AssumeRole call.
@@ -102,7 +104,7 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
         options["allow_http"] = "true";
     }
   } else if (provider == kCloudProviderGCP) {
-    if (!config.gcp_target_service_account.empty()) {
+    if (config.use_iam && !config.gcp_target_service_account.empty()) {
       // Bridge-private keys consumed by Rust `open_dataset`/`write_dataset`/
       // `drop` (see lance_bridgeimpl.rs). The bridge strips them out of
       // storage_options and installs an ImpersonatingGcsStoreProvider that
@@ -123,6 +125,7 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
     // Otherwise uses default credentials (VM metadata)
   } else if (provider == kCloudProviderAliyun) {
     if (!config.role_arn.empty()) {
+      set_credential_cache_key();
       // Per-tenant Aliyun role_arn. Machine identity
       // (ALIBABA_CLOUD_OIDC_TOKEN_FILE / OIDC_PROVIDER_ARN / ROLE_ARN) stays
       // in process env for the Rust AliyunOssStoreProvider to resolve the

--- a/cpp/test/format/external_table_arn_test.cpp
+++ b/cpp/test/format/external_table_arn_test.cpp
@@ -1729,6 +1729,33 @@ class ExternalTableAliyunOIDCArnTest : public ::testing::Test {
     FilesystemCache::getInstance().clean();
   }
 
+  class ScopedOidcTokenFileOverride {
+ public:
+    explicit ScopedOidcTokenFileOverride(const std::string& value) {
+      const char* old_value = std::getenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE");
+      if (old_value != nullptr) {
+        had_old_value_ = true;
+        old_value_ = old_value;
+      }
+      setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", value.c_str(), 1);
+    }
+
+    ~ScopedOidcTokenFileOverride() {
+      if (had_old_value_) {
+        setenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE", old_value_.c_str(), 1);
+      } else {
+        unsetenv("ALIBABA_CLOUD_OIDC_TOKEN_FILE");
+      }
+    }
+
+    ScopedOidcTokenFileOverride(const ScopedOidcTokenFileOverride&) = delete;
+    ScopedOidcTokenFileOverride& operator=(const ScopedOidcTokenFileOverride&) = delete;
+
+ private:
+    std::string old_value_;
+    bool had_old_value_ = false;
+  };
+
   // FFI properties payload shared by all four formats. Iceberg additionally
   // needs PROPERTY_ICEBERG_SNAPSHOT_ID; callers append.
   std::vector<std::pair<std::string, std::string>> BaseProps() const {
@@ -1886,6 +1913,74 @@ TEST_F(ExternalTableAliyunOIDCArnTest, ReadLanceWithOIDCChain) {
   loon_properties_free(&loon_props);
 }
 
+TEST_F(ExternalTableAliyunOIDCArnTest, LanceProviderCacheHitDoesNotReloadOidcToken) {
+  const uint64_t num_rows = 100;
+  ASSERT_AND_ASSIGN(auto result, CreateLanceTable(num_rows));
+
+  auto session_name = "lance-cache-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+  auto cache_read_props = read_props_;
+  api::SetValue(cache_read_props, "extfs.arn.session_name", session_name.c_str());
+
+  ASSERT_AND_ASSIGN(auto fs_config, FilesystemCache::resolve_config(cache_read_props, result.explore_dir.c_str()));
+  auto storage_options = lance::ToStorageOptions(fs_config);
+  auto cache_key = storage_options.find("milvus_fs_cache_key");
+  ASSERT_NE(cache_key, storage_options.end());
+  ASSERT_EQ(cache_key->second, fs_config.GetCacheKey());
+
+  auto props = BaseProps();
+  props.emplace_back("extfs.arn.session_name", session_name);
+  std::vector<const char*> c_keys, c_values;
+  c_keys.reserve(props.size());
+  c_values.reserve(props.size());
+  for (const auto& [k, v] : props) {
+    c_keys.push_back(k.c_str());
+    c_values.push_back(v.c_str());
+  }
+
+  LoonProperties loon_props = {};
+  auto rc = loon_properties_create(c_keys.data(), c_values.data(), c_keys.size(), &loon_props);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+
+  const char* columns_arr[] = {"id", "name", "value"};
+  uint64_t out_num_files = 0;
+  char* out_manifest_path = nullptr;
+  auto manifest_base = test_base_ + "/lance-cache-manifest";
+  rc = loon_exttable_explore(columns_arr, 3, LOON_FORMAT_LANCE_TABLE, manifest_base.c_str(), result.explore_dir.c_str(),
+                             &loon_props, &out_num_files, &out_manifest_path);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+  ASSERT_GT(out_num_files, 0u);
+  ASSERT_NE(out_manifest_path, nullptr);
+  free(out_manifest_path);
+  loon_properties_free(&loon_props);
+
+  {
+    ScopedOidcTokenFileOverride invalid_token_file("/path/that/does/not/exist/milvus-storage-oidc-token");
+    std::vector<std::string> columns = {"id", "name", "value"};
+    constexpr size_t cache_hit_iterations = 1000;
+    std::shared_ptr<FormatReader> reader;
+    std::cout << "[Aliyun OIDC Cache Test] Lance: starting " << cache_hit_iterations
+              << " cache-hit opens with an invalid token file; no additional STS request logs are expected"
+              << std::endl;
+    for (size_t iteration = 0; iteration < cache_hit_iterations; ++iteration) {
+      SCOPED_TRACE(::testing::Message() << "cache hit iteration " << iteration);
+      ASSERT_AND_ASSIGN(reader, FormatReader::create(result.schema, LOON_FORMAT_LANCE_TABLE, result.cgfile,
+                                                     cache_read_props, columns, nullptr));
+    }
+    std::cout << "[Aliyun OIDC Cache Test] Lance: completed " << cache_hit_iterations << " cache-hit opens"
+              << std::endl;
+
+    ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
+    ValidateRowGroupInfos(rg_infos, num_rows);
+
+    int64_t total_rows = 0;
+    for (size_t i = 0; i < rg_infos.size(); ++i) {
+      ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(i));
+      total_rows += batch->num_rows();
+    }
+    ASSERT_EQ(total_rows, static_cast<int64_t>(num_rows));
+  }
+}
+
 // Iceberg variant for the same OIDC chain. This reuses BaseProps() for the
 // our-side manifest bucket plus extfs.arn.* read credentials, and appends the
 // snapshot id required by the Iceberg bridge.
@@ -1954,6 +2049,66 @@ TEST_F(ExternalTableAliyunOIDCArnTest, ReadIcebergWithOIDCChain) {
 
   loon_manifest_destroy(out_manifest);
   free(out_manifest_path);
+  loon_properties_free(&loon_props);
+}
+
+TEST_F(ExternalTableAliyunOIDCArnTest, IcebergFactoryCacheHitDoesNotReloadOidcToken) {
+  const uint64_t num_rows = 100;
+  ASSERT_AND_ASSIGN(auto result, CreateIcebergTable(num_rows));
+
+  auto session_name = "iceberg-cache-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+  auto cache_read_props = read_props_;
+  api::SetValue(cache_read_props, "extfs.arn.session_name", session_name.c_str());
+  api::SetValue(cache_read_props, PROPERTY_ICEBERG_SNAPSHOT_ID, std::to_string(result.iceberg_snapshot_id).c_str());
+
+  ASSERT_AND_ASSIGN(auto fs_config, FilesystemCache::resolve_config(cache_read_props, result.explore_dir.c_str()));
+  auto storage_options = iceberg::ToStorageOptions(fs_config);
+  auto cache_key = storage_options.find("milvus_fs_cache_key");
+  ASSERT_NE(cache_key, storage_options.end());
+  ASSERT_EQ(cache_key->second, fs_config.GetCacheKey());
+
+  auto props = BaseProps();
+  props.emplace_back("extfs.arn.session_name", session_name);
+  props.emplace_back(PROPERTY_ICEBERG_SNAPSHOT_ID, std::to_string(result.iceberg_snapshot_id));
+  std::vector<const char*> c_keys, c_values;
+  c_keys.reserve(props.size());
+  c_values.reserve(props.size());
+  for (const auto& [k, v] : props) {
+    c_keys.push_back(k.c_str());
+    c_values.push_back(v.c_str());
+  }
+
+  LoonProperties loon_props = {};
+  auto rc = loon_properties_create(c_keys.data(), c_values.data(), c_keys.size(), &loon_props);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+
+  const char* columns_arr[] = {"id", "name", "value"};
+  uint64_t first_num_files = 0;
+  char* first_manifest_path = nullptr;
+  auto first_manifest_base = test_base_ + "/iceberg-cache-manifest-first";
+  rc = loon_exttable_explore(columns_arr, 3, LOON_FORMAT_ICEBERG_TABLE, first_manifest_base.c_str(),
+                             result.explore_dir.c_str(), &loon_props, &first_num_files, &first_manifest_path);
+  ASSERT_TRUE(loon_ffi_is_success(&rc)) << loon_ffi_get_errmsg(&rc);
+  ASSERT_GT(first_num_files, 0u);
+  ASSERT_NE(first_manifest_path, nullptr);
+  free(first_manifest_path);
+
+  {
+    ScopedOidcTokenFileOverride invalid_token_file("/path/that/does/not/exist/milvus-storage-oidc-token");
+    constexpr size_t cache_hit_iterations = 1000;
+    ASSERT_AND_ASSIGN(auto* iceberg_format, Format::get(LOON_FORMAT_ICEBERG_TABLE));
+    std::cout << "[Aliyun OIDC Cache Test] Iceberg: starting " << cache_hit_iterations
+              << " cache-hit explores with an invalid token file; no additional STS request logs are expected"
+              << std::endl;
+    for (size_t iteration = 0; iteration < cache_hit_iterations; ++iteration) {
+      SCOPED_TRACE(::testing::Message() << "cache hit iteration " << iteration);
+      ASSERT_AND_ASSIGN(auto files, iceberg_format->explore(result.explore_dir, cache_read_props));
+      ASSERT_EQ(files.size(), first_num_files);
+    }
+    std::cout << "[Aliyun OIDC Cache Test] Iceberg: completed " << cache_hit_iterations << " cache-hit explores"
+              << std::endl;
+  }
+
   loon_properties_free(&loon_props);
 }
 

--- a/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
@@ -89,6 +89,7 @@ TEST_F(IcebergStorageOptionsTest, AzureCredentialBrokerKeysExcludeFallbackCreden
   EXPECT_EQ(opts.count("adls.client-id"), 0);
   EXPECT_EQ(opts.count("adls.tenant-id"), 0);
   EXPECT_EQ(opts.count("adls.sas-token"), 0);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(IcebergStorageOptionsTest, AliyunKeys) {
@@ -152,12 +153,26 @@ TEST_F(IcebergStorageOptionsTest, GcpImpersonation) {
   ArrowFileSystemConfig config;
   config.storage_type = "remote";
   config.cloud_provider = kCloudProviderGCP;
+  config.use_iam = true;
   config.gcp_target_service_account = "target-sa@customer-project.iam.gserviceaccount.com";
 
   auto opts = ToStorageOptions(config);
 
   EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
   EXPECT_EQ(opts["gcs.service-account"], "target-sa@customer-project.iam.gserviceaccount.com");
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
+}
+
+TEST_F(IcebergStorageOptionsTest, GcpTargetServiceAccountRequiresIam) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "remote";
+  config.cloud_provider = kCloudProviderGCP;
+  config.gcp_target_service_account = "target-sa@customer-project.iam.gserviceaccount.com";
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts.size(), 1);
+  EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
 }
 
 TEST_F(IcebergStorageOptionsTest, GcpDefaultCredentials) {

--- a/cpp/test/format/lance/lance_storage_options_test.cpp
+++ b/cpp/test/format/lance/lance_storage_options_test.cpp
@@ -116,6 +116,7 @@ TEST_F(LanceStorageOptionsTest, AzureCredentialBrokerKeysExcludeFallbackCredenti
   EXPECT_EQ(opts["azure_broker_request_timeout_ms"], "5000");
   EXPECT_EQ(opts.count("azure_storage_account_key"), 0);
   EXPECT_EQ(opts.count("azure_storage_sas_token"), 0);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(LanceStorageOptionsTest, AliyunKeys) {
@@ -141,6 +142,7 @@ TEST_F(LanceStorageOptionsTest, GcpImpersonation) {
   ArrowFileSystemConfig config;
   config.storage_type = "remote";
   config.cloud_provider = kCloudProviderGCP;
+  config.use_iam = true;
   config.gcp_target_service_account = "target-sa@customer-project.iam.gserviceaccount.com";
   config.load_frequency = 1800;
 
@@ -150,6 +152,19 @@ TEST_F(LanceStorageOptionsTest, GcpImpersonation) {
   // Bridge-private keys; not forwarded to lance-io / object_store.
   EXPECT_EQ(opts["gcp_target_service_account"], "target-sa@customer-project.iam.gserviceaccount.com");
   EXPECT_EQ(opts["gcp_credential_refresh_secs"], "1800");
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
+}
+
+TEST_F(LanceStorageOptionsTest, GcpTargetServiceAccountRequiresIam) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "remote";
+  config.cloud_provider = kCloudProviderGCP;
+  config.gcp_target_service_account = "target-sa@customer-project.iam.gserviceaccount.com";
+
+  auto opts = ToStorageOptions(config);
+
+  EXPECT_EQ(opts.size(), 1);
+  EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
 }
 
 TEST_F(LanceStorageOptionsTest, GcpDefaultCredentials) {


### PR DESCRIPTION
Role-based cloud access was rebuilding its credential provider every time Lance opened a dataset or Iceberg created a FileIO. That gets expensive fast when callers create thousands of readers or writers, because the same filesystem identity repeatedly goes through provider setup, credential warm-up, STS calls, and, for Aliyun, OIDC token-file loading even though the role configuration has not changed. The goal is to reuse credential state at the process level without sharing mutable reader, writer, session, or FileIO state.

This change adds a bounded global LRU cache keyed by the existing filesystem cache key. C++ forwards that key for AWS and Aliyun role-based configurations, and the Rust bridge consumes it before passing storage options to upstream libraries. Lance and Iceberg keep separate typed caches for their provider and factory objects, serialize same-key initialization so only one caller creates an entry, leave failed initialization uncached, and evict the least recently used entry when the cache reaches its limit.

For AWS, AssumeRole now uses a shared single-flight credential provider. It warms credentials before publishing the provider, reuses them while they are fresh, and coordinates refreshes near expiration so concurrent callers do not duplicate STS work. Lance still creates a fresh session for each open, while Iceberg creates a fresh FileIO from the cached factory, keeping operation-specific state isolated.

For Aliyun, the cached Lance provider and Iceberg factory now own a refreshable OSS store. The OIDC-to-AssumeRole chain runs when the cache entry is first created and later only when credentials actually need refreshing, instead of running for every dataset open or metadata operation. The resolved configuration and refreshed STS credentials stay with that store, while the filesystem cache key keeps different roles, sessions, external IDs, endpoints, and tenants isolated.

This reduces repeated STS traffic, token-file reads, and provider allocations for high-volume reader and writer workloads. Cache-entry creation is logged without exposing credential material, and bridge-private options are removed before upstream storage code sees them so the caching behavior remains an internal implementation detail.