### PR TITLE
enhance: reuse Azure and GCP cloud credential providers across Lance and Iceberg

### DIFF
--- a/cpp/src/format/bridge/rust/src/azure_sas_provider.rs
+++ b/cpp/src/format/bridge/rust/src/azure_sas_provider.rs
@@ -22,6 +22,12 @@ use std::time::Duration;
 use anyhow::{Result as AnyResult, anyhow, bail};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use iceberg::io::{
+    ADLS_SAS_TOKEN, FileMetadata, FileRead, FileWrite, InputFile, OutputFile,
+    Storage as IcebergStorage, StorageConfig, StorageFactory,
+};
+use iceberg::{Error as IcebergError, ErrorKind as IcebergErrorKind, Result as IcebergResult};
+use iceberg_storage_opendal::OpenDalStorageFactory;
 use lance_core::error::{Error as LanceError, Result as LanceResult};
 use lance_io::object_store::StorageOptionsProvider;
 use serde::{Deserialize, Serialize};
@@ -314,18 +320,15 @@ impl AzureSasStorageOptionsProvider {
             "Azure SAS credential broker failure: {error}"
         ))))
     }
-}
 
-#[async_trait]
-impl StorageOptionsProvider for AzureSasStorageOptionsProvider {
-    async fn fetch_storage_options(&self) -> LanceResult<Option<HashMap<String, String>>> {
+    pub(crate) async fn current_credential(&self) -> AnyResult<AzureSasCredential> {
         let mut now = (self.clock)();
         {
             let cached = self.cached.read().await;
             if let Some(credential) = cached.as_ref()
                 && Self::is_fresh(credential, now)
             {
-                return Ok(Some(Self::to_options(credential)));
+                return Ok(credential.clone());
             }
         }
 
@@ -334,14 +337,13 @@ impl StorageOptionsProvider for AzureSasStorageOptionsProvider {
         if let Some(credential) = cached.as_ref()
             && Self::is_fresh(credential, now)
         {
-            return Ok(Some(Self::to_options(credential)));
+            return Ok(credential.clone());
         }
 
         match self.fetcher.fetch(now).await {
             Ok(credential) => {
-                let options = Self::to_options(&credential);
-                *cached = Some(credential);
-                Ok(Some(options))
+                *cached = Some(credential.clone());
+                Ok(credential)
             }
             Err(error) => {
                 let has_cached_sas = cached.is_some();
@@ -351,22 +353,208 @@ impl StorageOptionsProvider for AzureSasStorageOptionsProvider {
                     .unwrap_or(false);
                 eprintln!(
                     "Warning: Azure SAS credential broker refresh failed: {}, has_cached_sas={}, cached_expired={}",
-                    error,
-                    has_cached_sas,
-                    cached_expired
+                    error, has_cached_sas, cached_expired
                 );
-                if let Some(credential) = cached.as_ref() {
-                    Ok(Some(Self::to_options(credential)))
-                } else {
-                    Err(Self::lance_error(&error))
-                }
+                Err(error)
             }
         }
+    }
+}
+
+#[async_trait]
+impl StorageOptionsProvider for AzureSasStorageOptionsProvider {
+    async fn fetch_storage_options(&self) -> LanceResult<Option<HashMap<String, String>>> {
+        self.current_credential()
+            .await
+            .map(|credential| Some(Self::to_options(&credential)))
+            .map_err(|error| Self::lance_error(&error))
     }
 
     fn provider_id(&self) -> String {
         self.provider_id.clone()
     }
+}
+
+fn azure_iceberg_credential_error(error: anyhow::Error) -> IcebergError {
+    IcebergError::new(
+        IcebergErrorKind::Unexpected,
+        format!("Azure SAS credential resolution failed: {error}"),
+    )
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct AzureSasStorageFactory {
+    inner: OpenDalStorageFactory,
+    #[serde(skip)]
+    provider: Option<Arc<AzureSasStorageOptionsProvider>>,
+}
+
+impl AzureSasStorageFactory {
+    pub(crate) async fn new(
+        inner: OpenDalStorageFactory,
+        config: AzureBrokerConfig,
+    ) -> IcebergResult<Self> {
+        let provider = Arc::new(
+            AzureSasStorageOptionsProvider::new(config).map_err(azure_iceberg_credential_error)?,
+        );
+        provider
+            .current_credential()
+            .await
+            .map_err(azure_iceberg_credential_error)?;
+        Ok(Self {
+            inner,
+            provider: Some(provider),
+        })
+    }
+}
+
+impl fmt::Debug for AzureSasStorageFactory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AzureSasStorageFactory")
+            .field("has_runtime_provider", &self.provider.is_some())
+            .finish()
+    }
+}
+
+#[typetag::serde(name = "AzureSasStorageFactory")]
+impl StorageFactory for AzureSasStorageFactory {
+    fn build(&self, config: &StorageConfig) -> IcebergResult<Arc<dyn IcebergStorage>> {
+        let provider = self.provider.clone().ok_or_else(|| {
+            IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                "Azure SAS runtime provider is unavailable",
+            )
+        })?;
+        Ok(Arc::new(AzureSasStorage {
+            inner: self.inner.clone(),
+            props: Arc::new(config.props().clone()),
+            provider: Some(provider),
+            cached_storage: Arc::new(RwLock::new(None)),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct CachedAzureSasStorage {
+    token: String,
+    storage: Arc<dyn IcebergStorage>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct AzureSasStorage {
+    inner: OpenDalStorageFactory,
+    #[serde(skip)]
+    props: Arc<HashMap<String, String>>,
+    #[serde(skip)]
+    provider: Option<Arc<AzureSasStorageOptionsProvider>>,
+    #[serde(skip)]
+    cached_storage: Arc<RwLock<Option<CachedAzureSasStorage>>>,
+}
+
+impl fmt::Debug for AzureSasStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AzureSasStorage")
+            .field("has_runtime_provider", &self.provider.is_some())
+            .finish()
+    }
+}
+
+impl AzureSasStorage {
+    async fn current_storage(&self) -> IcebergResult<Arc<dyn IcebergStorage>> {
+        let provider = self.provider.as_ref().ok_or_else(|| {
+            IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                "Azure SAS runtime provider is unavailable",
+            )
+        })?;
+        let credential = provider
+            .current_credential()
+            .await
+            .map_err(azure_iceberg_credential_error)?;
+        let token = credential.token;
+        {
+            let cached = self.cached_storage.read().await;
+            if let Some(cached) = cached.as_ref()
+                && cached.token == token
+            {
+                return Ok(cached.storage.clone());
+            }
+        }
+
+        let mut cached = self.cached_storage.write().await;
+        if let Some(cached) = cached.as_ref()
+            && cached.token == token
+        {
+            return Ok(cached.storage.clone());
+        }
+
+        let mut props = self.props.as_ref().clone();
+        props.insert(ADLS_SAS_TOKEN.to_string(), token.clone());
+        let storage = self.inner.build(&StorageConfig::from_props(props))?;
+        *cached = Some(CachedAzureSasStorage {
+            token,
+            storage: storage.clone(),
+        });
+        Ok(storage)
+    }
+}
+
+#[typetag::serde(name = "AzureSasStorage")]
+#[async_trait]
+impl IcebergStorage for AzureSasStorage {
+    async fn exists(&self, path: &str) -> IcebergResult<bool> {
+        self.current_storage().await?.exists(path).await
+    }
+
+    async fn metadata(&self, path: &str) -> IcebergResult<FileMetadata> {
+        self.current_storage().await?.metadata(path).await
+    }
+
+    async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
+        self.current_storage().await?.read(path).await
+    }
+
+    async fn reader(&self, path: &str) -> IcebergResult<Box<dyn FileRead>> {
+        self.current_storage().await?.reader(path).await
+    }
+
+    async fn write(&self, path: &str, bytes: bytes::Bytes) -> IcebergResult<()> {
+        self.current_storage().await?.write(path, bytes).await
+    }
+
+    async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
+        self.current_storage().await?.writer(path).await
+    }
+
+    async fn delete(&self, path: &str) -> IcebergResult<()> {
+        self.current_storage().await?.delete(path).await
+    }
+
+    async fn delete_prefix(&self, path: &str) -> IcebergResult<()> {
+        self.current_storage().await?.delete_prefix(path).await
+    }
+
+    fn new_input(&self, path: &str) -> IcebergResult<InputFile> {
+        Ok(InputFile::new(Arc::new(self.clone()), path.to_string()))
+    }
+
+    fn new_output(&self, path: &str) -> IcebergResult<OutputFile> {
+        Ok(OutputFile::new(Arc::new(self.clone()), path.to_string()))
+    }
+}
+
+pub(crate) async fn build_lance_provider(
+    config: AzureBrokerConfig,
+) -> LanceResult<Arc<AzureSasStorageOptionsProvider>> {
+    let provider = Arc::new(
+        AzureSasStorageOptionsProvider::new(config)
+            .map_err(|error| LanceError::invalid_input(error.to_string()))?,
+    );
+    provider
+        .current_credential()
+        .await
+        .map_err(|error| AzureSasStorageOptionsProvider::lance_error(&error))?;
+    Ok(provider)
 }
 
 #[cfg(test)]
@@ -375,8 +563,11 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use futures::future::join_all;
+    use iceberg::io::{StorageConfig, StorageFactory};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::sync::{Barrier, Notify};
 
     use super::*;
 
@@ -393,9 +584,15 @@ mod tests {
         }
     }
 
+    fn inner_factory() -> OpenDalStorageFactory {
+        serde_json::from_str(r#"{"Azdls":{"configured_scheme":"Abfss"}}"#).unwrap()
+    }
+
     struct MockFetcher {
         responses: Mutex<VecDeque<Result<AzureSasCredential, &'static str>>>,
         calls: AtomicUsize,
+        started: Option<Arc<Notify>>,
+        release: Option<Arc<Notify>>,
     }
 
     impl MockFetcher {
@@ -403,6 +600,21 @@ mod tests {
             Self {
                 responses: Mutex::new(responses.into()),
                 calls: AtomicUsize::new(0),
+                started: None,
+                release: None,
+            }
+        }
+
+        fn with_gate(
+            responses: Vec<Result<AzureSasCredential, &'static str>>,
+            started: Arc<Notify>,
+            release: Arc<Notify>,
+        ) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                calls: AtomicUsize::new(0),
+                started: Some(started),
+                release: Some(release),
             }
         }
     }
@@ -411,6 +623,12 @@ mod tests {
     impl AzureSasFetcher for MockFetcher {
         async fn fetch(&self, _now: DateTime<Utc>) -> AnyResult<AzureSasCredential> {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(started) = &self.started {
+                started.notify_one();
+            }
+            if let Some(release) = &self.release {
+                release.notified().await;
+            }
             self.responses
                 .lock()
                 .unwrap()
@@ -418,6 +636,80 @@ mod tests {
                 .unwrap_or(Err("no_response"))
                 .map_err(|error| anyhow!(error))
         }
+    }
+
+    fn credential(now: DateTime<Utc>, signature: &str) -> AzureSasCredential {
+        AzureSasCredential {
+            token: format!("sv=1&sig={signature}"),
+            expires_at: now + chrono::Duration::hours(1),
+        }
+    }
+
+    fn test_provider(
+        fetcher: Arc<dyn AzureSasFetcher>,
+        now: DateTime<Utc>,
+    ) -> Arc<AzureSasStorageOptionsProvider> {
+        Arc::new(AzureSasStorageOptionsProvider::with_fetcher(
+            config(),
+            fetcher,
+            Arc::new(move || now),
+        ))
+    }
+
+    #[tokio::test]
+    async fn iceberg_factory_build_does_not_fetch_credentials() {
+        let now = Utc::now();
+        let fetcher = Arc::new(MockFetcher::new(vec![Ok(credential(now, "warm"))]));
+        let provider = test_provider(fetcher.clone(), now);
+        provider.current_credential().await.unwrap();
+        let factory = AzureSasStorageFactory {
+            inner: inner_factory(),
+            provider: Some(provider),
+        };
+
+        let _storage = factory.build(&StorageConfig::new()).unwrap();
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn iceberg_storage_reuses_delegated_storage_until_sas_changes() {
+        let now = Utc::now();
+        let provider = test_provider(Arc::new(MockFetcher::new(Vec::new())), now);
+        *provider.cached.write().await = Some(credential(now, "first"));
+        let storage = AzureSasStorage {
+            inner: inner_factory(),
+            props: Arc::new(HashMap::new()),
+            provider: Some(provider.clone()),
+            cached_storage: Arc::new(RwLock::new(None)),
+        };
+
+        let first = storage.current_storage().await.unwrap();
+        let second = storage.current_storage().await.unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+
+        *provider.cached.write().await = Some(credential(now, "second"));
+        let refreshed = storage.current_storage().await.unwrap();
+        assert!(!Arc::ptr_eq(&first, &refreshed));
+    }
+
+    #[test]
+    fn iceberg_storage_serialization_does_not_retain_unrelated_props() {
+        let now = Utc::now();
+        let factory = AzureSasStorageFactory {
+            inner: inner_factory(),
+            provider: Some(test_provider(Arc::new(MockFetcher::new(Vec::new())), now)),
+        };
+        let storage = factory
+            .build(
+                &StorageConfig::new()
+                    .with_prop(iceberg::io::ADLS_AUTHORITY_HOST, "https://login.example")
+                    .with_prop("unrelated.secret", "props-secret-sentinel"),
+            )
+            .unwrap();
+
+        let serialized = serde_json::to_string(&storage).unwrap();
+        assert!(!serialized.contains("props-secret-sentinel"));
+        assert!(!serialized.contains("unrelated.secret"));
     }
 
     #[test]
@@ -441,12 +733,16 @@ mod tests {
                 "azure_storage_account_name".to_string(),
                 "account".to_string(),
             ),
+            (
+                "adls.endpoint-suffix".to_string(),
+                "core.windows.net".to_string(),
+            ),
         ]);
-
         let extracted = AzureBrokerConfig::extract(&mut options).unwrap().unwrap();
         assert_eq!(extracted, config());
         assert!(BROKER_KEYS.iter().all(|key| !options.contains_key(*key)));
         assert_eq!(options["azure_storage_account_name"], "account");
+        assert_eq!(options["adls.endpoint-suffix"], "core.windows.net");
     }
 
     #[test]
@@ -519,7 +815,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn caches_and_retries_failed_refresh_with_old_token() {
+    async fn returns_refresh_error_with_cached_token() {
         let now = Arc::new(Mutex::new(Utc::now()));
         let initial_now = *now.lock().unwrap();
         let fetcher = Arc::new(MockFetcher::new(vec![
@@ -541,19 +837,22 @@ mod tests {
             Arc::new(move || *clock_now.lock().unwrap()),
         );
 
-        let first = provider.fetch_storage_options().await.unwrap().unwrap();
-        assert_eq!(first["azure_storage_sas_token"], "sv=1&sig=old");
+        let first = provider.current_credential().await.unwrap();
+        assert_eq!(first.token, "sv=1&sig=old");
 
         *now.lock().unwrap() += chrono::Duration::seconds(61);
-        let fallback1 = provider.fetch_storage_options().await.unwrap().unwrap();
-        let fallback2 = provider.fetch_storage_options().await.unwrap().unwrap();
-        assert_eq!(fallback1["azure_storage_sas_token"], "sv=1&sig=old");
-        assert_eq!(fallback2["azure_storage_sas_token"], "sv=1&sig=old");
-        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 3);
+        let error = provider.current_credential().await.err().unwrap();
+        assert_eq!(error.to_string(), "http_status=500");
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 2);
 
         *now.lock().unwrap() += chrono::Duration::seconds(60);
-        let refreshed = provider.fetch_storage_options().await.unwrap().unwrap();
-        assert_eq!(refreshed["azure_storage_sas_token"], "sv=2&sig=new");
+        assert!(*now.lock().unwrap() > initial_now + chrono::Duration::seconds(120));
+        let error = provider.current_credential().await.err().unwrap();
+        assert_eq!(error.to_string(), "http_status=500");
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 3);
+
+        let refreshed = provider.current_credential().await.unwrap();
+        assert_eq!(refreshed.token, "sv=2&sig=new");
         assert_eq!(fetcher.calls.load(Ordering::SeqCst), 4);
     }
 
@@ -563,7 +862,111 @@ mod tests {
         let fetcher = Arc::new(MockFetcher::new(vec![Err("transport_error")]));
         let provider =
             AzureSasStorageOptionsProvider::with_fetcher(config(), fetcher, Arc::new(move || now));
-        assert!(provider.fetch_storage_options().await.is_err());
+        assert!(provider.current_credential().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn current_credential_refresh_is_single_flight() {
+        const CALLERS: usize = 100;
+
+        let now = Utc::now();
+        let fetch_started = Arc::new(Notify::new());
+        let release_fetch = Arc::new(Notify::new());
+        let fetcher = Arc::new(MockFetcher::with_gate(
+            vec![Ok(AzureSasCredential {
+                token: "sv=1&sig=single-flight".to_string(),
+                expires_at: now + chrono::Duration::hours(1),
+            })],
+            fetch_started.clone(),
+            release_fetch.clone(),
+        ));
+        let provider = Arc::new(AzureSasStorageOptionsProvider::with_fetcher(
+            config(),
+            fetcher.clone(),
+            Arc::new(move || now),
+        ));
+        *provider.cached.write().await = Some(AzureSasCredential {
+            token: "sv=1&sig=stale".to_string(),
+            expires_at: now + chrono::Duration::seconds(1),
+        });
+
+        let start = Arc::new(Barrier::new(CALLERS + 1));
+        let attempted = Arc::new(AtomicUsize::new(0));
+        let all_callers_attempted = Arc::new(Notify::new());
+        let tasks = (0..CALLERS)
+            .map(|_| {
+                let provider = provider.clone();
+                let start = start.clone();
+                let attempted = attempted.clone();
+                let all_callers_attempted = all_callers_attempted.clone();
+                tokio::spawn(async move {
+                    start.wait().await;
+                    if attempted.fetch_add(1, Ordering::SeqCst) + 1 == CALLERS {
+                        all_callers_attempted.notify_one();
+                    }
+                    provider.current_credential().await.unwrap()
+                })
+            })
+            .collect::<Vec<_>>();
+
+        start.wait().await;
+        all_callers_attempted.notified().await;
+        fetch_started.notified().await;
+        assert_eq!(attempted.load(Ordering::SeqCst), CALLERS);
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 1);
+        release_fetch.notify_one();
+
+        let credentials = join_all(tasks)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>();
+
+        assert!(
+            credentials
+                .iter()
+                .all(|credential| credential.token == "sv=1&sig=single-flight")
+        );
+        assert_eq!(fetcher.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn lance_provider_warms_once() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        let response_body = serde_json::json!({
+            "success": true,
+            "credentials": {
+                "tempAk": "account",
+                "sessionToken": "sv=1&sig=warmed",
+                "expiredAt": (Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+            }
+        })
+        .to_string();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            server_requests.fetch_add(1, Ordering::SeqCst);
+            let mut request = [0_u8; 4096];
+            socket.read(&mut request).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let mut broker_config = config();
+        broker_config.endpoint = format!("http://{address}");
+        let provider = build_lance_provider(broker_config).await.unwrap();
+        server.await.unwrap();
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+
+        let options = provider.fetch_storage_options().await.unwrap().unwrap();
+        assert_eq!(options["azure_storage_sas_token"], "sv=1&sig=warmed");
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/cpp/src/format/bridge/rust/src/gcp_impersonation.rs
+++ b/cpp/src/format/bridge/rust/src/gcp_impersonation.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright Zilliz
 
-//! GCP Service Account Impersonation for lance-io.
+//! GCP Service Account Impersonation for Lance and Iceberg.
 //!
 //! Neither `object_store` (lance-io's default GCS backend) nor `opendal`
 //! natively supports the "VM default SA → IAM `generateAccessToken` →
 //! impersonated target SA" flow. The closest config keys both expect a JSON
 //! file path or already-issued credential, not a target-SA email.
 //!
-//! This module plugs the missing piece in by implementing two traits:
+//! This module plugs the missing piece into both storage stacks:
 //!
 //! * [`ImpersonatingGcsCredentialProvider`] — `object_store::CredentialProvider`
 //!   that, on each `get_credential()` call, returns a cached impersonated
@@ -17,8 +17,11 @@
 //!   that builds a `GoogleCloudStorageBuilder` wired to the credential
 //!   provider above, and is registered against the `gs` scheme to override
 //!   lance-io's default GCS provider for opens that opt in.
+//! * [`GcpImpersonationStorageFactory`] / [`GcpImpersonationStorage`] —
+//!   thin Iceberg wrappers that inject the current token and delegate storage
+//!   behavior to `iceberg-storage-opendal`.
 //!
-//! Wiring lives in `lance_bridgeimpl.rs`, which extracts the bridge-private
+//! Lance wiring lives in `lance_bridgeimpl.rs`, which extracts the bridge-private
 //! `gcp_target_service_account` and `gcp_credential_refresh_secs` keys from
 //! `storage_options` and installs this provider into a per-call `Session`'s
 //! `ObjectStoreRegistry`.
@@ -55,16 +58,23 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use object_store::{
-    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
-    ClientOptions, CredentialProvider, ObjectStore as OSObjectStore, RetryConfig,
-    Result as ObjectStoreResult,
+use iceberg::io::{
+    FileMetadata, FileRead, FileWrite, GCS_DISABLE_CONFIG_LOAD, GCS_DISABLE_VM_METADATA,
+    GCS_TOKEN, InputFile, OutputFile, Storage as IcebergStorage, StorageConfig, StorageFactory,
 };
-use serde::Deserialize;
+use iceberg::{Error as IcebergError, ErrorKind as IcebergErrorKind, Result as IcebergResult};
+use iceberg_storage_opendal::OpenDalStorageFactory;
+use object_store::{
+    ClientOptions, CredentialProvider, ObjectStore as OSObjectStore, Result as ObjectStoreResult,
+    RetryConfig,
+    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
+};
+use serde::{Deserialize, Serialize};
 use snafu::location;
 use std::str::FromStr;
 use tokio::sync::RwLock;
@@ -72,9 +82,11 @@ use url::Url;
 
 // lance-core's error types aren't a direct dep of the bridge; re-use lance's
 // re-export (`lance::{Error, Result}` forwards to `lance_core`).
+use lance::session::Session;
 use lance::{Error as LanceError, Result as LanceResult};
 use lance_io::object_store::{
-    ObjectStore, ObjectStoreParams, ObjectStoreProvider, DEFAULT_CLOUD_IO_PARALLELISM,
+    DEFAULT_CLOUD_IO_PARALLELISM, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
+    ObjectStoreRegistry,
 };
 
 /// lance-io's `DEFAULT_CLOUD_BLOCK_SIZE` is crate-private; mirror its 64 KiB
@@ -83,14 +95,50 @@ const GCS_DEFAULT_BLOCK_SIZE: usize = 64 * 1024;
 /// Mirrors lance-io's hard-coded download retry count (also crate-private).
 const GCS_DEFAULT_DOWNLOAD_RETRIES: usize = 3;
 
-/// Default IAM `generateAccessToken` lifetime in seconds (max without an org
-/// policy raising the cap).
-pub const DEFAULT_TOKEN_LIFETIME_SECS: u64 = 3600;
-
 /// How long before the cached token's expiry we trigger a refresh. Mirrors
 /// the AWS path's `REFRESH_OFFSET_SECS = 300` so callers see consistent
 /// refresh behavior across providers.
 pub const REFRESH_OFFSET_SECS: u64 = 300;
+
+pub(crate) const LANCE_TARGET_SERVICE_ACCOUNT: &str = "gcp_target_service_account";
+pub(crate) const ICEBERG_TARGET_SERVICE_ACCOUNT: &str = "gcs.service-account";
+pub(crate) const TOKEN_LIFETIME_SECONDS: &str = "gcp_credential_refresh_secs";
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct GcpImpersonationConfig {
+    target_sa: String,
+    token_lifetime_secs: u64,
+}
+
+impl GcpImpersonationConfig {
+    pub(crate) fn extract(
+        options: &mut HashMap<String, String>,
+        target_key: &str,
+    ) -> anyhow::Result<Option<Self>> {
+        let target_sa = options.remove(target_key).unwrap_or_default();
+        let lifetime = options
+            .remove(TOKEN_LIFETIME_SECONDS)
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(0);
+        if target_sa.is_empty() {
+            return Ok(None);
+        }
+        if !(900..=3600).contains(&lifetime) {
+            anyhow::bail!("gcp_credential_refresh_secs must be in [900, 3600], got {lifetime}");
+        }
+        Ok(Some(Self {
+            target_sa,
+            token_lifetime_secs: lifetime,
+        }))
+    }
+}
+
+impl fmt::Debug for GcpImpersonationConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GcpImpersonationConfig")
+            .finish_non_exhaustive()
+    }
+}
 
 /// Scope passed to `generateAccessToken`. `cloud-platform` is the broadest
 /// OAuth scope; the actual GCS permissions come from IAM bindings on the
@@ -143,13 +191,12 @@ struct GenerateAccessTokenResponse {
 }
 
 /// Neutral store name used in `object_store::Error::Generic` from the shared
-/// token-fetch helper; keeps error messages meaningful across both Lance
-/// (cached provider) and iceberg (one-shot) callers.
+/// token-fetch helper used by both Lance and Iceberg.
 const IMPERSONATION_STORE_NAME: &str = "gcp_impersonation";
 
 /// Run the VM-SA → IAM `generateAccessToken(target_sa)` exchange end-to-end
-/// and return the raw `accessToken` + `expireTime`. Shared by the cached
-/// Lance `CredentialProvider` and the one-shot iceberg bridge path.
+/// and return the raw `accessToken` + `expireTime` for the shared refreshable
+/// provider.
 async fn fetch_impersonated_access_token(
     http_client: &reqwest::Client,
     target_sa: &str,
@@ -203,25 +250,6 @@ async fn fetch_impersonated_access_token(
         store: IMPERSONATION_STORE_NAME,
         source: format!("generateAccessToken response was not valid JSON: {e}").into(),
     })
-}
-
-/// One-shot impersonated bearer fetch (no caching, no refresh).
-///
-/// Used by the iceberg bridge's `plan_files` path: iceberg-rust's
-/// `gcs_config_parse` doesn't recognize `gcs.service-account` as an
-/// impersonation target, so the bridge intercepts the key, calls this, and
-/// swaps it for `gcs.oauth2.token` (opendal bakes that into `GcsConfig.token`
-/// with `usize::MAX` expiry). A 1-hour token is plenty for a transient
-/// metadata/manifest read sweep — see
-/// `docs/iceberg-gcp-impersonation-analysis.md` for why refresh isn't needed
-/// here, in contrast to long-lived Lance scans.
-pub async fn fetch_impersonated_bearer(
-    target_sa: &str,
-    token_lifetime: Duration,
-) -> ObjectStoreResult<String> {
-    let client = build_http_client();
-    let resp = fetch_impersonated_access_token(&client, target_sa, token_lifetime).await?;
-    Ok(resp.access_token)
 }
 
 #[derive(Clone)]
@@ -286,40 +314,40 @@ impl ImpersonatingGcsCredentialProvider {
         }
     }
 
-    /// Fast path with read lock; on miss, escalate to write lock and refresh.
-    /// Returns `Ok(None)` when the write lock is contended so the outer
-    /// `get_credential` can back off briefly and retry — this matches the
-    /// pattern lance-io uses on the AWS side.
-    async fn try_get_credential(&self) -> ObjectStoreResult<Option<Arc<GcpCredential>>> {
+    /// Fast path with read lock; on miss, wait for the write lock and refresh.
+    async fn get_credential_with<F, Fut>(&self, fetch: F) -> ObjectStoreResult<Arc<GcpCredential>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = ObjectStoreResult<CachedToken>>,
+    {
         {
             let cached = self.cache.read().await;
             if !self.needs_refresh(&cached) {
                 if let Some(c) = &*cached {
-                    return Ok(Some(c.credential.clone()));
+                    return Ok(c.credential.clone());
                 }
             }
         }
 
-        let Ok(mut cache) = self.cache.try_write() else {
-            return Ok(None);
-        };
+        let mut cache = self.cache.write().await;
 
         // Double-check after acquiring write lock — another task may have
         // just refreshed.
         if !self.needs_refresh(&cache) {
             if let Some(c) = &*cache {
-                return Ok(Some(c.credential.clone()));
+                return Ok(c.credential.clone());
             }
         }
 
-        let token = self.fetch_impersonated_token().await?;
+        let token = fetch().await?;
         *cache = Some(token.clone());
-        Ok(Some(token.credential))
+        Ok(token.credential)
     }
 
     async fn fetch_impersonated_token(&self) -> ObjectStoreResult<CachedToken> {
         let iam_body =
-            fetch_impersonated_access_token(&self.http_client, &self.target_sa, self.token_lifetime).await?;
+            fetch_impersonated_access_token(&self.http_client, &self.target_sa, self.token_lifetime)
+                .await?;
 
         // Compute the expiry from IAM's RFC3339 `expireTime`. We rely on IAM's
         // clock rather than `now + lifetime` so clock skew between us and
@@ -346,15 +374,8 @@ impl CredentialProvider for ImpersonatingGcsCredentialProvider {
     type Credential = GcpCredential;
 
     async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
-        // Retry loop — `try_get_credential` returns `None` only when the write
-        // lock is held by an in-flight refresh. Yield briefly and retry; the
-        // refresher will populate the cache in well under the sleep budget.
-        loop {
-            if let Some(cred) = self.try_get_credential().await? {
-                return Ok(cred);
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        self.get_credential_with(|| self.fetch_impersonated_token())
+            .await
     }
 }
 
@@ -375,18 +396,12 @@ fn parse_rfc3339_to_ms(s: &str) -> Result<u64, String> {
 /// for that registry only — other schemes and other registries are unaffected.
 #[derive(Debug)]
 pub struct ImpersonatingGcsStoreProvider {
-    target_sa: String,
-    token_lifetime: Duration,
-    refresh_offset: Duration,
+    credentials: Arc<ImpersonatingGcsCredentialProvider>,
 }
 
 impl ImpersonatingGcsStoreProvider {
-    pub fn new(target_sa: String, token_lifetime: Duration, refresh_offset: Duration) -> Self {
-        Self {
-            target_sa,
-            token_lifetime,
-            refresh_offset,
-        }
+    fn new(credentials: Arc<ImpersonatingGcsCredentialProvider>) -> Self {
+        Self { credentials }
     }
 }
 
@@ -431,13 +446,9 @@ impl ObjectStoreProvider for ImpersonatingGcsStoreProvider {
             }
         }
 
-        let credential_provider: Arc<dyn CredentialProvider<Credential = GcpCredential>> =
-            Arc::new(ImpersonatingGcsCredentialProvider::new(
-                self.target_sa.clone(),
-                self.token_lifetime,
-                self.refresh_offset,
-            ));
-        builder = builder.with_credentials(credential_provider);
+        let credentials: Arc<dyn CredentialProvider<Credential = GcpCredential>> =
+            self.credentials.clone();
+        builder = builder.with_credentials(credentials);
 
         let built = builder.build().map_err(|e| LanceError::IO {
             source: Box::new(e),
@@ -460,24 +471,396 @@ impl ObjectStoreProvider for ImpersonatingGcsStoreProvider {
     }
 }
 
+pub(crate) async fn build_lance_provider(
+    config: &GcpImpersonationConfig,
+) -> LanceResult<Arc<dyn ObjectStoreProvider>> {
+    let credentials = Arc::new(ImpersonatingGcsCredentialProvider::new(
+        config.target_sa.clone(),
+        Duration::from_secs(config.token_lifetime_secs),
+        Duration::from_secs(REFRESH_OFFSET_SECS),
+    ));
+    credentials
+        .get_credential()
+        .await
+        .map_err(|error| LanceError::io_source(Box::new(error)))?;
+    Ok(Arc::new(ImpersonatingGcsStoreProvider::new(credentials)))
+}
+
+pub(crate) fn build_lance_session(provider: Arc<dyn ObjectStoreProvider>) -> Arc<Session> {
+    let registry = ObjectStoreRegistry::default();
+    registry.insert("gs", provider);
+    Arc::new(Session::new(0, 0, Arc::new(registry)))
+}
+
+fn gcp_iceberg_credential_error(error: object_store::Error) -> IcebergError {
+    IcebergError::new(
+        IcebergErrorKind::Unexpected,
+        format!("GCP impersonation credential resolution failed: {error}"),
+    )
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct GcpImpersonationStorageFactory {
+    #[serde(skip)]
+    provider: Option<Arc<ImpersonatingGcsCredentialProvider>>,
+}
+
+impl GcpImpersonationStorageFactory {
+    pub(crate) async fn new(config: GcpImpersonationConfig) -> IcebergResult<Self> {
+        let provider = Arc::new(ImpersonatingGcsCredentialProvider::new(
+            config.target_sa,
+            Duration::from_secs(config.token_lifetime_secs),
+            Duration::from_secs(REFRESH_OFFSET_SECS),
+        ));
+        provider
+            .get_credential()
+            .await
+            .map_err(gcp_iceberg_credential_error)?;
+        Ok(Self {
+            provider: Some(provider),
+        })
+    }
+}
+
+impl fmt::Debug for GcpImpersonationStorageFactory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GcpImpersonationStorageFactory")
+            .field("has_runtime_provider", &self.provider.is_some())
+            .finish()
+    }
+}
+
+#[typetag::serde(name = "GcpImpersonationStorageFactory")]
+impl StorageFactory for GcpImpersonationStorageFactory {
+    fn build(&self, config: &StorageConfig) -> IcebergResult<Arc<dyn IcebergStorage>> {
+        let provider = self.provider.clone().ok_or_else(|| {
+            IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                "GCP impersonation runtime provider is unavailable",
+            )
+        })?;
+        Ok(Arc::new(GcpImpersonationStorage {
+            props: Arc::new(config.props().clone()),
+            provider: Some(provider),
+            cached_storage: Arc::new(RwLock::new(None)),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct CachedGcpImpersonationStorage {
+    credential: Arc<GcpCredential>,
+    storage: Arc<dyn IcebergStorage>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct GcpImpersonationStorage {
+    #[serde(skip)]
+    props: Arc<HashMap<String, String>>,
+    #[serde(skip)]
+    provider: Option<Arc<ImpersonatingGcsCredentialProvider>>,
+    #[serde(skip)]
+    cached_storage: Arc<RwLock<Option<CachedGcpImpersonationStorage>>>,
+}
+
+impl fmt::Debug for GcpImpersonationStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GcpImpersonationStorage")
+            .field("has_runtime_provider", &self.provider.is_some())
+            .finish()
+    }
+}
+
+impl GcpImpersonationStorage {
+    async fn current_storage(&self) -> IcebergResult<Arc<dyn IcebergStorage>> {
+        let provider = self.provider.as_ref().ok_or_else(|| {
+            IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                "GCP impersonation runtime provider is unavailable",
+            )
+        })?;
+        let credential = provider
+            .get_credential()
+            .await
+            .map_err(gcp_iceberg_credential_error)?;
+        {
+            let cached = self.cached_storage.read().await;
+            if let Some(cached) = cached.as_ref()
+                && Arc::ptr_eq(&cached.credential, &credential)
+            {
+                return Ok(cached.storage.clone());
+            }
+        }
+
+        let mut cached = self.cached_storage.write().await;
+        if let Some(cached) = cached.as_ref()
+            && Arc::ptr_eq(&cached.credential, &credential)
+        {
+            return Ok(cached.storage.clone());
+        }
+
+        let mut props = self.props.as_ref().clone();
+        props.insert(GCS_TOKEN.to_string(), credential.bearer.clone());
+        props.insert(GCS_DISABLE_VM_METADATA.to_string(), "true".to_string());
+        props.insert(GCS_DISABLE_CONFIG_LOAD.to_string(), "true".to_string());
+        let storage = OpenDalStorageFactory::Gcs.build(&StorageConfig::from_props(props))?;
+        *cached = Some(CachedGcpImpersonationStorage {
+            credential,
+            storage: storage.clone(),
+        });
+        Ok(storage)
+    }
+}
+
+#[typetag::serde(name = "GcpImpersonationStorage")]
+#[async_trait]
+impl IcebergStorage for GcpImpersonationStorage {
+    async fn exists(&self, path: &str) -> IcebergResult<bool> {
+        self.current_storage().await?.exists(path).await
+    }
+
+    async fn metadata(&self, path: &str) -> IcebergResult<FileMetadata> {
+        self.current_storage().await?.metadata(path).await
+    }
+
+    async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
+        self.current_storage().await?.read(path).await
+    }
+
+    async fn reader(&self, path: &str) -> IcebergResult<Box<dyn FileRead>> {
+        self.current_storage().await?.reader(path).await
+    }
+
+    async fn write(&self, path: &str, bytes: bytes::Bytes) -> IcebergResult<()> {
+        self.current_storage().await?.write(path, bytes).await
+    }
+
+    async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
+        self.current_storage().await?.writer(path).await
+    }
+
+    async fn delete(&self, path: &str) -> IcebergResult<()> {
+        self.current_storage().await?.delete(path).await
+    }
+
+    async fn delete_prefix(&self, path: &str) -> IcebergResult<()> {
+        self.current_storage().await?.delete_prefix(path).await
+    }
+
+    fn new_input(&self, path: &str) -> IcebergResult<InputFile> {
+        Ok(InputFile::new(Arc::new(self.clone()), path.to_string()))
+    }
+
+    fn new_output(&self, path: &str) -> IcebergResult<OutputFile> {
+        Ok(OutputFile::new(Arc::new(self.clone()), path.to_string()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::future::join_all;
+    use iceberg::io::{StorageConfig, StorageFactory};
+    use tokio::sync::{Barrier, Notify};
+
     use super::*;
+
+    fn impersonation_config(target_sa: &str) -> GcpImpersonationConfig {
+        GcpImpersonationConfig {
+            target_sa: target_sa.to_string(),
+            token_lifetime_secs: 3600,
+        }
+    }
+
+    fn credential_provider(target_sa: &str) -> ImpersonatingGcsCredentialProvider {
+        ImpersonatingGcsCredentialProvider::new(
+            target_sa.to_string(),
+            Duration::from_secs(3600),
+            Duration::from_secs(300),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_credential_refresh_is_single_flight() {
+        const CALLERS: usize = 100;
+
+        let provider = Arc::new(credential_provider("target@example.com"));
+        let fetch_started = Arc::new(Notify::new());
+        let release_fetch = Arc::new(Notify::new());
+        let fetch_calls = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(CALLERS + 1));
+        let tasks = (0..CALLERS)
+            .map(|_| {
+                let provider = provider.clone();
+                let fetch_started = fetch_started.clone();
+                let release_fetch = release_fetch.clone();
+                let fetch_calls = fetch_calls.clone();
+                let start = start.clone();
+                tokio::spawn(async move {
+                    start.wait().await;
+                    provider
+                        .get_credential_with(|| async move {
+                            fetch_calls.fetch_add(1, Ordering::SeqCst);
+                            fetch_started.notify_one();
+                            release_fetch.notified().await;
+                            Ok(CachedToken {
+                                credential: Arc::new(GcpCredential {
+                                    bearer: "single-flight".to_string(),
+                                }),
+                                expires_at_ms: ImpersonatingGcsCredentialProvider::now_ms()
+                                    + 3_600_000,
+                            })
+                        })
+                        .await
+                        .unwrap()
+                })
+            })
+            .collect::<Vec<_>>();
+
+        start.wait().await;
+        fetch_started.notified().await;
+        assert_eq!(fetch_calls.load(Ordering::SeqCst), 1);
+        release_fetch.notify_one();
+
+        let credentials = join_all(tasks)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>();
+        assert_eq!(fetch_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            credentials
+                .iter()
+                .all(|credential| Arc::ptr_eq(credential, &credentials[0]))
+        );
+    }
+
+    #[test]
+    fn extracts_and_removes_private_options() {
+        for target_key in [LANCE_TARGET_SERVICE_ACCOUNT, ICEBERG_TARGET_SERVICE_ACCOUNT] {
+            let mut options = HashMap::from([
+                (target_key.to_string(), "target@example.com".to_string()),
+                (TOKEN_LIFETIME_SECONDS.to_string(), "3600".to_string()),
+                ("public_option".to_string(), "value".to_string()),
+            ]);
+
+            let config = GcpImpersonationConfig::extract(&mut options, target_key)
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(config, impersonation_config("target@example.com"));
+            assert!(!options.contains_key(target_key));
+            assert!(!options.contains_key(TOKEN_LIFETIME_SECONDS));
+            assert_eq!(options["public_option"], "value");
+        }
+    }
+
+    #[test]
+    fn rejects_missing_or_out_of_range_token_lifetime() {
+        for lifetime in [None, Some("invalid"), Some("899"), Some("3601")] {
+            let mut options = HashMap::from([(
+                LANCE_TARGET_SERVICE_ACCOUNT.to_string(),
+                "target@example.com".to_string(),
+            )]);
+            if let Some(lifetime) = lifetime {
+                options.insert(TOKEN_LIFETIME_SECONDS.to_string(), lifetime.to_string());
+            }
+
+            assert!(
+                GcpImpersonationConfig::extract(&mut options, LANCE_TARGET_SERVICE_ACCOUNT)
+                    .is_err()
+            );
+        }
+
+        for lifetime in ["900", "3600"] {
+            let mut options = HashMap::from([
+                (
+                    LANCE_TARGET_SERVICE_ACCOUNT.to_string(),
+                    "target@example.com".to_string(),
+                ),
+                (TOKEN_LIFETIME_SECONDS.to_string(), lifetime.to_string()),
+            ]);
+            assert!(
+                GcpImpersonationConfig::extract(&mut options, LANCE_TARGET_SERVICE_ACCOUNT)
+                    .unwrap()
+                    .is_some()
+            );
+        }
+    }
+
+    #[test]
+    fn iceberg_factory_build_does_not_resolve_credentials() {
+        let factory = GcpImpersonationStorageFactory {
+            provider: Some(Arc::new(credential_provider("target@example.com"))),
+        };
+
+        let _storage = factory.build(&StorageConfig::new()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn iceberg_storage_reuses_delegated_storage_until_token_changes() {
+        let provider = Arc::new(credential_provider("target@example.com"));
+        let first_credential = Arc::new(GcpCredential {
+            bearer: "cached-token".to_string(),
+        });
+        *provider.cache.write().await = Some(CachedToken {
+            credential: first_credential,
+            expires_at_ms: ImpersonatingGcsCredentialProvider::now_ms() + 3_600_000,
+        });
+        let storage = GcpImpersonationStorage {
+            props: Arc::new(HashMap::new()),
+            provider: Some(provider.clone()),
+            cached_storage: Arc::new(RwLock::new(None)),
+        };
+
+        let first = storage.current_storage().await.unwrap();
+        let second = storage.current_storage().await.unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+
+        *provider.cache.write().await = Some(CachedToken {
+            credential: Arc::new(GcpCredential {
+                bearer: "refreshed-token".to_string(),
+            }),
+            expires_at_ms: ImpersonatingGcsCredentialProvider::now_ms() + 3_600_000,
+        });
+        let refreshed = storage.current_storage().await.unwrap();
+        assert!(!Arc::ptr_eq(&first, &refreshed));
+    }
+
+    #[test]
+    fn iceberg_factory_and_storage_serialization_omit_runtime_credentials() {
+        let provider = Arc::new(credential_provider("secret-target@example.com"));
+        let factory = GcpImpersonationStorageFactory {
+            provider: Some(provider.clone()),
+        };
+        let storage = GcpImpersonationStorage {
+            props: Arc::new(HashMap::from([(
+                iceberg::io::GCS_SERVICE_PATH.to_string(),
+                "https://secret-endpoint".to_string(),
+            )])),
+            provider: Some(provider),
+            cached_storage: Arc::new(RwLock::new(None)),
+        };
+
+        for serialized in [
+            serde_json::to_string(&factory).unwrap(),
+            serde_json::to_string(&storage).unwrap(),
+        ] {
+            assert!(!serialized.contains("secret-target"));
+            assert!(!serialized.contains("secret-endpoint"));
+        }
+    }
 
     #[test]
     fn parse_rfc3339_basic() {
-        // `2026-04-17T03:23:14Z` → known epoch ms
         let ms = parse_rfc3339_to_ms("2026-04-17T03:23:14Z").unwrap();
-        // sanity bounds: between 2026-01-01 and 2027-01-01 in ms
         assert!(ms > 1_767_225_600_000);
         assert!(ms < 1_798_761_600_000);
     }
 
     #[test]
     fn parse_rfc3339_pre_epoch_rejected() {
-        // An `expireTime` before 1970 would have timestamp_millis() < 0 and,
-        // without explicit handling, wrap to a huge u64 that makes
-        // `needs_refresh` never fire. Must surface as an error instead.
         let err = parse_rfc3339_to_ms("1969-12-31T23:59:59Z").unwrap_err();
         assert!(err.contains("pre-epoch"));
     }
@@ -499,45 +882,26 @@ mod tests {
 
     #[test]
     fn needs_refresh_when_empty() {
-        let provider = ImpersonatingGcsCredentialProvider::new(
-            "x@y.iam.gserviceaccount.com".to_string(),
-            Duration::from_secs(3600),
-            Duration::from_secs(300),
-        );
+        let provider = credential_provider("x@y.iam.gserviceaccount.com");
         assert!(provider.needs_refresh(&None));
     }
 
     #[test]
     fn needs_refresh_within_offset() {
-        let provider = ImpersonatingGcsCredentialProvider::new(
-            "x@y.iam.gserviceaccount.com".to_string(),
-            Duration::from_secs(3600),
-            Duration::from_secs(300),
-        );
-        // Token expires in 100s, refresh offset is 300s → must refresh.
-        let expires_soon = ImpersonatingGcsCredentialProvider::now_ms() + 100_000;
+        let provider = credential_provider("x@y.iam.gserviceaccount.com");
         let cached = Some(CachedToken {
-            credential: Arc::new(GcpCredential {
-                bearer: "x".into(),
-            }),
-            expires_at_ms: expires_soon,
+            credential: Arc::new(GcpCredential { bearer: "x".into() }),
+            expires_at_ms: ImpersonatingGcsCredentialProvider::now_ms() + 100_000,
         });
         assert!(provider.needs_refresh(&cached));
     }
 
     #[test]
     fn no_refresh_when_fresh() {
-        let provider = ImpersonatingGcsCredentialProvider::new(
-            "x@y.iam.gserviceaccount.com".to_string(),
-            Duration::from_secs(3600),
-            Duration::from_secs(300),
-        );
-        let expires_far = ImpersonatingGcsCredentialProvider::now_ms() + 3_600_000;
+        let provider = credential_provider("x@y.iam.gserviceaccount.com");
         let cached = Some(CachedToken {
-            credential: Arc::new(GcpCredential {
-                bearer: "x".into(),
-            }),
-            expires_at_ms: expires_far,
+            credential: Arc::new(GcpCredential { bearer: "x".into() }),
+            expires_at_ms: ImpersonatingGcsCredentialProvider::now_ms() + 3_600_000,
         });
         assert!(!provider.needs_refresh(&cached));
     }

--- a/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
@@ -26,17 +26,33 @@ use iceberg::table::StaticTable;
 use iceberg_storage_opendal::OpenDalStorageFactory;
 use crate::aliyun_oss_provider::AliyunOssStorageFactory;
 use crate::aws_arn_provider::{AssumeRoleConfig, build_iceberg_factory};
-use crate::azure_sas_provider::{AzureBrokerClient, AzureBrokerConfig};
+use crate::azure_sas_provider::{AzureBrokerConfig, AzureSasStorageFactory};
 use crate::cloud_provider_cache::{
     CACHE_CAPACITY, CACHE_KEY, GlobalLruCache,
 };
-use crate::gcp_impersonation::{DEFAULT_TOKEN_LIFETIME_SECS, fetch_impersonated_bearer};
+use crate::gcp_impersonation::{
+    GcpImpersonationConfig, GcpImpersonationStorageFactory, ICEBERG_TARGET_SERVICE_ACCOUNT,
+};
 use crate::iceberg_ffi::IcebergFileInfo;
 
 const CLOUD_PROVIDER_KEY: &str = "cloud_provider";
 
 static ICEBERG_FACTORY_CACHE: LazyLock<GlobalLruCache<Arc<dyn StorageFactory>>> =
     LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
+
+fn azdls_factory(scheme: &str) -> anyhow::Result<OpenDalStorageFactory> {
+    // `OpenDalStorageFactory::Azdls { configured_scheme }` is public, but
+    // `AzureStorageScheme` is not re-exported by iceberg-storage-opendal.
+    let variant = match scheme {
+        "abfs" => "Abfs",
+        "abfss" => "Abfss",
+        "wasb" => "Wasb",
+        "wasbs" => "Wasbs",
+        _ => anyhow::bail!("Unsupported Azure storage scheme: {scheme}"),
+    };
+    let json = format!(r#"{{"Azdls":{{"configured_scheme":"{variant}"}}}}"#);
+    serde_json::from_str(&json).map_err(|error| anyhow::anyhow!("construct Azdls factory: {error}"))
+}
 
 /// Internal representation for a delete file reference, serialized to JSON.
 #[derive(serde::Serialize)]
@@ -55,58 +71,14 @@ pub(crate) fn vec_to_hashmap(keys: Vec<String>, values: Vec<String>) -> HashMap<
     keys.into_iter().zip(values.into_iter()).collect()
 }
 
-/// Consumes the bridge-private cloud provider and resolves any credentials
-/// that Iceberg/OpenDAL cannot obtain directly from the remaining options.
+/// Consumes and validates the bridge-private cloud provider selector.
 pub(crate) async fn prepare_cloud_storage_options(
     props: &mut HashMap<String, String>,
 ) -> anyhow::Result<()> {
-    let cloud_provider = props.remove(CLOUD_PROVIDER_KEY);
-
-    match cloud_provider.as_deref() {
-        Some("azure") => {
-            if let Some(config) = AzureBrokerConfig::extract(props)? {
-                let client = AzureBrokerClient::new(config)?;
-                let credential = match client.fetch(chrono::Utc::now()).await {
-                    Ok(credential) => credential,
-                    Err(error) => {
-                        eprintln!(
-                            "Warning: Azure SAS credential broker fetch failed: {}, has_cached_sas=false, cached_expired=false",
-                            error
-                        );
-                        return Err(error);
-                    }
-                };
-                props.insert("adls.sas-token".to_string(), credential.token);
-            }
-        }
-        Some("gcp") => {
-            // iceberg-rust does not treat `gcs.service-account` as an
-            // impersonation target. Replace it with a pre-fetched bearer for
-            // this short-lived operation.
-            if let Some(target_sa) = props.remove("gcs.service-account")
-                && !target_sa.is_empty()
-            {
-                let bearer = fetch_impersonated_bearer(
-                    &target_sa,
-                    std::time::Duration::from_secs(DEFAULT_TOKEN_LIFETIME_SECS),
-                )
-                .await?;
-                props.insert("gcs.oauth2.token".to_string(), bearer);
-            }
-        }
-        Some("aws") => {
-            // OpenDAL consumes the S3 and STS options directly.
-        }
-        Some("aliyun") => {
-            // AliyunOssStorageFactory consumes the OSS role options.
-        }
-        None => {
-            // Local files do not carry a cloud provider.
-        }
+    match props.remove(CLOUD_PROVIDER_KEY).as_deref() {
+        Some("aws" | "azure" | "gcp" | "aliyun") | None => Ok(()),
         Some(provider) => anyhow::bail!("Unsupported Iceberg cloud provider: {provider}"),
     }
-
-    Ok(())
 }
 
 /// Scheme → `iceberg-storage-opendal` variant. Hand-written because 0.9
@@ -118,6 +90,16 @@ async fn upstream_opendal_factory(
 ) -> anyhow::Result<Arc<dyn StorageFactory>> {
     let cache_key = props.remove(CACHE_KEY).filter(|key| !key.is_empty());
     let cloud_provider = props.get(CLOUD_PROVIDER_KEY).cloned();
+    let azure_broker = if cloud_provider.as_deref() == Some("azure") {
+        AzureBrokerConfig::extract(props)?
+    } else {
+        None
+    };
+    let gcp_impersonation = if cloud_provider.as_deref() == Some("gcp") {
+        GcpImpersonationConfig::extract(props, ICEBERG_TARGET_SERVICE_ACCOUNT)?
+    } else {
+        None
+    };
     let assume_role = if cloud_provider.as_deref() == Some("aws") {
         let role_arn = props
             .remove("client.assume-role.arn")
@@ -145,6 +127,42 @@ async fn upstream_opendal_factory(
     };
 
     match scheme {
+        "abfs" | "abfss" | "wasb" | "wasbs" if azure_broker.is_some() => {
+            let config = azure_broker.expect("guarded by is_some");
+            let inner = azdls_factory(scheme)?;
+            let scoped_cache_key = cache_key
+                .as_deref()
+                .map(|cache_key| format!("azure:{scheme}:{cache_key}"));
+            match scoped_cache_key.as_deref() {
+                Some(cache_key) => ICEBERG_FACTORY_CACHE
+                    .get(cache_key, || async {
+                        let factory = Arc::new(AzureSasStorageFactory::new(inner, config).await?)
+                            as Arc<dyn StorageFactory>;
+                        eprintln!(
+                            "created cloud cache entry: consumer=iceberg, cloud=azure, mechanism=broker_sas"
+                        );
+                        Ok::<_, anyhow::Error>(factory)
+                    })
+                    .await,
+                None => Ok(Arc::new(AzureSasStorageFactory::new(inner, config).await?)),
+            }
+        }
+        "gs" if gcp_impersonation.is_some() => {
+            let config = gcp_impersonation.expect("guarded by is_some");
+            match cache_key.as_deref() {
+                Some(cache_key) => ICEBERG_FACTORY_CACHE
+                    .get(cache_key, || async {
+                        let factory = Arc::new(GcpImpersonationStorageFactory::new(config).await?)
+                            as Arc<dyn StorageFactory>;
+                        eprintln!(
+                            "created cloud cache entry: consumer=iceberg, cloud=gcp, mechanism=service_account_impersonation"
+                        );
+                        Ok::<_, anyhow::Error>(factory)
+                    })
+                    .await,
+                None => Ok(Arc::new(GcpImpersonationStorageFactory::new(config).await?)),
+            }
+        }
         // The upstream OSS factory does not carry per-tenant `oss.role-arn`.
         "oss" if cloud_provider.as_deref() == Some("aliyun")
             && props.contains_key("oss.role-arn") =>
@@ -187,22 +205,7 @@ async fn upstream_opendal_factory(
             customized_credential_load: None,
         })),
         "gs" => Ok(Arc::new(OpenDalStorageFactory::Gcs)),
-        "abfs" | "abfss" | "wasb" | "wasbs" => {
-            // `OpenDalStorageFactory::Azdls { configured_scheme }` is pub,
-            // but its `AzureStorageScheme` field type isn't `pub use`'d in
-            // lib.rs — round-trip via the pub `Deserialize` impl instead.
-            let variant = match scheme {
-                "abfs" => "Abfs",
-                "abfss" => "Abfss",
-                "wasb" => "Wasb",
-                "wasbs" => "Wasbs",
-                _ => unreachable!(),
-            };
-            let json = format!(r#"{{"Azdls":{{"configured_scheme":"{variant}"}}}}"#);
-            let factory: OpenDalStorageFactory = serde_json::from_str(&json)
-                .map_err(|e| anyhow::anyhow!("construct Azdls factory: {e}"))?;
-            Ok(Arc::new(factory))
-        }
+        "abfs" | "abfss" | "wasb" | "wasbs" => Ok(Arc::new(azdls_factory(scheme)?)),
         "file" => Ok(Arc::new(LocalFsStorageFactory)),
         "memory" => Ok(Arc::new(MemoryStorageFactory)),
         other => anyhow::bail!("Unsupported scheme for iceberg FileIO: {other}"),
@@ -474,7 +477,219 @@ pub fn iceberg_plan_files(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+    use crate::azure_sas_provider::{
+        AZURE_BROKER_ACCOUNT_NAME, AZURE_BROKER_BUCKET, AZURE_BROKER_CLIENT_ID,
+        AZURE_BROKER_DURATION_SECONDS, AZURE_BROKER_ENDPOINT, AZURE_BROKER_REGION,
+        AZURE_BROKER_REQUEST_TIMEOUT_MS, AZURE_BROKER_TENANT_ID,
+    };
+    use crate::gcp_impersonation::{
+        GcpImpersonationConfig, ICEBERG_TARGET_SERVICE_ACCOUNT, TOKEN_LIFETIME_SECONDS,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    const AZURE_PRIVATE_KEYS: [&str; 8] = [
+        AZURE_BROKER_ENDPOINT,
+        AZURE_BROKER_CLIENT_ID,
+        AZURE_BROKER_TENANT_ID,
+        AZURE_BROKER_ACCOUNT_NAME,
+        AZURE_BROKER_REGION,
+        AZURE_BROKER_BUCKET,
+        AZURE_BROKER_DURATION_SECONDS,
+        AZURE_BROKER_REQUEST_TIMEOUT_MS,
+    ];
+
+    fn azure_broker_props() -> HashMap<String, String> {
+        HashMap::from([
+            (
+                AZURE_BROKER_ENDPOINT.to_string(),
+                "http://127.0.0.1:1".to_string(),
+            ),
+            (AZURE_BROKER_CLIENT_ID.to_string(), "client".to_string()),
+            (AZURE_BROKER_TENANT_ID.to_string(), "tenant".to_string()),
+            (AZURE_BROKER_ACCOUNT_NAME.to_string(), "account".to_string()),
+            (AZURE_BROKER_REGION.to_string(), "westus3".to_string()),
+            (AZURE_BROKER_BUCKET.to_string(), "container".to_string()),
+            (
+                AZURE_BROKER_DURATION_SECONDS.to_string(),
+                "3600".to_string(),
+            ),
+            (
+                AZURE_BROKER_REQUEST_TIMEOUT_MS.to_string(),
+                "20".to_string(),
+            ),
+            (
+                "adls.endpoint-suffix".to_string(),
+                "core.windows.net".to_string(),
+            ),
+        ])
+    }
+
+    fn gcp_impersonation_props() -> HashMap<String, String> {
+        HashMap::from([
+            (
+                ICEBERG_TARGET_SERVICE_ACCOUNT.to_string(),
+                "target@example.com".to_string(),
+            ),
+            (TOKEN_LIFETIME_SECONDS.to_string(), "3600".to_string()),
+        ])
+    }
+
+    #[tokio::test]
+    async fn prepare_cloud_storage_options_only_removes_supported_selector() {
+        for (provider, static_options) in [
+            (
+                "azure",
+                HashMap::from([
+                    ("adls.account-name".to_string(), "account".to_string()),
+                    (
+                        "adls.endpoint-suffix".to_string(),
+                        "core.windows.net".to_string(),
+                    ),
+                    ("adls.sas-token".to_string(), "static-sas".to_string()),
+                ]),
+            ),
+            (
+                "gcp",
+                HashMap::from([
+                    (
+                        "gcs.service-account-key".to_string(),
+                        "static-key".to_string(),
+                    ),
+                    ("gcs.oauth2.token".to_string(), "static-token".to_string()),
+                ]),
+            ),
+        ] {
+            let mut props = static_options.clone();
+            props.insert(CLOUD_PROVIDER_KEY.to_string(), provider.to_string());
+
+            prepare_cloud_storage_options(&mut props).await.unwrap();
+
+            assert_eq!(props, static_options);
+        }
+
+        for provider in ["aws", "aliyun"] {
+            let mut props = HashMap::from([
+                (CLOUD_PROVIDER_KEY.to_string(), provider.to_string()),
+                ("ordinary.option".to_string(), "value".to_string()),
+            ]);
+            prepare_cloud_storage_options(&mut props).await.unwrap();
+            assert_eq!(
+                props,
+                HashMap::from([("ordinary.option".to_string(), "value".to_string())])
+            );
+        }
+    }
+
+    #[test]
+    fn azure_and_gcp_private_options_are_removed_by_their_parsers() {
+        let mut azure_props = azure_broker_props();
+        azure_props.insert("ordinary.option".to_string(), "value".to_string());
+
+        assert!(
+            AzureBrokerConfig::extract(&mut azure_props)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            AZURE_PRIVATE_KEYS
+                .iter()
+                .all(|key| !azure_props.contains_key(*key))
+        );
+        assert_eq!(azure_props["adls.endpoint-suffix"], "core.windows.net");
+        assert_eq!(azure_props["ordinary.option"], "value");
+
+        let mut gcp_props = gcp_impersonation_props();
+        gcp_props.insert("ordinary.option".to_string(), "value".to_string());
+        assert!(
+            GcpImpersonationConfig::extract(&mut gcp_props, ICEBERG_TARGET_SERVICE_ACCOUNT,)
+                .unwrap()
+                .is_some()
+        );
+        assert!(!gcp_props.contains_key(ICEBERG_TARGET_SERVICE_ACCOUNT));
+        assert!(!gcp_props.contains_key(TOKEN_LIFETIME_SECONDS));
+        assert_eq!(gcp_props["ordinary.option"], "value");
+    }
+
+    #[tokio::test]
+    async fn unsupported_cloud_provider_is_rejected() {
+        let mut props =
+            HashMap::from([(CLOUD_PROVIDER_KEY.to_string(), "unsupported".to_string())]);
+
+        let error = prepare_cloud_storage_options(&mut props).await.unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Unsupported Iceberg cloud provider: unsupported"
+        );
+        assert!(!props.contains_key(CLOUD_PROVIDER_KEY));
+    }
+
+    #[tokio::test]
+    async fn azure_factory_cache_separates_resolved_schemes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        let response_body = serde_json::json!({
+            "success": true,
+            "credentials": {
+                "tempAk": "account",
+                "sessionToken": "sv=1&sig=scheme-separated",
+                "expiredAt": (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+            }
+        })
+        .to_string();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                server_requests.fetch_add(1, Ordering::SeqCst);
+                let mut request = [0_u8; 4096];
+                socket.read(&mut request).await.unwrap();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let cache_key = "test-azure-resolved-scheme-separation";
+        let mut abfss_props = azure_broker_props();
+        abfss_props.insert(
+            AZURE_BROKER_ENDPOINT.to_string(),
+            format!("http://{address}"),
+        );
+        abfss_props.insert(CLOUD_PROVIDER_KEY.to_string(), "azure".to_string());
+        abfss_props.insert(CACHE_KEY.to_string(), cache_key.to_string());
+
+        let mut wasbs_props = abfss_props.clone();
+        let abfss_factory = upstream_opendal_factory(
+            "abfss://container@account.dfs.core.windows.net/metadata/table.json",
+            "abfss",
+            &mut abfss_props,
+        )
+        .await
+        .unwrap();
+        let wasbs_factory = upstream_opendal_factory(
+            "wasbs://container@account.blob.core.windows.net/metadata/table.json",
+            "wasbs",
+            &mut wasbs_props,
+        )
+        .await
+        .unwrap();
+
+        assert!(!Arc::ptr_eq(&abfss_factory, &wasbs_factory));
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        server.abort();
+        let _ = server.await;
+    }
 
     #[test]
     fn test_vec_to_hashmap() {

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -40,9 +40,7 @@ use lance_table::utils::stream::ReadBatchFutStream;
 
 use lance::io::ObjectStoreParams;
 use lance::session::Session;
-use lance_io::object_store::{
-    ObjectStoreProvider, ObjectStoreRegistry, StorageOptionsAccessor,
-};
+use lance_io::object_store::{ObjectStoreProvider, StorageOptionsAccessor};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 
 use crate::aliyun_oss_provider::{AliyunOssStoreProvider, build_aliyun_oss_session};
@@ -50,16 +48,24 @@ use crate::aws_arn_provider::{
     AssumeRoleConfig, build_lance_provider as build_aws_arn_provider,
     build_lance_session as build_aws_arn_session,
 };
-use crate::azure_sas_provider::{AzureBrokerConfig, AzureSasStorageOptionsProvider};
-use crate::cloud_provider_cache::{
-    CACHE_CAPACITY, CACHE_KEY, GlobalLruCache,
+use crate::azure_sas_provider::{
+    AzureBrokerConfig, AzureSasStorageOptionsProvider,
+    build_lance_provider as build_azure_sas_provider,
 };
-use crate::gcp_impersonation::{ImpersonatingGcsStoreProvider, REFRESH_OFFSET_SECS};
+use crate::cloud_provider_cache::{CACHE_CAPACITY, CACHE_KEY, GlobalLruCache};
+use crate::gcp_impersonation::{
+    GcpImpersonationConfig, LANCE_TARGET_SERVICE_ACCOUNT,
+    build_lance_provider as build_gcp_impersonation_provider,
+    build_lance_session as build_gcp_impersonation_session,
+};
 
 const CLOUD_PROVIDER_KEY: &str = "cloud_provider";
 
 static LANCE_PROVIDER_CACHE: LazyLock<GlobalLruCache<Arc<dyn ObjectStoreProvider>>> =
     LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
+static LANCE_AZURE_PROVIDER_CACHE: LazyLock<
+    GlobalLruCache<Arc<AzureSasStorageOptionsProvider>>,
+> = LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
 
 #[derive(Clone)]
 pub struct BlockingDataset {
@@ -342,84 +348,10 @@ impl BlockingDataset {
 
 use crate::iceberg_bridgeimpl::vec_to_hashmap;
 
-/// GCP cross-tenant impersonation parameters extracted from `storage_options`.
-///
-/// The C++ side (`lance::ToStorageOptions` in `lance_common.cpp`) stamps these
-/// keys when `cloud_provider=gcp` and `gcp_target_service_account` is set.
-/// They are bridge-private — neither lance-io nor object_store know about them
-/// and we strip them here so they can't accidentally be forwarded.
-struct GcpImpersonationConfig {
-    target_sa: String,
-    /// Mapped from `load_frequency` on the C++ side. Becomes the IAM
-    /// `generateAccessToken` lifetime; the credential provider auto-refreshes
-    /// `REFRESH_OFFSET_SECS` ahead of expiry.
-    token_lifetime_secs: u64,
-}
-
-impl GcpImpersonationConfig {
-    /// Parse from `storage_options`. Returns `Ok(None)` if
-    /// `gcp_target_service_account` is not set.  Returns `Err` if
-    /// `gcp_credential_refresh_secs` is missing, malformed, or out of range
-    /// `[900, 3600]`.
-    fn extract(storage_options: &mut HashMap<String, String>) -> Result<Option<Self>> {
-        let Some(target_sa) = storage_options.remove("gcp_target_service_account") else {
-            return Ok(None);
-        };
-        if target_sa.is_empty() {
-            return Ok(None);
-        }
-        // Mirror `AssumeRoleConfig::parse`: missing / unparsable falls through
-        // to 0 and is rejected by the range check below.  The lower bound must
-        // be strictly greater than `REFRESH_OFFSET_SECS` (300s) — otherwise the
-        // cached token's `needs_refresh` window opens before it even issues,
-        // and every `get_credential` call hammers IAM (credential thrashing).
-        // Align the lower bound with AWS at 900s.  The upper bound is GCP
-        // IAM's hard cap on impersonated-token lifetime (3600s without an
-        // `iam.allowServiceAccountCredentialLifetimeExtension` org policy).
-        let token_lifetime_secs: u64 = storage_options
-            .remove("gcp_credential_refresh_secs")
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-        if token_lifetime_secs < 900 || token_lifetime_secs > 3600 {
-            return Err(LanceError::invalid_input(
-                format!(
-                    "gcp_credential_refresh_secs must be in [900, 3600], got {}",
-                    token_lifetime_secs
-                ),
-            ));
-        }
-        Ok(Some(Self {
-            target_sa,
-            token_lifetime_secs,
-        }))
-    }
-}
-
-/// Build a `Session` whose `ObjectStoreRegistry` overrides the `gs` scheme
-/// with an `ImpersonatingGcsStoreProvider`.
-///
-/// A fresh `Session` is built per call so that two concurrent opens with
-/// different target SAs cannot collide on a shared registry. Cache sizes
-/// remain zero because index/metadata caches are managed by the caller.
-fn build_gcp_impersonation_session(config: &GcpImpersonationConfig) -> Arc<Session> {
-    let registry = ObjectStoreRegistry::default();
-    registry.insert(
-        "gs",
-        Arc::new(ImpersonatingGcsStoreProvider::new(
-            config.target_sa.clone(),
-            std::time::Duration::from_secs(config.token_lifetime_secs),
-            std::time::Duration::from_secs(REFRESH_OFFSET_SECS),
-        )),
-    );
-    Arc::new(Session::new(0, 0, Arc::new(registry)))
-}
-
-pub fn open_dataset(
+fn build_object_store_params(
     uri: &str,
-    storage_options_keys: Vec<String>,
-    storage_options_values: Vec<String>,
-) -> Result<Box<BlockingDataset>> {
-    let mut storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
+    mut storage_options: HashMap<String, String>,
+) -> Result<(ObjectStoreParams, Option<Arc<Session>>)> {
     let credential_cache_key = storage_options.remove(CACHE_KEY);
     let cloud_provider = storage_options.remove(CLOUD_PROVIDER_KEY);
     if let Some(cloud_provider) = cloud_provider.as_deref()
@@ -432,7 +364,7 @@ pub fn open_dataset(
 
     // Configure each cloud provider's cross-tenant credential path in one
     // place. AWS, GCP, and Aliyun use a per-call Session with an overridden
-    // object-store provider, while Azure uses ObjectStoreParams directly.
+    // object-store provider. Azure uses Lance's StorageOptionsAccessor.
     let mut store_params = ObjectStoreParams::default();
     let mut custom_session = None;
     match cloud_provider.as_deref() {
@@ -472,41 +404,52 @@ pub fn open_dataset(
             }
         }
         Some("azure") => {
-            // Lance refreshes Azure credentials through StorageOptionsAccessor;
-            // the broker-backed provider supplies a fresh SAS token as needed.
-            store_params.storage_options_accessor = match AzureBrokerConfig::extract(
-                &mut storage_options,
-            )
-            .map_err(|error| LanceError::invalid_input(error.to_string()))?
+            if let Some(config) = AzureBrokerConfig::extract(&mut storage_options)
+                .map_err(|error| LanceError::invalid_input(error.to_string()))?
             {
-                Some(config) => {
-                    // Emulator and unsigned modes bypass SAS authentication, so
-                    // force both off when the broker is configured.
-                    storage_options.insert(
-                        "azure_storage_use_emulator".to_string(),
-                        "false".to_string(),
-                    );
-                    storage_options
-                        .insert("azure_skip_signature".to_string(), "false".to_string());
-                    let provider = Arc::new(
-                        AzureSasStorageOptionsProvider::new(config)
-                            .map_err(|error| LanceError::invalid_input(error.to_string()))?,
-                    );
-                    // Preserve the static Azure settings and overlay refreshed SAS
-                    // values returned by the provider.
-                    Some(Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                storage_options.insert("azure_storage_use_emulator".into(), "false".into());
+                storage_options.insert("azure_skip_signature".into(), "false".into());
+                let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
+                    Some(cache_key) => TOKIO_RT.block_on(LANCE_AZURE_PROVIDER_CACHE.get(
+                        cache_key,
+                        || async {
+                            let provider = build_azure_sas_provider(config).await?;
+                            eprintln!(
+                                "created cloud cache entry: consumer=lance, cloud=azure, mechanism=broker_sas"
+                            );
+                            Ok::<_, LanceError>(provider)
+                        },
+                    ))?,
+                    None => TOKIO_RT.block_on(build_azure_sas_provider(config))?,
+                };
+                store_params.storage_options_accessor = Some(Arc::new(
+                    StorageOptionsAccessor::with_initial_and_provider(
                         storage_options.clone(),
                         provider,
-                    )))
-                }
-                None => None,
-            };
+                    ),
+                ));
+            }
         }
         Some("gcp") => {
-            // Lance's stock GCS provider cannot refresh impersonated access
-            // tokens, so replace the `gs` provider for this dataset only.
-            custom_session = GcpImpersonationConfig::extract(&mut storage_options)?
-                .map(|config| build_gcp_impersonation_session(&config));
+            if let Some(config) =
+                GcpImpersonationConfig::extract(&mut storage_options, LANCE_TARGET_SERVICE_ACCOUNT)
+                    .map_err(|error| LanceError::invalid_input(error.to_string()))?
+            {
+                let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
+                    Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
+                        cache_key,
+                        || async {
+                            let provider = build_gcp_impersonation_provider(&config).await?;
+                            eprintln!(
+                                "created cloud cache entry: consumer=lance, cloud=gcp, mechanism=service_account_impersonation"
+                            );
+                            Ok::<_, LanceError>(provider)
+                        },
+                    ))?,
+                    None => TOKIO_RT.block_on(build_gcp_impersonation_provider(&config))?,
+                };
+                custom_session = Some(build_gcp_impersonation_session(provider));
+            }
         }
         Some("aliyun") if storage_options.contains_key("oss_role_arn") => {
             let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
@@ -541,6 +484,16 @@ pub fn open_dataset(
             StorageOptionsAccessor::with_static_options(storage_options),
         ));
     }
+    Ok((store_params, custom_session))
+}
+
+pub fn open_dataset(
+    uri: &str,
+    storage_options_keys: Vec<String>,
+    storage_options_values: Vec<String>,
+) -> Result<Box<BlockingDataset>> {
+    let storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
+    let (store_params, custom_session) = build_object_store_params(uri, storage_options)?;
     let read_params = ReadParams {
         index_cache_size_bytes: 0,
         metadata_cache_size_bytes: 0,
@@ -562,112 +515,8 @@ pub unsafe fn write_dataset(
     storage_options_values: Vec<String>,
     data_storage_format: LanceDataStorageFormat,
 ) -> Result<Box<BlockingDataset>> {
-    let mut storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
-    let credential_cache_key = storage_options.remove(CACHE_KEY);
-    let cloud_provider = storage_options.remove(CLOUD_PROVIDER_KEY);
-    if let Some(cloud_provider) = cloud_provider.as_deref()
-        && !matches!(cloud_provider, "aws" | "azure" | "gcp" | "aliyun")
-    {
-        return Err(LanceError::invalid_input(format!(
-            "Unsupported Lance cloud provider: {cloud_provider}"
-        )));
-    }
-    // Keep write-side credential selection symmetric with open_dataset.
-    let mut store_params = ObjectStoreParams::default();
-    let mut custom_session = None;
-    match cloud_provider.as_deref() {
-        Some("aws") => {
-            let role_arn = storage_options.remove("aws_role_arn").unwrap_or_default();
-            let session_name = storage_options
-                .remove("aws_session_name")
-                .unwrap_or_default();
-            let external_id = storage_options.remove("aws_external_id").unwrap_or_default();
-            let region = storage_options.get("aws_region").cloned().unwrap_or_default();
-            let refresh_secs_str = storage_options
-                .remove("aws_credential_refresh_secs")
-                .unwrap_or_default();
-            let credential_refresh_secs: u64 = refresh_secs_str.parse().unwrap_or(0);
-            let assume_role = AssumeRoleConfig::parse(
-                &role_arn,
-                &session_name,
-                &external_id,
-                &region,
-                credential_refresh_secs,
-            )?;
-            if let Some(config) = &assume_role {
-                let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
-                    Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
-                        cache_key,
-                        || async {
-                            let provider = build_aws_arn_provider(config).await?;
-                            eprintln!(
-                                "created cloud cache entry: consumer=lance, cloud=aws, mechanism=assume_role"
-                            );
-                            Ok::<_, LanceError>(provider)
-                        },
-                    ))?,
-                    None => TOKIO_RT.block_on(build_aws_arn_provider(config))?,
-                };
-                custom_session = Some(build_aws_arn_session(provider));
-            }
-        }
-        Some("azure") => {
-            store_params.storage_options_accessor = match AzureBrokerConfig::extract(
-                &mut storage_options,
-            )
-            .map_err(|error| LanceError::invalid_input(error.to_string()))?
-            {
-                Some(config) => {
-                    storage_options.insert(
-                        "azure_storage_use_emulator".to_string(),
-                        "false".to_string(),
-                    );
-                    storage_options
-                        .insert("azure_skip_signature".to_string(), "false".to_string());
-                    let provider = Arc::new(
-                        AzureSasStorageOptionsProvider::new(config)
-                            .map_err(|error| LanceError::invalid_input(error.to_string()))?,
-                    );
-                    Some(Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                        storage_options.clone(),
-                        provider,
-                    )))
-                }
-                None => None,
-            };
-        }
-        Some("gcp") => {
-            custom_session = GcpImpersonationConfig::extract(&mut storage_options)?
-                .map(|config| build_gcp_impersonation_session(&config));
-        }
-        Some("aliyun") if storage_options.contains_key("oss_role_arn") => {
-            let provider = match credential_cache_key.as_deref().filter(|key| !key.is_empty()) {
-                Some(cache_key) => TOKIO_RT.block_on(LANCE_PROVIDER_CACHE.get(
-                    cache_key,
-                    || async {
-                        let provider = Arc::new(
-                            AliyunOssStoreProvider::from_uri(uri, &storage_options).await?,
-                        ) as Arc<dyn ObjectStoreProvider>;
-                        eprintln!(
-                            "created cloud cache entry: consumer=lance, cloud=aliyun, mechanism=role"
-                        );
-                        Ok::<_, LanceError>(provider)
-                    },
-                ))?,
-                None => Arc::new(TOKIO_RT.block_on(AliyunOssStoreProvider::from_uri(
-                    uri,
-                    &storage_options,
-                ))?) as Arc<dyn ObjectStoreProvider>,
-            };
-            custom_session = Some(build_aliyun_oss_session(provider));
-        }
-        _ => {}
-    }
-    if store_params.storage_options_accessor.is_none() {
-        store_params.storage_options_accessor = Some(Arc::new(
-            StorageOptionsAccessor::with_static_options(storage_options),
-        ));
-    }
+    let storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
+    let (store_params, custom_session) = build_object_store_params(uri, storage_options)?;
 
     let stream_ptr = stream_ptr as *mut FFI_ArrowArrayStream;
     let stream = unsafe { std::ptr::replace(stream_ptr, FFI_ArrowArrayStream::empty()) };

--- a/cpp/src/format/iceberg/iceberg_common.cpp
+++ b/cpp/src/format/iceberg/iceberg_common.cpp
@@ -112,6 +112,7 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
     // Azure DFS endpoint (account.dfs.suffix) from scheme://container/path URIs.
     set("adls.endpoint-suffix", config.address);
     if (config.IsAzureCredentialBrokerEnabled()) {
+      set_credential_cache_key();
       set("azure_broker_endpoint", config.azure_credential_endpoint);
       set("azure_broker_client_id", config.azure_client_id);
       set("azure_broker_tenant_id", config.azure_tenant_id);
@@ -132,13 +133,15 @@ std::unordered_map<std::string, std::string> ToStorageOptions(const ArrowFileSys
     }
   } else if (provider == kCloudProviderGCP) {
     if (config.use_iam && !config.gcp_target_service_account.empty()) {
-      // Bridge-private: iceberg-rust 0.8's gcs_config_parse doesn't recognize
-      // this key as an impersonation target (it would be silently dropped).
-      // Instead, iceberg_bridgeimpl.rs::iceberg_plan_files intercepts it,
-      // fetches a token via VM-SA → IAM.generateAccessToken, and swaps it for
-      // `gcs.oauth2.token` before building the FileIO. See
-      // `docs/iceberg-gcp-impersonation-analysis.md`.
+      set_credential_cache_key();
+      // Bridge-private: the Rust bridge consumes this target before building
+      // FileIO, warms a refreshable impersonation provider inside the typed
+      // factory LRU, and reuses it while creating a fresh GCS operator for
+      // each Iceberg storage operation.
       set("gcs.service-account", config.gcp_target_service_account);
+      if (config.load_frequency > 0) {
+        options["gcp_credential_refresh_secs"] = std::to_string(config.load_frequency);
+      }
     }
     // Otherwise uses default credentials (VM metadata)
   } else if (provider == kCloudProviderAliyun) {

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -83,6 +83,7 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
   } else if (provider == kCloudProviderAzure) {
     set("azure_storage_account_name", config.access_key_id);
     if (config.IsAzureCredentialBrokerEnabled()) {
+      set_credential_cache_key();
       set("azure_broker_endpoint", config.azure_credential_endpoint);
       set("azure_broker_client_id", config.azure_client_id);
       set("azure_broker_tenant_id", config.azure_tenant_id);
@@ -105,6 +106,7 @@ StorageOptions ToStorageOptions(const ArrowFileSystemConfig& config) {
     }
   } else if (provider == kCloudProviderGCP) {
     if (config.use_iam && !config.gcp_target_service_account.empty()) {
+      set_credential_cache_key();
       // Bridge-private keys consumed by Rust `open_dataset`/`write_dataset`/
       // `drop` (see lance_bridgeimpl.rs). The bridge strips them out of
       // storage_options and installs an ImpersonatingGcsStoreProvider that

--- a/cpp/test/format/external_table_arn_test.cpp
+++ b/cpp/test/format/external_table_arn_test.cpp
@@ -35,14 +35,21 @@
 #define ARN_ENV_ROLE_ARN "ARN_TEST_ENV_ROLE_ARN"        // IAM role ARN to assume for reading
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
+#include <stdexcept>
 #include <thread>
 
 #include <arrow/api.h>
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <curl/curl.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/properties.h>
 
@@ -725,6 +732,110 @@ INSTANTIATE_TEST_SUITE_P(
 #define AZURE_ARN_ENV_TENANT_ID "AZURE_ARN_TEST_ENV_TENANT_ID"
 #define AZURE_ARN_ENV_CREDENTIAL_ENDPOINT "AZURE_ARN_TEST_ENV_CREDENTIAL_ENDPOINT"
 
+class OneShotHttpPostRelay {
+  public:
+  explicit OneShotHttpPostRelay(std::string upstream_endpoint)
+      : upstream_endpoint_(std::move(upstream_endpoint)),
+        acceptor_(io_context_, boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address_v4("127.0.0.1"), 0)) {
+    endpoint_ = "http://127.0.0.1:" + std::to_string(acceptor_.local_endpoint().port());
+    acceptor_.async_accept([this](const boost::system::error_code& error, boost::asio::ip::tcp::socket socket) {
+      if (error) {
+        return;
+      }
+
+      boost::system::error_code close_error;
+      acceptor_.close(close_error);
+      request_count_.fetch_add(1, std::memory_order_relaxed);
+
+      try {
+        boost::beast::flat_buffer buffer;
+        boost::beast::http::request<boost::beast::http::string_body> request;
+        boost::beast::http::read(socket, buffer, request);
+
+        std::string response_body;
+        char curl_error[CURL_ERROR_SIZE] = {};
+        auto* curl = curl_easy_init();
+        if (curl == nullptr) {
+          throw std::runtime_error("curl_easy_init failed");
+        }
+        auto* headers = curl_slist_append(nullptr, "Content-Type: application/json");
+        headers = curl_slist_append(headers, "Expect:");
+        curl_easy_setopt(curl, CURLOPT_URL, upstream_endpoint_.c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.body().data());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(request.body().size()));
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 10000L);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 30000L);
+        curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_error);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &OneShotHttpPostRelay::AppendResponseBody);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+
+        auto curl_status = curl_easy_perform(curl);
+        long response_code = 0;
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+        curl_slist_free_all(headers);
+        curl_easy_cleanup(curl);
+
+        if (curl_status != CURLE_OK) {
+          throw std::runtime_error(curl_error[0] == '\0' ? curl_easy_strerror(curl_status) : curl_error);
+        }
+        if (response_code < 100 || response_code > 599) {
+          throw std::runtime_error("upstream returned an invalid HTTP status");
+        }
+
+        boost::beast::http::response<boost::beast::http::string_body> response(
+            static_cast<boost::beast::http::status>(response_code), request.version());
+        response.set(boost::beast::http::field::content_type, "application/json");
+        response.keep_alive(false);
+        response.body() = std::move(response_body);
+        response.prepare_payload();
+        boost::beast::http::write(socket, response);
+      } catch (const std::exception& error) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        error_ = error.what();
+      }
+
+      boost::system::error_code shutdown_error;
+      socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, shutdown_error);
+    });
+    worker_ = std::thread([this] { io_context_.run(); });
+  }
+
+  ~OneShotHttpPostRelay() {
+    io_context_.stop();
+    if (worker_.joinable()) {
+      worker_.join();
+    }
+  }
+
+  const std::string& endpoint() const { return endpoint_; }
+
+  size_t request_count() const { return request_count_.load(std::memory_order_relaxed); }
+
+  std::string error() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return error_;
+  }
+
+  private:
+  static size_t AppendResponseBody(char* data, size_t size, size_t count, void* output) {
+    auto bytes = size * count;
+    static_cast<std::string*>(output)->append(data, bytes);
+    return bytes;
+  }
+
+  std::string upstream_endpoint_;
+  boost::asio::io_context io_context_;
+  boost::asio::ip::tcp::acceptor acceptor_;
+  std::thread worker_;
+  std::string endpoint_;
+  std::atomic<size_t> request_count_{0};
+  mutable std::mutex mutex_;
+  std::string error_;
+};
+
 class ExternalTableAzureArnTest : public ::testing::TestWithParam<std::string> {
   protected:
   void SetUp() override {
@@ -963,6 +1074,64 @@ TEST_P(ExternalTableAzureArnTest, ReadWithBrokeredSas) {
   loon_manifest_destroy(out_manifest);
   free(out_manifest_path);
   loon_properties_free(&loon_props);
+}
+
+TEST_P(ExternalTableAzureArnTest, ProviderCacheFetchesBrokeredSasOnce) {
+  const auto& format = GetParam();
+  if (format != LOON_FORMAT_LANCE_TABLE && format != LOON_FORMAT_ICEBERG_TABLE) {
+    GTEST_SKIP() << "Azure provider cache is used only by Lance and Iceberg";
+  }
+
+  const uint64_t num_rows = 100;
+  ASSERT_AND_ASSIGN(auto result, CreateTestTable(format, num_rows));
+
+  OneShotHttpPostRelay broker_relay(credential_endpoint_);
+  auto cache_read_props = read_props_;
+  api::SetValue(cache_read_props, "extfs.azsas.azure_credential_endpoint", broker_relay.endpoint().c_str());
+  ASSERT_AND_ASSIGN(auto fs_config, FilesystemCache::resolve_config(cache_read_props, result.explore_dir.c_str()));
+
+  constexpr size_t cache_hit_iterations = 10;
+  if (format == LOON_FORMAT_LANCE_TABLE) {
+    auto storage_options = lance::ToStorageOptions(fs_config);
+    auto cache_key = storage_options.find("milvus_fs_cache_key");
+    ASSERT_NE(cache_key, storage_options.end());
+    ASSERT_EQ(cache_key->second, fs_config.GetCacheKey());
+
+    std::vector<std::string> columns = {"id", "name", "value"};
+    std::shared_ptr<FormatReader> reader;
+    for (size_t iteration = 0; iteration < cache_hit_iterations; ++iteration) {
+      SCOPED_TRACE(::testing::Message() << "cache hit iteration " << iteration);
+      ASSERT_AND_ASSIGN(reader,
+                        FormatReader::create(result.schema, format, result.cgfile, cache_read_props, columns, nullptr));
+    }
+
+    ASSERT_AND_ASSIGN(auto rg_infos, reader->get_row_group_infos());
+    ValidateRowGroupInfos(rg_infos, num_rows);
+    int64_t total_rows = 0;
+    for (size_t i = 0; i < rg_infos.size(); ++i) {
+      ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(i));
+      total_rows += batch->num_rows();
+    }
+    ASSERT_EQ(total_rows, static_cast<int64_t>(num_rows));
+  } else {
+    auto snapshot_id = std::to_string(result.iceberg_snapshot_id);
+    api::SetValue(cache_read_props, PROPERTY_ICEBERG_SNAPSHOT_ID, snapshot_id.c_str());
+
+    auto storage_options = iceberg::ToStorageOptions(fs_config);
+    auto cache_key = storage_options.find("milvus_fs_cache_key");
+    ASSERT_NE(cache_key, storage_options.end());
+    ASSERT_EQ(cache_key->second, fs_config.GetCacheKey());
+
+    ASSERT_AND_ASSIGN(auto* iceberg_format, Format::get(format));
+    for (size_t iteration = 0; iteration < cache_hit_iterations; ++iteration) {
+      SCOPED_TRACE(::testing::Message() << "cache hit iteration " << iteration);
+      ASSERT_AND_ASSIGN(auto files, iceberg_format->explore(result.explore_dir, cache_read_props));
+      ASSERT_FALSE(files.empty());
+    }
+  }
+
+  ASSERT_EQ(broker_relay.request_count(), 1u);
+  ASSERT_TRUE(broker_relay.error().empty()) << broker_relay.error();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_storage_options_test.cpp
@@ -55,6 +55,7 @@ TEST_F(IcebergStorageOptionsTest, AzureKeys) {
   EXPECT_EQ(opts["adls.account-name"], "myaccount");
   EXPECT_EQ(opts["adls.account-key"], "myaccountkey");
   EXPECT_EQ(opts.count("azure_storage_account_name"), 0);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(IcebergStorageOptionsTest, AzureCredentialBrokerKeysExcludeFallbackCredentials) {
@@ -89,7 +90,7 @@ TEST_F(IcebergStorageOptionsTest, AzureCredentialBrokerKeysExcludeFallbackCreden
   EXPECT_EQ(opts.count("adls.client-id"), 0);
   EXPECT_EQ(opts.count("adls.tenant-id"), 0);
   EXPECT_EQ(opts.count("adls.sas-token"), 0);
-  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
+  EXPECT_EQ(opts["milvus_fs_cache_key"], config.GetCacheKey());
 }
 
 TEST_F(IcebergStorageOptionsTest, AliyunKeys) {
@@ -155,12 +156,14 @@ TEST_F(IcebergStorageOptionsTest, GcpImpersonation) {
   config.cloud_provider = kCloudProviderGCP;
   config.use_iam = true;
   config.gcp_target_service_account = "target-sa@customer-project.iam.gserviceaccount.com";
+  config.load_frequency = 1800;
 
   auto opts = ToStorageOptions(config);
 
   EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
   EXPECT_EQ(opts["gcs.service-account"], "target-sa@customer-project.iam.gserviceaccount.com");
-  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
+  EXPECT_EQ(opts["gcp_credential_refresh_secs"], "1800");
+  EXPECT_EQ(opts["milvus_fs_cache_key"], config.GetCacheKey());
 }
 
 TEST_F(IcebergStorageOptionsTest, GcpTargetServiceAccountRequiresIam) {
@@ -173,6 +176,7 @@ TEST_F(IcebergStorageOptionsTest, GcpTargetServiceAccountRequiresIam) {
 
   EXPECT_EQ(opts.size(), 1);
   EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(IcebergStorageOptionsTest, GcpDefaultCredentials) {
@@ -182,6 +186,7 @@ TEST_F(IcebergStorageOptionsTest, GcpDefaultCredentials) {
   auto opts = ToStorageOptions(config);
   EXPECT_EQ(opts.size(), 1);
   EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(IcebergStorageOptionsTest, BareEndpointUsesHttpWhenSslDisabled) {

--- a/cpp/test/format/lance/lance_storage_options_test.cpp
+++ b/cpp/test/format/lance/lance_storage_options_test.cpp
@@ -83,6 +83,7 @@ TEST_F(LanceStorageOptionsTest, AzureKeys) {
   EXPECT_EQ(opts["azure_storage_account_key"], "myaccountkey");
   EXPECT_EQ(opts["azure_endpoint"], "https://myaccount.blob.core.windows.net");
   EXPECT_EQ(opts.count("adls.account-name"), 0);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(LanceStorageOptionsTest, AzureCredentialBrokerKeysExcludeFallbackCredentials) {
@@ -116,7 +117,7 @@ TEST_F(LanceStorageOptionsTest, AzureCredentialBrokerKeysExcludeFallbackCredenti
   EXPECT_EQ(opts["azure_broker_request_timeout_ms"], "5000");
   EXPECT_EQ(opts.count("azure_storage_account_key"), 0);
   EXPECT_EQ(opts.count("azure_storage_sas_token"), 0);
-  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
+  EXPECT_EQ(opts["milvus_fs_cache_key"], config.GetCacheKey());
 }
 
 TEST_F(LanceStorageOptionsTest, AliyunKeys) {
@@ -152,7 +153,7 @@ TEST_F(LanceStorageOptionsTest, GcpImpersonation) {
   // Bridge-private keys; not forwarded to lance-io / object_store.
   EXPECT_EQ(opts["gcp_target_service_account"], "target-sa@customer-project.iam.gserviceaccount.com");
   EXPECT_EQ(opts["gcp_credential_refresh_secs"], "1800");
-  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
+  EXPECT_EQ(opts["milvus_fs_cache_key"], config.GetCacheKey());
 }
 
 TEST_F(LanceStorageOptionsTest, GcpTargetServiceAccountRequiresIam) {
@@ -165,6 +166,7 @@ TEST_F(LanceStorageOptionsTest, GcpTargetServiceAccountRequiresIam) {
 
   EXPECT_EQ(opts.size(), 1);
   EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(LanceStorageOptionsTest, GcpDefaultCredentials) {
@@ -178,6 +180,7 @@ TEST_F(LanceStorageOptionsTest, GcpDefaultCredentials) {
   // to the default credential chain (VM metadata).
   EXPECT_EQ(opts.size(), 1);
   EXPECT_EQ(opts["cloud_provider"], kCloudProviderGCP);
+  EXPECT_EQ(opts.count("milvus_fs_cache_key"), 0);
 }
 
 TEST_F(LanceStorageOptionsTest, LocalEmpty) {


### PR DESCRIPTION
Azure broker-issued SAS credentials and GCP service account impersonation were still creating new credential state whenever Lance opened or wrote a dataset and whenever Iceberg built storage. That gets expensive quickly when callers create thousands of readers or writers, because the same filesystem identity repeatedly goes through provider setup, credential warm-up, and broker or IAM requests even though the underlying cloud configuration has not changed.

This change forwards the existing filesystem cache key for Azure broker and GCP impersonation configurations, then uses it to reuse typed credential providers and storage factories in the Rust bridge. New providers resolve an initial credential before they are published, concurrent initialization for the same key is coordinated, failed initialization is not retained, and the bounded LRU keeps process-level reuse from growing without limit. Lance and Iceberg still use separate caches, while Azure Iceberg entries also include the resolved storage scheme so incompatible endpoints cannot share a factory.

For Azure, Lance now reuses a warmed SAS provider and overlays refreshed tokens on top of the static storage options. Iceberg uses the same refreshable credential flow through a lightweight storage wrapper that injects the current SAS token before delegating each operation to OpenDAL. Refreshes use a fast cached path and coordinate concurrent callers to avoid broker request spikes, while a previously cached SAS token remains available when a refresh temporarily fails and requests fail closed when no credential has ever been resolved.

For GCP, the shared impersonation module now owns configuration parsing, token lifetime validation, provider construction, and refresh behavior for both storage stacks. Lance installs the cached provider into a fresh session for each dataset operation, while Iceberg obtains the current impersonated bearer token and creates fresh GCS storage for each operation. Ambient configuration and VM metadata credentials are disabled on this path so the requested target service account remains the authoritative identity.

The Lance read and write paths now share one object store setup flow, which keeps cloud routing, cache lookup, and credential initialization consistent instead of maintaining two copies of the same logic. Bridge-private routing and credential options are consumed before reaching upstream libraries, and runtime provider state is excluded from serialization so cached credentials and unrelated storage properties are not exposed.

Overall, this reduces repeated provider allocations and unnecessary Azure broker or GCP IAM traffic for high-volume reader and writer workloads, while keeping sessions, storage instances, and operation-specific state isolated.