### PR TITLE
fix: upgrade aws-sdk-cpp to 1.11.842 for checksum retries

### DIFF
--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -172,7 +172,7 @@ class StorageConan(ConanFile):
         # as a direct dep so CMakeDeps generates standalone cmake config files.
         # Without this, find_package(Azure) can't find include directories.
         self.requires("azure-sdk-for-cpp/1.11.3@milvus/dev#395e8e7a0c29644d41ef160088128f14")
-        self.requires("aws-sdk-cpp/1.11.692@milvus/dev#c309ce91fa572fff68f9f4e36d477a04")
+        self.requires("aws-sdk-cpp/1.11.842@milvus/dev#363556887f622db23a10168c108dd55d", force=True)
         # Force override transitive deps to align with milvus-common
         self.requires("protobuf/5.27.0@milvus/dev#42f031a96d21c230a6e05bcac4bdd633", force=True)
         self.requires("grpc/1.67.1@milvus/dev#efeaa484b59bffaa579004d5e82ec4fd", force=True, override=True)


### PR DESCRIPTION
issue: #488

aws-sdk-cpp 1.11.692 can reuse checksum state from a partially consumed aws-chunked stream when a PutObject request is retried after a transport or low-speed timeout. The retry sends the complete body with a stale checksum trailer, causing MinIO to reject the write with HTTP 400 XAmzContentChecksumMismatch.

Upgrade the direct Conan dependency to aws-sdk-cpp 1.11.842 and its corresponding recipe revision. This version includes the upstream partially consumed stream fix(aws-sdk-cpp#3706), which only preserves a calculated checksum after the stream reaches EOF and correctly handles a rewound request body during retries.