### PR TITLE
feat: support Apache Paimon non-direct-file reads

### DIFF
--- a/cpp/include/milvus-storage/format/paimon/paimon_common.h
+++ b/cpp/include/milvus-storage/format/paimon/paimon_common.h
@@ -22,6 +22,11 @@
 
 namespace milvus_storage::paimon {
 
+inline constexpr char kReadPathKey[] = "read_path";
+inline constexpr char kRecordCountKey[] = "record_count";
+inline constexpr char kDirectFileReadPath[] = "direct-file";
+inline constexpr char kDataSplitReadPath[] = "data-split";
+
 arrow::Result<std::unordered_map<std::string, std::string>> ToStorageOptions(const ArrowFileSystemConfig& config);
 
 std::string ToStandardUri(const std::string& milvus_uri);

--- a/cpp/include/milvus-storage/format/paimon/paimon_format_reader.h
+++ b/cpp/include/milvus-storage/format/paimon/paimon_format_reader.h
@@ -67,6 +67,7 @@ class PaimonFormatReader final : public FormatReader {
         const std::string& predicate);
   };
 
+  ~PaimonFormatReader() override;
   [[nodiscard]] arrow::Status open() override;
   [[nodiscard]] arrow::Result<std::vector<RowGroupInfo>> get_row_group_infos() override;
   [[nodiscard]] arrow::Result<std::vector<uint64_t>> get_rg_column_memsz(int64_t row_group_index) const override;
@@ -106,6 +107,9 @@ class PaimonFormatReader final : public FormatReader {
   std::shared_ptr<BlockingPaimonDataSplitReader> split_reader_;
   std::vector<std::string> split_columns_;
   std::shared_ptr<arrow::Schema> output_schema_;
+  // Retain only the forward cursor used by the non-thread-safe get_chunk path.
+  // Batch and range operations keep independent streams.
+  std::unique_ptr<DataSplitStreamCursor> data_split_cursor_;
 };
 
 }  // namespace milvus_storage::paimon

--- a/cpp/include/milvus-storage/format/paimon/paimon_format_reader.h
+++ b/cpp/include/milvus-storage/format/paimon/paimon_format_reader.h
@@ -23,10 +23,14 @@
 
 namespace milvus_storage::paimon {
 
+class BlockingPaimonDataSplitReader;
+class DataSplitStreamCursor;
+
 class PaimonFormatReader final : public FormatReader {
   public:
   struct MetaTrait {
     struct Payload {
+      std::string read_path;
       std::string data_format;
       // Direct-file reads delegate to the underlying Parquet/Vortex reader, so
       // the payload keeps that reader's parsed metadata (the alternative
@@ -38,6 +42,12 @@ class PaimonFormatReader final : public FormatReader {
           direct_file_metadata;
       std::vector<RowGroupInfo> direct_physical_row_groups;
       std::shared_ptr<const std::vector<uint64_t>> sorted_deletions;
+      // Shared projection-agnostic bridge handle for the data-split read
+      // path. Creating it resolves the table schema and the pinned snapshot;
+      // sharing it across every reader built from this cached metadata keeps
+      // that cost per-descriptor instead of per-reader. Streams opened from
+      // it are per-reader and per-projection.
+      std::shared_ptr<BlockingPaimonDataSplitReader> split_reader_handle;
       uint64_t record_count = 0;
       uint64_t physical_row_count = 0;
     };
@@ -70,23 +80,31 @@ class PaimonFormatReader final : public FormatReader {
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
   private:
+  [[nodiscard]] bool is_data_split() const;
   PaimonFormatReader(MetaTrait::MetadataPtr metadata,
                      api::ColumnGroupFile file,
                      std::shared_ptr<arrow::Schema> read_schema,
                      std::vector<std::string> needed_columns,
                      std::shared_ptr<FormatReader> direct_file_reader,
+                     std::shared_ptr<BlockingPaimonDataSplitReader> split_reader,
+                     std::vector<std::string> split_columns,
                      std::shared_ptr<arrow::Schema> output_schema);
 
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> filter_direct_batch(
       const std::shared_ptr<arrow::RecordBatch>& batch, uint64_t physical_start) const;
   [[nodiscard]] arrow::Result<std::vector<int64_t>> logical_to_physical(
       const std::vector<int64_t>& logical_offsets) const;
+  [[nodiscard]] arrow::Result<std::unique_ptr<DataSplitStreamCursor>> make_data_split_cursor() const;
 
   MetaTrait::MetadataPtr metadata_;
   api::ColumnGroupFile file_;
   std::shared_ptr<arrow::Schema> read_schema_;
   std::vector<std::string> needed_columns_;
   std::shared_ptr<FormatReader> direct_file_reader_;
+  // Shared with (and owned by) the cached metadata payload; streams opened
+  // from it carry this reader's own projection in split_columns_.
+  std::shared_ptr<BlockingPaimonDataSplitReader> split_reader_;
+  std::vector<std::string> split_columns_;
   std::shared_ptr<arrow::Schema> output_schema_;
 };
 

--- a/cpp/include/milvus-storage/format/paimon/paimon_format_reader.h
+++ b/cpp/include/milvus-storage/format/paimon/paimon_format_reader.h
@@ -80,7 +80,6 @@ class PaimonFormatReader final : public FormatReader {
   [[nodiscard]] std::shared_ptr<arrow::Schema> get_schema() const override;
 
   private:
-  [[nodiscard]] bool is_data_split() const;
   PaimonFormatReader(MetaTrait::MetadataPtr metadata,
                      api::ColumnGroupFile file,
                      std::shared_ptr<arrow::Schema> read_schema,
@@ -89,6 +88,7 @@ class PaimonFormatReader final : public FormatReader {
                      std::shared_ptr<BlockingPaimonDataSplitReader> split_reader,
                      std::vector<std::string> split_columns,
                      std::shared_ptr<arrow::Schema> output_schema);
+  [[nodiscard]] bool is_data_split() const;
 
   [[nodiscard]] arrow::Result<std::shared_ptr<arrow::RecordBatch>> filter_direct_batch(
       const std::shared_ptr<arrow::RecordBatch>& batch, uint64_t physical_start) const;

--- a/cpp/src/format/bridge/rust/include/paimon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/paimon_bridge.h
@@ -35,6 +35,10 @@ struct PaimonFileInfo {
   std::string metadata_json;
 };
 
+struct PaimonTestTableInfo {
+  std::vector<int64_t> snapshot_ids;
+};
+
 arrow::Status MakePaimonBridgeErrorStatus(std::string_view message);
 
 arrow::Result<std::vector<PaimonFileInfo>> PlanFiles(const std::string& table_location,
@@ -47,6 +51,14 @@ arrow::Result<std::vector<uint64_t>> ReadDeletionVector(const std::string& path,
                                                         uint64_t length,
                                                         int64_t expected_cardinality,
                                                         const StorageOptions& storage_options);
+
+arrow::Result<PaimonTestTableInfo> CreateTestTableInfo(const std::string& table_location,
+                                                       uint64_t num_rows,
+                                                       const std::string& mode,
+                                                       const std::vector<int64_t>& deleted_positions = {},
+                                                       const StorageOptions& storage_options = {},
+                                                       const std::string& file_format = "parquet",
+                                                       uint32_t dimension = 0);
 
 arrow::Result<int64_t> CreateTestTable(const std::string& table_location,
                                        uint64_t num_rows,

--- a/cpp/src/format/bridge/rust/include/paimon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/paimon_bridge.h
@@ -25,6 +25,11 @@
 #include "rust/cxx.h"
 #include "rust-bridge/lib.h"
 
+namespace arrow {
+class RecordBatchReader;
+class Schema;
+}  // namespace arrow
+
 namespace milvus_storage::paimon {
 
 using StorageOptions = std::unordered_map<std::string, std::string>;
@@ -40,6 +45,11 @@ struct PaimonTestTableInfo {
 };
 
 arrow::Status MakePaimonBridgeErrorStatus(std::string_view message);
+
+namespace internal {
+std::shared_ptr<arrow::RecordBatchReader> WrapPaimonRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner,
+                                                                      std::shared_ptr<arrow::Schema> output_schema);
+}  // namespace internal
 
 arrow::Result<std::vector<PaimonFileInfo>> PlanFiles(const std::string& table_location,
                                                      int64_t snapshot_id,

--- a/cpp/src/format/bridge/rust/include/paimon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/paimon_bridge.h
@@ -12,13 +12,18 @@
 
 #pragma once
 
+#include <arrow/c/abi.h>
+
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
 
 #include <arrow/result.h>
+#include "rust/cxx.h"
+#include "rust-bridge/lib.h"
 
 namespace milvus_storage::paimon {
 
@@ -49,5 +54,30 @@ arrow::Result<int64_t> CreateTestTable(const std::string& table_location,
                                        const std::vector<int64_t>& deleted_positions = {},
                                        const std::string& file_format = "parquet",
                                        uint32_t dimension = 0);
+
+/// Projection-agnostic handle over one decoded DataSplit. `Open` performs the
+/// expensive work (descriptor decode, schema resolution, pinned-snapshot time
+/// travel) once; `OpenStream` starts a merge-read stream with a per-call
+/// projection, so one handle can be shared by every reader created from the
+/// same cached metadata.
+class BlockingPaimonDataSplitReader {
+  public:
+  static arrow::Result<std::unique_ptr<BlockingPaimonDataSplitReader>> Open(const std::string& metadata_json,
+                                                                            const std::string& expected_table_location,
+                                                                            const StorageOptions& storage_options);
+
+  explicit BlockingPaimonDataSplitReader(rust::Box<ffi::BlockingPaimonDataSplitReader> impl) : impl_(std::move(impl)) {}
+
+  BlockingPaimonDataSplitReader(BlockingPaimonDataSplitReader&&) noexcept = default;
+  BlockingPaimonDataSplitReader& operator=(BlockingPaimonDataSplitReader&&) noexcept = default;
+  BlockingPaimonDataSplitReader(const BlockingPaimonDataSplitReader&) = delete;
+  BlockingPaimonDataSplitReader& operator=(const BlockingPaimonDataSplitReader&) = delete;
+
+  arrow::Status ExportSchema(ArrowSchema* schema) const;
+  arrow::Result<ArrowArrayStream> OpenStream(const std::vector<std::string>& projected_columns) const;
+
+  private:
+  rust::Box<ffi::BlockingPaimonDataSplitReader> impl_;
+};
 
 }  // namespace milvus_storage::paimon

--- a/cpp/src/format/bridge/rust/include/paimon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/paimon_bridge.h
@@ -74,7 +74,7 @@ arrow::Result<int64_t> CreateTestTable(const std::string& table_location,
 /// same cached metadata.
 class BlockingPaimonDataSplitReader {
   public:
-  static arrow::Result<std::unique_ptr<BlockingPaimonDataSplitReader>> Open(const std::string& metadata_json,
+  static arrow::Result<std::shared_ptr<BlockingPaimonDataSplitReader>> Open(const std::string& metadata_json,
                                                                             const std::string& expected_table_location,
                                                                             const StorageOptions& storage_options);
 

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -243,7 +243,7 @@ pub mod paimon_ffi {
 
         unsafe fn open_stream(
             self: &BlockingPaimonDataSplitReader,
-            projected_columns: &CxxVector<CxxString>,
+            projected_columns: Vec<String>,
             out_stream_ptr: *mut u8,
         ) -> Result<()>;
     }

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -22,6 +22,7 @@ mod iceberg_testutil;
 mod lance_bridgeimpl;
 mod lance_memory_estimator;
 mod paimon_bridgeimpl;
+mod paimon_split_serde;
 mod paimon_testutil;
 mod predicate_parser;
 mod rust_runtime;
@@ -201,7 +202,7 @@ pub mod lance_ffi {
 
 #[cxx::bridge(namespace = "milvus_storage::paimon::ffi")]
 pub mod paimon_ffi {
-    /// A physical file that Paimon determined is safe to read directly.
+    /// A single physical file or atomic DataSplit returned by Paimon planning.
     struct PaimonFileInfo {
         path: String,
         file_size: u64,
@@ -209,6 +210,8 @@ pub mod paimon_ffi {
     }
 
     extern "Rust" {
+        type BlockingPaimonDataSplitReader;
+
         fn paimon_plan_files(
             table_location: &str,
             snapshot_id: i64,
@@ -225,6 +228,24 @@ pub mod paimon_ffi {
             storage_options_keys: Vec<String>,
             storage_options_values: Vec<String>,
         ) -> Result<Vec<u64>>;
+
+        fn paimon_open_data_split_reader(
+            metadata_json: &str,
+            expected_table_location: &str,
+            storage_options_keys: Vec<String>,
+            storage_options_values: Vec<String>,
+        ) -> Result<Box<BlockingPaimonDataSplitReader>>;
+
+        unsafe fn export_schema(
+            self: &BlockingPaimonDataSplitReader,
+            out_schema_ptr: *mut u8,
+        ) -> Result<()>;
+
+        unsafe fn open_stream(
+            self: &BlockingPaimonDataSplitReader,
+            projected_columns: &CxxVector<CxxString>,
+            out_stream_ptr: *mut u8,
+        ) -> Result<()>;
     }
 }
 

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -251,6 +251,10 @@ pub mod paimon_ffi {
 
 #[cxx::bridge(namespace = "milvus_storage::paimon::ffi")]
 pub mod paimon_test_ffi {
+    struct PaimonTestTableInfo {
+        snapshot_ids: Vec<i64>,
+    }
+
     extern "Rust" {
         /// Create a repository-owned local Paimon fixture through the public
         /// paimon-rust writer/commit APIs.
@@ -259,9 +263,11 @@ pub mod paimon_test_ffi {
             num_rows: u64,
             mode: &str,
             deleted_positions: Vec<i64>,
+            storage_options_keys: Vec<String>,
+            storage_options_values: Vec<String>,
             file_format: &str,
             dimension: u32,
-        ) -> Result<i64>;
+        ) -> Result<PaimonTestTableInfo>;
     }
 }
 

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -14,7 +14,11 @@
 
 #include <cerrno>
 #include <string_view>
+#include <utility>
 
+#include <arrow/array.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
 #include <arrow/util/io_util.h>
 
 #include "bridge_util.h"
@@ -31,6 +35,7 @@ constexpr std::string_view kNotImplementedMarker = "[paimon:error=not-implemente
 constexpr std::string_view kNotFoundMarker = "[paimon:error=not-found]";
 constexpr std::string_view kTransientThrottlingMarker = "[paimon:error=transient-throttling]";
 constexpr std::string_view kTransientServiceMarker = "[paimon:error=transient-service]";
+constexpr std::string_view kPaimonErrorMarker = "[paimon:error=";
 
 std::string StripMarker(std::string_view message, std::string_view marker) {
   auto position = message.find(marker);
@@ -57,6 +62,51 @@ arrow::Result<T> CatchRustResult(Fn&& fn) {
   }
 }
 
+arrow::Status TranslatePaimonStreamStatus(arrow::Status status) {
+  if (status.ok() || status.message().find(kPaimonErrorMarker) == std::string_view::npos) {
+    return status;
+  }
+  return MakePaimonBridgeErrorStatus(status.message());
+}
+
+class PaimonStreamReader final : public arrow::RecordBatchReader {
+  public:
+  PaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner, std::shared_ptr<arrow::Schema> output_schema)
+      : inner_(std::move(inner)), output_schema_(std::move(output_schema)) {}
+
+  std::shared_ptr<arrow::Schema> schema() const override { return output_schema_; }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+    ARROW_RETURN_NOT_OK(TranslatePaimonStreamStatus(inner_->ReadNext(batch)));
+    if (!*batch) {
+      return arrow::Status::OK();
+    }
+    if ((*batch)->num_columns() != output_schema_->num_fields()) {
+      return arrow::Status::Invalid("Paimon data-split stream returned an unexpected column count");
+    }
+    for (int index = 0; index < output_schema_->num_fields(); ++index) {
+      const auto& actual = (*batch)->schema()->field(index);
+      const auto& expected = output_schema_->field(index);
+      if (actual->name() != expected->name() || !actual->type()->Equals(expected->type())) {
+        return arrow::Status::Invalid("Paimon data-split stream schema mismatch at column ", index, ": expected ",
+                                      expected->ToString(), ", got ", actual->ToString());
+      }
+      if (!expected->nullable() && (*batch)->column(index)->null_count() != 0) {
+        return arrow::Status::Invalid("Paimon data-split stream returned nulls for non-nullable column: ",
+                                      expected->name());
+      }
+    }
+    *batch = arrow::RecordBatch::Make(output_schema_, (*batch)->num_rows(), (*batch)->columns());
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Close() override { return TranslatePaimonStreamStatus(inner_->Close()); }
+
+  private:
+  std::shared_ptr<arrow::RecordBatchReader> inner_;
+  std::shared_ptr<arrow::Schema> output_schema_;
+};
+
 }  // namespace
 
 arrow::Status MakePaimonBridgeErrorStatus(std::string_view message) {
@@ -80,6 +130,13 @@ arrow::Status MakePaimonBridgeErrorStatus(std::string_view message) {
   }
   return arrow::Status::IOError(message);
 }
+
+namespace internal {
+std::shared_ptr<arrow::RecordBatchReader> WrapPaimonRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner,
+                                                                      std::shared_ptr<arrow::Schema> output_schema) {
+  return std::make_shared<PaimonStreamReader>(std::move(inner), std::move(output_schema));
+}
+}  // namespace internal
 
 arrow::Result<std::vector<PaimonFileInfo>> PlanFiles(const std::string& table_location,
                                                      int64_t snapshot_id,

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -131,4 +131,38 @@ arrow::Result<int64_t> CreateTestTable(const std::string& table_location,
   });
 }
 
+arrow::Result<std::unique_ptr<BlockingPaimonDataSplitReader>> BlockingPaimonDataSplitReader::Open(
+    const std::string& metadata_json,
+    const std::string& expected_table_location,
+    const StorageOptions& storage_options) {
+  return CatchRustResult<std::unique_ptr<BlockingPaimonDataSplitReader>>([&]() {
+    rust::Vec<rust::String> keys;
+    rust::Vec<rust::String> values;
+    ConvertStorageOptions(storage_options, keys, values);
+    return std::make_unique<BlockingPaimonDataSplitReader>(ffi::paimon_open_data_split_reader(
+        rust::Str(metadata_json), rust::Str(expected_table_location), std::move(keys), std::move(values)));
+  });
+}
+
+arrow::Status BlockingPaimonDataSplitReader::ExportSchema(ArrowSchema* schema) const {
+  if (schema == nullptr) {
+    return arrow::Status::Invalid("cannot export Paimon schema into a null pointer");
+  }
+  try {
+    impl_->export_schema(reinterpret_cast<uint8_t*>(schema));
+    return arrow::Status::OK();
+  } catch (const rust::cxxbridge1::Error& error) {
+    return MakePaimonBridgeErrorStatus(error.what());
+  }
+}
+
+arrow::Result<ArrowArrayStream> BlockingPaimonDataSplitReader::OpenStream(
+    const std::vector<std::string>& projected_columns) const {
+  return CatchRustResult<ArrowArrayStream>([&]() {
+    ArrowArrayStream stream{};
+    impl_->open_stream(projected_columns, reinterpret_cast<uint8_t*>(&stream));
+    return stream;
+  });
+}
+
 }  // namespace milvus_storage::paimon

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -237,8 +237,13 @@ arrow::Status BlockingPaimonDataSplitReader::ExportSchema(ArrowSchema* schema) c
 arrow::Result<ArrowArrayStream> BlockingPaimonDataSplitReader::OpenStream(
     const std::vector<std::string>& projected_columns) const {
   return CatchRustResult<ArrowArrayStream>([&]() {
+    rust::Vec<rust::String> columns;
+    columns.reserve(projected_columns.size());
+    for (const auto& column : projected_columns) {
+      columns.push_back(rust::String(column));
+    }
     ArrowArrayStream stream{};
-    impl_->open_stream(projected_columns, reinterpret_cast<uint8_t*>(&stream));
+    impl_->open_stream(std::move(columns), reinterpret_cast<uint8_t*>(&stream));
     return stream;
   });
 }

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -114,21 +114,41 @@ arrow::Result<std::vector<uint64_t>> ReadDeletionVector(const std::string& path,
   });
 }
 
+arrow::Result<PaimonTestTableInfo> CreateTestTableInfo(const std::string& table_location,
+                                                       uint64_t num_rows,
+                                                       const std::string& mode,
+                                                       const std::vector<int64_t>& deleted_positions,
+                                                       const StorageOptions& storage_options,
+                                                       const std::string& file_format,
+                                                       uint32_t dimension) {
+  return CatchRustResult<PaimonTestTableInfo>([&]() {
+    rust::Vec<int64_t> positions;
+    positions.reserve(deleted_positions.size());
+    for (auto position : deleted_positions) {
+      positions.push_back(position);
+    }
+    rust::Vec<rust::String> keys;
+    rust::Vec<rust::String> values;
+    ConvertStorageOptions(storage_options, keys, values);
+    auto info =
+        ffi::paimon_create_test_table(rust::Str(table_location), num_rows, rust::Str(mode), std::move(positions),
+                                      std::move(keys), std::move(values), rust::Str(file_format), dimension);
+    return PaimonTestTableInfo{{info.snapshot_ids.begin(), info.snapshot_ids.end()}};
+  });
+}
+
 arrow::Result<int64_t> CreateTestTable(const std::string& table_location,
                                        uint64_t num_rows,
                                        const std::string& mode,
                                        const std::vector<int64_t>& deleted_positions,
                                        const std::string& file_format,
                                        uint32_t dimension) {
-  return CatchRustResult<int64_t>([&]() {
-    rust::Vec<int64_t> positions;
-    positions.reserve(deleted_positions.size());
-    for (auto position : deleted_positions) {
-      positions.push_back(position);
-    }
-    return ffi::paimon_create_test_table(rust::Str(table_location), num_rows, rust::Str(mode), std::move(positions),
-                                         rust::Str(file_format), dimension);
-  });
+  ARROW_ASSIGN_OR_RAISE(
+      auto info, CreateTestTableInfo(table_location, num_rows, mode, deleted_positions, {}, file_format, dimension));
+  if (info.snapshot_ids.empty()) {
+    return arrow::Status::Invalid("Paimon test table has no committed snapshot");
+  }
+  return info.snapshot_ids.back();
 }
 
 arrow::Result<std::unique_ptr<BlockingPaimonDataSplitReader>> BlockingPaimonDataSplitReader::Open(

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -25,6 +25,7 @@
 namespace milvus_storage::paimon {
 namespace {
 
+// Keep these markers in sync with ERROR_*_PREFIX in paimon_bridgeimpl.rs.
 constexpr std::string_view kInvalidMarker = "[paimon:error=invalid]";
 constexpr std::string_view kNotImplementedMarker = "[paimon:error=not-implemented]";
 constexpr std::string_view kNotFoundMarker = "[paimon:error=not-found]";

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -152,15 +152,15 @@ arrow::Result<int64_t> CreateTestTable(const std::string& table_location,
   return info.snapshot_ids.back();
 }
 
-arrow::Result<std::unique_ptr<BlockingPaimonDataSplitReader>> BlockingPaimonDataSplitReader::Open(
+arrow::Result<std::shared_ptr<BlockingPaimonDataSplitReader>> BlockingPaimonDataSplitReader::Open(
     const std::string& metadata_json,
     const std::string& expected_table_location,
     const StorageOptions& storage_options) {
-  return CatchRustResult<std::unique_ptr<BlockingPaimonDataSplitReader>>([&]() {
+  return CatchRustResult<std::shared_ptr<BlockingPaimonDataSplitReader>>([&]() {
     rust::Vec<rust::String> keys;
     rust::Vec<rust::String> values;
     ConvertStorageOptions(storage_options, keys, values);
-    return std::make_unique<BlockingPaimonDataSplitReader>(ffi::paimon_open_data_split_reader(
+    return std::make_shared<BlockingPaimonDataSplitReader>(ffi::paimon_open_data_split_reader(
         rust::Str(metadata_json), rust::Str(expected_table_location), std::move(keys), std::move(values)));
   });
 }

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -997,23 +997,15 @@ struct PaimonStreamReader {
 }
 
 fn classify_stream_error(error: paimon::Error) -> ArrowError {
-    let message = error.to_string();
-    if matches!(
-        &error,
-        paimon::Error::IoUnexpected { source, .. } if source.is_temporary()
-    ) {
-        return ArrowError::IoError(
-            message,
-            std::io::Error::new(std::io::ErrorKind::Other, error),
-        );
-    }
-    if matches!(
-        &error,
-        paimon::Error::Unsupported { .. } | paimon::Error::IoUnsupported { .. }
-    ) {
+    let classified = classify_bridge_error(anyhow!(error));
+    let message = format!("{classified:#}");
+    if message.contains(ERROR_NOT_IMPLEMENTED_PREFIX) {
         return ArrowError::NotYetImplemented(message);
     }
-    ArrowError::InvalidArgumentError(message)
+    if message.contains(ERROR_INVALID_PREFIX) {
+        return ArrowError::InvalidArgumentError(message);
+    }
+    ArrowError::IoError(message.clone(), std::io::Error::other(message))
 }
 
 impl Iterator for PaimonStreamReader {
@@ -1179,7 +1171,7 @@ mod tests {
             .unwrap()
     }
 
-    fn stream_error_code(error: paimon::Error) -> i32 {
+    fn stream_error(error: paimon::Error) -> (i32, String) {
         let stream = futures::stream::iter([Err(error)]).boxed();
         let reader = PaimonStreamReader {
             stream,
@@ -1187,11 +1179,22 @@ mod tests {
         };
         let mut ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
         let mut array = FFI_ArrowArray::empty();
-        unsafe { ffi_stream.get_next.unwrap()(&mut ffi_stream, &mut array) }
+        let code = unsafe { ffi_stream.get_next.unwrap()(&mut ffi_stream, &mut array) };
+        let message = unsafe {
+            let error = ffi_stream.get_last_error.unwrap()(&mut ffi_stream);
+            if error.is_null() {
+                String::new()
+            } else {
+                std::ffi::CStr::from_ptr(error)
+                    .to_string_lossy()
+                    .into_owned()
+            }
+        };
+        (code, message)
     }
 
     #[test]
-    fn stream_errors_keep_retryability_across_arrow_ffi() {
+    fn stream_errors_keep_classification_across_arrow_ffi() {
         let temporary = opendal_paimon::Error::new(
             opendal_paimon::ErrorKind::RateLimited,
             "temporary object-store failure",
@@ -1201,7 +1204,39 @@ mod tests {
             message: "stream read failed".to_string(),
             source: Box::new(temporary),
         };
-        assert_eq!(stream_error_code(temporary), 5); // EIO
+        let (code, message) = stream_error(temporary);
+        assert_eq!(code, 5); // EIO
+        assert!(
+            message.contains(ERROR_TRANSIENT_THROTTLING_PREFIX),
+            "{message}"
+        );
+
+        let temporary = opendal_paimon::Error::new(
+            opendal_paimon::ErrorKind::Unexpected,
+            "temporary object-store failure",
+        )
+        .set_temporary();
+        let temporary = paimon::Error::IoUnexpected {
+            message: "stream read failed".to_string(),
+            source: Box::new(temporary),
+        };
+        let (code, message) = stream_error(temporary);
+        assert_eq!(code, 5); // EIO
+        assert!(
+            message.contains(ERROR_TRANSIENT_SERVICE_PREFIX),
+            "{message}"
+        );
+
+        let not_found = paimon::Error::IoUnexpected {
+            message: "stream read failed".to_string(),
+            source: Box::new(opendal_paimon::Error::new(
+                opendal_paimon::ErrorKind::NotFound,
+                "missing object",
+            )),
+        };
+        let (code, message) = stream_error(not_found);
+        assert_eq!(code, 5); // EIO
+        assert!(message.contains(ERROR_NOT_FOUND_PREFIX), "{message}");
 
         let permanent = paimon::Error::IoUnexpected {
             message: "stream read failed".to_string(),
@@ -1210,13 +1245,17 @@ mod tests {
                 "permanent object-store failure",
             )),
         };
-        assert_eq!(stream_error_code(permanent), 22); // EINVAL
+        let (code, message) = stream_error(permanent);
+        assert_eq!(code, 5); // EIO
+        assert!(!message.contains(ERROR_INVALID_PREFIX), "{message}");
 
         let invalid = paimon::Error::DataInvalid {
             message: "corrupt record batch".to_string(),
             source: None,
         };
-        assert_eq!(stream_error_code(invalid), 22); // EINVAL
+        let (code, message) = stream_error(invalid);
+        assert_eq!(code, 22); // EINVAL
+        assert!(message.contains(ERROR_INVALID_PREFIX), "{message}");
     }
 
     #[test]

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -10,16 +10,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Paimon direct-file planning and deletion-vector bridge.
+//! Paimon planning and streaming bridge.
 
 use anyhow::{Context, Result, anyhow, bail, ensure};
+use arrow_schema58::SchemaRef;
+use arrow58::error::ArrowError;
+use arrow58::ffi::FFI_ArrowSchema;
+use arrow58::ffi_stream::FFI_ArrowArrayStream;
+use arrow58::record_batch::{RecordBatch, RecordBatchReader};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use cxx::{CxxString, CxxVector};
+use futures::{StreamExt, stream::BoxStream};
 use paimon::catalog::Identifier;
 use paimon::io::{FileIO, FileRead};
 use paimon::spec::{CoreOptions, MergeEngine, SCAN_SNAPSHOT_ID_OPTION};
 use paimon::table::{SchemaManager, SnapshotManager};
 use paimon::{DataSplit, DeletionFile, Table};
 use roaring::RoaringBitmap;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Cursor;
 
@@ -38,6 +47,7 @@ const DELETION_VECTOR_MAGIC: u32 = 1_581_511_376;
 /// Java writes this magic little-endian and records the complete serialized
 /// size in `DeletionFile.length`, unlike the bitmap32 envelope.
 const DELETION_VECTOR_BITMAP64_MAGIC: u32 = 1_681_511_377;
+const MAX_DATA_SPLIT_METADATA_BYTES: usize = 12 * 1024 * 1024;
 
 // CXX carries Rust errors as strings. These stable markers are consumed only
 // by the C++ bridge, which converts them into Arrow statuses before returning
@@ -93,6 +103,7 @@ fn classify_bridge_error(error: anyhow::Error) -> anyhow::Error {
 enum ScanMode {
     Auto,
     DirectFile,
+    DataSplit,
 }
 
 impl ScanMode {
@@ -100,18 +111,25 @@ impl ScanMode {
         match value.trim().to_ascii_lowercase().as_str() {
             "" | "auto" => Ok(Self::Auto),
             "direct-file" => Ok(Self::DirectFile),
-            "data-split" => bail!(not_implemented_message(
-                "Paimon data-split reads are not supported"
-            )),
+            "data-split" => Ok(Self::DataSplit),
             other => bail!(invalid_message(format_args!(
-                "invalid Paimon scan mode '{other}'; expected auto or direct-file"
+                "invalid Paimon scan mode '{other}'; expected auto, direct-file, or data-split"
             ))),
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadPath {
+    DirectFile,
+    DataSplit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RouteReason {
+    AutoDirectFile,
+    ForcedDirectFile,
+    ForcedDataSplit,
     MergeSemantics,
     RowRange,
     SchemaEvolution,
@@ -121,18 +139,10 @@ enum RouteReason {
     UnsupportedFormat,
 }
 
-impl RouteReason {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::MergeSemantics => "merge-semantics",
-            Self::RowRange => "row-range",
-            Self::SchemaEvolution => "schema-evolution",
-            Self::DataEvolution => "data-evolution",
-            Self::PartitionColumns => "partition-columns",
-            Self::DedicatedVectorFile => "dedicated-vector-file",
-            Self::UnsupportedFormat => "unsupported-format",
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RouteDecision {
+    read_path: ReadPath,
+    reason: RouteReason,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -161,17 +171,36 @@ impl TableReadSemantics {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+impl ReadPath {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectFile => "direct-file",
+            Self::DataSplit => "data-split",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct PaimonMetadata {
     version: u32,
     read_path: String,
     data_format: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    snapshot_id: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bucket: Option<i32>,
     record_count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    table_location: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    codec: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payload: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     deletion_file: Option<DeletionFileDescriptor>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct DeletionFileDescriptor {
     path: String,
     offset: u64,
@@ -455,17 +484,27 @@ fn decide_route(
     split: &DataSplit,
     table_schema_id: i64,
     table: TableReadSemantics,
-) -> Result<()> {
+) -> Result<RouteDecision> {
     match mode {
+        ScanMode::DataSplit => Ok(RouteDecision {
+            read_path: ReadPath::DataSplit,
+            reason: RouteReason::ForcedDataSplit,
+        }),
         ScanMode::Auto => match direct_file_ineligibility(split, table_schema_id, table) {
-            None => Ok(()),
-            Some((reason, detail)) => bail!(not_implemented_message(format_args!(
-                "Paimon split requires data-split reading ({}): {detail}",
-                reason.as_str()
-            ))),
+            None => Ok(RouteDecision {
+                read_path: ReadPath::DirectFile,
+                reason: RouteReason::AutoDirectFile,
+            }),
+            Some((reason, _)) => Ok(RouteDecision {
+                read_path: ReadPath::DataSplit,
+                reason,
+            }),
         },
         ScanMode::DirectFile => match direct_file_ineligibility(split, table_schema_id, table) {
-            None => Ok(()),
+            None => Ok(RouteDecision {
+                read_path: ReadPath::DirectFile,
+                reason: RouteReason::ForcedDirectFile,
+            }),
             Some((_, detail)) => bail!(not_implemented_message(format_args!(
                 "Paimon split cannot use direct-file: {detail}"
             ))),
@@ -477,6 +516,138 @@ fn checked_non_negative(value: i64, name: &str) -> Result<u64> {
     u64::try_from(value).with_context(|| {
         invalid_message(format_args!("Paimon {name} is negative: {value}"))
     })
+}
+
+fn metadata_split_row_count(split: &DataSplit) -> Result<Option<u64>> {
+    if split.row_ranges().is_some() {
+        return Ok(None);
+    }
+    split
+        .merged_row_count()
+        .map(|count| checked_non_negative(count, "merged row count"))
+        .transpose()
+}
+
+async fn count_split_rows(table: &Table, split: &DataSplit) -> Result<u64> {
+    // `DataSplit::merged_row_count` describes the full file group and does
+    // not account for an attached row-range selection. Such splits must be
+    // counted through the actual Paimon reader.
+    if let Some(count) = metadata_split_row_count(split)? {
+        return Ok(count);
+    }
+
+    // Count through Paimon's merge reader, but request a zero-column Arrow
+    // projection so the fallback scans row cardinality rather than payload.
+    let mut builder = table.new_read_builder();
+    builder.with_projection(&[])?;
+    let read = builder.new_read()?;
+    let mut stream = read.to_arrow(std::slice::from_ref(split))?;
+    let mut rows = 0u64;
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        rows = rows
+            .checked_add(u64::try_from(batch.num_rows())?)
+            .ok_or_else(|| anyhow!(invalid_message("Paimon split row count overflow")))?;
+    }
+    Ok(rows)
+}
+
+fn encode_split_metadata(
+    table_location: &str,
+    split: &DataSplit,
+    record_count: u64,
+) -> Result<String> {
+    let encoded = crate::paimon_split_serde::serialize(split)
+        .map_err(|error| anyhow!(invalid_message(error)))?;
+    serde_json::to_string(&PaimonMetadata {
+        version: METADATA_VERSION,
+        read_path: ReadPath::DataSplit.as_str().to_string(),
+        data_format: "paimon".to_string(),
+        snapshot_id: Some(split.snapshot_id()),
+        bucket: Some(split.bucket()),
+        record_count,
+        table_location: Some(table_location.to_string()),
+        codec: Some(encoded.codec.to_string()),
+        payload: Some(BASE64_STANDARD.encode(encoded.payload)),
+        deletion_file: None,
+    })
+    .map_err(Into::into)
+}
+
+fn decode_split_metadata(metadata_json: &str) -> Result<(PaimonMetadata, DataSplit)> {
+    ensure!(
+        metadata_json.len() <= MAX_DATA_SPLIT_METADATA_BYTES,
+        invalid_message(format_args!(
+            "Paimon metadata descriptor is {} bytes, above the {} byte limit",
+            metadata_json.len(),
+            MAX_DATA_SPLIT_METADATA_BYTES
+        ))
+    );
+    let metadata: PaimonMetadata =
+        serde_json::from_str(metadata_json).context("cannot parse Paimon metadata descriptor")?;
+    ensure!(
+        metadata.version == METADATA_VERSION,
+        "unsupported Paimon metadata version {}; expected {}",
+        metadata.version,
+        METADATA_VERSION
+    );
+    ensure!(
+        metadata.read_path == ReadPath::DataSplit.as_str(),
+        "Paimon descriptor read_path is '{}', expected data-split",
+        metadata.read_path
+    );
+    let codec = metadata.codec.as_deref().unwrap_or_default();
+    let encoded = metadata
+        .payload
+        .as_deref()
+        .ok_or_else(|| anyhow!("Paimon data-split descriptor has no payload"))?;
+    let max_base64_bytes = crate::paimon_split_serde::MAX_DESCRIPTOR_BYTES
+        .div_ceil(3)
+        .checked_mul(4)
+        .ok_or_else(|| anyhow!("Paimon descriptor base64 limit overflow"))?;
+    ensure!(
+        encoded.len() <= max_base64_bytes,
+        "Paimon split payload is too large before base64 decoding"
+    );
+    let payload = BASE64_STANDARD
+        .decode(encoded)
+        .context("cannot decode Paimon split payload as base64")?;
+    let split = crate::paimon_split_serde::deserialize(codec, &payload)?;
+    Ok((metadata, split))
+}
+
+fn validate_data_split_binding(
+    metadata: &PaimonMetadata,
+    split: &DataSplit,
+    expected_table_location: &str,
+) -> Result<()> {
+    let table_location = metadata
+        .table_location
+        .as_deref()
+        .ok_or_else(|| anyhow!("Paimon data-split descriptor has no table_location"))?;
+    ensure!(
+        !expected_table_location.is_empty(),
+        "Paimon data-split reader requires an expected table location"
+    );
+    ensure!(
+        table_location == expected_table_location,
+        "Paimon descriptor table location '{}' disagrees with manifest table location '{}'",
+        table_location,
+        expected_table_location
+    );
+    ensure!(
+        metadata.snapshot_id == Some(split.snapshot_id()),
+        "Paimon descriptor snapshot {:?} disagrees with split snapshot {}",
+        metadata.snapshot_id,
+        split.snapshot_id()
+    );
+    ensure!(
+        metadata.bucket == Some(split.bucket()),
+        "Paimon descriptor bucket {:?} disagrees with split bucket {}",
+        metadata.bucket,
+        split.bucket()
+    );
+    Ok(())
 }
 
 fn deletion_descriptor(file: &DeletionFile) -> Result<DeletionFileDescriptor> {
@@ -506,9 +677,14 @@ fn encode_direct_metadata(
 ) -> Result<String> {
     serde_json::to_string(&PaimonMetadata {
         version: METADATA_VERSION,
-        read_path: "direct-file".to_string(),
+        read_path: ReadPath::DirectFile.as_str().to_string(),
         data_format: data_format.to_string(),
+        snapshot_id: None,
+        bucket: None,
         record_count,
+        table_location: None,
+        codec: None,
+        payload: None,
         deletion_file: deletion_file.map(deletion_descriptor).transpose()?,
     })
     .map_err(Into::into)
@@ -531,43 +707,66 @@ pub fn paimon_plan_files(
         let plan = table.new_read_builder().new_scan().plan().await?;
         let mut result = Vec::new();
         for split in plan.splits() {
-            decide_route(mode, split, table.schema().id(), table_read_semantics)?;
-            for (index, file) in split.data_files().iter().enumerate() {
-                let deletion = split.deletion_file_for_data_file_index(index);
-                let physical_rows = checked_non_negative(file.row_count, "data file row count")?;
-                let deleted_rows = match deletion {
-                    None => 0,
-                    Some(deletion) => match deletion.cardinality() {
-                        Some(cardinality) => {
-                            checked_non_negative(cardinality, "deletion vector cardinality")?
-                        }
-                        None => read_deletion_vector(&options, deletion).await?.len() as u64,
-                    },
-                };
-                ensure!(
-                    deleted_rows <= physical_rows,
-                    invalid_message(format_args!(
-                        "Paimon deletion cardinality {deleted_rows} exceeds physical row count \
-                         {physical_rows} for {}",
-                        file.file_name
-                    ))
-                );
-                let record_count = physical_rows - deleted_rows;
-                // Empty data files do not become zero-row column groups.
-                if record_count == 0 {
-                    continue;
+            let route = decide_route(
+                mode,
+                split,
+                table.schema().id(),
+                table_read_semantics,
+            )?;
+            match route.read_path {
+                ReadPath::DataSplit => {
+                    let record_count = count_split_rows(&table, split).await?;
+                    if record_count == 0 {
+                        continue;
+                    }
+                    result.push(PaimonFileInfo {
+                        path: table_location.to_string(),
+                        file_size: 0,
+                        metadata_json: encode_split_metadata(table_location, split, record_count)?,
+                    });
                 }
-                let path = split.data_file_path(file);
-                let data_format = file_format(&path);
-                result.push(PaimonFileInfo {
-                    path,
-                    file_size: checked_non_negative(file.file_size, "data file size")?,
-                    metadata_json: encode_direct_metadata(
-                        data_format,
-                        record_count,
-                        deletion,
-                    )?,
-                });
+                ReadPath::DirectFile => {
+                    for (index, file) in split.data_files().iter().enumerate() {
+                        let deletion = split.deletion_file_for_data_file_index(index);
+                        let physical_rows = checked_non_negative(file.row_count, "data file row count")?;
+                        let deleted_rows = match deletion {
+                            None => 0,
+                            Some(deletion) => match deletion.cardinality() {
+                                Some(cardinality) => checked_non_negative(
+                                    cardinality,
+                                    "deletion vector cardinality",
+                                )?,
+                                None => {
+                                    read_deletion_vector(&options, deletion).await?.len() as u64
+                                }
+                            },
+                        };
+                        ensure!(
+                            deleted_rows <= physical_rows,
+                            invalid_message(format_args!(
+                                "Paimon deletion cardinality {deleted_rows} exceeds physical row count \
+                                 {physical_rows} for {}",
+                                file.file_name
+                            ))
+                        );
+                        let record_count = physical_rows - deleted_rows;
+                        // Empty data files do not become zero-row column groups.
+                        if record_count == 0 {
+                            continue;
+                        }
+                        let path = split.data_file_path(file);
+                        let data_format = file_format(&path);
+                        result.push(PaimonFileInfo {
+                            path,
+                            file_size: checked_non_negative(file.file_size, "data file size")?,
+                            metadata_json: encode_direct_metadata(
+                                data_format,
+                                record_count,
+                                deletion,
+                            )?,
+                        });
+                    }
+                }
             }
         }
         Ok(result)
@@ -790,9 +989,154 @@ pub fn paimon_read_deletion_vector(
     .map_err(classify_bridge_error)
 }
 
+type PaimonBatchStream = BoxStream<'static, paimon::Result<RecordBatch>>;
+
+struct PaimonStreamReader {
+    stream: PaimonBatchStream,
+    schema: SchemaRef,
+}
+
+fn classify_stream_error(error: paimon::Error) -> ArrowError {
+    let message = error.to_string();
+    if matches!(
+        &error,
+        paimon::Error::IoUnexpected { source, .. } if source.is_temporary()
+    ) {
+        return ArrowError::IoError(
+            message,
+            std::io::Error::new(std::io::ErrorKind::Other, error),
+        );
+    }
+    if matches!(
+        &error,
+        paimon::Error::Unsupported { .. } | paimon::Error::IoUnsupported { .. }
+    ) {
+        return ArrowError::NotYetImplemented(message);
+    }
+    ArrowError::InvalidArgumentError(message)
+}
+
+impl Iterator for PaimonStreamReader {
+    type Item = std::result::Result<RecordBatch, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        TOKIO_RT
+            .block_on(self.stream.next())
+            .map(|result| result.map_err(classify_stream_error))
+    }
+}
+
+impl RecordBatchReader for PaimonStreamReader {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+/// Projection-agnostic handle over one decoded DataSplit.
+///
+/// Opening this handle performs the expensive descriptor work exactly once:
+/// payload decode + identity binding, `SchemaManager` schema resolution, and
+/// the pinned-snapshot time travel. Streams are then opened per call with a
+/// caller-supplied projection, so one cached handle serves every reader
+/// instance created from the same metadata (see
+/// `PaimonFormatReader::MetaTrait`).
+pub struct BlockingPaimonDataSplitReader {
+    table: Table,
+    split: DataSplit,
+    schema: SchemaRef,
+}
+
+fn open_data_split_reader_impl(
+    metadata_json: &str,
+    expected_table_location: &str,
+    storage_options_keys: Vec<String>,
+    storage_options_values: Vec<String>,
+) -> Result<Box<BlockingPaimonDataSplitReader>> {
+    let options = options_from_vecs(storage_options_keys, storage_options_values)?;
+    let (metadata, split) = decode_split_metadata(metadata_json).map_err(|error| {
+        anyhow!("{ERROR_INVALID_PREFIX} invalid Paimon data-split descriptor: {error:#}")
+    })?;
+    validate_data_split_binding(&metadata, &split, expected_table_location).map_err(|error| {
+        anyhow!("{ERROR_INVALID_PREFIX} invalid Paimon data-split binding: {error:#}")
+    })?;
+    let table_location = metadata
+        .table_location
+        .as_deref()
+        .ok_or_else(|| anyhow!("Paimon data-split descriptor has no table_location"))?;
+    let table = TOKIO_RT.block_on(load_table(table_location, &options, metadata.snapshot_id))?;
+    let read = table.new_read_builder().new_read()?;
+    let schema = paimon::arrow::build_target_arrow_schema(read.read_type())?;
+    Ok(Box::new(BlockingPaimonDataSplitReader {
+        table,
+        split,
+        schema,
+    }))
+}
+
+pub fn paimon_open_data_split_reader(
+    metadata_json: &str,
+    expected_table_location: &str,
+    storage_options_keys: Vec<String>,
+    storage_options_values: Vec<String>,
+) -> Result<Box<BlockingPaimonDataSplitReader>> {
+    open_data_split_reader_impl(
+        metadata_json,
+        expected_table_location,
+        storage_options_keys,
+        storage_options_values,
+    )
+    .map_err(classify_bridge_error)
+}
+
+impl BlockingPaimonDataSplitReader {
+    /// Export the full (unprojected) read schema of the split.
+    pub unsafe fn export_schema(&self, out_schema_ptr: *mut u8) -> Result<()> {
+        let ffi_schema = FFI_ArrowSchema::try_from(self.schema.as_ref())
+            .with_context(|| invalid_message("cannot export Paimon data-split schema"))?;
+        unsafe { std::ptr::write(out_schema_ptr.cast::<FFI_ArrowSchema>(), ffi_schema) };
+        Ok(())
+    }
+
+    /// Open a new merge-read stream with the given projection (empty selects
+    /// every column). Only `&self` state is touched, so concurrent streams
+    /// from one shared handle are safe.
+    pub unsafe fn open_stream(
+        &self,
+        projected_columns: &CxxVector<CxxString>,
+        out_stream_ptr: *mut u8,
+    ) -> Result<()> {
+        unsafe { self.open_stream_impl(projected_columns, out_stream_ptr) }
+            .map_err(classify_bridge_error)
+    }
+
+    unsafe fn open_stream_impl(
+        &self,
+        projected_columns: &CxxVector<CxxString>,
+        out_stream_ptr: *mut u8,
+    ) -> Result<()> {
+        let mut builder = self.table.new_read_builder();
+        if !projected_columns.is_empty() {
+            let projected_refs = projected_columns
+                .iter()
+                .map(|column| column.to_str())
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .with_context(|| invalid_message("Paimon projection contains invalid UTF-8"))?;
+            builder.with_projection(&projected_refs)?;
+        }
+        let read = builder.new_read()?;
+        let schema = paimon::arrow::build_target_arrow_schema(read.read_type())?;
+        let stream = read.to_arrow(std::slice::from_ref(&self.split))?;
+        let reader = PaimonStreamReader { stream, schema };
+        let ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
+        unsafe { std::ptr::write(out_stream_ptr.cast::<FFI_ArrowArrayStream>(), ffi_stream) };
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow58::ffi::FFI_ArrowArray;
     use paimon::spec::{BinaryRow, DataFileMeta};
     use paimon::{DeletionFile, RowRange};
 
@@ -835,6 +1179,46 @@ mod tests {
             .unwrap()
     }
 
+    fn stream_error_code(error: paimon::Error) -> i32 {
+        let stream = futures::stream::iter([Err(error)]).boxed();
+        let reader = PaimonStreamReader {
+            stream,
+            schema: std::sync::Arc::new(arrow_schema58::Schema::empty()),
+        };
+        let mut ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
+        let mut array = FFI_ArrowArray::empty();
+        unsafe { ffi_stream.get_next.unwrap()(&mut ffi_stream, &mut array) }
+    }
+
+    #[test]
+    fn stream_errors_keep_retryability_across_arrow_ffi() {
+        let temporary = opendal_paimon::Error::new(
+            opendal_paimon::ErrorKind::RateLimited,
+            "temporary object-store failure",
+        )
+        .set_temporary();
+        let temporary = paimon::Error::IoUnexpected {
+            message: "stream read failed".to_string(),
+            source: Box::new(temporary),
+        };
+        assert_eq!(stream_error_code(temporary), 5); // EIO
+
+        let permanent = paimon::Error::IoUnexpected {
+            message: "stream read failed".to_string(),
+            source: Box::new(opendal_paimon::Error::new(
+                opendal_paimon::ErrorKind::PermissionDenied,
+                "permanent object-store failure",
+            )),
+        };
+        assert_eq!(stream_error_code(permanent), 22); // EINVAL
+
+        let invalid = paimon::Error::DataInvalid {
+            message: "corrupt record batch".to_string(),
+            source: None,
+        };
+        assert_eq!(stream_error_code(invalid), 22); // EINVAL
+    }
+
     #[test]
     fn scan_mode_errors_are_classified() {
         let invalid = ScanMode::parse("invalid-mode").unwrap_err();
@@ -843,13 +1227,7 @@ mod tests {
             "{invalid}"
         );
 
-        let unsupported = ScanMode::parse("data-split").unwrap_err();
-        assert!(
-            unsupported
-                .to_string()
-                .contains(ERROR_NOT_IMPLEMENTED_PREFIX),
-            "{unsupported}"
-        );
+        assert_eq!(ScanMode::parse("data-split").unwrap(), ScanMode::DataSplit);
     }
 
     #[test]
@@ -888,6 +1266,8 @@ mod tests {
             .with_raw_convertible(true)
             .build()
             .unwrap();
+        assert_eq!(with_range.merged_row_count(), Some(10));
+        assert_eq!(metadata_split_row_count(&with_range).unwrap(), None);
         let mut evolved_file = test_file("data.parquet");
         evolved_file.write_cols = Some(vec!["id".to_string()]);
         let with_write_cols = DataSplit::builder()
@@ -976,64 +1356,118 @@ mod tests {
             .unwrap();
 
         let cases = vec![
-            ("raw append", ScanMode::Auto, parquet, true),
-            ("raw with deletion vector", ScanMode::Auto, with_dv, true),
-            ("merge-on-read", ScanMode::Auto, mor.clone(), false),
-            ("row range", ScanMode::Auto, with_range, false),
-            ("data evolution", ScanMode::Auto, with_write_cols, false),
-            ("sidecar file", ScanMode::Auto, with_sidecar, false),
-            ("vortex", ScanMode::Auto, vortex.clone(), true),
+            (
+                "raw append",
+                ScanMode::Auto,
+                parquet.clone(),
+                Some((ReadPath::DirectFile, RouteReason::AutoDirectFile)),
+            ),
+            (
+                "forced data-split",
+                ScanMode::DataSplit,
+                parquet,
+                Some((ReadPath::DataSplit, RouteReason::ForcedDataSplit)),
+            ),
+            (
+                "raw with deletion vector",
+                ScanMode::Auto,
+                with_dv,
+                Some((ReadPath::DirectFile, RouteReason::AutoDirectFile)),
+            ),
+            (
+                "merge-on-read",
+                ScanMode::Auto,
+                mor.clone(),
+                Some((ReadPath::DataSplit, RouteReason::MergeSemantics)),
+            ),
+            (
+                "row range",
+                ScanMode::Auto,
+                with_range,
+                Some((ReadPath::DataSplit, RouteReason::RowRange)),
+            ),
+            (
+                "data evolution",
+                ScanMode::Auto,
+                with_write_cols,
+                Some((ReadPath::DataSplit, RouteReason::DataEvolution)),
+            ),
+            (
+                "sidecar file",
+                ScanMode::Auto,
+                with_sidecar,
+                Some((ReadPath::DataSplit, RouteReason::DataEvolution)),
+            ),
+            (
+                "vortex",
+                ScanMode::Auto,
+                vortex.clone(),
+                Some((ReadPath::DirectFile, RouteReason::AutoDirectFile)),
+            ),
             (
                 "other non-Parquet",
                 ScanMode::Auto,
                 test_split(true, "data.orc"),
-                false,
+                Some((ReadPath::DataSplit, RouteReason::UnsupportedFormat)),
             ),
             (
                 "legacy compacted file without delete count",
                 ScanMode::Auto,
                 legacy_level,
-                true,
+                Some((ReadPath::DirectFile, RouteReason::AutoDirectFile)),
             ),
             (
                 "dedicated vector file",
                 ScanMode::Auto,
                 dedicated_vector,
-                false,
+                Some((ReadPath::DataSplit, RouteReason::DedicatedVectorFile)),
             ),
             (
                 "data file delete count",
                 ScanMode::Auto,
                 with_delete_count,
-                false,
+                Some((ReadPath::DataSplit, RouteReason::MergeSemantics)),
             ),
-            ("schema evolution", ScanMode::Auto, old_schema, false),
+            (
+                "schema evolution",
+                ScanMode::Auto,
+                old_schema,
+                Some((ReadPath::DataSplit, RouteReason::SchemaEvolution)),
+            ),
             (
                 "mixed row tracking",
                 ScanMode::Auto,
                 mixed_row_tracking,
-                false,
+                Some((ReadPath::DataSplit, RouteReason::DataEvolution)),
             ),
             (
                 "overlapping row ids",
                 ScanMode::Auto,
                 overlapping_row_ids,
-                false,
+                Some((ReadPath::DataSplit, RouteReason::DataEvolution)),
             ),
             (
                 "forced direct merge-on-read",
                 ScanMode::DirectFile,
                 mor,
-                false,
+                None,
             ),
-            ("forced direct vortex", ScanMode::DirectFile, vortex, true),
+            (
+                "forced direct vortex",
+                ScanMode::DirectFile,
+                vortex,
+                Some((ReadPath::DirectFile, RouteReason::ForcedDirectFile)),
+            ),
         ];
-        for (name, mode, split, supported) in cases {
-            assert_eq!(
-                decide_route(mode, &split, 0, TableReadSemantics::default()).is_ok(),
-                supported,
-                "{name}"
-            );
+        for (name, mode, split, expected) in cases {
+            let actual = decide_route(mode, &split, 0, TableReadSemantics::default());
+            match expected {
+                Some((path, reason)) => {
+                    let actual = actual.unwrap();
+                    assert_eq!((actual.read_path, actual.reason), (path, reason), "{name}");
+                }
+                None => assert!(actual.is_err(), "{name}"),
+            }
         }
     }
 
@@ -1044,7 +1478,11 @@ mod tests {
             merge_engine: Some(MergeEngine::PartialUpdate),
             ..Default::default()
         };
-        assert!(decide_route(ScanMode::Auto, &raw, 0, partial_update).is_err());
+        let route = decide_route(ScanMode::Auto, &raw, 0, partial_update).unwrap();
+        assert_eq!(
+            (route.read_path, route.reason),
+            (ReadPath::DataSplit, RouteReason::MergeSemantics)
+        );
 
         let aggregation_mor_dv = TableReadSemantics {
             merge_engine: Some(MergeEngine::Aggregation),
@@ -1053,7 +1491,11 @@ mod tests {
             has_blob_fields: false,
             has_partition_keys: false,
         };
-        assert!(decide_route(ScanMode::Auto, &raw, 0, aggregation_mor_dv).is_err());
+        let route = decide_route(ScanMode::Auto, &raw, 0, aggregation_mor_dv).unwrap();
+        assert_eq!(
+            (route.read_path, route.reason),
+            (ReadPath::DataSplit, RouteReason::MergeSemantics)
+        );
 
         let mut compacted_file = test_file("compacted.parquet");
         compacted_file.level = 1;
@@ -1075,7 +1517,11 @@ mod tests {
             has_blob_fields: false,
             has_partition_keys: false,
         };
-        assert!(decide_route(ScanMode::Auto, &compacted, 0, materialized_dv).is_ok());
+        let route = decide_route(ScanMode::Auto, &compacted, 0, materialized_dv).unwrap();
+        assert_eq!(
+            (route.read_path, route.reason),
+            (ReadPath::DirectFile, RouteReason::AutoDirectFile)
+        );
 
         let mut legacy_file = test_file("legacy.parquet");
         legacy_file.level = 1;
@@ -1093,10 +1539,10 @@ mod tests {
             merge_engine: Some(MergeEngine::Deduplicate),
             ..Default::default()
         };
-        let error = decide_route(ScanMode::Auto, &legacy, 0, deduplicate).unwrap_err();
-        assert!(
-            error.to_string().contains("has no delete row count"),
-            "{error}"
+        let route = decide_route(ScanMode::Auto, &legacy, 0, deduplicate).unwrap();
+        assert_eq!(
+            (route.read_path, route.reason),
+            (ReadPath::DataSplit, RouteReason::MergeSemantics)
         );
         // Append-only tables do not assign merge semantics to the missing
         // statistic and remain safe for direct-file reads.
@@ -1114,14 +1560,97 @@ mod tests {
             has_blob_fields: true,
             ..Default::default()
         };
-        assert!(decide_route(ScanMode::Auto, &raw, 0, blob_table).is_err());
+        let route = decide_route(ScanMode::Auto, &raw, 0, blob_table).unwrap();
+        assert_eq!(
+            (route.read_path, route.reason),
+            (ReadPath::DataSplit, RouteReason::DataEvolution)
+        );
 
         let partitioned_table = TableReadSemantics {
             has_partition_keys: true,
             ..Default::default()
         };
-        let error = decide_route(ScanMode::Auto, &raw, 0, partitioned_table).unwrap_err();
-        assert!(error.to_string().contains("partition columns"), "{error}");
+        let route = decide_route(ScanMode::Auto, &raw, 0, partitioned_table).unwrap();
+        assert_eq!(
+            (route.read_path, route.reason),
+            (ReadPath::DataSplit, RouteReason::PartitionColumns)
+        );
+    }
+
+    #[test]
+    fn descriptor_round_trip_and_corruption_detection() {
+        let split = test_split(false, "data.parquet");
+        let encoded = encode_split_metadata("file:///tmp/table", &split, 10).unwrap();
+        let (metadata, decoded) = decode_split_metadata(&encoded).unwrap();
+        assert_eq!(metadata.version, 1);
+        assert_eq!(decoded.snapshot_id(), 7);
+        validate_data_split_binding(&metadata, &decoded, "file:///tmp/table").unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(parsed["codec"], "paimon-split");
+        assert!(parsed.get("codec_version").is_none());
+        assert!(parsed.get("producer_revision").is_none());
+        assert!(parsed.get("descriptor_identity").is_none());
+        let mut unsupported: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        unsupported["codec"] = serde_json::Value::String("paimon-unknown".to_string());
+        let error = decode_split_metadata(&unsupported.to_string()).unwrap_err();
+        assert!(error.to_string().contains("unsupported Paimon"));
+
+        let mut malformed: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        malformed["payload"] = serde_json::Value::String("not-base64".to_string());
+        assert!(decode_split_metadata(&malformed.to_string()).is_err());
+
+        let mut wrong_version: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        wrong_version["version"] = serde_json::Value::from(2);
+        assert!(decode_split_metadata(&wrong_version.to_string()).is_err());
+
+        let mut invalid_split = serde_json::to_value(split).unwrap();
+        invalid_split["data_files"][0]["_ROW_COUNT"] = serde_json::Value::from(-1);
+        let invalid_split: DataSplit = serde_json::from_value(invalid_split).unwrap();
+        let error = encode_split_metadata("file:///tmp/table", &invalid_split, 10).unwrap_err();
+        assert!(error.to_string().contains(ERROR_INVALID_PREFIX), "{error}");
+    }
+
+    #[test]
+    fn descriptor_binding_rejects_outer_payload_mismatches() {
+        let split = test_split(false, "data.parquet");
+        let encoded = encode_split_metadata("file:///tmp/table", &split, 10).unwrap();
+        let (metadata, decoded) = decode_split_metadata(&encoded).unwrap();
+
+        for (name, altered, expected) in [
+            (
+                "table",
+                PaimonMetadata {
+                    table_location: Some("file:///tmp/other".to_string()),
+                    ..metadata.clone()
+                },
+                "table location",
+            ),
+            (
+                "snapshot",
+                PaimonMetadata {
+                    snapshot_id: metadata.snapshot_id.map(|value| value + 1),
+                    ..metadata.clone()
+                },
+                "snapshot",
+            ),
+            (
+                "bucket",
+                PaimonMetadata {
+                    bucket: metadata.bucket.map(|value| value + 1),
+                    ..metadata.clone()
+                },
+                "bucket",
+            ),
+        ] {
+            let error = validate_data_split_binding(&altered, &decoded, "file:///tmp/table")
+                .expect_err(name);
+            assert!(error.to_string().contains(expected), "{name}: {error}");
+        }
+
+        let error = validate_data_split_binding(&metadata, &decoded, "file:///tmp/manifest-table")
+            .unwrap_err();
+        assert!(error.to_string().contains("manifest table location"));
     }
 
     #[test]

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -51,7 +51,8 @@ const MAX_DATA_SPLIT_METADATA_BYTES: usize = 12 * 1024 * 1024;
 
 // CXX carries Rust errors as strings. These stable markers are consumed only
 // by the C++ bridge, which converts them into Arrow statuses before returning
-// to format callers.
+// to format callers. Keep their spelling in sync with paimon_bridge.cpp and
+// paimon_format_reader.cpp.
 fn invalid_message(message: impl std::fmt::Display) -> String {
     format!("{ERROR_INVALID_PREFIX} {message}")
 }
@@ -69,6 +70,21 @@ fn classify_bridge_error(error: anyhow::Error) -> anyhow::Error {
         return error;
     }
 
+    // Paimon's Parquet adapter stringifies FileRead errors before wrapping them.
+    if let Some((_, storage_error)) =
+        message.split_once("IO operation failed on underlying storage: ")
+    {
+        let marker = if storage_error.starts_with("NotFound (") {
+            Some(ERROR_NOT_FOUND_PREFIX)
+        } else if storage_error.starts_with("RateLimited (temporary)") {
+            Some(ERROR_TRANSIENT_THROTTLING_PREFIX)
+        } else if storage_error.contains("(temporary)") {
+            Some(ERROR_TRANSIENT_SERVICE_PREFIX)
+        } else {
+            None
+        };
+        return marker.map_or(error, |marker| anyhow!("{marker} {message}"));
+    }
     let marker = error.chain().find_map(|cause| {
         let error = cause.downcast_ref::<paimon::Error>()?;
         match error {
@@ -1191,6 +1207,36 @@ mod tests {
             }
         };
         (code, message)
+    }
+
+    #[test]
+    fn stringified_stream_errors_keep_storage_classification() {
+        let cases = [
+            (
+                "IO operation failed on underlying storage: NotFound (permanent)",
+                Some(ERROR_NOT_FOUND_PREFIX),
+            ),
+            (
+                "IO operation failed on underlying storage: RateLimited (temporary)",
+                Some(ERROR_TRANSIENT_THROTTLING_PREFIX),
+            ),
+            (
+                "IO operation failed on underlying storage: Unexpected (temporary)",
+                Some(ERROR_TRANSIENT_SERVICE_PREFIX),
+            ),
+            (
+                "IO operation failed on underlying storage: PermissionDenied (permanent)",
+                None,
+            ),
+        ];
+        for (message, marker) in cases {
+            let classified = format!("{:#}", classify_bridge_error(anyhow!(message)));
+            if let Some(marker) = marker {
+                assert!(classified.contains(marker), "{classified}");
+            } else {
+                assert!(!classified.contains("[paimon:error="), "{classified}");
+            }
+        }
     }
 
     #[test]

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -20,7 +20,6 @@ use arrow58::ffi_stream::FFI_ArrowArrayStream;
 use arrow58::record_batch::{RecordBatch, RecordBatchReader};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use cxx::{CxxString, CxxVector};
 use futures::{StreamExt, stream::BoxStream};
 use paimon::catalog::Identifier;
 use paimon::io::{FileIO, FileRead};
@@ -1110,7 +1109,7 @@ impl BlockingPaimonDataSplitReader {
     /// from one shared handle are safe.
     pub unsafe fn open_stream(
         &self,
-        projected_columns: &CxxVector<CxxString>,
+        projected_columns: Vec<String>,
         out_stream_ptr: *mut u8,
     ) -> Result<()> {
         unsafe { self.open_stream_impl(projected_columns, out_stream_ptr) }
@@ -1119,16 +1118,15 @@ impl BlockingPaimonDataSplitReader {
 
     unsafe fn open_stream_impl(
         &self,
-        projected_columns: &CxxVector<CxxString>,
+        projected_columns: Vec<String>,
         out_stream_ptr: *mut u8,
     ) -> Result<()> {
         let mut builder = self.table.new_read_builder();
         if !projected_columns.is_empty() {
             let projected_refs = projected_columns
                 .iter()
-                .map(|column| column.to_str())
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .with_context(|| invalid_message("Paimon projection contains invalid UTF-8"))?;
+                .map(String::as_str)
+                .collect::<Vec<_>>();
             builder.with_projection(&projected_refs)?;
         }
         let read = builder.new_read()?;

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -1121,6 +1121,8 @@ impl BlockingPaimonDataSplitReader {
         projected_columns: Vec<String>,
         out_stream_ptr: *mut u8,
     ) -> Result<()> {
+        // FIXME(yanbinyang): Reuse file metadata across projected streams once
+        // paimon-rust exposes a scan-scoped read context, avoiding repeated footer reads.
         let mut builder = self.table.new_read_builder();
         if !projected_columns.is_empty() {
             let projected_refs = projected_columns

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -1658,15 +1658,18 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let table_location = directory.path().join("snap-table");
         let table_location = table_location.to_str().unwrap();
-        let snapshot_id = crate::paimon_testutil::paimon_create_test_table(
+        let table_info = crate::paimon_testutil::paimon_create_test_table(
             table_location,
             10,
             "append",
+            Vec::new(),
+            Vec::new(),
             Vec::new(),
             "parquet",
             0,
         )
         .unwrap();
+        let snapshot_id = *table_info.snapshot_ids.last().unwrap();
 
         let schema0_path = format!("{table_location}/schema/schema-0");
         let mut historical_schema: serde_json::Value =
@@ -1714,15 +1717,18 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let table_location = directory.path().join("snap-table");
         let table_location = table_location.to_str().unwrap();
-        let snapshot_id = crate::paimon_testutil::paimon_create_test_table(
+        let table_info = crate::paimon_testutil::paimon_create_test_table(
             table_location,
             10,
             "append",
+            Vec::new(),
+            Vec::new(),
             Vec::new(),
             "parquet",
             0,
         )
         .unwrap();
+        let snapshot_id = *table_info.snapshot_ids.last().unwrap();
 
         // A pinned snapshot that exists must load.
         let table = TOKIO_RT
@@ -1762,15 +1768,18 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let table_location = directory.path().join("snap-table");
         let table_location = table_location.to_str().unwrap();
-        let snapshot_id = crate::paimon_testutil::paimon_create_test_table(
+        let table_info = crate::paimon_testutil::paimon_create_test_table(
             table_location,
             10,
             "append",
+            Vec::new(),
+            Vec::new(),
             Vec::new(),
             "parquet",
             0,
         )
         .unwrap();
+        let snapshot_id = *table_info.snapshot_ids.last().unwrap();
         // Corrupt metadata is invalid data, not evidence that the snapshot
         // expired. It must not carry refresh advice.
         let snapshot_file = format!("{table_location}/snapshot/snapshot-{snapshot_id}");

--- a/cpp/src/format/bridge/rust/src/paimon_split_serde.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_split_serde.rs
@@ -1,0 +1,464 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Persistence boundary for Paimon `DataSplit`.
+//!
+//! The payload uses paimon-rust's Java-compatible `SplitSerializer` frame.
+//! The outer Milvus metadata selects the codec; the payload owns its wire
+//! version, magic, and split type.
+
+use paimon::DataSplit;
+use paimon::spec::POSTPONE_BUCKET;
+
+pub(crate) const NATIVE_CODEC: &str = "paimon-split";
+pub(crate) const CURRENT_CODEC: &str = NATIVE_CODEC;
+
+pub(crate) const MAX_DESCRIPTOR_BYTES: usize = 8 * 1024 * 1024;
+pub(crate) const MAX_DESCRIPTOR_DATA_FILES: usize = 4096;
+pub(crate) const MAX_DESCRIPTOR_ROW_RANGES: usize = 65536;
+
+#[derive(Debug)]
+pub(crate) struct SplitSerdeError(String);
+
+impl SplitSerdeError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for SplitSerdeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SplitSerdeError {}
+
+pub(crate) struct EncodedDataSplit {
+    pub(crate) codec: &'static str,
+    pub(crate) payload: Vec<u8>,
+}
+
+/// Validate fields that Milvus relies on before the split reaches storage I/O.
+pub(crate) fn validate_split(split: &DataSplit) -> Result<(), SplitSerdeError> {
+    if split.snapshot_id() <= 0 {
+        return Err(SplitSerdeError::new(format!(
+            "Paimon split descriptor pins non-positive snapshot id {}",
+            split.snapshot_id()
+        )));
+    }
+    if split.bucket() < POSTPONE_BUCKET {
+        return Err(SplitSerdeError::new(format!(
+            "Paimon split descriptor has invalid bucket {}",
+            split.bucket()
+        )));
+    }
+    if split.bucket_path().is_empty() {
+        return Err(SplitSerdeError::new(
+            "Paimon split descriptor has an empty bucket path",
+        ));
+    }
+    if split.total_buckets() < POSTPONE_BUCKET {
+        return Err(SplitSerdeError::new(format!(
+            "Paimon split descriptor has invalid total bucket count {}",
+            split.total_buckets()
+        )));
+    }
+    if split.total_buckets() > 0 && (split.bucket() < 0 || split.bucket() >= split.total_buckets())
+    {
+        return Err(SplitSerdeError::new(format!(
+            "Paimon split descriptor bucket {} is outside [0, {})",
+            split.bucket(),
+            split.total_buckets()
+        )));
+    }
+
+    let files = split.data_files();
+    if files.is_empty() {
+        return Err(SplitSerdeError::new(
+            "Paimon split descriptor contains no data files",
+        ));
+    }
+    if files.len() > MAX_DESCRIPTOR_DATA_FILES {
+        return Err(SplitSerdeError::new(format!(
+            "Paimon split descriptor references {} data files, above the {} limit",
+            files.len(),
+            MAX_DESCRIPTOR_DATA_FILES
+        )));
+    }
+
+    let mut total_rows = 0i64;
+    for file in files {
+        if file.file_name.is_empty() {
+            return Err(SplitSerdeError::new(
+                "Paimon split descriptor contains a data file without a name",
+            ));
+        }
+        if file.row_count < 0 {
+            return Err(SplitSerdeError::new(format!(
+                "Paimon data file '{}' has a negative row count: {}",
+                file.file_name, file.row_count
+            )));
+        }
+        if file.file_size < 0 {
+            return Err(SplitSerdeError::new(format!(
+                "Paimon data file '{}' has a negative file size: {}",
+                file.file_name, file.file_size
+            )));
+        }
+        total_rows = total_rows.checked_add(file.row_count).ok_or_else(|| {
+            SplitSerdeError::new("Paimon split descriptor total row count overflows int64")
+        })?;
+        if let Some(first_row_id) = file.first_row_id {
+            if first_row_id < 0 || file.row_count == 0 {
+                return Err(SplitSerdeError::new(format!(
+                    "Paimon data file '{}' has invalid row-id range start {} for {} rows",
+                    file.file_name, first_row_id, file.row_count
+                )));
+            }
+            if first_row_id.checked_add(file.row_count - 1).is_none() {
+                return Err(SplitSerdeError::new(format!(
+                    "Paimon data file '{}' row-id range overflows int64",
+                    file.file_name
+                )));
+            }
+        }
+        if let Some(count) = file.delete_row_count {
+            if count < 0 || count > file.row_count {
+                return Err(SplitSerdeError::new(format!(
+                    "Paimon data file '{}' has delete row count {} outside [0, {}]",
+                    file.file_name, count, file.row_count
+                )));
+            }
+        }
+    }
+
+    if let Some(deletion_files) = split.data_deletion_files() {
+        if deletion_files.len() != files.len() {
+            return Err(SplitSerdeError::new(format!(
+                "Paimon split descriptor has {} deletion-file slots for {} data files",
+                deletion_files.len(),
+                files.len()
+            )));
+        }
+        for (index, slot) in deletion_files.iter().enumerate() {
+            if let Some(deletion_file) = slot {
+                if deletion_file.path().is_empty()
+                    || deletion_file.offset() < 0
+                    || deletion_file.length() <= 0
+                {
+                    return Err(SplitSerdeError::new(format!(
+                        "Paimon split descriptor deletion slot {index} has an invalid region"
+                    )));
+                }
+                if let Some(cardinality) = deletion_file.cardinality() {
+                    if cardinality < 0 || cardinality > files[index].row_count {
+                        return Err(SplitSerdeError::new(format!(
+                            "Paimon split descriptor deletion slot {index} has cardinality \
+                             {cardinality} outside [0, {}]",
+                            files[index].row_count
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(ranges) = split.row_ranges() {
+        if ranges.len() > MAX_DESCRIPTOR_ROW_RANGES {
+            return Err(SplitSerdeError::new(format!(
+                "Paimon split descriptor carries {} row ranges, above the {} limit",
+                ranges.len(),
+                MAX_DESCRIPTOR_ROW_RANGES
+            )));
+        }
+        for range in ranges {
+            if range.from() < 0
+                || range.to() < range.from()
+                || range
+                    .to()
+                    .checked_sub(range.from())
+                    .and_then(|span| span.checked_add(1))
+                    .is_none()
+            {
+                return Err(SplitSerdeError::new(format!(
+                    "Paimon split descriptor has an invalid row range [{}, {}]",
+                    range.from(),
+                    range.to()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Drop planner-only file statistics before persisting the split.
+// TODO: Replace this serde round-trip when paimon-rust exposes a stats API.
+fn split_without_stats(split: &DataSplit) -> Result<DataSplit, SplitSerdeError> {
+    let mut value = serde_json::to_value(split)
+        .map_err(|error| SplitSerdeError::new(format!("failed to copy Paimon split: {error}")))?;
+    let empty_stats = serde_json::json!({
+        "_MIN_VALUES": [],
+        "_MAX_VALUES": [],
+        "_NULL_COUNTS": []
+    });
+    if let Some(files) = value
+        .get_mut("data_files")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for file in files {
+            let Some(fields) = file.as_object_mut() else {
+                continue;
+            };
+            for key in ["_KEY_STATS", "_VALUE_STATS"] {
+                if fields.contains_key(key) {
+                    fields.insert(key.to_string(), empty_stats.clone());
+                }
+            }
+            if fields.contains_key("_VALUE_STATS_COLS") {
+                fields.insert("_VALUE_STATS_COLS".to_string(), serde_json::Value::Null);
+            }
+        }
+    }
+    serde_json::from_value(value).map_err(|error| {
+        SplitSerdeError::new(format!("failed to strip Paimon split stats: {error}"))
+    })
+}
+
+fn serialize_native(split: &DataSplit) -> Result<Vec<u8>, SplitSerdeError> {
+    let payload = split.serialize_split_v1().map_err(|error| {
+        SplitSerdeError::new(format!("failed to serialize Paimon split: {error}"))
+    })?;
+    if payload.len() > MAX_DESCRIPTOR_BYTES {
+        return Err(SplitSerdeError::new(format!(
+            "serialized Paimon split descriptor is {} bytes, above the {} limit",
+            payload.len(),
+            MAX_DESCRIPTOR_BYTES
+        )));
+    }
+    Ok(payload)
+}
+
+fn deserialize_native(payload: &[u8]) -> Result<DataSplit, SplitSerdeError> {
+    if payload.is_empty() {
+        return Err(SplitSerdeError::new(
+            "Paimon split descriptor must not be empty",
+        ));
+    }
+    if payload.len() > MAX_DESCRIPTOR_BYTES {
+        return Err(SplitSerdeError::new(format!(
+            "Paimon split descriptor is {} bytes, above the {} limit",
+            payload.len(),
+            MAX_DESCRIPTOR_BYTES
+        )));
+    }
+    let split = DataSplit::deserialize_split_v1(payload).map_err(|error| {
+        SplitSerdeError::new(format!(
+            "invalid Paimon split descriptor ({error}); refresh the external table"
+        ))
+    })?;
+    validate_split(&split)?;
+    Ok(split)
+}
+
+pub(crate) fn serialize(split: &DataSplit) -> Result<EncodedDataSplit, SplitSerdeError> {
+    validate_split(split)?;
+    Ok(EncodedDataSplit {
+        codec: CURRENT_CODEC,
+        payload: serialize_native(&split_without_stats(split)?)?,
+    })
+}
+
+pub(crate) fn deserialize(codec: &str, payload: &[u8]) -> Result<DataSplit, SplitSerdeError> {
+    match codec {
+        NATIVE_CODEC => deserialize_native(payload),
+        codec => Err(SplitSerdeError::new(format!(
+            "unsupported Paimon split codec '{codec}'"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paimon::spec::{BinaryRow, DataFileMeta};
+    use paimon::{DataSplitBuilder, DeletionFile, RowRange};
+
+    fn data_file(name: &str, rows: i64) -> DataFileMeta {
+        serde_json::from_value(serde_json::json!({
+            "_FILE_NAME": name,
+            "_FILE_SIZE": 128,
+            "_ROW_COUNT": rows,
+            "_MIN_KEY": [],
+            "_MAX_KEY": [],
+            "_KEY_STATS": {"_MIN_VALUES": [], "_MAX_VALUES": [], "_NULL_COUNTS": []},
+            "_VALUE_STATS": {"_MIN_VALUES": [], "_MAX_VALUES": [], "_NULL_COUNTS": []},
+            "_MIN_SEQUENCE_NUMBER": 0,
+            "_MAX_SEQUENCE_NUMBER": 0,
+            "_SCHEMA_ID": 0,
+            "_LEVEL": 1,
+            "_EXTRA_FILES": [],
+            "_CREATION_TIME": null,
+            "_DELETE_ROW_COUNT": null,
+            "_EMBEDDED_FILE_INDEX": null
+        }))
+        .unwrap()
+    }
+
+    fn test_split(partition: BinaryRow) -> DataSplit {
+        DataSplitBuilder::new()
+            .with_snapshot(5)
+            .with_partition(partition)
+            .with_bucket(0)
+            .with_bucket_path("file:/warehouse/db.db/tbl/bucket-0".to_string())
+            .with_total_buckets(1)
+            .with_data_files(vec![data_file("data-native.parquet", 20)])
+            .with_data_deletion_files(vec![Some(DeletionFile::new(
+                "file:/warehouse/db.db/tbl/index/index-dv-native".to_string(),
+                4,
+                24,
+                Some(2),
+            ))])
+            .with_row_ranges(vec![RowRange::new(2, 7)])
+            .with_raw_convertible(false)
+            .build()
+            .unwrap()
+    }
+
+    fn native_test_split() -> DataSplit {
+        test_split(BinaryRow::from_bytes(
+            0,
+            vec![0; BinaryRow::cal_fix_part_size_in_bytes(0) as usize],
+        ))
+    }
+
+    #[test]
+    fn native_round_trip_preserves_split_fields() {
+        let encoded = serialize(&native_test_split()).unwrap();
+        assert_eq!(encoded.codec, NATIVE_CODEC);
+        let decoded = deserialize(encoded.codec, &encoded.payload).unwrap();
+        assert_eq!(decoded.snapshot_id(), 5);
+        assert_eq!(decoded.row_ranges().unwrap(), &[RowRange::new(2, 7)]);
+        let deletion = decoded.deletion_file_for_data_file_index(0).unwrap();
+        assert_eq!((deletion.offset(), deletion.length()), (4, 24));
+    }
+
+    #[test]
+    fn native_round_trip_supports_empty_partition() {
+        let encoded = serialize(&test_split(BinaryRow::new(0))).unwrap();
+        let decoded = deserialize(encoded.codec, &encoded.payload).unwrap();
+        assert_eq!(decoded.partition().arity(), 0);
+        assert_eq!(
+            decoded.partition().to_serialized_bytes().len(),
+            std::mem::size_of::<i32>() + BinaryRow::cal_fix_part_size_in_bytes(0) as usize
+        );
+    }
+
+    #[test]
+    fn native_decoder_rejects_truncation_and_trailing_bytes() {
+        let encoded = serialize(&native_test_split()).unwrap();
+        let truncated = &encoded.payload[..encoded.payload.len() - 1];
+        assert!(deserialize(encoded.codec, truncated).is_err());
+
+        let mut trailing = encoded.payload;
+        trailing.push(0);
+        assert!(deserialize(NATIVE_CODEC, &trailing).is_err());
+    }
+
+    #[test]
+    fn stats_are_not_persisted() {
+        let mut value = serde_json::to_value(native_test_split()).unwrap();
+        let filler: Vec<u8> = (0..4096).map(|byte| (byte % 251) as u8).collect();
+        let stats = serde_json::json!({
+            "_MIN_VALUES": filler,
+            "_MAX_VALUES": filler,
+            "_NULL_COUNTS": [0, 1, 0],
+        });
+        value["data_files"][0]["_KEY_STATS"] = stats.clone();
+        value["data_files"][0]["_VALUE_STATS"] = stats;
+        value["data_files"][0]["_VALUE_STATS_COLS"] = serde_json::json!(["id", "name", "value"]);
+        let split: DataSplit = serde_json::from_value(value).unwrap();
+
+        let with_stats = serialize_native(&split).unwrap();
+        let encoded = serialize(&split).unwrap();
+        assert!(encoded.payload.len() * 4 < with_stats.len());
+
+        let decoded = deserialize(encoded.codec, &encoded.payload).unwrap();
+        let decoded = serde_json::to_value(decoded).unwrap();
+        assert_eq!(
+            decoded["data_files"][0]["_KEY_STATS"]["_MIN_VALUES"],
+            serde_json::json!([])
+        );
+        assert_eq!(
+            decoded["data_files"][0]["_VALUE_STATS_COLS"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn codec_and_size_limits_are_enforced() {
+        let payload = serialize(&native_test_split()).unwrap().payload;
+        assert!(
+            deserialize("unknown", &payload)
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported")
+        );
+
+        let oversized = vec![0; MAX_DESCRIPTOR_BYTES + 1];
+        assert!(
+            deserialize(NATIVE_CODEC, &oversized)
+                .unwrap_err()
+                .to_string()
+                .contains("limit")
+        );
+    }
+
+    #[test]
+    fn structural_validation_rejects_invalid_file_and_deletion_metadata() {
+        let mut value = serde_json::to_value(native_test_split()).unwrap();
+        value["data_files"][0]["_ROW_COUNT"] = serde_json::json!(-1);
+        let split: DataSplit = serde_json::from_value(value).unwrap();
+        assert!(
+            validate_split(&split)
+                .unwrap_err()
+                .to_string()
+                .contains("negative row count")
+        );
+
+        let error = DataSplitBuilder::new()
+            .with_snapshot(5)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(0)
+            .with_bucket_path("file:/warehouse/db.db/tbl/bucket-0".to_string())
+            .with_total_buckets(1)
+            .with_data_files(vec![data_file("data.parquet", 10)])
+            .with_data_deletion_files(vec![None, None])
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains("must match data_files length"));
+    }
+
+    #[test]
+    fn structural_validation_accepts_known_bucket_sentinels() {
+        let split = DataSplitBuilder::new()
+            .with_snapshot(5)
+            .with_partition(BinaryRow::new(0))
+            .with_bucket(POSTPONE_BUCKET)
+            .with_bucket_path("file:/warehouse/db.db/tbl".to_string())
+            .with_total_buckets(POSTPONE_BUCKET)
+            .with_data_files(vec![data_file("data.parquet", 10)])
+            .build()
+            .unwrap();
+        validate_split(&split).unwrap();
+    }
+}

--- a/cpp/src/format/bridge/rust/src/paimon_testutil.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_testutil.rs
@@ -15,22 +15,24 @@
 //! The fixture is produced through paimon-rust's public writer and commit APIs;
 //! it deliberately does not depend on a machine-local Java table generator.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Result, bail, ensure};
 use arrow_array58::builder::{Float32Builder, ListBuilder};
-use arrow_array58::{ArrayRef, Float64Array, Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow_array58::{ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray};
 use arrow_schema58::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
 use bytes::Bytes;
 use paimon::Table;
 use paimon::catalog::Identifier;
 use paimon::io::FileIO;
 use paimon::spec::{
-    ArrayType, BigIntType, DataType, DoubleType, FloatType, IntType, Schema, TableSchema,
-    VarCharType,
+    ArrayType, BigIntType, DataType, DoubleType, FloatType, Schema, TableSchema, VarCharType,
 };
 
 use crate::TOKIO_RT;
+use crate::paimon_test_ffi::PaimonTestTableInfo;
+
 fn fixture_schema(mode: &str, file_format: &str, dimension: u32) -> Result<TableSchema> {
     ensure!(
         matches!(file_format, "parquet" | "vortex"),
@@ -53,10 +55,16 @@ fn fixture_schema(mode: &str, file_format: &str, dimension: u32) -> Result<Table
             )
     } else {
         Schema::builder()
-            .column("id", DataType::Int(IntType::new()))
+            .column("id", DataType::BigInt(BigIntType::new()))
             .column("name", DataType::VarChar(VarCharType::string_type()))
             .column("value", DataType::Double(DoubleType::new()))
     };
+    if vector_fixture && mode == "mor" {
+        builder = builder.column(
+            "op",
+            DataType::VarChar(VarCharType::with_nullable(false, VarCharType::MAX_LENGTH)?),
+        );
+    }
     builder = builder
         // Keep test splits intentionally small and deterministic.
         .option("source.split.target-size", "1b")
@@ -70,6 +78,9 @@ fn fixture_schema(mode: &str, file_format: &str, dimension: u32) -> Result<Table
             builder = builder
                 .primary_key([if vector_fixture { "pk" } else { "id" }])
                 .option("bucket", "1");
+            if vector_fixture {
+                builder = builder.option("rowkind.field", "op");
+            }
         }
         "deletion-vector" => {
             builder = builder
@@ -89,28 +100,28 @@ fn scalar_fixture_batch(start: u64, rows: u64, value_multiplier: i32) -> Result<
         .checked_add(rows)
         .ok_or_else(|| anyhow::anyhow!("Paimon fixture row range overflow"))?;
     ensure!(
-        end <= i32::MAX as u64,
+        end <= i64::MAX as u64,
         "Paimon fixture supports at most {} rows",
-        i32::MAX
+        i64::MAX
     );
-    let ids: Vec<i32> = (start..end).map(|value| value as i32).collect();
+    let ids: Vec<i64> = (start..end).map(|value| value as i64).collect();
     let names: Vec<String> = ids
         .iter()
-        .map(|id| format!("row_{}", id.saturating_mul(value_multiplier)))
+        .map(|id| format!("row_{}", id.saturating_mul(i64::from(value_multiplier))))
         .collect();
     let values: Vec<f64> = ids
         .iter()
-        .map(|id| f64::from(*id) * 1.5 * f64::from(value_multiplier))
+        .map(|id| *id as f64 * 1.5 * f64::from(value_multiplier))
         .collect();
     let schema = Arc::new(ArrowSchema::new(vec![
-        ArrowField::new("id", ArrowDataType::Int32, false),
+        ArrowField::new("id", ArrowDataType::Int64, false),
         ArrowField::new("name", ArrowDataType::Utf8, false),
         ArrowField::new("value", ArrowDataType::Float64, false),
     ]));
     Ok(RecordBatch::try_new(
         schema,
         vec![
-            Arc::new(Int32Array::from(ids)),
+            Arc::new(Int64Array::from(ids)),
             Arc::new(StringArray::from(names)),
             Arc::new(Float64Array::from(values)),
         ],
@@ -179,6 +190,57 @@ fn fixture_batch(
     }
 }
 
+fn vector_mor_batch(rows: &[(i64, &str, &str)], dimension: u32) -> Result<RecordBatch> {
+    let ids = rows.iter().map(|(pk, _, _)| *pk).collect::<Vec<_>>();
+    let labels = rows.iter().map(|(_, label, _)| *label).collect::<Vec<_>>();
+    let operations = rows.iter().map(|(_, _, op)| *op).collect::<Vec<_>>();
+    let element_field = Arc::new(ArrowField::new("element", ArrowDataType::Float32, false));
+    let mut vectors = ListBuilder::new(Float32Builder::new()).with_field(element_field.clone());
+    for id in &ids {
+        for component in 0..dimension {
+            vectors
+                .values()
+                .append_value(*id as f32 + component as f32 / dimension as f32);
+        }
+        vectors.append(true);
+    }
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("pk", ArrowDataType::Int64, false),
+        ArrowField::new("label", ArrowDataType::Utf8, false),
+        ArrowField::new("vector", ArrowDataType::List(element_field), false),
+        ArrowField::new("op", ArrowDataType::Utf8, false),
+    ]));
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(ids)) as ArrayRef,
+            Arc::new(StringArray::from(labels)) as ArrayRef,
+            Arc::new(vectors.finish()) as ArrayRef,
+            Arc::new(StringArray::from(operations)) as ArrayRef,
+        ],
+    )?)
+}
+
+fn vector_mor_range_batch(
+    start: i64,
+    rows: u64,
+    dimension: u32,
+    operation: &str,
+) -> Result<RecordBatch> {
+    let rows_i64 = i64::try_from(rows).map_err(|_| anyhow::anyhow!("row count exceeds i64"))?;
+    let end = start
+        .checked_add(rows_i64)
+        .ok_or_else(|| anyhow::anyhow!("fixture row range exceeds i64"))?;
+    let values = (start..end)
+        .map(|pk| (pk, format!("label_{pk}"), operation))
+        .collect::<Vec<_>>();
+    let borrowed = values
+        .iter()
+        .map(|(pk, label, op)| (*pk, label.as_str(), *op))
+        .collect::<Vec<_>>();
+    vector_mor_batch(&borrowed, dimension)
+}
+
 async fn commit_batch(table: &Table, batch: &RecordBatch) -> Result<i64> {
     let write_builder = table.new_write_builder();
     let mut writer = write_builder.new_write()?;
@@ -211,13 +273,25 @@ pub fn paimon_create_test_table(
     num_rows: u64,
     mode: &str,
     deleted_positions: Vec<i64>,
+    storage_options_keys: Vec<String>,
+    storage_options_values: Vec<String>,
     file_format: &str,
     dimension: u32,
-) -> Result<i64> {
+) -> Result<PaimonTestTableInfo> {
     let mode = mode.to_string();
     let file_format = file_format.to_string();
     TOKIO_RT.block_on(async move {
-        let file_io = FileIO::from_path(table_location)?.build()?;
+        ensure!(
+            storage_options_keys.len() == storage_options_values.len(),
+            "Paimon fixture storage option key/value count mismatch"
+        );
+        let storage_options: HashMap<String, String> = storage_options_keys
+            .into_iter()
+            .zip(storage_options_values)
+            .collect();
+        let file_io = FileIO::from_path(table_location)?
+            .with_props(storage_options)
+            .build()?;
         file_io
             .mkdirs(&format!("{table_location}/snapshot"))
             .await?;
@@ -234,25 +308,46 @@ pub fn paimon_create_test_table(
             None,
         );
 
-        let first_batch = fixture_batch(0, num_rows, 1, dimension)?;
-        commit_batch(&table, &first_batch).await?;
-        if mode == "mor" && num_rows > 1 {
+        let first_batch = if mode == "mor" && dimension > 0 {
+            ensure!(
+                num_rows >= 3,
+                "Paimon vector merge-on-read fixture requires at least three rows"
+            );
+            vector_mor_range_batch(0, num_rows, dimension, "+I")?
+        } else {
+            fixture_batch(0, num_rows, 1, dimension)?
+        };
+        let mut snapshot_ids = vec![commit_batch(&table, &first_batch).await?];
+        if mode == "mor" && dimension > 0 {
+            let inserted_pk =
+                i64::try_from(num_rows).map_err(|_| anyhow::anyhow!("row count exceeds i64"))?;
+            let inserted_label = format!("label_{inserted_pk}");
+            let changes = [
+                (1, "label_1_updated", "+U"),
+                (2, "label_2_deleted", "-D"),
+                (inserted_pk, inserted_label.as_str(), "+I"),
+            ];
+            snapshot_ids.push(commit_batch(&table, &vector_mor_batch(&changes, dimension)?).await?);
+        } else if mode == "mor" && num_rows > 1 {
             // Overwrite the upper half of the key range in a second commit so
             // the resulting split requires Paimon's merge reader.
             let start = num_rows / 2;
-            commit_batch(
-                &table,
-                &fixture_batch(start, num_rows - start, 10, dimension)?,
-            )
-            .await?;
+            snapshot_ids.push(
+                commit_batch(
+                    &table,
+                    &fixture_batch(start, num_rows - start, 10, dimension)?,
+                )
+                .await?,
+            );
         } else if mode == "deletion-vector" && !deleted_positions.is_empty() {
             let write_builder = table.new_write_builder();
             let mut writer = write_builder.new_delete()?;
             writer.add_row_ids(deleted_positions)?;
             let messages = writer.prepare_commit().await?;
             write_builder.new_commit().commit(messages).await?;
+            snapshot_ids.push(latest_snapshot_id(&table).await?);
         }
 
-        latest_snapshot_id(&table).await
+        Ok(PaimonTestTableInfo { snapshot_ids })
     })
 }

--- a/cpp/src/format/paimon/paimon_format.cpp
+++ b/cpp/src/format/paimon/paimon_format.cpp
@@ -35,17 +35,19 @@ arrow::Result<std::vector<api::ColumnGroupFile>> PaimonFormat::explore(const std
   files.reserve(planned.size());
   for (const auto& info : planned) {
     int64_t record_count = -1;
+    std::string read_path;
     try {
       auto metadata = nlohmann::json::parse(info.metadata_json);
       if (!metadata.is_object()) {
         return arrow::Status::Invalid("Paimon planning metadata must be a JSON object");
       }
-      if (metadata.value("read_path", std::string{}) != "direct-file") {
-        return arrow::Status::Invalid("Paimon planner returned a non-direct metadata descriptor");
-      }
-      record_count = metadata.value("record_count", int64_t{-1});
+      read_path = metadata.value(paimon::kReadPathKey, std::string{});
+      record_count = metadata.value(paimon::kRecordCountKey, int64_t{-1});
     } catch (const nlohmann::json::exception& error) {
       return arrow::Status::Invalid("Invalid Paimon planning metadata: ", error.what());
+    }
+    if (read_path != paimon::kDirectFileReadPath && read_path != paimon::kDataSplitReadPath) {
+      return arrow::Status::Invalid("Paimon planning metadata has an invalid read_path: ", read_path);
     }
     if (record_count < 0) {
       return arrow::Status::Invalid("Paimon planning metadata has an invalid record_count");
@@ -55,7 +57,7 @@ arrow::Result<std::vector<api::ColumnGroupFile>> PaimonFormat::explore(const std
     }
     api::ColumnGroupFile file{paimon::ToMilvusUri(info.path, fs_config.address), 0, record_count, {}};
     file.Set(api::kPropertyMetadata, info.metadata_json);
-    if (info.file_size > 0) {
+    if (read_path == paimon::kDirectFileReadPath && info.file_size > 0) {
       file.Set(api::kPropertyFileSize, info.file_size);
     }
     files.push_back(std::move(file));

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -49,24 +49,47 @@ arrow::Status TranslatePaimonStreamStatus(arrow::Status status) {
   return MakePaimonBridgeErrorStatus(status.message());
 }
 
-class PaimonErrorTranslatingReader final : public arrow::RecordBatchReader {
+class PaimonStreamReader final : public arrow::RecordBatchReader {
   public:
-  explicit PaimonErrorTranslatingReader(std::shared_ptr<arrow::RecordBatchReader> inner) : inner_(std::move(inner)) {}
+  PaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner, std::shared_ptr<arrow::Schema> output_schema)
+      : inner_(std::move(inner)), output_schema_(std::move(output_schema)) {}
 
-  std::shared_ptr<arrow::Schema> schema() const override { return inner_->schema(); }
+  std::shared_ptr<arrow::Schema> schema() const override { return output_schema_; }
 
   arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
-    return TranslatePaimonStreamStatus(inner_->ReadNext(batch));
+    ARROW_RETURN_NOT_OK(TranslatePaimonStreamStatus(inner_->ReadNext(batch)));
+    if (!*batch) {
+      return arrow::Status::OK();
+    }
+    if ((*batch)->num_columns() != output_schema_->num_fields()) {
+      return arrow::Status::Invalid("Paimon data-split stream returned an unexpected column count");
+    }
+    for (int index = 0; index < output_schema_->num_fields(); ++index) {
+      const auto& actual = (*batch)->schema()->field(index);
+      const auto& expected = output_schema_->field(index);
+      if (actual->name() != expected->name() || !actual->type()->Equals(expected->type())) {
+        return arrow::Status::Invalid("Paimon data-split stream schema mismatch at column ", index, ": expected ",
+                                      expected->ToString(), ", got ", actual->ToString());
+      }
+      if (!expected->nullable() && (*batch)->column(index)->null_count() != 0) {
+        return arrow::Status::Invalid("Paimon data-split stream returned nulls for non-nullable column: ",
+                                      expected->name());
+      }
+    }
+    *batch = arrow::RecordBatch::Make(output_schema_, (*batch)->num_rows(), (*batch)->columns());
+    return arrow::Status::OK();
   }
 
   arrow::Status Close() override { return TranslatePaimonStreamStatus(inner_->Close()); }
 
   private:
   std::shared_ptr<arrow::RecordBatchReader> inner_;
+  std::shared_ptr<arrow::Schema> output_schema_;
 };
 
-std::shared_ptr<arrow::RecordBatchReader> WrapPaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner) {
-  return std::make_shared<PaimonErrorTranslatingReader>(std::move(inner));
+std::shared_ptr<arrow::RecordBatchReader> WrapPaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner,
+                                                                 std::shared_ptr<arrow::Schema> output_schema) {
+  return std::make_shared<PaimonStreamReader>(std::move(inner), std::move(output_schema));
 }
 
 struct ParsedMetadata {
@@ -650,7 +673,7 @@ arrow::Status PaimonFormatReader::open() {
 arrow::Result<std::unique_ptr<DataSplitStreamCursor>> PaimonFormatReader::make_data_split_cursor() const {
   ARROW_ASSIGN_OR_RAISE(auto stream, split_reader_->OpenStream(split_columns_));
   ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
-  return std::make_unique<DataSplitStreamCursor>(WrapPaimonStreamReader(std::move(reader)),
+  return std::make_unique<DataSplitStreamCursor>(WrapPaimonStreamReader(std::move(reader), output_schema_),
                                                  metadata_->payload.record_count);
 }
 

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -132,19 +132,17 @@ arrow::Result<std::vector<RowGroupInfo>> MakeDirectLogicalRowGroups(const std::v
 arrow::Result<std::shared_ptr<arrow::Schema>> ProjectSchema(const std::shared_ptr<arrow::Schema>& file_schema,
                                                             const std::shared_ptr<arrow::Schema>& read_schema,
                                                             const std::vector<std::string>& columns) {
-  if (read_schema) {
-    return read_schema;
-  }
-  if (!file_schema) {
+  auto source_schema = read_schema ? read_schema : file_schema;
+  if (!source_schema) {
     return arrow::Status::Invalid("Paimon file schema is unavailable");
   }
   if (columns.empty()) {
-    return file_schema;
+    return source_schema;
   }
   std::vector<std::shared_ptr<arrow::Field>> fields;
   fields.reserve(columns.size());
   for (const auto& column : columns) {
-    auto field = file_schema->GetFieldByName(column);
+    auto field = source_schema->GetFieldByName(column);
     if (!field) {
       return arrow::Status::Invalid("Paimon column not found: ", column);
     }
@@ -570,7 +568,7 @@ arrow::Result<std::shared_ptr<PaimonFormatReader>> PaimonFormatReader::MetaTrait
     }
     std::shared_ptr<parquet::ParquetFormatReader> parquet_reader;
     ARROW_ASSIGN_OR_RAISE(parquet_reader, parquet::ParquetFormatReader::MetaTrait::create_from_metadata(
-                                              *cached, file, read_schema, needed_columns, ""));
+                                              *cached, file, output_schema, needed_columns, ""));
     direct_file_reader = std::static_pointer_cast<FormatReader>(std::move(parquet_reader));
   } else if (metadata->payload.data_format == "vortex") {
     auto cached =
@@ -580,7 +578,7 @@ arrow::Result<std::shared_ptr<PaimonFormatReader>> PaimonFormatReader::MetaTrait
     }
     std::shared_ptr<vortex::VortexFormatReader> vortex_reader;
     ARROW_ASSIGN_OR_RAISE(vortex_reader, vortex::VortexFormatReader::MetaTrait::create_from_metadata(
-                                             *cached, file, read_schema, needed_columns, ""));
+                                             *cached, file, output_schema, needed_columns, ""));
     direct_file_reader = std::static_pointer_cast<FormatReader>(std::move(vortex_reader));
   } else {
     return arrow::Status::NotImplemented("Paimon direct-file does not support format: ", metadata->payload.data_format);

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -100,6 +100,9 @@ arrow::Result<ParsedMetadata> ParseMetadata(const std::string& json) {
   if (record_count < 0) {
     return arrow::Status::Invalid("Paimon metadata has negative record_count");
   }
+  if (read_path == kDataSplitReadPath && record_count == 0) {
+    return arrow::Status::Invalid("Paimon data-split metadata has zero record_count");
+  }
   return ParsedMetadata{
       .read_path = std::move(read_path),
       .data_format = std::move(data_format),

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <exception>
 #include <limits>
-#include <string_view>
 #include <utility>
 
 #include <arrow/array/builder_primitive.h>
@@ -38,59 +37,6 @@ namespace milvus_storage::paimon {
 namespace {
 
 constexpr size_t kMaxPaimonMetadataBytes = 12 * 1024 * 1024;
-// Rust emits this prefix from paimon_bridgeimpl.rs; detailed marker mapping is
-// centralized in MakePaimonBridgeErrorStatus.
-constexpr std::string_view kPaimonErrorMarker = "[paimon:error=";
-
-arrow::Status TranslatePaimonStreamStatus(arrow::Status status) {
-  if (status.ok() || status.message().find(kPaimonErrorMarker) == std::string_view::npos) {
-    return status;
-  }
-  return MakePaimonBridgeErrorStatus(status.message());
-}
-
-class PaimonStreamReader final : public arrow::RecordBatchReader {
-  public:
-  PaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner, std::shared_ptr<arrow::Schema> output_schema)
-      : inner_(std::move(inner)), output_schema_(std::move(output_schema)) {}
-
-  std::shared_ptr<arrow::Schema> schema() const override { return output_schema_; }
-
-  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
-    ARROW_RETURN_NOT_OK(TranslatePaimonStreamStatus(inner_->ReadNext(batch)));
-    if (!*batch) {
-      return arrow::Status::OK();
-    }
-    if ((*batch)->num_columns() != output_schema_->num_fields()) {
-      return arrow::Status::Invalid("Paimon data-split stream returned an unexpected column count");
-    }
-    for (int index = 0; index < output_schema_->num_fields(); ++index) {
-      const auto& actual = (*batch)->schema()->field(index);
-      const auto& expected = output_schema_->field(index);
-      if (actual->name() != expected->name() || !actual->type()->Equals(expected->type())) {
-        return arrow::Status::Invalid("Paimon data-split stream schema mismatch at column ", index, ": expected ",
-                                      expected->ToString(), ", got ", actual->ToString());
-      }
-      if (!expected->nullable() && (*batch)->column(index)->null_count() != 0) {
-        return arrow::Status::Invalid("Paimon data-split stream returned nulls for non-nullable column: ",
-                                      expected->name());
-      }
-    }
-    *batch = arrow::RecordBatch::Make(output_schema_, (*batch)->num_rows(), (*batch)->columns());
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Close() override { return TranslatePaimonStreamStatus(inner_->Close()); }
-
-  private:
-  std::shared_ptr<arrow::RecordBatchReader> inner_;
-  std::shared_ptr<arrow::Schema> output_schema_;
-};
-
-std::shared_ptr<arrow::RecordBatchReader> WrapPaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner,
-                                                                 std::shared_ptr<arrow::Schema> output_schema) {
-  return std::make_shared<PaimonStreamReader>(std::move(inner), std::move(output_schema));
-}
 
 struct ParsedMetadata {
   std::string read_path;
@@ -677,8 +623,8 @@ arrow::Status PaimonFormatReader::open() {
 arrow::Result<std::unique_ptr<DataSplitStreamCursor>> PaimonFormatReader::make_data_split_cursor() const {
   ARROW_ASSIGN_OR_RAISE(auto stream, split_reader_->OpenStream(split_columns_));
   ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
-  return std::make_unique<DataSplitStreamCursor>(WrapPaimonStreamReader(std::move(reader), output_schema_),
-                                                 metadata_->payload.record_count);
+  return std::make_unique<DataSplitStreamCursor>(
+      internal::WrapPaimonRecordBatchReader(std::move(reader), output_schema_), metadata_->payload.record_count);
 }
 
 arrow::Result<std::vector<RowGroupInfo>> PaimonFormatReader::get_row_group_infos() {

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -21,11 +21,13 @@
 
 #include <arrow/array/builder_primitive.h>
 #include <arrow/array/builder_binary.h>
+#include <arrow/c/bridge.h>
 #include <arrow/compute/api.h>
 #include <arrow/table.h>
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
+#include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/paimon/paimon_common.h"
@@ -34,7 +36,10 @@
 namespace milvus_storage::paimon {
 namespace {
 
+constexpr size_t kMaxPaimonMetadataBytes = 12 * 1024 * 1024;
+
 struct ParsedMetadata {
+  std::string read_path;
   std::string data_format;
   uint64_t record_count = 0;
   nlohmann::json deletion_file;
@@ -52,26 +57,39 @@ arrow::Result<ParsedMetadata> ParseMetadata(const std::string& json) {
       return arrow::Status::Invalid("Paimon metadata must be a JSON object");
     }
     version = value.value("version", int64_t{0});
-    read_path = value.value("read_path", std::string{});
-    record_count = value.value("record_count", int64_t{0});
+    read_path = value.value(kReadPathKey, std::string{});
+    record_count = value.value(kRecordCountKey, int64_t{0});
     data_format = value.value("data_format", std::string{});
     deletion_file = value.value("deletion_file", nlohmann::json(nullptr));
   } catch (const nlohmann::json::exception& error) {
     return arrow::Status::Invalid("Paimon metadata has invalid JSON or field types: ", error.what());
   }
   LOG_STORAGE_DEBUG_ << "Paimon metadata version=" << version;
-  if (read_path != "direct-file") {
-    return read_path == "data-split" ? arrow::Status::NotImplemented("Paimon data-split reads are not supported")
-                                     : arrow::Status::Invalid("Paimon metadata read_path must be direct-file");
+  if (read_path != kDirectFileReadPath && read_path != kDataSplitReadPath) {
+    return arrow::Status::Invalid("Invalid Paimon metadata read_path: ", read_path);
   }
   if (record_count < 0) {
     return arrow::Status::Invalid("Paimon metadata has negative record_count");
   }
   return ParsedMetadata{
+      .read_path = std::move(read_path),
       .data_format = std::move(data_format),
       .record_count = static_cast<uint64_t>(record_count),
       .deletion_file = std::move(deletion_file),
   };
+}
+
+arrow::Result<std::vector<RowGroupInfo>> MakeLogicalRowGroups(uint64_t row_count, uint64_t chunk_rows) {
+  std::vector<RowGroupInfo> groups;
+  for (uint64_t start = 0; start < row_count;) {
+    auto end = start + std::min(chunk_rows, row_count - start);
+    groups.push_back(RowGroupInfo{.start_offset = static_cast<size_t>(start),
+                                  .end_offset = static_cast<size_t>(end),
+                                  .memory_size = 0,
+                                  .memory_size_available = false});
+    start = end;
+  }
+  return groups;
 }
 
 arrow::Result<std::vector<RowGroupInfo>> MakeDirectLogicalRowGroups(const std::vector<RowGroupInfo>& physical,
@@ -228,6 +246,172 @@ class DirectDeletionReader final : public arrow::RecordBatchReader {
   std::shared_ptr<const std::vector<uint64_t>> deletions_;
 };
 
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> CombineBatches(
+    const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches, const std::shared_ptr<arrow::Schema>& schema) {
+  if (batches.empty()) {
+    return arrow::RecordBatch::MakeEmpty(schema);
+  }
+  if (batches.size() == 1) {
+    return batches.front();
+  }
+  ARROW_ASSIGN_OR_RAISE(auto table, arrow::Table::FromRecordBatches(batches));
+  return table->CombineChunksToBatch();
+}
+
+}  // namespace
+
+// Forward-only cursor. It retains at most the current Paimon batch remainder;
+// there is no look-ahead or history cache.
+class DataSplitStreamCursor {
+  public:
+  DataSplitStreamCursor(std::shared_ptr<arrow::RecordBatchReader> source, uint64_t declared_rows)
+      : source_(std::move(source)), declared_rows_(declared_rows) {}
+
+  arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> ReadRange(uint64_t start, uint64_t end) {
+    if (end < start || end > declared_rows_) {
+      return arrow::Status::Invalid("Invalid Paimon data-split range");
+    }
+    if (start < position_) {
+      return arrow::Status::Invalid("Paimon stream cursor cannot seek backwards");
+    }
+    ARROW_RETURN_NOT_OK(Consume(start - position_, nullptr));
+    std::vector<std::shared_ptr<arrow::RecordBatch>> output;
+    ARROW_RETURN_NOT_OK(Consume(end - start, &output));
+    if (end == declared_rows_) {
+      ARROW_RETURN_NOT_OK(ValidateExhausted());
+    }
+    return output;
+  }
+
+  arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> TakeRows(const std::vector<int64_t>& row_indices) {
+    int64_t previous = -1;
+    for (auto row : row_indices) {
+      if (row <= previous || row < 0 || static_cast<uint64_t>(row) >= declared_rows_) {
+        return arrow::Status::Invalid("Paimon take indices must be sorted, unique, and in range");
+      }
+      previous = row;
+    }
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> selected;
+    size_t next_row = 0;
+    while (next_row < row_indices.size()) {
+      if (!pending_ || pending_offset_ == static_cast<uint64_t>(pending_->num_rows())) {
+        pending_.reset();
+        pending_offset_ = 0;
+        ARROW_RETURN_NOT_OK(source_->ReadNext(&pending_));
+        if (!pending_) {
+          return arrow::Status::Invalid("Paimon data-split ended before a requested take index");
+        }
+      }
+
+      const auto available = static_cast<uint64_t>(pending_->num_rows()) - pending_offset_;
+      const auto batch_start = position_;
+      if (batch_start > declared_rows_ || available > declared_rows_ - batch_start) {
+        return arrow::Status::Invalid("Paimon data-split produced more rows than its declared row count");
+      }
+      const auto batch_end = batch_start + available;
+      if (static_cast<uint64_t>(row_indices[next_row]) >= batch_end) {
+        pending_offset_ += available;
+        position_ += available;
+        continue;
+      }
+
+      std::vector<int64_t> local_indices;
+      while (next_row < row_indices.size() && static_cast<uint64_t>(row_indices[next_row]) < batch_end) {
+        local_indices.push_back(static_cast<int64_t>(pending_offset_) + row_indices[next_row] -
+                                static_cast<int64_t>(batch_start));
+        ++next_row;
+      }
+      ARROW_ASSIGN_OR_RAISE(auto table, arrow::Table::FromRecordBatches({pending_}));
+      ARROW_ASSIGN_OR_RAISE(auto compact, CopySelectedRows(table, local_indices));
+      ARROW_ASSIGN_OR_RAISE(auto compact_batch, compact->CombineChunksToBatch());
+      selected.push_back(std::move(compact_batch));
+      pending_offset_ += available;
+      position_ += available;
+    }
+    if (static_cast<uint64_t>(row_indices.back()) + 1 == declared_rows_) {
+      ARROW_RETURN_NOT_OK(ValidateExhausted());
+    }
+    return selected;
+  }
+
+  private:
+  arrow::Status ValidateExhausted() {
+    if (pending_ && pending_offset_ < static_cast<uint64_t>(pending_->num_rows())) {
+      return arrow::Status::Invalid("Paimon data-split produced more rows than its declared row count");
+    }
+    pending_.reset();
+    pending_offset_ = 0;
+    while (true) {
+      std::shared_ptr<arrow::RecordBatch> extra;
+      ARROW_RETURN_NOT_OK(source_->ReadNext(&extra));
+      if (!extra) {
+        return arrow::Status::OK();
+      }
+      if (extra->num_rows() != 0) {
+        return arrow::Status::Invalid("Paimon data-split produced more rows than its declared row count");
+      }
+    }
+  }
+
+  arrow::Status Consume(uint64_t rows, std::vector<std::shared_ptr<arrow::RecordBatch>>* output) {
+    while (rows > 0) {
+      if (!pending_ || pending_offset_ == static_cast<uint64_t>(pending_->num_rows())) {
+        pending_.reset();
+        pending_offset_ = 0;
+        ARROW_RETURN_NOT_OK(source_->ReadNext(&pending_));
+        if (!pending_) {
+          return arrow::Status::Invalid("Paimon data-split ended before its declared row count");
+        }
+      }
+      auto available = static_cast<uint64_t>(pending_->num_rows()) - pending_offset_;
+      auto count = std::min(rows, available);
+      if (output != nullptr) {
+        output->push_back(pending_->Slice(static_cast<int64_t>(pending_offset_), static_cast<int64_t>(count)));
+      }
+      pending_offset_ += count;
+      position_ += count;
+      rows -= count;
+    }
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<arrow::RecordBatchReader> source_;
+  std::shared_ptr<arrow::RecordBatch> pending_;
+  uint64_t pending_offset_ = 0;
+  uint64_t position_ = 0;
+  uint64_t declared_rows_;
+};
+
+namespace {
+
+class DataSplitRangeReader final : public arrow::RecordBatchReader {
+  public:
+  DataSplitRangeReader(std::unique_ptr<DataSplitStreamCursor> cursor,
+                       std::vector<std::pair<uint64_t, uint64_t>> ranges,
+                       std::shared_ptr<arrow::Schema> schema)
+      : cursor_(std::move(cursor)), ranges_(std::move(ranges)), schema_(std::move(schema)) {}
+
+  std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* output) override {
+    *output = nullptr;
+    if (next_range_ == ranges_.size()) {
+      return arrow::Status::OK();
+    }
+    const auto [start, end] = ranges_[next_range_++];
+    ARROW_ASSIGN_OR_RAISE(auto batches, cursor_->ReadRange(start, end));
+    ARROW_ASSIGN_OR_RAISE(*output, CombineBatches(batches, schema_));
+    return arrow::Status::OK();
+  }
+
+  private:
+  std::unique_ptr<DataSplitStreamCursor> cursor_;
+  std::vector<std::pair<uint64_t, uint64_t>> ranges_;
+  std::shared_ptr<arrow::Schema> schema_;
+  size_t next_range_ = 0;
+};
+
 }  // namespace
 
 std::string PaimonFormatReader::MetaTrait::cache_key(const api::ColumnGroupFile& file) {
@@ -241,6 +425,10 @@ arrow::Result<PaimonFormatReader::MetaTrait::MetadataPtr> PaimonFormatReader::Me
   if (metadata_json.empty()) {
     return arrow::Status::Invalid("Paimon column group is missing metadata");
   }
+  if (metadata_json.size() > kMaxPaimonMetadataBytes) {
+    return arrow::Status::Invalid("Paimon metadata is too large: ", metadata_json.size(), " bytes exceeds ",
+                                  kMaxPaimonMetadataBytes);
+  }
   ARROW_ASSIGN_OR_RAISE(auto parsed, ParseMetadata(metadata_json));
   ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, file.path));
   ARROW_ASSIGN_OR_RAISE(auto storage_options, ToStorageOptions(fs_config));
@@ -248,76 +436,94 @@ arrow::Result<PaimonFormatReader::MetaTrait::MetadataPtr> PaimonFormatReader::Me
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key(file);
   metadata->path = file.path;
+  metadata->payload.read_path = parsed.read_path;
   metadata->payload.data_format = parsed.data_format;
   metadata->payload.record_count = parsed.record_count;
 
-  size_t direct_cache_size = 0;
-  if (parsed.data_format == "parquet") {
-    ARROW_ASSIGN_OR_RAISE(auto parquet_metadata,
-                          parquet::ParquetFormatReader::MetaTrait::load_metadata(file, properties, key_retriever));
-    metadata->file_schema = parquet_metadata->file_schema;
-    metadata->payload.direct_physical_row_groups = parquet_metadata->row_group_infos;
-    direct_cache_size = parquet_metadata->cache_size;
-    metadata->payload.direct_file_metadata = std::move(parquet_metadata);
-  } else if (parsed.data_format == "vortex") {
-    ARROW_ASSIGN_OR_RAISE(auto vortex_metadata,
-                          vortex::VortexFormatReader::MetaTrait::load_metadata(file, properties, key_retriever));
-    metadata->file_schema = vortex_metadata->file_schema;
-    metadata->payload.direct_physical_row_groups = vortex_metadata->row_group_infos;
-    direct_cache_size = vortex_metadata->cache_size;
-    metadata->payload.direct_file_metadata = std::move(vortex_metadata);
-  } else {
-    return arrow::Status::NotImplemented("Paimon direct-file does not support format: ", parsed.data_format);
-  }
-  auto& physical_groups = metadata->payload.direct_physical_row_groups;
-  uint64_t physical_rows = physical_groups.empty() ? 0 : physical_groups.back().end_offset;
-  metadata->payload.physical_row_count = physical_rows;
+  if (parsed.read_path == kDirectFileReadPath) {
+    size_t direct_cache_size = 0;
+    if (parsed.data_format == "parquet") {
+      ARROW_ASSIGN_OR_RAISE(auto parquet_metadata,
+                            parquet::ParquetFormatReader::MetaTrait::load_metadata(file, properties, key_retriever));
+      metadata->file_schema = parquet_metadata->file_schema;
+      metadata->payload.direct_physical_row_groups = parquet_metadata->row_group_infos;
+      direct_cache_size = parquet_metadata->cache_size;
+      metadata->payload.direct_file_metadata = std::move(parquet_metadata);
+    } else if (parsed.data_format == "vortex") {
+      ARROW_ASSIGN_OR_RAISE(auto vortex_metadata,
+                            vortex::VortexFormatReader::MetaTrait::load_metadata(file, properties, key_retriever));
+      metadata->file_schema = vortex_metadata->file_schema;
+      metadata->payload.direct_physical_row_groups = vortex_metadata->row_group_infos;
+      direct_cache_size = vortex_metadata->cache_size;
+      metadata->payload.direct_file_metadata = std::move(vortex_metadata);
+    } else {
+      return arrow::Status::NotImplemented("Paimon direct-file does not support format: ", parsed.data_format);
+    }
+    auto& physical_groups = metadata->payload.direct_physical_row_groups;
+    uint64_t physical_rows = physical_groups.empty() ? 0 : physical_groups.back().end_offset;
+    metadata->payload.physical_row_count = physical_rows;
 
-  auto deletions = std::make_shared<std::vector<uint64_t>>();
-  if (!parsed.deletion_file.is_null()) {
-    if (!parsed.deletion_file.is_object()) {
-      return arrow::Status::Invalid("Paimon deletion_file must be an object");
-    }
-    std::string path;
-    int64_t offset = -1;
-    int64_t length = -1;
-    int64_t cardinality = -1;
-    try {
-      path = parsed.deletion_file.value("path", std::string{});
-      offset = parsed.deletion_file.value("offset", int64_t{-1});
-      length = parsed.deletion_file.value("length", int64_t{-1});
-      cardinality = parsed.deletion_file.value("cardinality", int64_t{-1});
-    } catch (const nlohmann::json::exception& error) {
-      return arrow::Status::Invalid("Paimon deletion_file has invalid field types: ", error.what());
-    }
-    if (path.empty() || offset < 0 || length < 0) {
-      return arrow::Status::Invalid("Paimon deletion_file has invalid path or range");
-    }
-    ARROW_ASSIGN_OR_RAISE(auto positions,
-                          ReadDeletionVector(path, static_cast<uint64_t>(offset), static_cast<uint64_t>(length),
-                                             cardinality, storage_options));
-    deletions->reserve(positions.size());
-    for (auto position : positions) {
-      if (position >= physical_rows) {
-        return arrow::Status::Invalid("Paimon deletion position exceeds physical row count");
+    auto deletions = std::make_shared<std::vector<uint64_t>>();
+    if (!parsed.deletion_file.is_null()) {
+      if (!parsed.deletion_file.is_object()) {
+        return arrow::Status::Invalid("Paimon deletion_file must be an object");
       }
-      deletions->push_back(position);
+      std::string path;
+      int64_t offset = -1;
+      int64_t length = -1;
+      int64_t cardinality = -1;
+      try {
+        path = parsed.deletion_file.value("path", std::string{});
+        offset = parsed.deletion_file.value("offset", int64_t{-1});
+        length = parsed.deletion_file.value("length", int64_t{-1});
+        cardinality = parsed.deletion_file.value("cardinality", int64_t{-1});
+      } catch (const nlohmann::json::exception& error) {
+        return arrow::Status::Invalid("Paimon deletion_file has invalid field types: ", error.what());
+      }
+      if (path.empty() || offset < 0 || length < 0) {
+        return arrow::Status::Invalid("Paimon deletion_file has invalid path or range");
+      }
+      ARROW_ASSIGN_OR_RAISE(auto positions,
+                            ReadDeletionVector(path, static_cast<uint64_t>(offset), static_cast<uint64_t>(length),
+                                               cardinality, storage_options));
+      deletions->reserve(positions.size());
+      for (auto position : positions) {
+        if (position >= physical_rows) {
+          return arrow::Status::Invalid("Paimon deletion position exceeds physical row count");
+        }
+        deletions->push_back(position);
+      }
     }
+    std::sort(deletions->begin(), deletions->end());
+    if (std::adjacent_find(deletions->begin(), deletions->end()) != deletions->end()) {
+      return arrow::Status::Invalid("Paimon deletion vector contains duplicate positions");
+    }
+    metadata->payload.sorted_deletions = deletions;
+    ARROW_ASSIGN_OR_RAISE(metadata->row_group_infos, MakeDirectLogicalRowGroups(physical_groups, *deletions));
+    auto logical_rows = metadata->row_group_infos.empty() ? 0 : metadata->row_group_infos.back().end_offset;
+    if (logical_rows != parsed.record_count) {
+      return arrow::Status::Invalid("Paimon direct-file row count mismatch: descriptor=", parsed.record_count,
+                                    ", reader=", logical_rows);
+    }
+    metadata->cache_size = direct_cache_size + deletions->size() * sizeof(uint64_t) + metadata_json.size() +
+                           physical_groups.size() * sizeof(RowGroupInfo);
+  } else {
+    ARROW_ASSIGN_OR_RAISE(auto logical_chunk_rows,
+                          api::GetValue<uint64_t>(properties, PROPERTY_READER_LOGICAL_CHUNK_ROWS));
+    ARROW_ASSIGN_OR_RAISE(
+        auto reader, BlockingPaimonDataSplitReader::Open(metadata_json, ToStandardUri(file.path), storage_options));
+    ArrowSchema c_schema{};
+    ARROW_RETURN_NOT_OK(reader->ExportSchema(&c_schema));
+    ARROW_ASSIGN_OR_RAISE(metadata->file_schema, arrow::ImportSchema(&c_schema));
+    // Keep the handle: every reader created from this cached metadata shares
+    // it, so schema and snapshot resolution happen once per descriptor.
+    metadata->payload.split_reader_handle = std::move(reader);
+    ARROW_ASSIGN_OR_RAISE(metadata->row_group_infos, MakeLogicalRowGroups(parsed.record_count, logical_chunk_rows));
+    metadata->cache_size =
+        sizeof(Metadata) + metadata_json.size() + metadata->row_group_infos.size() * sizeof(RowGroupInfo);
+    MetadataPtr result = metadata;
+    return result;
   }
-  std::sort(deletions->begin(), deletions->end());
-  if (std::adjacent_find(deletions->begin(), deletions->end()) != deletions->end()) {
-    return arrow::Status::Invalid("Paimon deletion vector contains duplicate positions");
-  }
-  metadata->payload.sorted_deletions = deletions;
-  ARROW_ASSIGN_OR_RAISE(metadata->row_group_infos, MakeDirectLogicalRowGroups(physical_groups, *deletions));
-  auto logical_rows = metadata->row_group_infos.empty() ? 0 : metadata->row_group_infos.back().end_offset;
-  if (logical_rows != parsed.record_count) {
-    return arrow::Status::Invalid("Paimon direct-file row count mismatch: descriptor=", parsed.record_count,
-                                  ", reader=", logical_rows);
-  }
-  metadata->cache_size = direct_cache_size + deletions->size() * sizeof(uint64_t) + metadata_json.size() +
-                         physical_groups.size() * sizeof(RowGroupInfo);
-
   MetadataPtr result = metadata;
   return result;
 }
@@ -332,6 +538,22 @@ arrow::Result<std::shared_ptr<PaimonFormatReader>> PaimonFormatReader::MetaTrait
     return arrow::Status::Invalid("Cannot create Paimon reader from null metadata");
   }
   ARROW_ASSIGN_OR_RAISE(auto output_schema, ProjectSchema(metadata->file_schema, read_schema, needed_columns));
+  if (metadata->payload.read_path == kDataSplitReadPath) {
+    auto split_columns = needed_columns;
+    if (split_columns.empty() && read_schema) {
+      split_columns = read_schema->field_names();
+    }
+    // Reuse the projection-agnostic handle owned by the cached metadata:
+    // no per-reader schema/snapshot resolution happens here anymore.
+    auto split_reader = metadata->payload.split_reader_handle;
+    if (!split_reader) {
+      return arrow::Status::Invalid("Paimon data-split reader handle is unavailable in cached metadata");
+    }
+    return std::shared_ptr<PaimonFormatReader>(
+        new PaimonFormatReader(std::move(metadata), file, read_schema, needed_columns, nullptr, std::move(split_reader),
+                               std::move(split_columns), std::move(output_schema)));
+  }
+
   std::shared_ptr<FormatReader> direct_file_reader;
   if (metadata->payload.data_format == "parquet") {
     auto cached =
@@ -356,8 +578,9 @@ arrow::Result<std::shared_ptr<PaimonFormatReader>> PaimonFormatReader::MetaTrait
   } else {
     return arrow::Status::NotImplemented("Paimon direct-file does not support format: ", metadata->payload.data_format);
   }
-  return std::shared_ptr<PaimonFormatReader>(new PaimonFormatReader(
-      std::move(metadata), file, read_schema, needed_columns, std::move(direct_file_reader), std::move(output_schema)));
+  return std::shared_ptr<PaimonFormatReader>(
+      new PaimonFormatReader(std::move(metadata), file, read_schema, needed_columns, std::move(direct_file_reader),
+                             nullptr, std::vector<std::string>{}, std::move(output_schema)));
 }
 
 PaimonFormatReader::PaimonFormatReader(MetaTrait::MetadataPtr metadata,
@@ -365,19 +588,35 @@ PaimonFormatReader::PaimonFormatReader(MetaTrait::MetadataPtr metadata,
                                        std::shared_ptr<arrow::Schema> read_schema,
                                        std::vector<std::string> needed_columns,
                                        std::shared_ptr<FormatReader> direct_file_reader,
+                                       std::shared_ptr<BlockingPaimonDataSplitReader> split_reader,
+                                       std::vector<std::string> split_columns,
                                        std::shared_ptr<arrow::Schema> output_schema)
     : metadata_(std::move(metadata)),
       file_(std::move(file)),
       read_schema_(std::move(read_schema)),
       needed_columns_(std::move(needed_columns)),
       direct_file_reader_(std::move(direct_file_reader)),
+      split_reader_(std::move(split_reader)),
+      split_columns_(std::move(split_columns)),
       output_schema_(std::move(output_schema)) {}
 
+bool PaimonFormatReader::is_data_split() const { return metadata_->payload.read_path == kDataSplitReadPath; }
+
 arrow::Status PaimonFormatReader::open() {
-  if (!direct_file_reader_) {
+  if (is_data_split()) {
+    if (!split_reader_) {
+      return arrow::Status::Invalid("Paimon data-split reader is unavailable");
+    }
+  } else if (!direct_file_reader_) {
     return arrow::Status::Invalid("Paimon direct-file reader is unavailable");
   }
   return arrow::Status::OK();
+}
+
+arrow::Result<std::unique_ptr<DataSplitStreamCursor>> PaimonFormatReader::make_data_split_cursor() const {
+  ARROW_ASSIGN_OR_RAISE(auto stream, split_reader_->OpenStream(split_columns_));
+  ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
+  return std::make_unique<DataSplitStreamCursor>(std::move(reader), metadata_->payload.record_count);
 }
 
 arrow::Result<std::vector<RowGroupInfo>> PaimonFormatReader::get_row_group_infos() {
@@ -405,6 +644,10 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> PaimonFormatReader::get_chunk
   if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= metadata_->row_group_infos.size()) {
     return arrow::Status::Invalid("Paimon row group index out of range: ", row_group_index);
   }
+  if (is_data_split()) {
+    ARROW_ASSIGN_OR_RAISE(auto chunks, get_chunks({row_group_index}));
+    return chunks.front();
+  }
   const auto& group = metadata_->row_group_infos[row_group_index];
   if (group.start_offset == group.end_offset) {
     return arrow::RecordBatch::MakeEmpty(output_schema_);
@@ -419,6 +662,23 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> PaimonFormatRead
   std::vector<std::shared_ptr<arrow::RecordBatch>> output;
   output.reserve(indices.size());
   if (indices.empty()) {
+    return output;
+  }
+  if (is_data_split()) {
+    int previous = -1;
+    for (auto index : indices) {
+      if (index <= previous || index < 0 || static_cast<size_t>(index) >= metadata_->row_group_infos.size()) {
+        return arrow::Status::Invalid("Paimon get_chunks requires sorted unique row group indices");
+      }
+      previous = index;
+    }
+    ARROW_ASSIGN_OR_RAISE(auto cursor, make_data_split_cursor());
+    for (auto index : indices) {
+      const auto& group = metadata_->row_group_infos[index];
+      ARROW_ASSIGN_OR_RAISE(auto batches, cursor->ReadRange(group.start_offset, group.end_offset));
+      ARROW_ASSIGN_OR_RAISE(auto batch, CombineBatches(batches, output_schema_));
+      output.push_back(std::move(batch));
+    }
     return output;
   }
   for (auto index : indices) {
@@ -469,6 +729,11 @@ arrow::Result<std::shared_ptr<arrow::Table>> PaimonFormatReader::take(const std:
   if (indices.empty()) {
     return arrow::Table::MakeEmpty(output_schema_);
   }
+  if (is_data_split()) {
+    ARROW_ASSIGN_OR_RAISE(auto cursor, make_data_split_cursor());
+    ARROW_ASSIGN_OR_RAISE(auto selected_batches, cursor->TakeRows(indices));
+    return arrow::Table::FromRecordBatches(output_schema_, selected_batches);
+  }
   ARROW_ASSIGN_OR_RAISE(auto physical, logical_to_physical(indices));
   return direct_file_reader_->take(physical);
 }
@@ -481,6 +746,25 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> PaimonFormatReader::rea
   if (start == end) {
     ARROW_ASSIGN_OR_RAISE(auto empty, arrow::RecordBatch::MakeEmpty(output_schema_));
     return arrow::RecordBatchReader::Make({empty});
+  }
+  if (is_data_split()) {
+    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    for (const auto& group : metadata_->row_group_infos) {
+      const auto group_start = static_cast<uint64_t>(group.start_offset);
+      const auto group_end = static_cast<uint64_t>(group.end_offset);
+      if (group_end <= start) {
+        continue;
+      }
+      if (group_start >= end) {
+        break;
+      }
+      ranges.emplace_back(std::max(start, group_start), std::min(end, group_end));
+    }
+    if (ranges.empty()) {
+      return arrow::Status::Invalid("Paimon data-split range does not intersect a logical chunk");
+    }
+    ARROW_ASSIGN_OR_RAISE(auto cursor, make_data_split_cursor());
+    return std::make_shared<DataSplitRangeReader>(std::move(cursor), std::move(ranges), output_schema_);
   }
   ARROW_ASSIGN_OR_RAISE(auto physical,
                         logical_to_physical({static_cast<int64_t>(start), static_cast<int64_t>(end - 1)}));
@@ -498,5 +782,4 @@ arrow::Result<std::shared_ptr<FormatReader>> PaimonFormatReader::clone_reader() 
 }
 
 std::shared_ptr<arrow::Schema> PaimonFormatReader::get_schema() const { return metadata_->file_schema; }
-
 }  // namespace milvus_storage::paimon

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -38,6 +38,8 @@ namespace milvus_storage::paimon {
 namespace {
 
 constexpr size_t kMaxPaimonMetadataBytes = 12 * 1024 * 1024;
+// Rust emits this prefix from paimon_bridgeimpl.rs; detailed marker mapping is
+// centralized in MakePaimonBridgeErrorStatus.
 constexpr std::string_view kPaimonErrorMarker = "[paimon:error=";
 
 arrow::Status TranslatePaimonStreamStatus(arrow::Status status) {

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -340,6 +340,8 @@ class DataSplitStreamCursor {
     return output;
   }
 
+  [[nodiscard]] uint64_t position() const { return position_; }
+
   arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> TakeRows(const std::vector<int64_t>& row_indices) {
     int64_t previous = -1;
     for (auto row : row_indices) {
@@ -439,6 +441,8 @@ class DataSplitStreamCursor {
   uint64_t position_ = 0;
   uint64_t declared_rows_;
 };
+
+PaimonFormatReader::~PaimonFormatReader() = default;
 
 namespace {
 
@@ -703,8 +707,20 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> PaimonFormatReader::get_chunk
     return arrow::Status::Invalid("Paimon row group index out of range: ", row_group_index);
   }
   if (is_data_split()) {
-    ARROW_ASSIGN_OR_RAISE(auto chunks, get_chunks({row_group_index}));
-    return chunks.front();
+    const auto& group = metadata_->row_group_infos[row_group_index];
+    if (!data_split_cursor_ || group.start_offset < data_split_cursor_->position()) {
+      ARROW_ASSIGN_OR_RAISE(data_split_cursor_, make_data_split_cursor());
+    }
+    auto batches = data_split_cursor_->ReadRange(group.start_offset, group.end_offset);
+    if (!batches.ok()) {
+      data_split_cursor_.reset();
+      return batches.status();
+    }
+    auto batch = CombineBatches(*batches, output_schema_);
+    if (!batch.ok()) {
+      data_split_cursor_.reset();
+    }
+    return batch;
   }
   const auto& group = metadata_->row_group_infos[row_group_index];
   if (group.start_offset == group.end_offset) {

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <exception>
 #include <limits>
+#include <string_view>
 #include <utility>
 
 #include <arrow/array/builder_primitive.h>
@@ -37,6 +38,34 @@ namespace milvus_storage::paimon {
 namespace {
 
 constexpr size_t kMaxPaimonMetadataBytes = 12 * 1024 * 1024;
+constexpr std::string_view kPaimonErrorMarker = "[paimon:error=";
+
+arrow::Status TranslatePaimonStreamStatus(arrow::Status status) {
+  if (status.ok() || status.message().find(kPaimonErrorMarker) == std::string_view::npos) {
+    return status;
+  }
+  return MakePaimonBridgeErrorStatus(status.message());
+}
+
+class PaimonErrorTranslatingReader final : public arrow::RecordBatchReader {
+  public:
+  explicit PaimonErrorTranslatingReader(std::shared_ptr<arrow::RecordBatchReader> inner) : inner_(std::move(inner)) {}
+
+  std::shared_ptr<arrow::Schema> schema() const override { return inner_->schema(); }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+    return TranslatePaimonStreamStatus(inner_->ReadNext(batch));
+  }
+
+  arrow::Status Close() override { return TranslatePaimonStreamStatus(inner_->Close()); }
+
+  private:
+  std::shared_ptr<arrow::RecordBatchReader> inner_;
+};
+
+std::shared_ptr<arrow::RecordBatchReader> WrapPaimonStreamReader(std::shared_ptr<arrow::RecordBatchReader> inner) {
+  return std::make_shared<PaimonErrorTranslatingReader>(std::move(inner));
+}
 
 struct ParsedMetadata {
   std::string read_path;
@@ -616,7 +645,8 @@ arrow::Status PaimonFormatReader::open() {
 arrow::Result<std::unique_ptr<DataSplitStreamCursor>> PaimonFormatReader::make_data_split_cursor() const {
   ARROW_ASSIGN_OR_RAISE(auto stream, split_reader_->OpenStream(split_columns_));
   ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&stream));
-  return std::make_unique<DataSplitStreamCursor>(std::move(reader), metadata_->payload.record_count);
+  return std::make_unique<DataSplitStreamCursor>(WrapPaimonStreamReader(std::move(reader)),
+                                                 metadata_->payload.record_count);
 }
 
 arrow::Result<std::vector<RowGroupInfo>> PaimonFormatReader::get_row_group_infos() {

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -585,15 +585,15 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
         int64_t(32LL * 1024 * 1024),                                                            // 32 MB
         ValidatePropertyType() + ValidatePropertyRange<int64_t>(1, 4LL * 1024 * 1024 * 1024)),  // max 4 GB
 
-    REGISTER_PROPERTY(
-        PROPERTY_READER_LOGICAL_CHUNK_ROWS,
-        PropertyType::UINT64,
-        "The logical chunk rows for Vortex/Lance-table reader, notice that the actual chunk rows maybe smaller."
-        "Although vortex does not divide according to row groups, but it still have the split strategy to"
-        "split the row ranges(default strategy is base on the layout rows). So this property can help to"
-        "control the rows read per chunk. The actual chunk rows is min(logical_chunk_rows, layout_rows).",
-        uint64_t(8192),  // 8192 rows
-        ValidatePropertyType() + ValidatePropertyRange<uint64_t>(1, UINT64_MAX)),
+    REGISTER_PROPERTY(PROPERTY_READER_LOGICAL_CHUNK_ROWS,
+                      PropertyType::UINT64,
+                      "The logical chunk rows for Vortex/Lance-table/Paimon data-split readers; the actual chunk rows "
+                      "may be smaller. "
+                      "Although vortex does not divide according to row groups, but it still have the split strategy to"
+                      "split the row ranges(default strategy is base on the layout rows). So this property can help to"
+                      "control the rows read per chunk. The actual chunk rows is min(logical_chunk_rows, layout_rows).",
+                      uint64_t(8192),  // 8192 rows
+                      ValidatePropertyType() + ValidatePropertyRange<uint64_t>(1, UINT64_MAX)),
     REGISTER_PROPERTY(PROPERTY_READER_METADATA_CACHE_ENABLE,
                       PropertyType::BOOL,
                       "Whether to cache reusable format reader metadata while reading.",
@@ -623,9 +623,9 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
 
     REGISTER_PROPERTY(PROPERTY_PAIMON_SCAN_MODE,
                       PropertyType::STRING,
-                      "Paimon split routing mode: auto or direct-file.",
+                      "Paimon split routing mode: auto, direct-file, or data-split.",
                       "auto",
-                      ValidatePropertyType() + ValidatePropertyEnum<std::string>("auto", "direct-file")),
+                      ValidatePropertyType() + ValidatePropertyEnum<std::string>("auto", "direct-file", "data-split")),
     REGISTER_PROPERTY(PROPERTY_PAIMON_SNAPSHOT_ID,
                       PropertyType::INT64,
                       "Paimon snapshot ID. -1 reads the latest snapshot.",

--- a/cpp/test/api_properties_test.cpp
+++ b/cpp/test/api_properties_test.cpp
@@ -164,12 +164,12 @@ TEST_F(APIPropertiesTest, paimon_scan_mode) {
 
   EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_PAIMON_SCAN_MODE), "auto");
 
-  for (const auto* mode : {"auto", "direct-file"}) {
+  for (const auto* mode : {"auto", "direct-file", "data-split"}) {
     EXPECT_EQ(SetValue(pp, PROPERTY_PAIMON_SCAN_MODE, mode), std::nullopt);
     EXPECT_EQ(GetValueNoError<std::string>(pp, PROPERTY_PAIMON_SCAN_MODE), mode);
   }
 
-  EXPECT_NE(SetValue(pp, PROPERTY_PAIMON_SCAN_MODE, "data-split"), std::nullopt);
+  EXPECT_NE(SetValue(pp, PROPERTY_PAIMON_SCAN_MODE, "invalid"), std::nullopt);
   EXPECT_STREQ(loon_properties_paimon_scan_mode, PROPERTY_PAIMON_SCAN_MODE);
 
   EXPECT_EQ(GetValueNoError<int64_t>(pp, PROPERTY_PAIMON_SNAPSHOT_ID), -1);

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -687,6 +687,33 @@ TEST_F(PaimonIntegrationTest, DataSplitTakeCompactsSparseBatches) {
   }
 }
 
+TEST_F(PaimonIntegrationTest, DataSplitHonorsReadSchemaForTakeAndRange) {
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 17, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+
+  auto read_schema = arrow::schema({arrow::field("id", arrow::int64(), false)});
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(read_schema, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+
+  ASSERT_AND_ASSIGN(auto taken, reader->take({0, 8, 16}));
+  EXPECT_TRUE(taken->schema()->Equals(*read_schema));
+  ASSERT_EQ(taken->num_rows(), 3);
+
+  ASSERT_AND_ASSIGN(auto range, reader->read_with_range(3, 9));
+  ASSERT_AND_ASSIGN(auto range_table, arrow::Table::FromRecordBatchReader(range.get()));
+  EXPECT_TRUE(range_table->schema()->Equals(*read_schema));
+  EXPECT_EQ(range_table->num_rows(), 6);
+
+  auto incompatible_schema = arrow::schema({arrow::field("id", arrow::int32())});
+  ASSERT_AND_ASSIGN(auto incompatible_reader, FormatReader::create(incompatible_schema, LOON_FORMAT_PAIMON_TABLE,
+                                                                   files.front(), properties_, {"id"}, nullptr));
+  auto incompatible = incompatible_reader->take({0});
+  ASSERT_FALSE(incompatible.ok());
+  EXPECT_TRUE(incompatible.status().IsInvalid()) << incompatible.status().ToString();
+  EXPECT_NE(incompatible.status().ToString().find("schema mismatch"), std::string::npos);
+}
+
 TEST_F(PaimonIntegrationTest, AsyncDataSplitChunksSpanSourceBatches) {
   constexpr uint64_t kRows = 10000;
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -722,6 +722,54 @@ TEST_F(PaimonIntegrationTest, DataSplitTakeCompactsSparseBatches) {
   }
 }
 
+TEST_F(PaimonIntegrationTest, ProjectsReadSchemaParentForDirectFileAndDataSplit) {
+  struct TestCase {
+    std::string mode;
+    std::string format;
+    std::string read_path;
+  };
+  const std::vector<TestCase> cases = {
+      {"append", "parquet", "direct-file"},
+      {"append", "vortex", "direct-file"},
+      {"mor", "parquet", "data-split"},
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(fmt::format("mode={}, format={}", test_case.mode, test_case.format));
+    table_dir_ = fmt::format("/tmp/milvus-storage-paimon-projection-{}-{}", test_case.mode, test_case.format);
+    std::filesystem::remove_all(table_dir_);
+    FilesystemCache::getInstance().clean();
+    ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 17, test_case.mode, {}, test_case.format).status());
+    ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+    ASSERT_FALSE(files.empty());
+    EXPECT_EQ(ReadPath(files.front()), test_case.read_path);
+
+    auto read_schema = arrow::schema({arrow::field("id", arrow::int64()), arrow::field("name", arrow::utf8()),
+                                      arrow::field("value", arrow::float64())});
+    ASSERT_AND_ASSIGN(auto reader, FormatReader::create(read_schema, LOON_FORMAT_PAIMON_TABLE, files.front(),
+                                                        properties_, {"name", "id"}, nullptr));
+    ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
+    EXPECT_EQ(batch->schema()->field_names(), (std::vector<std::string>{"name", "id"}));
+    ASSERT_GT(batch->num_rows(), 0);
+    auto names = std::dynamic_pointer_cast<arrow::StringArray>(batch->column(0));
+    auto ids = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(1));
+    ASSERT_NE(names, nullptr);
+    ASSERT_NE(ids, nullptr);
+    EXPECT_EQ(names->GetString(0), "row_0");
+    EXPECT_EQ(ids->Value(0), 0);
+
+    ASSERT_AND_ASSIGN(auto taken, reader->take({0}));
+    EXPECT_EQ(taken->schema()->field_names(), (std::vector<std::string>{"name", "id"}));
+    auto taken_names = std::dynamic_pointer_cast<arrow::StringArray>(taken->column(0)->chunk(0));
+    auto taken_ids = std::dynamic_pointer_cast<arrow::Int64Array>(taken->column(1)->chunk(0));
+    ASSERT_NE(taken_names, nullptr);
+    ASSERT_NE(taken_ids, nullptr);
+    EXPECT_EQ(taken_names->GetString(0), "row_0");
+    EXPECT_EQ(taken_ids->Value(0), 0);
+    std::filesystem::remove_all(table_dir_);
+  }
+}
+
 TEST_F(PaimonIntegrationTest, DataSplitHonorsReadSchemaForTakeAndRange) {
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 17, "mor").status());
   ASSERT_AND_ASSIGN(auto files, Explore("auto"));

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -727,6 +727,20 @@ TEST_F(PaimonIntegrationTest, MalformedDataSplitDescriptorFailsAsInvalid) {
   EXPECT_TRUE(reader.status().IsInvalid()) << reader.status().ToString();
 }
 
+TEST_F(PaimonIntegrationTest, ZeroRowDataSplitDescriptorFailsAsInvalid) {
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "append").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("data-split"));
+  ASSERT_EQ(files.size(), 1);
+
+  auto descriptor = folly::parseJson(files.front().Get<std::string>(api::kPropertyMetadata));
+  descriptor["record_count"] = 0;
+  files.front().Set(api::kPropertyMetadata, folly::toJson(descriptor));
+  auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
+  ASSERT_FALSE(reader.ok());
+  EXPECT_TRUE(reader.status().IsInvalid()) << reader.status().ToString();
+  EXPECT_NE(reader.status().ToString().find("zero record_count"), std::string::npos);
+}
+
 TEST_F(PaimonIntegrationTest, FullyDeletedTableProducesNoEntries) {
   constexpr uint64_t kRows = 6;
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "deletion-vector", {0, 1, 2, 3, 4, 5}).status());

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -659,6 +659,24 @@ TEST_F(PaimonIntegrationTest, DataSplitReadsNonContiguousChunks) {
   }
 }
 
+TEST_F(PaimonIntegrationTest, DataSplitSupportsForwardAndBackwardChunkReads) {
+  constexpr uint64_t kRows = 4096;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "512"), std::nullopt);
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  for (auto chunk : {1, 2, 3, 1, 2}) {
+    ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(chunk));
+    const auto& ids = static_cast<const arrow::Int64Array&>(*batch->column(0));
+    ASSERT_EQ(ids.length(), 512);
+    EXPECT_EQ(ids.Value(0), chunk * 512);
+    EXPECT_EQ(ids.Value(511), chunk * 512 + 511);
+  }
+}
+
 TEST_F(PaimonIntegrationTest, DataSplitTakeCompactsSparseBatches) {
   constexpr uint64_t kRows = 4096;
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -72,6 +72,23 @@ class PaimonIntegrationTest : public ::testing::Test {
   std::string table_dir_;
 };
 
+class FailingRecordBatchReader : public arrow::RecordBatchReader {
+  public:
+  explicit FailingRecordBatchReader(arrow::Status status) : status_(std::move(status)) {}
+
+  std::shared_ptr<arrow::Schema> schema() const override { return arrow::schema({}); }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+    *batch = nullptr;
+    return status_;
+  }
+
+  arrow::Status Close() override { return status_; }
+
+  private:
+  arrow::Status status_;
+};
+
 std::string ReadPath(const api::ColumnGroupFile& file) {
   return folly::parseJson(file.Get<std::string>(api::kPropertyMetadata))["read_path"].asString();
 }
@@ -852,7 +869,35 @@ TEST(PaimonBridgeErrorClassification, MarkersMapToArrowStatuses) {
   EXPECT_TRUE(paimon::MakePaimonBridgeErrorStatus("unclassified storage failure").IsIOError());
 }
 
-TEST_F(PaimonIntegrationTest, DataSplitMidStreamNotFoundPreservesErrno) {
+TEST(PaimonBridgeErrorClassification, StreamReaderTranslatesReadNextNotFound) {
+  auto inner =
+      std::make_shared<FailingRecordBatchReader>(arrow::Status::IOError("[paimon:error=not-found] missing object"));
+  auto reader = paimon::internal::WrapPaimonRecordBatchReader(std::move(inner), arrow::schema({}));
+
+  std::shared_ptr<arrow::RecordBatch> batch;
+  auto status = reader->ReadNext(&batch);
+
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
+  EXPECT_EQ(status.ToString().find("[paimon:error="), std::string::npos);
+}
+
+TEST(PaimonBridgeErrorClassification, StreamReaderTranslatesReadNextThrottling) {
+  auto inner = std::make_shared<FailingRecordBatchReader>(
+      arrow::Status::IOError("[paimon:error=transient-throttling] object store rate limit"));
+  auto reader = paimon::internal::WrapPaimonRecordBatchReader(std::move(inner), arrow::schema({}));
+
+  std::shared_ptr<arrow::RecordBatch> batch;
+  auto status = reader->ReadNext(&batch);
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
+  EXPECT_TRUE(detail->retryable());
+  EXPECT_EQ(status.ToString().find("[paimon:error="), std::string::npos);
+}
+
+TEST_F(PaimonIntegrationTest, DataSplitMissingObjectPreservesErrno) {
   constexpr uint64_t kRows = 12;
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "append").status());
 
@@ -860,8 +905,9 @@ TEST_F(PaimonIntegrationTest, DataSplitMidStreamNotFoundPreservesErrno) {
   ASSERT_EQ(files.size(), 1);
   ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
                                                       {"id"}, nullptr));
-  ASSERT_AND_ASSIGN(auto stream, reader->read_with_range(0, kRows));
 
+  // Delete before opening the stream so the assertion is independent of
+  // paimon-rust's eager/lazy open behavior and POSIX unlink semantics.
   size_t removed_files = 0;
   for (const auto& entry : std::filesystem::recursive_directory_iterator(table_dir_)) {
     if (entry.is_regular_file() && entry.path().extension() == ".parquet") {
@@ -871,11 +917,17 @@ TEST_F(PaimonIntegrationTest, DataSplitMidStreamNotFoundPreservesErrno) {
   }
   ASSERT_GT(removed_files, 0);
 
-  std::shared_ptr<arrow::RecordBatch> batch;
+  auto stream = reader->read_with_range(0, kRows);
   arrow::Status status;
-  do {
-    status = stream->ReadNext(&batch);
-  } while (status.ok() && batch);
+  if (!stream.ok()) {
+    status = stream.status();
+  } else {
+    auto stream_reader = stream.ValueOrDie();
+    std::shared_ptr<arrow::RecordBatch> batch;
+    do {
+      status = stream_reader->ReadNext(&batch);
+    } while (status.ok() && batch);
+  }
 
   ASSERT_FALSE(status.ok());
   EXPECT_TRUE(status.IsIOError()) << status.ToString();

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -807,6 +807,37 @@ TEST(PaimonBridgeErrorClassification, MarkersMapToArrowStatuses) {
   EXPECT_TRUE(paimon::MakePaimonBridgeErrorStatus("unclassified storage failure").IsIOError());
 }
 
+TEST_F(PaimonIntegrationTest, DataSplitMidStreamNotFoundPreservesErrno) {
+  constexpr uint64_t kRows = 12;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "append").status());
+
+  ASSERT_AND_ASSIGN(auto files, Explore("data-split"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  ASSERT_AND_ASSIGN(auto stream, reader->read_with_range(0, kRows));
+
+  size_t removed_files = 0;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(table_dir_)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".parquet") {
+      ASSERT_TRUE(std::filesystem::remove(entry.path()));
+      ++removed_files;
+    }
+  }
+  ASSERT_GT(removed_files, 0);
+
+  std::shared_ptr<arrow::RecordBatch> batch;
+  arrow::Status status;
+  do {
+    status = stream->ReadNext(&batch);
+  } while (status.ok() && batch);
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
+  EXPECT_EQ(status.ToString().find("[paimon:error="), std::string::npos);
+}
+
 TEST_F(PaimonIntegrationTest, MissingPinnedSnapshotFailsPlanAsInvalidWithRefresh) {
   ASSERT_AND_ASSIGN(auto snapshot_id, paimon::CreateTestTable(table_dir_, 10, "append"));
   ASSERT_EQ(api::SetValue(properties_, PROPERTY_PAIMON_SNAPSHOT_ID, std::to_string(snapshot_id + 1000).c_str()),

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -96,11 +96,11 @@ int64_t ReadAllRows(const std::shared_ptr<FormatReader>& reader) {
 }
 
 arrow::Status RewriteParquetWithRowGroups(const std::string& path, int32_t rows_per_group, int32_t group_count) {
-  auto schema = arrow::schema({arrow::field("id", arrow::int32(), false)});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64(), false)});
   ARROW_ASSIGN_OR_RAISE(auto sink, arrow::io::FileOutputStream::Open(path));
   ARROW_ASSIGN_OR_RAISE(auto writer, ::parquet::arrow::FileWriter::Open(*schema, arrow::default_memory_pool(), sink));
   for (int32_t group = 0; group < group_count; ++group) {
-    arrow::Int32Builder builder;
+    arrow::Int64Builder builder;
     for (int32_t row = 0; row < rows_per_group; ++row) {
       ARROW_RETURN_NOT_OK(builder.Append(group * rows_per_group + row));
     }
@@ -139,7 +139,7 @@ TEST_F(PaimonIntegrationTest, ReadsWithoutMetadataCache) {
   column_group->columns = {"id", "name"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = files;
-  auto schema = arrow::schema({arrow::field("id", arrow::int32()), arrow::field("name", arrow::utf8())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64()), arrow::field("name", arrow::utf8())});
   ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE, "false"), std::nullopt);
 
   ASSERT_AND_ASSIGN(auto reader,
@@ -163,11 +163,11 @@ TEST_F(PaimonIntegrationTest, DeletionVectorReadsBypassDisabledMetadataCache) {
   column_group->columns = {"id", "name"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = files;
-  auto schema = arrow::schema({arrow::field("id", arrow::int32()), arrow::field("name", arrow::utf8())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64()), arrow::field("name", arrow::utf8())});
   ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE, "false"), std::nullopt);
 
   const auto key = paimon::PaimonFormatReader::MetaTrait::cache_key(files.front());
-  const std::vector<int32_t> expected_ids = {0, 2, 3, 4, 6, 7, 8};
+  const std::vector<int64_t> expected_ids = {0, 2, 3, 4, 6, 7, 8};
   MetadataCache cache;
   for (int round = 0; round < 2; ++round) {
     ASSERT_AND_ASSIGN(auto reader, api::ColumnGroupReader::create(schema, column_group, {"id", "name"}, properties_,
@@ -176,9 +176,9 @@ TEST_F(PaimonIntegrationTest, DeletionVectorReadsBypassDisabledMetadataCache) {
     std::vector<int64_t> chunk_indices(reader->total_number_of_chunks());
     std::iota(chunk_indices.begin(), chunk_indices.end(), 0);
     ASSERT_AND_ASSIGN(auto batches, reader->get_chunks(chunk_indices, 1));
-    std::vector<int32_t> ids;
+    std::vector<int64_t> ids;
     for (const auto& batch : batches) {
-      auto column = std::dynamic_pointer_cast<arrow::Int32Array>(batch->column(0));
+      auto column = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(0));
       ASSERT_NE(column, nullptr);
       for (int64_t row = 0; row < column->length(); ++row) {
         ids.push_back(column->Value(row));
@@ -214,11 +214,11 @@ TEST_F(PaimonIntegrationTest, AutoUsesDirectFileForAppendVortex) {
 
   ASSERT_AND_ASSIGN(auto taken, reader->take({0, 4, 16}));
   ASSERT_EQ(taken->num_rows(), 3);
-  const std::vector<int32_t> expected = {0, 4, 16};
+  const std::vector<int64_t> expected = {0, 4, 16};
   for (int64_t row = 0; row < taken->num_rows(); ++row) {
     ASSERT_AND_ASSIGN(auto scalar, taken->column(0)->GetScalar(row));
-    ASSERT_NE(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar), nullptr);
-    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar)->value, expected[row]);
+    ASSERT_NE(std::dynamic_pointer_cast<arrow::Int64Scalar>(scalar), nullptr);
+    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int64Scalar>(scalar)->value, expected[row]);
   }
 
   ASSERT_AND_ASSIGN(auto range, reader->read_with_range(3, 9));
@@ -226,8 +226,8 @@ TEST_F(PaimonIntegrationTest, AutoUsesDirectFileForAppendVortex) {
   ASSERT_EQ(range_table->num_rows(), 6);
   ASSERT_AND_ASSIGN(auto first, range_table->column(0)->GetScalar(0));
   ASSERT_AND_ASSIGN(auto last, range_table->column(0)->GetScalar(5));
-  EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int32Scalar>(first)->value, 3);
-  EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int32Scalar>(last)->value, 8);
+  EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int64Scalar>(first)->value, 3);
+  EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int64Scalar>(last)->value, 8);
 
   ASSERT_AND_ASSIGN(auto clone, reader->clone_reader());
   EXPECT_EQ(ReadAllRows(clone), static_cast<int64_t>(kRows));
@@ -246,10 +246,10 @@ TEST_F(PaimonIntegrationTest, VortexDeletionVectorUsesDirectFile) {
                                                       {"id"}, nullptr));
   ASSERT_AND_ASSIGN(auto taken, reader->take({0, 1, 4, 6}));
   ASSERT_EQ(taken->num_rows(), 4);
-  const std::vector<int32_t> expected = {0, 2, 6, 8};
+  const std::vector<int64_t> expected = {0, 2, 6, 8};
   for (int64_t row = 0; row < taken->num_rows(); ++row) {
     ASSERT_AND_ASSIGN(auto scalar, taken->column(0)->GetScalar(row));
-    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar)->value, expected[row]);
+    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int64Scalar>(scalar)->value, expected[row]);
   }
 }
 
@@ -312,7 +312,7 @@ TEST_F(PaimonIntegrationTest, ExplicitDataSplitReadsAppendTable) {
   column_group->columns = {"id"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = files;
-  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64())});
   MetadataCache cache;
   ASSERT_AND_ASSIGN(auto column_group_reader,
                     api::ColumnGroupReader::create(schema, column_group, {"id"}, properties_, nullptr, "", cache));
@@ -320,6 +320,28 @@ TEST_F(PaimonIntegrationTest, ExplicitDataSplitReadsAppendTable) {
   EXPECT_FALSE(cache.get<paimon::PaimonFormatReader>()
                    ->get(paimon::PaimonFormatReader::MetaTrait::cache_key(files.front()))
                    .has_value());
+}
+
+TEST_F(PaimonIntegrationTest, ExplicitDataSplitAppliesDeletionVector) {
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "deletion-vector", {1, 5, 9}).status());
+
+  ASSERT_AND_ASSIGN(auto files, Explore("data-split"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_EQ(ReadPath(files.front()), "data-split");
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+
+  std::vector<int64_t> ids;
+  ASSERT_AND_ASSIGN(auto groups, reader->get_row_group_infos());
+  for (size_t group = 0; group < groups.size(); ++group) {
+    ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(static_cast<int>(group)));
+    auto values = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(0));
+    ASSERT_NE(values, nullptr);
+    for (int64_t row = 0; row < values->length(); ++row) {
+      ids.push_back(values->Value(row));
+    }
+  }
+  EXPECT_EQ(ids, (std::vector<int64_t>{0, 2, 3, 4, 6, 7, 8}));
 }
 
 TEST_F(PaimonIntegrationTest, InvalidScanModeFailsAsInvalid) {
@@ -408,7 +430,7 @@ TEST_F(PaimonIntegrationTest, AutoUsesDirectFileAndAppliesDeletionVector) {
 
   ASSERT_AND_ASSIGN(auto taken, reader->take({0, 1, 4, 6}));
   ASSERT_EQ(taken->num_rows(), 4);
-  auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(taken->column(0)->chunk(0));
+  auto ids = std::dynamic_pointer_cast<arrow::Int64Array>(taken->column(0)->chunk(0));
   ASSERT_NE(ids, nullptr);
   EXPECT_EQ(ids->Value(0), 0);
   EXPECT_EQ(ids->Value(1), 2);
@@ -425,7 +447,7 @@ TEST_F(PaimonIntegrationTest, AutoUsesDirectFileAndAppliesDeletionVector) {
   ASSERT_AND_ASSIGN(auto range, reader->read_with_range(1, 5));
   ASSERT_AND_ASSIGN(auto range_table, arrow::Table::FromRecordBatchReader(range.get()));
   ASSERT_EQ(range_table->num_rows(), 4);
-  auto range_ids = std::dynamic_pointer_cast<arrow::Int32Array>(range_table->column(0)->chunk(0));
+  auto range_ids = std::dynamic_pointer_cast<arrow::Int64Array>(range_table->column(0)->chunk(0));
   ASSERT_NE(range_ids, nullptr);
   EXPECT_EQ(range_ids->Value(0), 2);
   EXPECT_EQ(range_ids->Value(1), 3);
@@ -497,22 +519,22 @@ TEST_F(PaimonIntegrationTest, DirectFileFragmentRangeUsesPostDeletionLogicalRows
   column_group->columns = {"id"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = {std::move(fragment)};
-  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64())});
   ASSERT_AND_ASSIGN(auto reader, api::ColumnGroupReader::create(schema, column_group, {"id"}, properties_, nullptr));
   ASSERT_EQ(reader->total_rows(), 4);
 
   std::vector<int64_t> chunk_indices(reader->total_number_of_chunks());
   std::iota(chunk_indices.begin(), chunk_indices.end(), 0);
   ASSERT_AND_ASSIGN(auto batches, reader->get_chunks(chunk_indices, 1));
-  std::vector<int32_t> ids;
+  std::vector<int64_t> ids;
   for (const auto& batch : batches) {
-    auto values = std::dynamic_pointer_cast<arrow::Int32Array>(batch->column(0));
+    auto values = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(0));
     ASSERT_NE(values, nullptr);
     for (int64_t row = 0; row < values->length(); ++row) {
       ids.push_back(values->Value(row));
     }
   }
-  EXPECT_EQ(ids, (std::vector<int32_t>{2, 3, 4, 6}));
+  EXPECT_EQ(ids, (std::vector<int64_t>{2, 3, 4, 6}));
 }
 
 TEST_F(PaimonIntegrationTest, IgnoredPredicatePreservesDirectFileFragmentRange) {
@@ -527,13 +549,13 @@ TEST_F(PaimonIntegrationTest, IgnoredPredicatePreservesDirectFileFragmentRange) 
   column_group->columns = {"id"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = {std::move(fragment)};
-  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64())});
   ASSERT_AND_ASSIGN(auto reader,
                     api::ColumnGroupReader::create(schema, column_group, {"id"}, properties_, nullptr, "id >= 0"));
 
   ASSERT_EQ(reader->total_number_of_chunks(), 1);
   ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
-  const auto& ids = static_cast<const arrow::Int32Array&>(*batch->column(0));
+  const auto& ids = static_cast<const arrow::Int64Array&>(*batch->column(0));
   ASSERT_EQ(ids.length(), 4);
   EXPECT_EQ(ids.Value(0), 2);
   EXPECT_EQ(ids.Value(1), 3);
@@ -558,7 +580,22 @@ TEST_F(PaimonIntegrationTest, AutoUsesDataSplitForMergeOnRead) {
 
   ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
                                                       {"id", "name"}, nullptr));
-  EXPECT_EQ(ReadAllRows(reader), static_cast<int64_t>(kRows));
+  int64_t rows = 0;
+  ASSERT_AND_ASSIGN(auto groups, reader->get_row_group_infos());
+  for (size_t group = 0; group < groups.size(); ++group) {
+    ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(static_cast<int>(group)));
+    auto ids = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(0));
+    auto names = std::dynamic_pointer_cast<arrow::StringArray>(batch->column(1));
+    ASSERT_NE(ids, nullptr);
+    ASSERT_NE(names, nullptr);
+    for (int64_t row = 0; row < batch->num_rows(); ++row) {
+      const auto id = ids->Value(row);
+      const auto multiplier = id < static_cast<int64_t>(kRows / 2) ? 1 : 10;
+      EXPECT_EQ(names->GetString(row), fmt::format("row_{}", id * multiplier));
+      ++rows;
+    }
+  }
+  EXPECT_EQ(rows, static_cast<int64_t>(kRows));
 }
 
 TEST_F(PaimonIntegrationTest, DataSplitSupportsRangeAndCloneReads) {
@@ -574,7 +611,7 @@ TEST_F(PaimonIntegrationTest, DataSplitSupportsRangeAndCloneReads) {
   EXPECT_EQ(range_table->num_rows(), 6);
   for (int64_t row = 0; row < range_table->num_rows(); ++row) {
     ASSERT_AND_ASSIGN(auto scalar, range_table->column(0)->GetScalar(row));
-    auto id = std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar);
+    auto id = std::dynamic_pointer_cast<arrow::Int64Scalar>(scalar);
     ASSERT_NE(id, nullptr);
     EXPECT_EQ(id->value, row + 3);
   }
@@ -595,7 +632,7 @@ TEST_F(PaimonIntegrationTest, DataSplitLogicalChunkSpansPaimonBatches) {
                                                       {"id"}, nullptr));
   ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
   ASSERT_EQ(batch->num_rows(), 8192);
-  auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(batch->column(0));
+  auto ids = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(0));
   ASSERT_NE(ids, nullptr);
   EXPECT_EQ(ids->Value(0), 0);
   EXPECT_EQ(ids->Value(8191), 8191);
@@ -614,7 +651,7 @@ TEST_F(PaimonIntegrationTest, DataSplitReadsNonContiguousChunks) {
   ASSERT_AND_ASSIGN(auto batches, reader->get_chunks(chunks));
   ASSERT_EQ(batches.size(), chunks.size());
   for (size_t index = 0; index < batches.size(); ++index) {
-    auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(batches[index]->column(0));
+    auto ids = std::dynamic_pointer_cast<arrow::Int64Array>(batches[index]->column(0));
     ASSERT_NE(ids, nullptr);
     ASSERT_EQ(ids->length(), 512);
     EXPECT_EQ(ids->Value(0), chunks[index] * 512);
@@ -640,13 +677,13 @@ TEST_F(PaimonIntegrationTest, DataSplitTakeCompactsSparseBatches) {
     ASSERT_NE(chunk->data()->buffers[1], nullptr);
     value_buffer_bytes += chunk->data()->buffers[1]->size();
   }
-  EXPECT_LE(value_buffer_bytes, static_cast<int64_t>(3 * sizeof(int32_t)));
+  EXPECT_LE(value_buffer_bytes, static_cast<int64_t>(3 * sizeof(int64_t)));
 
-  const std::vector<int32_t> expected = {0, 2048, 4095};
+  const std::vector<int64_t> expected = {0, 2048, 4095};
   for (int64_t row = 0; row < taken->num_rows(); ++row) {
     ASSERT_AND_ASSIGN(auto scalar, id_column->GetScalar(row));
-    ASSERT_NE(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar), nullptr);
-    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar)->value, expected[row]);
+    ASSERT_NE(std::dynamic_pointer_cast<arrow::Int64Scalar>(scalar), nullptr);
+    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int64Scalar>(scalar)->value, expected[row]);
   }
 }
 
@@ -660,7 +697,7 @@ TEST_F(PaimonIntegrationTest, AsyncDataSplitChunksSpanSourceBatches) {
   auto column_groups = std::make_shared<api::ColumnGroups>();
   column_groups->push_back(std::make_shared<api::ColumnGroup>(
       api::ColumnGroup{.columns = {"id"}, .format = LOON_FORMAT_PAIMON_TABLE, .files = {files.front()}}));
-  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64())});
   auto reader = api::Reader::create(column_groups, schema, nullptr, properties_);
   ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
 
@@ -668,7 +705,7 @@ TEST_F(PaimonIntegrationTest, AsyncDataSplitChunksSpanSourceBatches) {
   ASSERT_AND_ASSIGN(auto batches, std::move(chunk_reader->get_chunks_async(chunks, 8)).get());
   ASSERT_EQ(batches.size(), chunks.size());
   for (size_t index = 0; index < batches.size(); ++index) {
-    auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(batches[index]->column(0));
+    auto ids = std::dynamic_pointer_cast<arrow::Int64Array>(batches[index]->column(0));
     ASSERT_NE(ids, nullptr);
     const int64_t expected_rows = index == 0 ? 8192 : 1808;
     ASSERT_EQ(ids->length(), expected_rows);
@@ -707,19 +744,19 @@ TEST_F(PaimonIntegrationTest, FullyDeletedTrailingRowGroupIsNotExposedAsChunk) {
   column_group->columns = {"id"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = files;
-  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64())});
   ASSERT_AND_ASSIGN(auto reader, api::ColumnGroupReader::create(schema, column_group, {"id"}, properties_, nullptr));
   ASSERT_EQ(reader->total_number_of_chunks(), 2);
 
   ASSERT_AND_ASSIGN(auto batches, reader->get_chunks({0, 1}, 1));
-  std::vector<int32_t> ids;
+  std::vector<int64_t> ids;
   for (const auto& batch : batches) {
-    const auto& values = static_cast<const arrow::Int32Array&>(*batch->column(0));
+    const auto& values = static_cast<const arrow::Int64Array&>(*batch->column(0));
     for (int64_t row = 0; row < values.length(); ++row) {
       ids.push_back(values.Value(row));
     }
   }
-  EXPECT_EQ(ids, (std::vector<int32_t>{0, 1, 2, 3, 4, 5, 6, 7}));
+  EXPECT_EQ(ids, (std::vector<int64_t>{0, 1, 2, 3, 4, 5, 6, 7}));
 }
 
 TEST_F(PaimonIntegrationTest, MissingTableFailsAndWriterIsReadOnly) {
@@ -728,7 +765,7 @@ TEST_F(PaimonIntegrationTest, MissingTableFailsAndWriterIsReadOnly) {
   ASSERT_FALSE(files.ok());
 
   ASSERT_AND_ASSIGN(auto* format, Format::get(LOON_FORMAT_PAIMON_TABLE));
-  auto writer = format->create_writer(nullptr, arrow::schema({arrow::field("id", arrow::int32())}), "unused", "unused",
+  auto writer = format->create_writer(nullptr, arrow::schema({arrow::field("id", arrow::int64())}), "unused", "unused",
                                       properties_);
   ASSERT_FALSE(writer.ok());
   EXPECT_TRUE(writer.status().IsNotImplemented());
@@ -784,7 +821,7 @@ TEST_F(PaimonIntegrationTest, VortexWithoutMemoryStatisticsReturnsNotImplemented
   column_group->columns = {"id", "name"};
   column_group->format = LOON_FORMAT_PAIMON_TABLE;
   column_group->files = files;
-  auto schema = arrow::schema({arrow::field("id", arrow::int32()), arrow::field("name", arrow::utf8())});
+  auto schema = arrow::schema({arrow::field("id", arrow::int64()), arrow::field("name", arrow::utf8())});
   ASSERT_AND_ASSIGN(auto reader,
                     api::ColumnGroupReader::create(schema, column_group, {"id", "name"}, properties_, nullptr));
   ASSERT_GT(reader->total_number_of_chunks(), 0);

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -34,6 +34,7 @@
 #include "milvus-storage/format/paimon/paimon_common.h"
 #include "milvus-storage/format/paimon/paimon_format_reader.h"
 #include "milvus-storage/properties.h"
+#include "milvus-storage/reader.h"
 #include "paimon_bridge.h"
 #include "test_env.h"
 
@@ -289,14 +290,36 @@ TEST_F(PaimonIntegrationTest, ScanOptionsAreValidatedForLatestAndPinnedSnapshots
   EXPECT_NE(files.status().ToString().find("scan.watermark"), std::string::npos);
 }
 
-TEST_F(PaimonIntegrationTest, MergeOnReadTableFailsClosedAsNotImplemented) {
-  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "mor").status());
+TEST_F(PaimonIntegrationTest, ExplicitDataSplitReadsAppendTable) {
+  constexpr uint64_t kRows = 10;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "append").status());
 
-  auto files = Explore("auto");
-  ASSERT_FALSE(files.ok());
-  EXPECT_TRUE(files.status().IsNotImplemented()) << files.status().ToString();
-  const auto message = files.status().ToString();
-  EXPECT_NE(message.find("data-split reading"), std::string::npos) << message;
+  ASSERT_AND_ASSIGN(auto files, Explore("data-split"));
+  ASSERT_EQ(files.size(), 1);
+  EXPECT_EQ(ReadPath(files.front()), "data-split");
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_METADATA_CACHE_ENABLE, "false"), std::nullopt);
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  ASSERT_AND_ASSIGN(auto row_groups, reader->get_row_group_infos());
+  ASSERT_FALSE(row_groups.empty());
+  EXPECT_FALSE(row_groups.front().memory_size_available);
+  auto column_sizes = reader->get_rg_column_memsz(0);
+  ASSERT_FALSE(column_sizes.ok());
+  EXPECT_TRUE(column_sizes.status().IsNotImplemented()) << column_sizes.status().ToString();
+  EXPECT_EQ(ReadAllRows(reader), static_cast<int64_t>(kRows));
+
+  auto column_group = std::make_shared<api::ColumnGroup>();
+  column_group->columns = {"id"};
+  column_group->format = LOON_FORMAT_PAIMON_TABLE;
+  column_group->files = files;
+  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  MetadataCache cache;
+  ASSERT_AND_ASSIGN(auto column_group_reader,
+                    api::ColumnGroupReader::create(schema, column_group, {"id"}, properties_, nullptr, "", cache));
+  EXPECT_EQ(column_group_reader->total_rows(), static_cast<int64_t>(kRows));
+  EXPECT_FALSE(cache.get<paimon::PaimonFormatReader>()
+                   ->get(paimon::PaimonFormatReader::MetaTrait::cache_key(files.front()))
+                   .has_value());
 }
 
 TEST_F(PaimonIntegrationTest, InvalidScanModeFailsAsInvalid) {
@@ -525,7 +548,136 @@ TEST_F(PaimonIntegrationTest, ExplicitDirectFileRejectsMergeOnRead) {
   EXPECT_NE(files.status().ToString().find("cannot use direct-file"), std::string::npos);
 }
 
-TEST_F(PaimonIntegrationTest, DataSplitDescriptorFailsClosedAsNotImplemented) {
+TEST_F(PaimonIntegrationTest, AutoUsesDataSplitForMergeOnRead) {
+  constexpr uint64_t kRows = 17;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_EQ(ReadPath(files.front()), "data-split");
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id", "name"}, nullptr));
+  EXPECT_EQ(ReadAllRows(reader), static_cast<int64_t>(kRows));
+}
+
+TEST_F(PaimonIntegrationTest, DataSplitSupportsRangeAndCloneReads) {
+  constexpr uint64_t kRows = 17;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  ASSERT_AND_ASSIGN(auto range, reader->read_with_range(3, 9));
+  ASSERT_AND_ASSIGN(auto range_table, arrow::Table::FromRecordBatchReader(range.get()));
+  EXPECT_EQ(range_table->num_rows(), 6);
+  for (int64_t row = 0; row < range_table->num_rows(); ++row) {
+    ASSERT_AND_ASSIGN(auto scalar, range_table->column(0)->GetScalar(row));
+    auto id = std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar);
+    ASSERT_NE(id, nullptr);
+    EXPECT_EQ(id->value, row + 3);
+  }
+
+  ASSERT_AND_ASSIGN(auto clone, reader->clone_reader());
+  ASSERT_AND_ASSIGN(auto cloned_head, clone->get_chunk(0));
+  EXPECT_EQ(cloned_head->num_rows(), 4);
+}
+
+TEST_F(PaimonIntegrationTest, DataSplitLogicalChunkSpansPaimonBatches) {
+  constexpr uint64_t kRows = 10000;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "8192"), std::nullopt);
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
+  ASSERT_EQ(batch->num_rows(), 8192);
+  auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(batch->column(0));
+  ASSERT_NE(ids, nullptr);
+  EXPECT_EQ(ids->Value(0), 0);
+  EXPECT_EQ(ids->Value(8191), 8191);
+}
+
+TEST_F(PaimonIntegrationTest, DataSplitReadsNonContiguousChunks) {
+  constexpr uint64_t kRows = 4096;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "512"), std::nullopt);
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  const std::vector<int> chunks = {0, 2, 4, 6};
+  ASSERT_AND_ASSIGN(auto batches, reader->get_chunks(chunks));
+  ASSERT_EQ(batches.size(), chunks.size());
+  for (size_t index = 0; index < batches.size(); ++index) {
+    auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(batches[index]->column(0));
+    ASSERT_NE(ids, nullptr);
+    ASSERT_EQ(ids->length(), 512);
+    EXPECT_EQ(ids->Value(0), chunks[index] * 512);
+    EXPECT_EQ(ids->Value(511), chunks[index] * 512 + 511);
+  }
+}
+
+TEST_F(PaimonIntegrationTest, DataSplitTakeCompactsSparseBatches) {
+  constexpr uint64_t kRows = 4096;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+
+  ASSERT_AND_ASSIGN(auto reader, FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_,
+                                                      {"id"}, nullptr));
+  ASSERT_AND_ASSIGN(auto taken, reader->take({0, 2048, 4095}));
+  ASSERT_EQ(taken->num_rows(), 3);
+
+  int64_t value_buffer_bytes = 0;
+  const auto& id_column = taken->column(0);
+  for (const auto& chunk : id_column->chunks()) {
+    ASSERT_GE(chunk->data()->buffers.size(), 2);
+    ASSERT_NE(chunk->data()->buffers[1], nullptr);
+    value_buffer_bytes += chunk->data()->buffers[1]->size();
+  }
+  EXPECT_LE(value_buffer_bytes, static_cast<int64_t>(3 * sizeof(int32_t)));
+
+  const std::vector<int32_t> expected = {0, 2048, 4095};
+  for (int64_t row = 0; row < taken->num_rows(); ++row) {
+    ASSERT_AND_ASSIGN(auto scalar, id_column->GetScalar(row));
+    ASSERT_NE(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar), nullptr);
+    EXPECT_EQ(std::dynamic_pointer_cast<arrow::Int32Scalar>(scalar)->value, expected[row]);
+  }
+}
+
+TEST_F(PaimonIntegrationTest, AsyncDataSplitChunksSpanSourceBatches) {
+  constexpr uint64_t kRows = 10000;
+  ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, kRows, "mor").status());
+  ASSERT_AND_ASSIGN(auto files, Explore("auto"));
+  ASSERT_EQ(files.size(), 1);
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "8192"), std::nullopt);
+
+  auto column_groups = std::make_shared<api::ColumnGroups>();
+  column_groups->push_back(std::make_shared<api::ColumnGroup>(
+      api::ColumnGroup{.columns = {"id"}, .format = LOON_FORMAT_PAIMON_TABLE, .files = {files.front()}}));
+  auto schema = arrow::schema({arrow::field("id", arrow::int32())});
+  auto reader = api::Reader::create(column_groups, schema, nullptr, properties_);
+  ASSERT_AND_ASSIGN(auto chunk_reader, reader->get_chunk_reader(0));
+
+  const std::vector<int64_t> chunks = {0, 1};
+  ASSERT_AND_ASSIGN(auto batches, std::move(chunk_reader->get_chunks_async(chunks, 8)).get());
+  ASSERT_EQ(batches.size(), chunks.size());
+  for (size_t index = 0; index < batches.size(); ++index) {
+    auto ids = std::dynamic_pointer_cast<arrow::Int32Array>(batches[index]->column(0));
+    ASSERT_NE(ids, nullptr);
+    const int64_t expected_rows = index == 0 ? 8192 : 1808;
+    ASSERT_EQ(ids->length(), expected_rows);
+    EXPECT_EQ(ids->Value(0), chunks[index] * 8192);
+    EXPECT_EQ(ids->Value(expected_rows - 1), chunks[index] * 8192 + expected_rows - 1);
+  }
+}
+
+TEST_F(PaimonIntegrationTest, MalformedDataSplitDescriptorFailsAsInvalid) {
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "append").status());
   ASSERT_AND_ASSIGN(auto files, Explore("auto"));
   ASSERT_EQ(files.size(), 1);
@@ -535,7 +687,7 @@ TEST_F(PaimonIntegrationTest, DataSplitDescriptorFailsClosedAsNotImplemented) {
   files.front().Set(api::kPropertyMetadata, folly::toJson(descriptor));
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
-  EXPECT_TRUE(reader.status().IsNotImplemented()) << reader.status().ToString();
+  EXPECT_TRUE(reader.status().IsInvalid()) << reader.status().ToString();
 }
 
 TEST_F(PaimonIntegrationTest, FullyDeletedTableProducesNoEntries) {

--- a/cpp/test/tools/loon_test.cpp
+++ b/cpp/test/tools/loon_test.cpp
@@ -125,6 +125,11 @@ TEST_F(LoonTest, CreateAndReadPaimonAppend) {
                                 properties_);
 }
 
+TEST_F(LoonTest, CreateAndReadPaimonMergeOnRead) {
+  VerifyPaimonManifestRoundTrip(base_dir_ + "/paimon_mor", target_dir_ + "/paimon_mor", "mor", 30, {}, fs_,
+                                properties_);
+}
+
 TEST_F(LoonTest, CreateAndReadPaimonDeletionVector) {
   VerifyPaimonManifestRoundTrip(base_dir_ + "/paimon_dv", target_dir_ + "/paimon_dv", "deletion-vector", 30, {0, 5, 29},
                                 fs_, properties_);

--- a/cpp/tools/loon.cpp
+++ b/cpp/tools/loon.cpp
@@ -16,7 +16,8 @@
 // the manifest-based loon storage system.
 //
 // Usage:
-//   loon demo-table --type <type> --path <dir> [--rows N] [--deletes pos1,...]
+//   loon demo-table --type <type> --path <dir> [--scenario <scenario>]
+//                   [--rows N] [--dim N] [--deletes pos1,...]
 //   loon create     --format <format> --source <uri> --target <base_path>
 //                   --columns col1,col2,...  [--prop key=value ...]
 //   loon describe   <manifest_path> [--prop key=value ...]
@@ -46,8 +47,10 @@
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include "milvus-storage/format/iceberg/iceberg_common.h"
+#include "milvus-storage/format/paimon/paimon_common.h"
 #include "iceberg_bridge.h"
 #include "lance_bridge.h"
+#include "paimon_bridge.h"
 
 using milvus_storage::FilesystemCache;
 using milvus_storage::FormatReader;
@@ -127,6 +130,9 @@ static int DoDemoTable(int argc, char** argv) {
   std::string type;
   std::string path;
   uint64_t rows = 100;
+  uint32_t dimension = 0;
+  std::string scenario = "append-only";
+  bool scenario_explicit = false;
   std::vector<int64_t> deletes;
   std::vector<std::string> extra_props;
 
@@ -138,6 +144,11 @@ static int DoDemoTable(int argc, char** argv) {
       path = argv[++i];
     } else if (arg == "--rows" && i + 1 < argc) {
       rows = std::stoull(argv[++i]);
+    } else if (arg == "--dim" && i + 1 < argc) {
+      dimension = static_cast<uint32_t>(std::stoul(argv[++i]));
+    } else if (arg == "--scenario" && i + 1 < argc) {
+      scenario = argv[++i];
+      scenario_explicit = true;
     } else if (arg == "--deletes" && i + 1 < argc) {
       deletes = ParseInt64List(argv[++i]);
     } else if (arg == "--prop" && i + 1 < argc) {
@@ -147,24 +158,91 @@ static int DoDemoTable(int argc, char** argv) {
 
   if (type.empty() || path.empty()) {
     std::cerr << "Usage: loon demo-table --type <type> --path <dir>"
-              << " [--rows N] [--deletes pos1,pos2,...] [--prop key=value ...]" << std::endl;
+              << " [--scenario <scenario>] [--rows N] [--dim N]"
+              << " [--deletes pos1,pos2,...] [--prop key=value ...]" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Types: iceberg" << std::endl;
+    std::cerr << "Types: iceberg, paimon" << std::endl;
+    std::cerr << "Paimon scenarios: append-only (default), merge-on-read, deletion-vector" << std::endl;
     std::cerr << std::endl;
-    std::cerr << "Creates a demo table with schema (id int64, name string,"
-              << " value float64)." << std::endl;
+    std::cerr << "Scalar schema: id int64, name string, value float64." << std::endl;
+    std::cerr << "Paimon --dim schema: pk int64, label string, vector array<float>." << std::endl;
     std::cerr << R"(Data: id=0..N-1, name="row_0".."row_{N-1}", value=id*1.5)" << std::endl;
     std::cerr << std::endl;
     std::cerr << "For cloud storage, pass extfs.* properties via --prop." << std::endl;
     return 1;
   }
 
-  if (type != "iceberg") {
-    std::cerr << "Error: unsupported type '" << type << "'. Supported: iceberg" << std::endl;
+  if (type != "iceberg" && type != "paimon") {
+    std::cerr << "Error: unsupported type '" << type << "'. Supported: iceberg, paimon" << std::endl;
+    return 1;
+  }
+  if (type != "paimon" && scenario_explicit) {
+    std::cerr << "Error: --scenario is only valid for --type paimon" << std::endl;
+    return 1;
+  }
+  if (type != "paimon" && dimension > 0) {
+    std::cerr << "Error: --dim is only valid for --type paimon" << std::endl;
     return 1;
   }
 
   try {
+    if (type == "paimon") {
+      if (scenario != "append-only" && scenario != "merge-on-read" && scenario != "deletion-vector") {
+        std::cerr << "Error: unsupported Paimon scenario '" << scenario
+                  << "'. Supported: append-only, merge-on-read, deletion-vector" << std::endl;
+        return 1;
+      }
+      if (scenario == "deletion-vector" && deletes.empty()) {
+        std::cerr << "Error: deletion-vector requires --deletes pos1,pos2,..." << std::endl;
+        return 1;
+      }
+      if (scenario != "deletion-vector" && !deletes.empty()) {
+        std::cerr << "Error: --deletes is only valid with --scenario deletion-vector" << std::endl;
+        return 1;
+      }
+
+      milvus_storage::paimon::StorageOptions storage_options;
+      std::string table_path = path;
+      if (path.find("://") != std::string::npos || !extra_props.empty()) {
+        Properties properties;
+        SetValue(properties, PROPERTY_FS_ROOT_PATH, "/");
+        ApplyProps(properties, extra_props);
+        FilesystemCache::getInstance().clean();
+        auto config = FilesystemCache::resolve_config(properties, path);
+        if (!config.ok()) {
+          throw std::runtime_error(config.status().ToString());
+        }
+        auto options = milvus_storage::paimon::ToStorageOptions(config.ValueOrDie());
+        if (!options.ok()) {
+          throw std::runtime_error(options.status().ToString());
+        }
+        storage_options = std::move(options).ValueOrDie();
+        table_path = milvus_storage::paimon::ToStandardUri(path);
+      } else {
+        table_path = ResolvePath(path);
+      }
+
+      const auto mode = scenario == "append-only" ? "append" : scenario == "merge-on-read" ? "mor" : scenario;
+      auto info = milvus_storage::paimon::CreateTestTableInfo(table_path, rows, mode, deletes, storage_options,
+                                                              "parquet", dimension);
+      if (!info.ok()) {
+        throw std::runtime_error(info.status().ToString());
+      }
+      std::cout << "Created paimon table:" << std::endl;
+      std::cout << "  path:        " << table_path << std::endl;
+      std::cout << "  snapshots:   [";
+      for (size_t index = 0; index < info->snapshot_ids.size(); ++index) {
+        if (index > 0) {
+          std::cout << ",";
+        }
+        std::cout << info->snapshot_ids[index];
+      }
+      std::cout << "]" << std::endl;
+      std::cout << "  scenario:    " << scenario << std::endl;
+      std::cout << "  rows:        " << rows << std::endl;
+      return 0;
+    }
+
     // Build storage options from properties (if any)
     std::unordered_map<std::string, std::string> storage_options;
     std::string table_path = path;
@@ -751,9 +829,11 @@ static void PrintUsage() {
             << std::endl
             << "demo-table:" << std::endl
             << "  loon demo-table --type <type> --path <dir> \\" << std::endl
-            << "                  [--rows N] [--deletes pos1,pos2,...]" << std::endl
+            << "                  [--scenario <scenario>] [--rows N] [--dim N] \\" << std::endl
+            << "                  [--deletes pos1,pos2,...] [--prop key=value ...]" << std::endl
             << std::endl
-            << "  Types: iceberg" << std::endl
+            << "  Types: iceberg, paimon" << std::endl
+            << "  Paimon scenarios: append-only (default), merge-on-read, deletion-vector" << std::endl
             << std::endl
             << "create:" << std::endl
             << "  loon create --format <format> --source <uri> \\" << std::endl

--- a/cpp/tools/loon.cpp
+++ b/cpp/tools/loon.cpp
@@ -25,6 +25,7 @@
 //                   [--take pos1,pos2,...] [--predicate "expr"]
 //                   [--verbose] [--prop key=value ...]
 
+#include <charconv>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -88,6 +89,14 @@ static std::vector<std::string> Split(const std::string& s, char delim) {
   return parts;
 }
 
+template <typename T>
+static bool ParseUnsigned(std::string_view input, T& output) {
+  const auto* begin = input.data();
+  const auto* end = begin + input.size();
+  const auto [parsed_end, error] = std::from_chars(begin, end, output);
+  return error == std::errc{} && parsed_end == end;
+}
+
 static std::vector<int64_t> ParseInt64List(const std::string& s) {
   std::vector<int64_t> result;
   for (const auto& part : Split(s, ',')) {
@@ -143,9 +152,15 @@ static int DoDemoTable(int argc, char** argv) {
     } else if (arg == "--path" && i + 1 < argc) {
       path = argv[++i];
     } else if (arg == "--rows" && i + 1 < argc) {
-      rows = std::stoull(argv[++i]);
+      if (!ParseUnsigned(argv[++i], rows)) {
+        std::cerr << "Error: --rows requires an unsigned integer" << std::endl;
+        return 1;
+      }
     } else if (arg == "--dim" && i + 1 < argc) {
-      dimension = static_cast<uint32_t>(std::stoul(argv[++i]));
+      if (!ParseUnsigned(argv[++i], dimension)) {
+        std::cerr << "Error: --dim requires an unsigned integer" << std::endl;
+        return 1;
+      }
     } else if (arg == "--scenario" && i + 1 < argc) {
       scenario = argv[++i];
       scenario_explicit = true;


### PR DESCRIPTION
Part of #593

Design + tracking: milvus-io/milvus#45881

Related tracking: milvus-io/milvus#50632

Consumed by: milvus-io/milvus#51897

## What changed

Add native Apache Paimon DataSplit reads as a follow-up to #602.

- Persist and validate versioned native DataSplit descriptors using paimon-rust 0.3.0.
- Stream projected Arrow batches without materializing a complete split.
- Stream each DataSplit read operation without materializing the complete split, while keeping the forward-only adapter inside the Paimon reader.
- Add the `data-split` scan mode and automatic fallback when direct-file reads cannot preserve Paimon semantics.
- Add Loon fixtures for append-only, deletion-vector, and merge-on-read tables.

## Routing

- `auto` keeps safe raw-convertible Parquet and Vortex splits on the direct-file path.
- `auto` falls back to DataSplit for merge-on-read, row ranges, partition columns, schema or data evolution, sidecars, and unsupported direct-file formats.
- `direct-file` fails explicitly when a split cannot be read safely.
- `data-split` forces native Paimon execution.

The direct-file behavior introduced by #602 remains unchanged.

Compared with the earlier combined #594 implementation, this PR is limited to DataSplit execution, uses the released native split codec, avoids whole-split materialization, coalesces normal eager and lazy loads onto a forward stream, and isolates take, range, and backward reads from the shared load cursor.

## Test plan

- Rust unit tests
- Paimon C++ integration and error-classification tests
- Loon append-only, deletion-vector, and merge-on-read scenarios
- Milvus external-collection Go unit tests
- Milvus standalone client/v3 E2E with auto, direct-file, DataSplit, deletion-vector, merge-on-read, and pinned snapshots

Signed-off-by: YangYanbin <warlock.yyb@alibaba-inc.com>
