### PR TITLE
feat: publish index artifacts through transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ python/venv/
 python/env/
 .claude/
 .worktrees/
+AGENTS.md

--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -151,6 +151,7 @@
     loon_transaction_append_files;
     loon_transaction_add_delta_log;
     loon_transaction_update_stat;
+    loon_transaction_add_index_info;
 
     # External table interface
     loon_exttable_explore;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -149,6 +149,7 @@ _loon_transaction_add_column_group
 _loon_transaction_append_files
 _loon_transaction_add_delta_log
 _loon_transaction_update_stat
+_loon_transaction_add_index_info
 
 # External table interface
 _loon_exttable_explore

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -284,14 +284,6 @@ typedef struct LoonIndexes {
 } LoonIndexes;
 
 /**
- * @brief Result of committing a manifest revision.
- */
-typedef struct LoonManifestCommitInfo {
-  int64_t manifest_version;
-  int32_t manifest_minor_version;
-} LoonManifestCommitInfo;
-
-/**
  * @brief C structure representing a Manifest
  */
 typedef struct LoonManifest {
@@ -757,16 +749,6 @@ FFI_EXPORT LoonFFIResult loon_transaction_get_read_version(LoonTransactionHandle
  * @return result of FFI
  */
 FFI_EXPORT LoonFFIResult loon_transaction_commit(LoonTransactionHandle handle, int64_t* out_committed_version);
-
-/**
- * @brief Commits a transaction and returns the complete manifest reference.
- *
- * @param handle Transaction handle
- * @param out_commit_info Output committed revision and manifest minor version
- * @return result of FFI
- */
-FFI_EXPORT LoonFFIResult loon_transaction_commit_with_info(LoonTransactionHandle handle,
-                                                           LoonManifestCommitInfo* out_commit_info);
 
 /**
  * @brief Destroys a Transaction

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -267,12 +267,29 @@ typedef struct LoonLobFiles {
 } LoonLobFiles;
 
 /**
- * @brief Metadata for one already-written index file.
+ * @brief Metadata for one completed index artifact.
+ *
+ * Fields through index_file_keys are the typed metadata required to load an
+ * artifact. property_keys/property_values are reserved for index-specific
+ * parameters such as metric_type and Knowhere options.
  */
 typedef struct LoonIndexInfo {
   const char* column_name;
+  const char* index_name;
   const char* index_type;
-  const char* path;
+  const char* path;  ///< Artifact directory/prefix
+  int64_t field_id;
+  int64_t index_id;
+  int64_t build_id;
+  int64_t index_version;
+  int64_t num_rows;
+  int64_t serialized_size;
+  int64_t mem_size;
+  int32_t current_index_version;
+  int32_t current_scalar_index_version;
+  int32_t index_store_path_version;
+  const char** index_file_keys;
+  uint32_t num_index_file_keys;
   const char** property_keys;
   const char** property_values;
   uint32_t num_properties;
@@ -299,10 +316,9 @@ typedef struct LoonManifest {
   // LOB files (TEXT column metadata)
   LoonLobFiles lob_files;
 
-  // Index metadata and persistent feature marker. Appended to retain the
-  // layout of the existing prefix for older consumers.
+  // Index metadata. Appended to retain the layout of the existing prefix for
+  // older consumers.
   LoonIndexes indexes;
-  int32_t minor_version;
 } LoonManifest;
 
 /**
@@ -830,8 +846,7 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
  * The transaction stores metadata only; it does not create or write the file
  * identified by index_info->path.
  */
-FFI_EXPORT LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle,
-                                                         const LoonIndexInfo* index_info);
+FFI_EXPORT LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, const LoonIndexInfo* index_info);
 
 /**
  * @brief Add a LOB file info to the transaction updates

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -267,6 +267,31 @@ typedef struct LoonLobFiles {
 } LoonLobFiles;
 
 /**
+ * @brief Metadata for one already-written index file.
+ */
+typedef struct LoonIndexInfo {
+  const char* column_name;
+  const char* index_type;
+  const char* path;
+  const char** property_keys;
+  const char** property_values;
+  uint32_t num_properties;
+} LoonIndexInfo;
+
+typedef struct LoonIndexes {
+  LoonIndexInfo* indexes;
+  uint32_t num_indexes;
+} LoonIndexes;
+
+/**
+ * @brief Result of committing a manifest revision.
+ */
+typedef struct LoonManifestCommitInfo {
+  int64_t manifest_version;
+  int32_t manifest_minor_version;
+} LoonManifestCommitInfo;
+
+/**
  * @brief C structure representing a Manifest
  */
 typedef struct LoonManifest {
@@ -281,10 +306,19 @@ typedef struct LoonManifest {
 
   // LOB files (TEXT column metadata)
   LoonLobFiles lob_files;
+
+  // Index metadata and persistent feature marker. Appended to retain the
+  // layout of the existing prefix for older consumers.
+  LoonIndexes indexes;
+  int32_t minor_version;
 } LoonManifest;
 
 /**
  * @brief Destroys a CManifest and frees all allocated memory
+ *
+ * A manifest returned by this library owns all of its nested storage,
+ * including index strings, index property arrays, and their entries. Release
+ * it only with this function.
  *
  * @param manifest CManifest to destroy (can be null)
  */
@@ -725,6 +759,16 @@ FFI_EXPORT LoonFFIResult loon_transaction_get_read_version(LoonTransactionHandle
 FFI_EXPORT LoonFFIResult loon_transaction_commit(LoonTransactionHandle handle, int64_t* out_committed_version);
 
 /**
+ * @brief Commits a transaction and returns the complete manifest reference.
+ *
+ * @param handle Transaction handle
+ * @param out_commit_info Output committed revision and manifest minor version
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_transaction_commit_with_info(LoonTransactionHandle handle,
+                                                           LoonManifestCommitInfo* out_commit_info);
+
+/**
  * @brief Destroys a Transaction
  *
  * @param handle Transaction handle to destroy
@@ -797,6 +841,15 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
                                                       const char* const* metadata_keys,
                                                       const char* const* metadata_values,
                                                       size_t metadata_len);
+
+/**
+ * @brief Record metadata for an index file that has already been written.
+ *
+ * The transaction stores metadata only; it does not create or write the file
+ * identified by index_info->path.
+ */
+FFI_EXPORT LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle,
+                                                         const LoonIndexInfo* index_info);
 
 /**
  * @brief Add a LOB file info to the transaction updates

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -274,6 +274,9 @@ typedef struct LoonLobFiles {
  * parameters such as metric_type and Knowhere options.
  */
 typedef struct LoonIndexInfo {
+  // A dropped index is represented by removing its Index entry from the
+  // manifest. Build-task state is intentionally not persisted here: this
+  // structure describes only a completed artifact that QueryNode can load.
   const char* column_name;
   const char* index_name;
   const char* index_type;

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <optional>
 
 #include <arrow/status.h>
@@ -104,8 +105,9 @@ struct Index {
   int32_t current_index_version = 0;
   int32_t current_scalar_index_version = 0;
   int32_t index_store_path_version = 0;
-  std::vector<std::string> index_file_keys;       ///< File names relative to path
-  std::map<std::string, std::string> properties;  ///< Index-specific properties
+  std::vector<std::string> index_file_keys;  ///< File names relative to path
+  std::unordered_map<std::string, std::string>
+      properties;  ///< Index-specific properties; key lookup is the common operation
 };
 
 /**

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -37,7 +37,8 @@ namespace milvus_storage::api {
 // - Version 3: Changed stats from map<string, vector<string>> to map<string, Statistics>
 // - Version 4: Changed ColumnGroupFile fields (metadata) to properties map
 // - Version 5: Added lob_files field for LOB (Large Object) file metadata
-constexpr int32_t MANIFEST_VERSION = 5;
+// - Version 6: Added minor_version to supplement Index metadata with a presence marker
+constexpr int32_t MANIFEST_VERSION = 6;
 
 /**
  * @brief Persistent feature marker for a manifest revision.

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -37,20 +37,8 @@ namespace milvus_storage::api {
 // - Version 3: Changed stats from map<string, vector<string>> to map<string, Statistics>
 // - Version 4: Changed ColumnGroupFile fields (metadata) to properties map
 // - Version 5: Added lob_files field for LOB (Large Object) file metadata
-// - Version 6: Added minor_version to supplement Index metadata with a presence marker
+// - Version 6: Bumped to supplement Index metadata for transaction publication
 constexpr int32_t MANIFEST_VERSION = 6;
-
-/**
- * @brief Persistent feature marker for a manifest revision.
- *
- * This is intentionally distinct from MANIFEST_VERSION, which denotes the
- * serialization format.  The value is derived from the final manifest state:
- * a manifest with index metadata is INDEX_INFO and one without it is NONE.
- */
-enum class ManifestMinorVersion : int32_t {
-  NONE = 0,
-  INDEX_INFO = 1,
-};
 
 /**
  * @brief Metadata for a single LOB (Large Object) file
@@ -97,14 +85,26 @@ struct DeltaLog {
 /**
  * @brief Index metadata for a column
  *
- * The properties map provides flexibility for index builders to store additional
- * metadata such as index_id, build_id, version, num_rows, index_size, metric_type,
- * and algorithm-specific parameters (M, efConstruction, etc.).
+ * Fields through index_file_keys are the completed artifact's typed load
+ * metadata.  Properties are reserved for index-type-specific parameters, such
+ * as metric_type, M, and efConstruction.
  */
 struct Index {
-  std::string column_name;  ///< Column this index is built on
+  std::string column_name;  ///< Column this index is built on; field_id is authoritative for loading
+  std::string index_name;   ///< User-visible index name carried in the QueryNode load request
   std::string index_type;   ///< Index type: "hnsw", "ivf-sq", "ivf-pq", "inverted", "bitmap", "ordered"
-  std::string path;         ///< Relative path to index file in _index/ directory
+  std::string path;         ///< Artifact directory/prefix; combine with index_file_keys for full file paths
+  int64_t field_id = 0;
+  int64_t index_id = 0;
+  int64_t build_id = 0;
+  int64_t index_version = 0;
+  int64_t num_rows = 0;
+  int64_t serialized_size = 0;  ///< Total object-storage bytes
+  int64_t mem_size = 0;         ///< Estimated loaded memory bytes
+  int32_t current_index_version = 0;
+  int32_t current_scalar_index_version = 0;
+  int32_t index_store_path_version = 0;
+  std::vector<std::string> index_file_keys;       ///< File names relative to path
   std::map<std::string, std::string> properties;  ///< Index-specific properties
 };
 
@@ -207,17 +207,6 @@ class Manifest final {
    * @brief Get the manifest format version
    */
   [[nodiscard]] int32_t version() const { return version_; }
-
-  /**
-   * @brief Get the persistent feature marker for this manifest revision.
-   *
-   * The marker is stored in the Avro record, but is derived from index
-   * metadata so every producer observes the same invariant.
-   */
-  [[nodiscard]] int32_t minorVersion() const {
-    return indexes_.empty() ? static_cast<int32_t>(ManifestMinorVersion::NONE)
-                            : static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO);
-  }
 
   /**
    * @brief Read a manifest from filesystem, using cache for immutable manifests.

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -40,6 +40,18 @@ namespace milvus_storage::api {
 constexpr int32_t MANIFEST_VERSION = 5;
 
 /**
+ * @brief Persistent feature marker for a manifest revision.
+ *
+ * This is intentionally distinct from MANIFEST_VERSION, which denotes the
+ * serialization format.  The value is derived from the final manifest state:
+ * a manifest with index metadata is INDEX_INFO and one without it is NONE.
+ */
+enum class ManifestMinorVersion : int32_t {
+  NONE = 0,
+  INDEX_INFO = 1,
+};
+
+/**
  * @brief Metadata for a single LOB (Large Object) file
  *
  * LOB files store large text/binary data separately from the main columnar storage.
@@ -194,6 +206,17 @@ class Manifest final {
    * @brief Get the manifest format version
    */
   [[nodiscard]] int32_t version() const { return version_; }
+
+  /**
+   * @brief Get the persistent feature marker for this manifest revision.
+   *
+   * The marker is stored in the Avro record, but is derived from index
+   * metadata so every producer observes the same invariant.
+   */
+  [[nodiscard]] int32_t minorVersion() const {
+    return indexes_.empty() ? static_cast<int32_t>(ManifestMinorVersion::NONE)
+                            : static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO);
+  }
 
   /**
    * @brief Read a manifest from filesystem, using cache for immutable manifests.

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -255,13 +255,6 @@ class Transaction {
   Transaction& AddIndexInfo(const Index& index);
 
   /**
-   * @brief Add or replace an index
-   * @param index Index to add (replaces if same column_name + index_type exists)
-   * @return Reference to this transaction for method chaining
-   */
-  Transaction& AddIndex(const Index& index);
-
-  /**
    * @brief Drop an index by column name and type
    * @param column_name Column the index is on
    * @param index_type Type of the index

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -36,14 +36,6 @@ namespace milvus_storage::api::transaction {
 static constexpr int64_t LATEST = -1;
 
 /**
- * @brief Metadata needed to publish an immutable manifest revision.
- */
-struct ManifestCommitInfo {
-  int64_t manifest_version;
-  int32_t manifest_minor_version;
-};
-
-/**
  * @brief Transaction updates tracking class
  *
  * Records all changes made during a transaction that can be used by the resolver
@@ -202,14 +194,6 @@ class Transaction {
   // Commit using Updates (uses the resolver set via Open)
   // Returns the committed version number on success
   arrow::Result<int64_t> Commit();
-
-  /**
-   * @brief Commit and return the revision together with its feature marker.
-   *
-   * The marker lets a metadata publisher persist the manifest reference and
-   * its index-information state atomically.
-   */
-  arrow::Result<ManifestCommitInfo> CommitWithInfo();
 
   // Get manifest on read version
   // Returns empty manifest if read_version_ is 0 (no manifest exists)

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -36,6 +36,14 @@ namespace milvus_storage::api::transaction {
 static constexpr int64_t LATEST = -1;
 
 /**
+ * @brief Metadata needed to publish an immutable manifest revision.
+ */
+struct ManifestCommitInfo {
+  int64_t manifest_version;
+  int32_t manifest_minor_version;
+};
+
+/**
  * @brief Transaction updates tracking class
  *
  * Records all changes made during a transaction that can be used by the resolver
@@ -195,6 +203,14 @@ class Transaction {
   // Returns the committed version number on success
   arrow::Result<int64_t> Commit();
 
+  /**
+   * @brief Commit and return the revision together with its feature marker.
+   *
+   * The marker lets a metadata publisher persist the manifest reference and
+   * its index-information state atomically.
+   */
+  arrow::Result<ManifestCommitInfo> CommitWithInfo();
+
   // Get manifest on read version
   // Returns empty manifest if read_version_ is 0 (no manifest exists)
   arrow::Result<std::shared_ptr<Manifest>> GetManifest();
@@ -245,6 +261,14 @@ class Transaction {
    * @return Reference to this transaction for method chaining
    */
   Transaction& UpdateStat(const std::string& key, const Statistics& stat);
+
+  /**
+   * @brief Record or replace metadata for an already-written index file.
+   *
+   * This method only records Index metadata. It does not perform index-file
+   * I/O or return a file handle.
+   */
+  Transaction& AddIndexInfo(const Index& index);
 
   /**
    * @brief Add or replace an index

--- a/cpp/src/ffi/bridge.cpp
+++ b/cpp/src/ffi/bridge.cpp
@@ -181,6 +181,12 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
   assert(manifest != nullptr && out_cmanifest != nullptr);
 
   try {
+    const auto copy_string = [](const std::string& value) {
+      auto* result = new char[value.size() + 1];
+      std::memcpy(result, value.c_str(), value.size() + 1);
+      return result;
+    };
+
     // Value-initialize to ensure all pointers are nullptr
     *out_cmanifest = new LoonManifest{};
     (*out_cmanifest)->column_groups.column_group_array = nullptr;
@@ -199,7 +205,6 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
     (*out_cmanifest)->lob_files.num_files = 0;
     (*out_cmanifest)->indexes.indexes = nullptr;
     (*out_cmanifest)->indexes.num_indexes = 0;
-    (*out_cmanifest)->minor_version = manifest->minorVersion();
 
     // Export column groups directly into embedded structure
     const auto& cgs = manifest->columnGroups();
@@ -222,11 +227,7 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
       (*out_cmanifest)->delta_logs.num_delta_logs = static_cast<uint32_t>(delta_log_paths.size());
 
       for (size_t i = 0; i < delta_log_paths.size(); i++) {
-        size_t len = delta_log_paths[i].length();
-        char* path_str = new char[len + 1];
-        std::memcpy(path_str, delta_log_paths[i].c_str(), len);
-        path_str[len] = '\0';
-        (*out_cmanifest)->delta_logs.delta_log_paths[i] = path_str;
+        (*out_cmanifest)->delta_logs.delta_log_paths[i] = copy_string(delta_log_paths[i]);
         (*out_cmanifest)->delta_logs.delta_log_num_entries[i] = delta_log_num_entries[i];
       }
     }
@@ -245,22 +246,13 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
 
       size_t idx = 0;
       for (const auto& [key, stat] : stats) {
-        // Copy key
-        size_t key_len = key.length();
-        char* key_str = new char[key_len + 1];
-        std::memcpy(key_str, key.c_str(), key_len);
-        key_str[key_len] = '\0';
-        (*out_cmanifest)->stats.stat_keys[idx] = key_str;
+        (*out_cmanifest)->stats.stat_keys[idx] = copy_string(key);
 
         // Copy file paths
         size_t num_files = stat.paths.size();
         (*out_cmanifest)->stats.stat_files[idx] = new const char* [num_files] {};
         for (size_t j = 0; j < num_files; j++) {
-          size_t file_len = stat.paths[j].length();
-          char* file_str = new char[file_len + 1];
-          std::memcpy(file_str, stat.paths[j].c_str(), file_len);
-          file_str[file_len] = '\0';
-          (*out_cmanifest)->stats.stat_files[idx][j] = file_str;
+          (*out_cmanifest)->stats.stat_files[idx][j] = copy_string(stat.paths[j]);
         }
         (*out_cmanifest)->stats.stat_file_counts[idx] = num_files;
 
@@ -271,17 +263,8 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
           (*out_cmanifest)->stats.stat_metadata_values[idx] = new const char* [num_metadata] {};
           size_t m_idx = 0;
           for (const auto& [meta_key, meta_val] : stat.metadata) {
-            size_t mk_len = meta_key.length();
-            char* mk_str = new char[mk_len + 1];
-            std::memcpy(mk_str, meta_key.c_str(), mk_len);
-            mk_str[mk_len] = '\0';
-            (*out_cmanifest)->stats.stat_metadata_keys[idx][m_idx] = mk_str;
-
-            size_t mv_len = meta_val.length();
-            char* mv_str = new char[mv_len + 1];
-            std::memcpy(mv_str, meta_val.c_str(), mv_len);
-            mv_str[mv_len] = '\0';
-            (*out_cmanifest)->stats.stat_metadata_values[idx][m_idx] = mv_str;
+            (*out_cmanifest)->stats.stat_metadata_keys[idx][m_idx] = copy_string(meta_key);
+            (*out_cmanifest)->stats.stat_metadata_values[idx][m_idx] = copy_string(meta_val);
             m_idx++;
           }
         }
@@ -301,12 +284,7 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
         const auto& lob_file = lob_files[i];
         auto& out_lob = (*out_cmanifest)->lob_files.files[i];
 
-        // Copy path
-        size_t path_len = lob_file.path.length();
-        char* path_str = new char[path_len + 1];
-        std::memcpy(path_str, lob_file.path.c_str(), path_len);
-        path_str[path_len] = '\0';
-        out_lob.path = path_str;
+        out_lob.path = copy_string(lob_file.path);
 
         out_lob.field_id = lob_file.field_id;
         out_lob.total_rows = lob_file.total_rows;
@@ -328,15 +306,27 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
         const auto& index = indexes[i];
         auto& out_index = (*out_cmanifest)->indexes.indexes[i];
 
-        auto copy_string = [](const std::string& value) {
-          auto* result = new char[value.size() + 1];
-          std::memcpy(result, value.c_str(), value.size() + 1);
-          return result;
-        };
-
         out_index.column_name = copy_string(index.column_name);
+        out_index.index_name = copy_string(index.index_name);
         out_index.index_type = copy_string(index.index_type);
         out_index.path = copy_string(index.path);
+        out_index.field_id = index.field_id;
+        out_index.index_id = index.index_id;
+        out_index.build_id = index.build_id;
+        out_index.index_version = index.index_version;
+        out_index.num_rows = index.num_rows;
+        out_index.serialized_size = index.serialized_size;
+        out_index.mem_size = index.mem_size;
+        out_index.current_index_version = index.current_index_version;
+        out_index.current_scalar_index_version = index.current_scalar_index_version;
+        out_index.index_store_path_version = index.index_store_path_version;
+        out_index.num_index_file_keys = static_cast<uint32_t>(index.index_file_keys.size());
+        if (!index.index_file_keys.empty()) {
+          out_index.index_file_keys = new const char* [index.index_file_keys.size()] {};
+          for (size_t file_index = 0; file_index < index.index_file_keys.size(); ++file_index) {
+            out_index.index_file_keys[file_index] = copy_string(index.index_file_keys[file_index]);
+          }
+        }
         out_index.num_properties = static_cast<uint32_t>(index.properties.size());
         if (!index.properties.empty()) {
           out_index.property_keys = new const char* [index.properties.size()] {};
@@ -422,8 +412,31 @@ arrow::Status manifest_import(const LoonManifest* cmanifest,
 
     Index index;
     index.column_name = in_index.column_name;
+    if (in_index.index_name) {
+      index.index_name = in_index.index_name;
+    }
     index.index_type = in_index.index_type;
     index.path = in_index.path;
+    index.field_id = in_index.field_id;
+    index.index_id = in_index.index_id;
+    index.build_id = in_index.build_id;
+    index.index_version = in_index.index_version;
+    index.num_rows = in_index.num_rows;
+    index.serialized_size = in_index.serialized_size;
+    index.mem_size = in_index.mem_size;
+    index.current_index_version = in_index.current_index_version;
+    index.current_scalar_index_version = in_index.current_scalar_index_version;
+    index.index_store_path_version = in_index.index_store_path_version;
+    if (in_index.num_index_file_keys > 0 && !in_index.index_file_keys) {
+      return arrow::Status::Invalid("Index metadata file keys are missing");
+    }
+    index.index_file_keys.reserve(in_index.num_index_file_keys);
+    for (uint32_t j = 0; j < in_index.num_index_file_keys; ++j) {
+      if (!in_index.index_file_keys[j]) {
+        return arrow::Status::Invalid("Index metadata file key is null");
+      }
+      index.index_file_keys.emplace_back(in_index.index_file_keys[j]);
+    }
     for (uint32_t j = 0; j < in_index.num_properties; ++j) {
       if (!in_index.property_keys[j] || !in_index.property_values[j]) {
         return arrow::Status::Invalid("Index metadata property key or value is null");
@@ -441,8 +454,7 @@ arrow::Status manifest_import(const LoonManifest* cmanifest,
     if (!in_lob.path) {
       return arrow::Status::Invalid("LOB file path is null");
     }
-    lob_files.emplace_back(in_lob.path, in_lob.field_id, in_lob.total_rows, in_lob.valid_rows,
-                           in_lob.file_size_bytes);
+    lob_files.emplace_back(in_lob.path, in_lob.field_id, in_lob.total_rows, in_lob.valid_rows, in_lob.file_size_bytes);
   }
 
   // Create Manifest
@@ -526,20 +538,22 @@ std::string manifest_debug_string(const LoonManifest* cmanifest) {
   result += fmt::format("  LobFiles(num_files={}):\n", cmanifest->lob_files.num_files);
   for (uint32_t i = 0; i < cmanifest->lob_files.num_files; ++i) {
     const auto& lob_file = cmanifest->lob_files.files[i];
-    result += fmt::format(
-        "    LobFile[{}]: path={}, field_id={}, total_rows={}, valid_rows={}, file_size_bytes={}\n", i,
-        lob_file.path ? lob_file.path : "(null)", lob_file.field_id, lob_file.total_rows, lob_file.valid_rows,
-        lob_file.file_size_bytes);
+    result += fmt::format("    LobFile[{}]: path={}, field_id={}, total_rows={}, valid_rows={}, file_size_bytes={}\n",
+                          i, lob_file.path ? lob_file.path : "(null)", lob_file.field_id, lob_file.total_rows,
+                          lob_file.valid_rows, lob_file.file_size_bytes);
   }
 
-  result += fmt::format("  Indexes(num_indexes={}, minor_version={}):\n", cmanifest->indexes.num_indexes,
-                        cmanifest->minor_version);
+  result += fmt::format("  Indexes(num_indexes={}):\n", cmanifest->indexes.num_indexes);
   for (uint32_t i = 0; i < cmanifest->indexes.num_indexes; ++i) {
     const auto& index = cmanifest->indexes.indexes[i];
-    result += fmt::format("    Index[{}]: column_name={}, index_type={}, path={}, num_properties={}\n", i,
-                          index.column_name ? index.column_name : "(null)",
-                          index.index_type ? index.index_type : "(null)", index.path ? index.path : "(null)",
-                          index.num_properties);
+    result += fmt::format(
+        "    Index[{}]: column_name={}, field_id={}, index_name={}, index_type={}, index_id={}, build_id={}, "
+        "index_version={}, "
+        "path={}, num_files={}, serialized_size={}, mem_size={}, num_properties={}\n",
+        i, index.column_name ? index.column_name : "(null)", index.field_id,
+        index.index_name ? index.index_name : "(null)", index.index_type ? index.index_type : "(null)", index.index_id,
+        index.build_id, index.index_version, index.path ? index.path : "(null)", index.num_index_file_keys,
+        index.serialized_size, index.mem_size, index.num_properties);
   }
 
   return result;

--- a/cpp/src/ffi/bridge.cpp
+++ b/cpp/src/ffi/bridge.cpp
@@ -197,6 +197,9 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
     (*out_cmanifest)->stats.num_stats = 0;
     (*out_cmanifest)->lob_files.files = nullptr;
     (*out_cmanifest)->lob_files.num_files = 0;
+    (*out_cmanifest)->indexes.indexes = nullptr;
+    (*out_cmanifest)->indexes.num_indexes = 0;
+    (*out_cmanifest)->minor_version = manifest->minorVersion();
 
     // Export column groups directly into embedded structure
     const auto& cgs = manifest->columnGroups();
@@ -312,6 +315,42 @@ arrow::Status manifest_export(const std::shared_ptr<milvus_storage::api::Manifes
       }
     }
 
+    // Export indexes.
+    const auto& indexes = manifest->indexes();
+    if (!indexes.empty()) {
+      // Publish each allocation in the output structure immediately. If a
+      // later allocation throws, the catch block below delegates cleanup of
+      // this partially constructed object to loon_manifest_destroy().
+      (*out_cmanifest)->indexes.indexes = new LoonIndexInfo[indexes.size()]{};
+      (*out_cmanifest)->indexes.num_indexes = static_cast<uint32_t>(indexes.size());
+
+      for (size_t i = 0; i < indexes.size(); ++i) {
+        const auto& index = indexes[i];
+        auto& out_index = (*out_cmanifest)->indexes.indexes[i];
+
+        auto copy_string = [](const std::string& value) {
+          auto* result = new char[value.size() + 1];
+          std::memcpy(result, value.c_str(), value.size() + 1);
+          return result;
+        };
+
+        out_index.column_name = copy_string(index.column_name);
+        out_index.index_type = copy_string(index.index_type);
+        out_index.path = copy_string(index.path);
+        out_index.num_properties = static_cast<uint32_t>(index.properties.size());
+        if (!index.properties.empty()) {
+          out_index.property_keys = new const char* [index.properties.size()] {};
+          out_index.property_values = new const char* [index.properties.size()] {};
+          size_t property_index = 0;
+          for (const auto& [key, value] : index.properties) {
+            out_index.property_keys[property_index] = copy_string(key);
+            out_index.property_values[property_index] = copy_string(value);
+            ++property_index;
+          }
+        }
+      }
+    }
+
     return arrow::Status::OK();
   } catch (const std::exception& e) {
     if (*out_cmanifest) {
@@ -369,8 +408,45 @@ arrow::Status manifest_import(const LoonManifest* cmanifest,
     stats[key] = std::move(stat);
   }
 
+  // Import index metadata.
+  std::vector<Index> indexes;
+  indexes.reserve(cmanifest->indexes.num_indexes);
+  for (uint32_t i = 0; i < cmanifest->indexes.num_indexes; ++i) {
+    const auto& in_index = cmanifest->indexes.indexes[i];
+    if (!in_index.column_name || !in_index.index_type || !in_index.path) {
+      return arrow::Status::Invalid("Index metadata requires column_name, index_type, and path");
+    }
+    if (in_index.num_properties > 0 && (!in_index.property_keys || !in_index.property_values)) {
+      return arrow::Status::Invalid("Index metadata properties are missing");
+    }
+
+    Index index;
+    index.column_name = in_index.column_name;
+    index.index_type = in_index.index_type;
+    index.path = in_index.path;
+    for (uint32_t j = 0; j < in_index.num_properties; ++j) {
+      if (!in_index.property_keys[j] || !in_index.property_values[j]) {
+        return arrow::Status::Invalid("Index metadata property key or value is null");
+      }
+      index.properties[in_index.property_keys[j]] = in_index.property_values[j];
+    }
+    indexes.push_back(std::move(index));
+  }
+
+  // Import LOB files too so an FFI manifest round trip preserves every field.
+  std::vector<LobFileInfo> lob_files;
+  lob_files.reserve(cmanifest->lob_files.num_files);
+  for (uint32_t i = 0; i < cmanifest->lob_files.num_files; ++i) {
+    const auto& in_lob = cmanifest->lob_files.files[i];
+    if (!in_lob.path) {
+      return arrow::Status::Invalid("LOB file path is null");
+    }
+    lob_files.emplace_back(in_lob.path, in_lob.field_id, in_lob.total_rows, in_lob.valid_rows,
+                           in_lob.file_size_bytes);
+  }
+
   // Create Manifest
-  *out_manifest = std::make_shared<Manifest>(std::move(cgs), delta_logs, stats);
+  *out_manifest = std::make_shared<Manifest>(std::move(cgs), delta_logs, stats, indexes, lob_files);
 
   return arrow::Status::OK();
 }
@@ -445,6 +521,25 @@ std::string manifest_debug_string(const LoonManifest* cmanifest) {
                               cmanifest->stats.stat_metadata_values[i][j]);
       }
     }
+  }
+
+  result += fmt::format("  LobFiles(num_files={}):\n", cmanifest->lob_files.num_files);
+  for (uint32_t i = 0; i < cmanifest->lob_files.num_files; ++i) {
+    const auto& lob_file = cmanifest->lob_files.files[i];
+    result += fmt::format(
+        "    LobFile[{}]: path={}, field_id={}, total_rows={}, valid_rows={}, file_size_bytes={}\n", i,
+        lob_file.path ? lob_file.path : "(null)", lob_file.field_id, lob_file.total_rows, lob_file.valid_rows,
+        lob_file.file_size_bytes);
+  }
+
+  result += fmt::format("  Indexes(num_indexes={}, minor_version={}):\n", cmanifest->indexes.num_indexes,
+                        cmanifest->minor_version);
+  for (uint32_t i = 0; i < cmanifest->indexes.num_indexes; ++i) {
+    const auto& index = cmanifest->indexes.indexes[i];
+    result += fmt::format("    Index[{}]: column_name={}, index_type={}, path={}, num_properties={}\n", i,
+                          index.column_name ? index.column_name : "(null)",
+                          index.index_type ? index.index_type : "(null)", index.path ? index.path : "(null)",
+                          index.num_properties);
   }
 
   return result;

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -282,8 +282,31 @@ LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, cons
   try {
     Index index;
     index.column_name = index_info->column_name;
+    if (index_info->index_name) {
+      index.index_name = index_info->index_name;
+    }
     index.index_type = index_info->index_type;
     index.path = index_info->path;
+    index.field_id = index_info->field_id;
+    index.index_id = index_info->index_id;
+    index.build_id = index_info->build_id;
+    index.index_version = index_info->index_version;
+    index.num_rows = index_info->num_rows;
+    index.serialized_size = index_info->serialized_size;
+    index.mem_size = index_info->mem_size;
+    index.current_index_version = index_info->current_index_version;
+    index.current_scalar_index_version = index_info->current_scalar_index_version;
+    index.index_store_path_version = index_info->index_store_path_version;
+    if (index_info->num_index_file_keys > 0 && !index_info->index_file_keys) {
+      RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: index file keys must not be null");
+    }
+    index.index_file_keys.reserve(index_info->num_index_file_keys);
+    for (uint32_t i = 0; i < index_info->num_index_file_keys; ++i) {
+      if (!index_info->index_file_keys[i]) {
+        RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: index file key must not be null");
+      }
+      index.index_file_keys.emplace_back(index_info->index_file_keys[i]);
+    }
     for (uint32_t i = 0; i < index_info->num_properties; ++i) {
       if (!index_info->property_keys[i] || !index_info->property_values[i]) {
         RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: index property key and value must not be null");
@@ -417,8 +440,15 @@ void loon_manifest_destroy(LoonManifest* cmanifest) {
     for (uint32_t i = 0; i < cmanifest->indexes.num_indexes; ++i) {
       auto& index = cmanifest->indexes.indexes[i];
       delete[] const_cast<char*>(index.column_name);
+      delete[] const_cast<char*>(index.index_name);
       delete[] const_cast<char*>(index.index_type);
       delete[] const_cast<char*>(index.path);
+      if (index.index_file_keys) {
+        for (uint32_t j = 0; j < index.num_index_file_keys; ++j) {
+          delete[] const_cast<char*>(index.index_file_keys[j]);
+        }
+        delete[] index.index_file_keys;
+      }
       if (index.property_keys) {
         for (uint32_t j = 0; j < index.num_properties; ++j) {
           delete[] const_cast<char*>(index.property_keys[j]);

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -99,6 +99,27 @@ LoonFFIResult loon_transaction_commit(LoonTransactionHandle handle, int64_t* out
   RETURN_UNREACHABLE();
 }
 
+LoonFFIResult loon_transaction_commit_with_info(LoonTransactionHandle handle,
+                                                LoonManifestCommitInfo* out_commit_info) {
+  if (!handle || !out_commit_info) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_commit_info must not be null");
+  }
+  try {
+    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
+    auto commit_result = cpp_transaction->CommitWithInfo();
+    RETURN_ARROW_ERROR_IF(commit_result.status(), LOON_LOGICAL_ERROR, commit_result.status().ToString());
+
+    const auto& commit_info = commit_result.ValueOrDie();
+    out_commit_info->manifest_version = commit_info.manifest_version;
+    out_commit_info->manifest_minor_version = commit_info.manifest_minor_version;
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
 void loon_transaction_destroy(LoonTransactionHandle handle) {
   if (handle) {
     auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
@@ -271,6 +292,36 @@ LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle handle,
   RETURN_UNREACHABLE();
 }
 
+LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, const LoonIndexInfo* index_info) {
+  if (!handle || !index_info || !index_info->column_name || !index_info->index_type || !index_info->path) {
+    RETURN_ERROR(LOON_INVALID_ARGS,
+                 "Invalid arguments: handle, index_info, column_name, index_type, and path must not be null");
+  }
+  if (index_info->num_properties > 0 && (!index_info->property_keys || !index_info->property_values)) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: index properties must not be null");
+  }
+  try {
+    Index index;
+    index.column_name = index_info->column_name;
+    index.index_type = index_info->index_type;
+    index.path = index_info->path;
+    for (uint32_t i = 0; i < index_info->num_properties; ++i) {
+      if (!index_info->property_keys[i] || !index_info->property_values[i]) {
+        RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: index property key and value must not be null");
+      }
+      index.properties[index_info->property_keys[i]] = index_info->property_values[i];
+    }
+
+    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
+    cpp_transaction->AddIndexInfo(index);
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
 LoonFFIResult loon_transaction_add_lob_file(LoonTransactionHandle handle, const LoonLobFileInfo* lob_file) {
   if (!handle || !lob_file) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and lob_file must not be null");
@@ -381,6 +432,31 @@ void loon_manifest_destroy(LoonManifest* cmanifest) {
     cmanifest->lob_files.files = nullptr;
   }
   cmanifest->lob_files.num_files = 0;
+
+  // Destroy indexes
+  if (cmanifest->indexes.indexes) {
+    for (uint32_t i = 0; i < cmanifest->indexes.num_indexes; ++i) {
+      auto& index = cmanifest->indexes.indexes[i];
+      delete[] const_cast<char*>(index.column_name);
+      delete[] const_cast<char*>(index.index_type);
+      delete[] const_cast<char*>(index.path);
+      if (index.property_keys) {
+        for (uint32_t j = 0; j < index.num_properties; ++j) {
+          delete[] const_cast<char*>(index.property_keys[j]);
+        }
+        delete[] index.property_keys;
+      }
+      if (index.property_values) {
+        for (uint32_t j = 0; j < index.num_properties; ++j) {
+          delete[] const_cast<char*>(index.property_values[j]);
+        }
+        delete[] index.property_values;
+      }
+    }
+    delete[] cmanifest->indexes.indexes;
+    cmanifest->indexes.indexes = nullptr;
+  }
+  cmanifest->indexes.num_indexes = 0;
 
   // Free the structure itself
   delete cmanifest;

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -99,27 +99,6 @@ LoonFFIResult loon_transaction_commit(LoonTransactionHandle handle, int64_t* out
   RETURN_UNREACHABLE();
 }
 
-LoonFFIResult loon_transaction_commit_with_info(LoonTransactionHandle handle,
-                                                LoonManifestCommitInfo* out_commit_info) {
-  if (!handle || !out_commit_info) {
-    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and out_commit_info must not be null");
-  }
-  try {
-    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
-    auto commit_result = cpp_transaction->CommitWithInfo();
-    RETURN_ARROW_ERROR_IF(commit_result.status(), LOON_LOGICAL_ERROR, commit_result.status().ToString());
-
-    const auto& commit_info = commit_result.ValueOrDie();
-    out_commit_info->manifest_version = commit_info.manifest_version;
-    out_commit_info->manifest_minor_version = commit_info.manifest_minor_version;
-    RETURN_SUCCESS();
-  } catch (std::exception& e) {
-    RETURN_EXCEPTION(e.what());
-  }
-
-  RETURN_UNREACHABLE();
-}
-
 void loon_transaction_destroy(LoonTransactionHandle handle) {
   if (handle) {
     auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -195,6 +195,7 @@ struct codec_traits<milvus_storage::api::Manifest> {
     avro::encode(e, m.stats());
     avro::encode(e, m.indexes());
     avro::encode(e, m.lobFiles());
+    avro::encode(e, m.minorVersion());
   }
 
   static void decode(Decoder& d, milvus_storage::api::Manifest& m) {
@@ -203,6 +204,13 @@ struct codec_traits<milvus_storage::api::Manifest> {
     avro::decode(d, m.stats());
     avro::decode(d, m.indexes());
     avro::decode(d, m.lobFiles());
+
+    // The persistent value is consumed for schema compatibility.  The public
+    // marker is derived from indexes(), which keeps old and malformed records
+    // consistent with the current manifest-state invariant.
+    int32_t encoded_minor_version = 0;
+    avro::decode(d, encoded_minor_version);
+    static_cast<void>(encoded_minor_version);
   }
 };
 
@@ -263,7 +271,8 @@ static const char* const MANIFEST_SCHEMA_JSON = R"({
         {"name": "valid_rows", "type": "long"},
         {"name": "file_size_bytes", "type": "long"}
       ]
-    }}, "default": []}
+    }}, "default": []},
+    {"name": "minor_version", "type": "int", "default": 0}
   ]
 })";
 

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -498,10 +498,15 @@ void Manifest::deserializeLegacy(std::istream& input_stream) {
     }
   }
 
-  if (version >= 2) {
-    // Raw MILV manifests predate the typed Index load metadata added in
-    // version 6. Decode their original four-field layout explicitly instead
-    // of using codec_traits<Index>, which expects the new fields.
+  if (version >= MANIFEST_VERSION) {
+    // Raw MILV manifests at version 6 or newer use the current typed Index
+    // layout.  This branch is retained for forward compatibility; current
+    // writers use Avro OCF and therefore normally take the path above.
+    avro::decode(*decoder, indexes_);
+  } else if (version >= 2) {
+    // Raw MILV manifests from versions 2 through 5 predate the typed Index
+    // load metadata.  Their Index records contain only column_name,
+    // index_type, path, and properties, so decode that layout explicitly.
     indexes_.clear();
     for (size_t n = decoder->arrayStart(); n != 0; n = decoder->arrayNext()) {
       for (size_t i = 0; i < n; ++i) {

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -499,7 +499,20 @@ void Manifest::deserializeLegacy(std::istream& input_stream) {
   }
 
   if (version >= 2) {
-    avro::decode(*decoder, indexes_);
+    // Raw MILV manifests predate the typed Index load metadata added in
+    // version 6. Decode their original four-field layout explicitly instead
+    // of using codec_traits<Index>, which expects the new fields.
+    indexes_.clear();
+    for (size_t n = decoder->arrayStart(); n != 0; n = decoder->arrayNext()) {
+      for (size_t i = 0; i < n; ++i) {
+        Index index;
+        avro::decode(*decoder, index.column_name);
+        avro::decode(*decoder, index.index_type);
+        avro::decode(*decoder, index.path);
+        avro::decode(*decoder, index.properties);
+        indexes_.push_back(std::move(index));
+      }
+    }
   } else {
     indexes_.clear();
   }

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -142,15 +142,39 @@ template <>
 struct codec_traits<milvus_storage::api::Index> {
   static void encode(Encoder& e, const milvus_storage::api::Index& idx) {
     avro::encode(e, idx.column_name);
+    avro::encode(e, idx.index_name);
     avro::encode(e, idx.index_type);
     avro::encode(e, idx.path);
+    avro::encode(e, idx.field_id);
+    avro::encode(e, idx.index_id);
+    avro::encode(e, idx.build_id);
+    avro::encode(e, idx.index_version);
+    avro::encode(e, idx.num_rows);
+    avro::encode(e, idx.serialized_size);
+    avro::encode(e, idx.mem_size);
+    avro::encode(e, idx.current_index_version);
+    avro::encode(e, idx.current_scalar_index_version);
+    avro::encode(e, idx.index_store_path_version);
+    avro::encode(e, idx.index_file_keys);
     avro::encode(e, idx.properties);
   }
 
   static void decode(Decoder& d, milvus_storage::api::Index& idx) {
     avro::decode(d, idx.column_name);
+    avro::decode(d, idx.index_name);
     avro::decode(d, idx.index_type);
     avro::decode(d, idx.path);
+    avro::decode(d, idx.field_id);
+    avro::decode(d, idx.index_id);
+    avro::decode(d, idx.build_id);
+    avro::decode(d, idx.index_version);
+    avro::decode(d, idx.num_rows);
+    avro::decode(d, idx.serialized_size);
+    avro::decode(d, idx.mem_size);
+    avro::decode(d, idx.current_index_version);
+    avro::decode(d, idx.current_scalar_index_version);
+    avro::decode(d, idx.index_store_path_version);
+    avro::decode(d, idx.index_file_keys);
     avro::decode(d, idx.properties);
   }
 };
@@ -195,7 +219,6 @@ struct codec_traits<milvus_storage::api::Manifest> {
     avro::encode(e, m.stats());
     avro::encode(e, m.indexes());
     avro::encode(e, m.lobFiles());
-    avro::encode(e, m.minorVersion());
   }
 
   static void decode(Decoder& d, milvus_storage::api::Manifest& m) {
@@ -204,13 +227,6 @@ struct codec_traits<milvus_storage::api::Manifest> {
     avro::decode(d, m.stats());
     avro::decode(d, m.indexes());
     avro::decode(d, m.lobFiles());
-
-    // The persistent value is consumed for schema compatibility.  The public
-    // marker is derived from indexes(), which keeps old and malformed records
-    // consistent with the current manifest-state invariant.
-    int32_t encoded_minor_version = 0;
-    avro::decode(d, encoded_minor_version);
-    static_cast<void>(encoded_minor_version);
   }
 };
 
@@ -258,8 +274,20 @@ static const char* const MANIFEST_SCHEMA_JSON = R"({
     {"name": "indexes", "type": {"type": "array", "items": {
       "type": "record", "name": "Index", "fields": [
         {"name": "column_name", "type": "string"},
+        {"name": "index_name", "type": "string", "default": ""},
         {"name": "index_type", "type": "string"},
         {"name": "path", "type": "string"},
+        {"name": "field_id", "type": "long", "default": 0},
+        {"name": "index_id", "type": "long", "default": 0},
+        {"name": "build_id", "type": "long", "default": 0},
+        {"name": "index_version", "type": "long", "default": 0},
+        {"name": "num_rows", "type": "long", "default": 0},
+        {"name": "serialized_size", "type": "long", "default": 0},
+        {"name": "mem_size", "type": "long", "default": 0},
+        {"name": "current_index_version", "type": "int", "default": 0},
+        {"name": "current_scalar_index_version", "type": "int", "default": 0},
+        {"name": "index_store_path_version", "type": "int", "default": 0},
+        {"name": "index_file_keys", "type": {"type": "array", "items": "string"}, "default": []},
         {"name": "properties", "type": {"type": "map", "values": "string"}, "default": {}}
       ]
     }}, "default": []},
@@ -271,8 +299,7 @@ static const char* const MANIFEST_SCHEMA_JSON = R"({
         {"name": "valid_rows", "type": "long"},
         {"name": "file_size_bytes", "type": "long"}
       ]
-    }}, "default": []},
-    {"name": "minor_version", "type": "int", "default": 0}
+    }}, "default": []}
   ]
 })";
 

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -346,11 +346,6 @@ Transaction::Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
       retry_limit_(retry_limit) {}
 
 arrow::Result<int64_t> Transaction::Commit() {
-  ARROW_ASSIGN_OR_RAISE(auto commit_info, CommitWithInfo());
-  return commit_info.manifest_version;
-}
-
-arrow::Result<ManifestCommitInfo> Transaction::CommitWithInfo() {
   // Fault injection point for testing
   FIU_RETURN_ON(FIUKEY_MANIFEST_COMMIT_FAIL,
                 arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_COMMIT_FAIL)));
@@ -412,15 +407,12 @@ arrow::Result<ManifestCommitInfo> Transaction::CommitWithInfo() {
     // Try to commit the resolved manifest
     auto status = write_manifest(resolved_manifest, latest_version, committed_version);
 
-    // If commit succeeded, return all metadata needed for publication.
+    // If commit succeeded, return the committed revision.
     if (status.ok()) {
       LOG_STORAGE_DEBUG_ << fmt::format(
           "Manifest committed successfully: [committed_version={}][read_version={}][retries={}]", committed_version,
           read_version_, retry_count);
-      return ManifestCommitInfo{
-          .manifest_version = committed_version,
-          .manifest_minor_version = resolved_manifest->minorVersion(),
-      };
+      return committed_version;
     }
 
     // If commit failed due to conflict (file already exists), retry if within limit

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -346,6 +346,11 @@ Transaction::Transaction(const milvus_storage::ArrowFileSystemPtr& fs,
       retry_limit_(retry_limit) {}
 
 arrow::Result<int64_t> Transaction::Commit() {
+  ARROW_ASSIGN_OR_RAISE(auto commit_info, CommitWithInfo());
+  return commit_info.manifest_version;
+}
+
+arrow::Result<ManifestCommitInfo> Transaction::CommitWithInfo() {
   // Fault injection point for testing
   FIU_RETURN_ON(FIUKEY_MANIFEST_COMMIT_FAIL,
                 arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_MANIFEST_COMMIT_FAIL)));
@@ -407,12 +412,15 @@ arrow::Result<int64_t> Transaction::Commit() {
     // Try to commit the resolved manifest
     auto status = write_manifest(resolved_manifest, latest_version, committed_version);
 
-    // If commit succeeded, return the committed version
+    // If commit succeeded, return all metadata needed for publication.
     if (status.ok()) {
       LOG_STORAGE_DEBUG_ << fmt::format(
           "Manifest committed successfully: [committed_version={}][read_version={}][retries={}]", committed_version,
           read_version_, retry_count);
-      return committed_version;
+      return ManifestCommitInfo{
+          .manifest_version = committed_version,
+          .manifest_minor_version = resolved_manifest->minorVersion(),
+      };
     }
 
     // If commit failed due to conflict (file already exists), retry if within limit
@@ -495,9 +503,13 @@ Transaction& Transaction::UpdateStat(const std::string& key, const Statistics& s
   return *this;
 }
 
-Transaction& Transaction::AddIndex(const Index& index) {
+Transaction& Transaction::AddIndexInfo(const Index& index) {
   updates_.AddIndex(index);
   return *this;
+}
+
+Transaction& Transaction::AddIndex(const Index& index) {
+  return AddIndexInfo(index);
 }
 
 Transaction& Transaction::DropIndex(const std::string& column_name, const std::string& index_type) {

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -500,10 +500,6 @@ Transaction& Transaction::AddIndexInfo(const Index& index) {
   return *this;
 }
 
-Transaction& Transaction::AddIndex(const Index& index) {
-  return AddIndexInfo(index);
-}
-
 Transaction& Transaction::DropIndex(const std::string& column_name, const std::string& index_type) {
   updates_.DropIndex(column_name, index_type);
   return *this;

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -239,6 +239,66 @@ TEST_F(TransactionTest, AddFieldTest) {
   }
 }
 
+TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCompatibility) {
+  Index first_index{.column_name = "vector",
+                    .index_type = "hnsw",
+                    .path = base_path_ + "/_index/vector-v1.idx",
+                    .properties = {{"index_id", "100"}, {"build_id", "101"}}};
+
+  // Index bytes are already written by the caller. The transaction publishes
+  // only their metadata and reports the minor version to the metadata layer.
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    transaction->AddIndexInfo(first_index);
+    ASSERT_AND_ASSIGN(auto commit_info, transaction->CommitWithInfo());
+    EXPECT_EQ(commit_info.manifest_version, 1);
+    EXPECT_EQ(commit_info.manifest_minor_version, static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
+  }
+
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
+    ASSERT_EQ(manifest->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
+    const auto* index = manifest->getIndex("vector", "hnsw");
+    ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->path, first_index.path);
+    EXPECT_EQ(index->properties, first_index.properties);
+  }
+
+  // AddIndex remains source-compatible and replaces the matching metadata.
+  Index replacement_index = first_index;
+  replacement_index.path = base_path_ + "/_index/vector-v2.idx";
+  replacement_index.properties["build_id"] = "102";
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    transaction->AddIndex(replacement_index);
+    ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
+    EXPECT_EQ(committed_version, 2);
+  }
+
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
+    ASSERT_EQ(manifest->indexes().size(), 1);
+    ASSERT_NE(manifest->getIndex("vector", "hnsw"), nullptr);
+    EXPECT_EQ(manifest->getIndex("vector", "hnsw")->path, replacement_index.path);
+  }
+
+  // Removing the final index resets the marker in the committed manifest.
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    transaction->DropIndex("vector", "hnsw");
+    ASSERT_AND_ASSIGN(auto commit_info, transaction->CommitWithInfo());
+    EXPECT_EQ(commit_info.manifest_version, 3);
+    EXPECT_EQ(commit_info.manifest_minor_version, static_cast<int32_t>(ManifestMinorVersion::NONE));
+  }
+
+  ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
+  EXPECT_TRUE(manifest->indexes().empty());
+  EXPECT_EQ(manifest->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::NONE));
+}
+
 TEST_F(TransactionTest, ConflictResolveOverwriteTest) {
   // initial 5 commit with one column group
   for (size_t i = 0; i < 5; ++i) {

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -239,11 +239,23 @@ TEST_F(TransactionTest, AddFieldTest) {
   }
 }
 
-TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCompatibility) {
+TEST_F(TransactionTest, AddIndexInfoPersistsCompletedIndexMetadata) {
   Index first_index{.column_name = "vector",
+                    .index_name = "vector_hnsw",
                     .index_type = "hnsw",
                     .path = base_path_ + "/_index/vector-v1.idx",
-                    .properties = {{"index_id", "100"}, {"build_id", "101"}}};
+                    .field_id = 100,
+                    .index_id = 200,
+                    .build_id = 300,
+                    .index_version = 4,
+                    .num_rows = 1000,
+                    .serialized_size = 1024,
+                    .mem_size = 2048,
+                    .current_index_version = 15,
+                    .current_scalar_index_version = 7,
+                    .index_store_path_version = 1,
+                    .index_file_keys = {"index.bin", "raw_data.bin"},
+                    .properties = {{"metric_type", "COSINE"}, {"M", "16"}}};
 
   // Index bytes are already written by the caller. The transaction publishes
   // only their metadata.
@@ -257,20 +269,32 @@ TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCom
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
     ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
-    ASSERT_EQ(manifest->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
     const auto* index = manifest->getIndex("vector", "hnsw");
     ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->index_name, first_index.index_name);
     EXPECT_EQ(index->path, first_index.path);
+    EXPECT_EQ(index->field_id, first_index.field_id);
+    EXPECT_EQ(index->index_id, first_index.index_id);
+    EXPECT_EQ(index->build_id, first_index.build_id);
+    EXPECT_EQ(index->index_version, first_index.index_version);
+    EXPECT_EQ(index->num_rows, first_index.num_rows);
+    EXPECT_EQ(index->serialized_size, first_index.serialized_size);
+    EXPECT_EQ(index->mem_size, first_index.mem_size);
+    EXPECT_EQ(index->current_index_version, first_index.current_index_version);
+    EXPECT_EQ(index->current_scalar_index_version, first_index.current_scalar_index_version);
+    EXPECT_EQ(index->index_store_path_version, first_index.index_store_path_version);
+    EXPECT_EQ(index->index_file_keys, first_index.index_file_keys);
     EXPECT_EQ(index->properties, first_index.properties);
   }
 
-  // AddIndex remains source-compatible and replaces the matching metadata.
+  // Replacing the matching index metadata updates the recorded artifact.
   Index replacement_index = first_index;
   replacement_index.path = base_path_ + "/_index/vector-v2.idx";
-  replacement_index.properties["build_id"] = "102";
+  replacement_index.build_id = 301;
+  replacement_index.index_file_keys = {"index-v2.bin"};
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
-    transaction->AddIndex(replacement_index);
+    transaction->AddIndexInfo(replacement_index);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     EXPECT_EQ(committed_version, 2);
   }
@@ -279,11 +303,14 @@ TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCom
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
     ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
     ASSERT_EQ(manifest->indexes().size(), 1);
-    ASSERT_NE(manifest->getIndex("vector", "hnsw"), nullptr);
-    EXPECT_EQ(manifest->getIndex("vector", "hnsw")->path, replacement_index.path);
+    const auto* index = manifest->getIndex("vector", "hnsw");
+    ASSERT_NE(index, nullptr);
+    EXPECT_EQ(index->path, replacement_index.path);
+    EXPECT_EQ(index->build_id, replacement_index.build_id);
+    EXPECT_EQ(index->index_file_keys, replacement_index.index_file_keys);
   }
 
-  // Removing the final index resets the marker in the committed manifest.
+  // Removing the final index removes all manifest-published index metadata.
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
     transaction->DropIndex("vector", "hnsw");
@@ -294,7 +321,6 @@ TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCom
   ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
   ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
   EXPECT_TRUE(manifest->indexes().empty());
-  EXPECT_EQ(manifest->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::NONE));
 }
 
 TEST_F(TransactionTest, ConflictResolveOverwriteTest) {
@@ -578,7 +604,7 @@ TEST_F(TransactionTest, IndexBasicOperationsTest) {
     idx.path = base_path_ + "/_index/id_hnsw.idx";
     idx.properties = {{"ef_construction", "128"}, {"M", "16"}};
 
-    transaction->AddIndex(idx);
+    transaction->AddIndexInfo(idx);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 2);
 
@@ -636,8 +662,8 @@ TEST_F(TransactionTest, IndexUniqueConstraintTest) {
     idx2.path = base_path_ + "/_index/id_hnsw_v2.idx";
     idx2.properties = {{"version", "2"}};
 
-    transaction->AddIndex(idx1);
-    transaction->AddIndex(idx2);  // Same key, should replace
+    transaction->AddIndexInfo(idx1);
+    transaction->AddIndexInfo(idx2);  // Same key, should replace
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 2);
 
@@ -661,7 +687,7 @@ TEST_F(TransactionTest, IndexUniqueConstraintTest) {
     idx.path = base_path_ + "/_index/id_inverted.idx";
     idx.properties = {};
 
-    transaction->AddIndex(idx);
+    transaction->AddIndexInfo(idx);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 3);
 
@@ -687,7 +713,7 @@ TEST_F(TransactionTest, IndexDeprecationOnAppendFilesTest) {
     idx.path = base_path_ + "/_index/id_hnsw.idx";
     idx.properties = {};
 
-    transaction->AddIndex(idx);
+    transaction->AddIndexInfo(idx);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 1);
 
@@ -726,7 +752,7 @@ TEST_F(TransactionTest, IndexNotDeprecatedByDeltaLogTest) {
     idx.path = base_path_ + "/_index/id_hnsw.idx";
     idx.properties = {};
 
-    transaction->AddIndex(idx);
+    transaction->AddIndexInfo(idx);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 1);
   }
@@ -785,8 +811,8 @@ TEST_F(TransactionTest, IndexMultipleColumnsDeprecationTest) {
     idx2.path = base_path_ + "/_index/vector_ivfpq.idx";
     idx2.properties = {};
 
-    transaction->AddIndex(idx1);
-    transaction->AddIndex(idx2);
+    transaction->AddIndexInfo(idx1);
+    transaction->AddIndexInfo(idx2);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 1);
 
@@ -1128,7 +1154,7 @@ TEST_F(TransactionTest, DropColumnAutoDropsIndex) {
     idx.column_name = "name";
     idx.index_type = "inverted";
     idx.path = base_path_ + "/_index/name_inverted.idx";
-    transaction->AddIndex(idx);
+    transaction->AddIndexInfo(idx);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 2);
   }

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -246,13 +246,12 @@ TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCom
                     .properties = {{"index_id", "100"}, {"build_id", "101"}}};
 
   // Index bytes are already written by the caller. The transaction publishes
-  // only their metadata and reports the minor version to the metadata layer.
+  // only their metadata.
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
     transaction->AddIndexInfo(first_index);
-    ASSERT_AND_ASSIGN(auto commit_info, transaction->CommitWithInfo());
-    EXPECT_EQ(commit_info.manifest_version, 1);
-    EXPECT_EQ(commit_info.manifest_minor_version, static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
+    ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
+    EXPECT_EQ(committed_version, 1);
   }
 
   {
@@ -288,9 +287,8 @@ TEST_F(TransactionTest, AddIndexInfoPublishesMinorVersionAndPreservesAddIndexCom
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
     transaction->DropIndex("vector", "hnsw");
-    ASSERT_AND_ASSIGN(auto commit_info, transaction->CommitWithInfo());
-    EXPECT_EQ(commit_info.manifest_version, 3);
-    EXPECT_EQ(commit_info.manifest_minor_version, static_cast<int32_t>(ManifestMinorVersion::NONE));
+    ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
+    EXPECT_EQ(committed_version, 3);
   }
 
   ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));

--- a/cpp/test/column_groups_test.cpp
+++ b/cpp/test/column_groups_test.cpp
@@ -498,6 +498,9 @@ TEST_F(ColumnGroupsTest, LegacyV2Deserialize) {
   EXPECT_TRUE(deserialized->stats().empty());
   EXPECT_EQ(deserialized->indexes().size(), 1);
   EXPECT_EQ(deserialized->indexes()[0].index_type, "ivf");
+  EXPECT_TRUE(deserialized->indexes()[0].index_name.empty());
+  EXPECT_EQ(deserialized->indexes()[0].field_id, 0);
+  EXPECT_TRUE(deserialized->indexes()[0].index_file_keys.empty());
 }
 
 TEST_F(ColumnGroupsTest, IndexRoundTripPreservesData) {

--- a/cpp/test/column_groups_test.cpp
+++ b/cpp/test/column_groups_test.cpp
@@ -326,7 +326,11 @@ static void encodeIndex(avro::Encoder& e, const Index& idx) {
   avro::encode(e, idx.column_name);
   avro::encode(e, idx.index_type);
   avro::encode(e, idx.path);
-  avro::encode(e, idx.properties);
+  // The legacy test fixture uses the original Avro map representation.  The
+  // public Index now uses unordered_map for lookup efficiency, while the
+  // compatibility encoder remains independent of the implementation type.
+  std::map<std::string, std::string> properties(idx.properties.begin(), idx.properties.end());
+  avro::encode(e, properties);
 }
 
 static void encodeStatistics(avro::Encoder& e, const Statistics& stat) {

--- a/cpp/test/ffi/bridge_test.cpp
+++ b/cpp/test/ffi/bridge_test.cpp
@@ -259,34 +259,70 @@ TEST_F(BridgeTest, ExportImportManifestEmpty) {
   loon_manifest_destroy(cmanifest);
 }
 
-TEST_F(BridgeTest, ExportImportManifestWithIndexInfoAndMinorVersion) {
+TEST_F(BridgeTest, ExportImportManifestWithIndexInfo) {
   std::vector<Index> indexes = {{.column_name = "vector",
+                                 .index_name = "vector_hnsw",
                                  .index_type = "HNSW",
-                                 .path = "_index/vector-hnsw.idx",
-                                 .properties = {{"index_id", "10"}, {"build_id", "20"}}}};
-  auto manifest = std::make_shared<Manifest>(ColumnGroups{}, std::vector<DeltaLog>{},
-                                             std::map<std::string, Statistics>{}, indexes);
+                                 .path = "_index/vector-hnsw",
+                                 .field_id = 100,
+                                 .index_id = 10,
+                                 .build_id = 20,
+                                 .index_version = 3,
+                                 .num_rows = 1000,
+                                 .serialized_size = 1024,
+                                 .mem_size = 2048,
+                                 .current_index_version = 15,
+                                 .current_scalar_index_version = 7,
+                                 .index_store_path_version = 1,
+                                 .index_file_keys = {"index.bin", "raw_data.bin"},
+                                 .properties = {{"metric_type", "COSINE"}, {"M", "16"}}}};
+  auto manifest =
+      std::make_shared<Manifest>(ColumnGroups{}, std::vector<DeltaLog>{}, std::map<std::string, Statistics>{}, indexes);
 
   LoonManifest* cmanifest = nullptr;
   ASSERT_STATUS_OK(manifest_export(manifest, &cmanifest));
   ASSERT_NE(cmanifest, nullptr);
-  ASSERT_EQ(cmanifest->minor_version, static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
   ASSERT_EQ(cmanifest->indexes.num_indexes, 1);
   const auto& cindex = cmanifest->indexes.indexes[0];
   ASSERT_STREQ(cindex.column_name, "vector");
+  ASSERT_STREQ(cindex.index_name, "vector_hnsw");
   ASSERT_STREQ(cindex.index_type, "HNSW");
-  ASSERT_STREQ(cindex.path, "_index/vector-hnsw.idx");
+  ASSERT_STREQ(cindex.path, "_index/vector-hnsw");
+  ASSERT_EQ(cindex.field_id, 100);
+  ASSERT_EQ(cindex.index_id, 10);
+  ASSERT_EQ(cindex.build_id, 20);
+  ASSERT_EQ(cindex.index_version, 3);
+  ASSERT_EQ(cindex.num_rows, 1000);
+  ASSERT_EQ(cindex.serialized_size, 1024);
+  ASSERT_EQ(cindex.mem_size, 2048);
+  ASSERT_EQ(cindex.current_index_version, 15);
+  ASSERT_EQ(cindex.current_scalar_index_version, 7);
+  ASSERT_EQ(cindex.index_store_path_version, 1);
+  ASSERT_EQ(cindex.num_index_file_keys, 2);
+  ASSERT_STREQ(cindex.index_file_keys[0], "index.bin");
+  ASSERT_STREQ(cindex.index_file_keys[1], "raw_data.bin");
   ASSERT_EQ(cindex.num_properties, 2);
 
   std::shared_ptr<Manifest> imported_manifest;
   ASSERT_STATUS_OK(manifest_import(cmanifest, &imported_manifest));
   ASSERT_NE(imported_manifest, nullptr);
-  ASSERT_EQ(imported_manifest->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
   const auto* imported_index = imported_manifest->getIndex("vector", "HNSW");
   ASSERT_NE(imported_index, nullptr);
-  EXPECT_EQ(imported_index->path, "_index/vector-hnsw.idx");
-  EXPECT_EQ(imported_index->properties.at("index_id"), "10");
-  EXPECT_EQ(imported_index->properties.at("build_id"), "20");
+  EXPECT_EQ(imported_index->index_name, "vector_hnsw");
+  EXPECT_EQ(imported_index->path, "_index/vector-hnsw");
+  EXPECT_EQ(imported_index->field_id, 100);
+  EXPECT_EQ(imported_index->index_id, 10);
+  EXPECT_EQ(imported_index->build_id, 20);
+  EXPECT_EQ(imported_index->index_version, 3);
+  EXPECT_EQ(imported_index->num_rows, 1000);
+  EXPECT_EQ(imported_index->serialized_size, 1024);
+  EXPECT_EQ(imported_index->mem_size, 2048);
+  EXPECT_EQ(imported_index->current_index_version, 15);
+  EXPECT_EQ(imported_index->current_scalar_index_version, 7);
+  EXPECT_EQ(imported_index->index_store_path_version, 1);
+  EXPECT_EQ(imported_index->index_file_keys, std::vector<std::string>({"index.bin", "raw_data.bin"}));
+  EXPECT_EQ(imported_index->properties.at("metric_type"), "COSINE");
+  EXPECT_EQ(imported_index->properties.at("M"), "16");
 
   loon_manifest_destroy(cmanifest);
 }

--- a/cpp/test/ffi/bridge_test.cpp
+++ b/cpp/test/ffi/bridge_test.cpp
@@ -259,6 +259,56 @@ TEST_F(BridgeTest, ExportImportManifestEmpty) {
   loon_manifest_destroy(cmanifest);
 }
 
+TEST_F(BridgeTest, ExportImportManifestWithIndexInfoAndMinorVersion) {
+  std::vector<Index> indexes = {{.column_name = "vector",
+                                 .index_type = "HNSW",
+                                 .path = "_index/vector-hnsw.idx",
+                                 .properties = {{"index_id", "10"}, {"build_id", "20"}}}};
+  auto manifest = std::make_shared<Manifest>(ColumnGroups{}, std::vector<DeltaLog>{},
+                                             std::map<std::string, Statistics>{}, indexes);
+
+  LoonManifest* cmanifest = nullptr;
+  ASSERT_STATUS_OK(manifest_export(manifest, &cmanifest));
+  ASSERT_NE(cmanifest, nullptr);
+  ASSERT_EQ(cmanifest->minor_version, static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
+  ASSERT_EQ(cmanifest->indexes.num_indexes, 1);
+  const auto& cindex = cmanifest->indexes.indexes[0];
+  ASSERT_STREQ(cindex.column_name, "vector");
+  ASSERT_STREQ(cindex.index_type, "HNSW");
+  ASSERT_STREQ(cindex.path, "_index/vector-hnsw.idx");
+  ASSERT_EQ(cindex.num_properties, 2);
+
+  std::shared_ptr<Manifest> imported_manifest;
+  ASSERT_STATUS_OK(manifest_import(cmanifest, &imported_manifest));
+  ASSERT_NE(imported_manifest, nullptr);
+  ASSERT_EQ(imported_manifest->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
+  const auto* imported_index = imported_manifest->getIndex("vector", "HNSW");
+  ASSERT_NE(imported_index, nullptr);
+  EXPECT_EQ(imported_index->path, "_index/vector-hnsw.idx");
+  EXPECT_EQ(imported_index->properties.at("index_id"), "10");
+  EXPECT_EQ(imported_index->properties.at("build_id"), "20");
+
+  loon_manifest_destroy(cmanifest);
+}
+
+TEST_F(BridgeTest, ManifestDestroyReleasesIndexInfo) {
+  std::vector<Index> indexes = {{.column_name = "vector",
+                                 .index_type = "HNSW",
+                                 .path = "_index/vector-hnsw.idx",
+                                 .properties = {{"index_id", "10"}, {"build_id", "20"}}}};
+
+  // Repeat the complete ownership cycle so sanitizer-enabled builds verify
+  // every index allocation has a matching release in loon_manifest_destroy.
+  for (int i = 0; i < 16; ++i) {
+    auto manifest = std::make_shared<Manifest>(ColumnGroups{}, std::vector<DeltaLog>{},
+                                               std::map<std::string, Statistics>{}, indexes);
+    LoonManifest* cmanifest = nullptr;
+    ASSERT_STATUS_OK(manifest_export(manifest, &cmanifest));
+    ASSERT_NE(cmanifest, nullptr);
+    loon_manifest_destroy(cmanifest);
+  }
+}
+
 // Test export column groups with empty input
 TEST_F(BridgeTest, ExportEmptyColumnGroups) {
   ColumnGroups cgs;
@@ -315,7 +365,8 @@ TEST_F(BridgeTest, ManifestDebugStringValid) {
   std::map<std::string, Statistics> stats;
   stats["stat_key"] = Statistics{{"stat_file.parquet"}, {}};
 
-  auto manifest = std::make_shared<Manifest>(std::move(cgs), delta_logs, stats);
+  std::vector<LobFileInfo> lob_files = {{"lobs/100/_data/lob.vortex", 100, 20, 18, 1024}};
+  auto manifest = std::make_shared<Manifest>(std::move(cgs), delta_logs, stats, std::vector<Index>{}, lob_files);
 
   LoonManifest* cmanifest = nullptr;
   ASSERT_STATUS_OK(manifest_export(manifest, &cmanifest));
@@ -325,6 +376,9 @@ TEST_F(BridgeTest, ManifestDebugStringValid) {
   ASSERT_TRUE(result.find("DeltaLogs") != std::string::npos);
   ASSERT_TRUE(result.find("delta.log") != std::string::npos);
   ASSERT_TRUE(result.find("Stats") != std::string::npos);
+  ASSERT_TRUE(result.find("LobFiles(num_files=1)") != std::string::npos);
+  ASSERT_TRUE(result.find("field_id=100") != std::string::npos);
+  ASSERT_TRUE(result.find("file_size_bytes=1024") != std::string::npos);
 
   loon_manifest_destroy(cmanifest);
 }

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -286,6 +286,58 @@ static void test_add_column_group(void) {
   loon_properties_free(&pp);
 }
 
+static void test_add_index_info_and_commit_with_info(void) {
+  LoonProperties pp;
+  LoonFFIResult rc;
+  LoonTransactionHandle transaction = 0;
+  LoonTransactionHandle read_transaction = 0;
+  LoonManifest* cmanifest = NULL;
+  LoonManifestCommitInfo commit_info = {0};
+  const char* property_keys[] = {"index_id", "build_id"};
+  const char* property_values[] = {"100", "101"};
+  LoonIndexInfo index_info = {
+      .column_name = "vector",
+      .index_type = "HNSW",
+      .path = "vector-hnsw.idx",
+      .property_keys = property_keys,
+      .property_values = property_values,
+      .num_properties = 2,
+  };
+
+  create_test_pp(&pp);
+  FileSystemHandle fs = get_fs(&pp);
+  recreate_dir(fs, TEST_BASE_PATH);
+
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &transaction);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  rc = loon_transaction_add_index_info(transaction, &index_info);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+
+  rc = loon_transaction_commit_with_info(transaction, &commit_info);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_eq(commit_info.manifest_version, 1);
+  ck_assert_int_eq(commit_info.manifest_minor_version, 1);
+  loon_transaction_destroy(transaction);
+
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &read_transaction);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_eq(cmanifest->minor_version, 1);
+  ck_assert_int_eq(cmanifest->indexes.num_indexes, 1);
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].column_name, "vector");
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].index_type, "HNSW");
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].path, TEST_BASE_PATH "/_index/vector-hnsw.idx");
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].num_properties, 2);
+
+  loon_manifest_destroy(cmanifest);
+  loon_transaction_destroy(read_transaction);
+  clean_test_dir(fs, TEST_BASE_PATH);
+  loon_filesystem_destroy(fs);
+  loon_properties_free(&pp);
+}
+
 // Test loon_transaction_add_delta_log
 static void test_add_delta_log(void) {
   LoonTransactionHandle tranhandle;
@@ -759,6 +811,8 @@ void run_manifest_suite(void) {
   RUN_TEST(test_abort);
   loon_reset_context();
   RUN_TEST(test_add_column_group);
+  loon_reset_context();
+  RUN_TEST(test_add_index_info_and_commit_with_info);
   loon_reset_context();
   RUN_TEST(test_add_delta_log);
   loon_reset_context();

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -293,12 +293,26 @@ static void test_add_index_info_and_commit(void) {
   LoonTransactionHandle read_transaction = 0;
   LoonManifest* cmanifest = NULL;
   int64_t committed_version = 0;
-  const char* property_keys[] = {"index_id", "build_id"};
-  const char* property_values[] = {"100", "101"};
+  const char* index_file_keys[] = {"index.bin", "raw_data.bin"};
+  const char* property_keys[] = {"metric_type", "M"};
+  const char* property_values[] = {"COSINE", "16"};
   LoonIndexInfo index_info = {
       .column_name = "vector",
+      .index_name = "vector_hnsw",
       .index_type = "HNSW",
-      .path = "vector-hnsw.idx",
+      .path = "vector-hnsw",
+      .field_id = 100,
+      .index_id = 200,
+      .build_id = 300,
+      .index_version = 4,
+      .num_rows = 1000,
+      .serialized_size = 1024,
+      .mem_size = 2048,
+      .current_index_version = 15,
+      .current_scalar_index_version = 7,
+      .index_store_path_version = 1,
+      .index_file_keys = index_file_keys,
+      .num_index_file_keys = 2,
       .property_keys = property_keys,
       .property_values = property_values,
       .num_properties = 2,
@@ -323,11 +337,24 @@ static void test_add_index_info_and_commit(void) {
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
-  ck_assert_int_eq(cmanifest->minor_version, 1);
   ck_assert_int_eq(cmanifest->indexes.num_indexes, 1);
   ck_assert_str_eq(cmanifest->indexes.indexes[0].column_name, "vector");
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].index_name, "vector_hnsw");
   ck_assert_str_eq(cmanifest->indexes.indexes[0].index_type, "HNSW");
-  ck_assert_str_eq(cmanifest->indexes.indexes[0].path, TEST_BASE_PATH "/_index/vector-hnsw.idx");
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].path, TEST_BASE_PATH "/_index/vector-hnsw");
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].field_id, 100);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].index_id, 200);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].build_id, 300);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].index_version, 4);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].num_rows, 1000);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].serialized_size, 1024);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].mem_size, 2048);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].current_index_version, 15);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].current_scalar_index_version, 7);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].index_store_path_version, 1);
+  ck_assert_int_eq(cmanifest->indexes.indexes[0].num_index_file_keys, 2);
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].index_file_keys[0], "index.bin");
+  ck_assert_str_eq(cmanifest->indexes.indexes[0].index_file_keys[1], "raw_data.bin");
   ck_assert_int_eq(cmanifest->indexes.indexes[0].num_properties, 2);
 
   loon_manifest_destroy(cmanifest);

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -286,13 +286,13 @@ static void test_add_column_group(void) {
   loon_properties_free(&pp);
 }
 
-static void test_add_index_info_and_commit_with_info(void) {
+static void test_add_index_info_and_commit(void) {
   LoonProperties pp;
   LoonFFIResult rc;
   LoonTransactionHandle transaction = 0;
   LoonTransactionHandle read_transaction = 0;
   LoonManifest* cmanifest = NULL;
-  LoonManifestCommitInfo commit_info = {0};
+  int64_t committed_version = 0;
   const char* property_keys[] = {"index_id", "build_id"};
   const char* property_values[] = {"100", "101"};
   LoonIndexInfo index_info = {
@@ -314,10 +314,9 @@ static void test_add_index_info_and_commit_with_info(void) {
   rc = loon_transaction_add_index_info(transaction, &index_info);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 
-  rc = loon_transaction_commit_with_info(transaction, &commit_info);
+  rc = loon_transaction_commit(transaction, &committed_version);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
-  ck_assert_int_eq(commit_info.manifest_version, 1);
-  ck_assert_int_eq(commit_info.manifest_minor_version, 1);
+  ck_assert_int_eq(committed_version, 1);
   loon_transaction_destroy(transaction);
 
   rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &read_transaction);
@@ -812,7 +811,7 @@ void run_manifest_suite(void) {
   loon_reset_context();
   RUN_TEST(test_add_column_group);
   loon_reset_context();
-  RUN_TEST(test_add_index_info_and_commit_with_info);
+  RUN_TEST(test_add_index_info_and_commit);
   loon_reset_context();
   RUN_TEST(test_add_delta_log);
   loon_reset_context();

--- a/cpp/test/manifest_test.cpp
+++ b/cpp/test/manifest_test.cpp
@@ -85,7 +85,6 @@ TEST_F(ManifestTest, EmptyManifestRoundTrip) {
   EXPECT_TRUE(read_back->stats().empty());
   EXPECT_TRUE(read_back->indexes().empty());
   EXPECT_TRUE(read_back->lobFiles().empty());
-  EXPECT_EQ(read_back->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::NONE));
 }
 
 TEST_F(ManifestTest, ColumnGroupsRoundTrip) {
@@ -154,8 +153,20 @@ TEST_F(ManifestTest, StatsRoundTrip) {
 
 TEST_F(ManifestTest, IndexesRoundTrip) {
   Index idx1{.column_name = "vector",
+             .index_name = "vector_hnsw",
              .index_type = "hnsw",
-             .path = get_index_filepath(base_path_, "vec_hnsw.idx"),
+             .path = get_index_filepath(base_path_, "vec_hnsw"),
+             .field_id = 100,
+             .index_id = 200,
+             .build_id = 300,
+             .index_version = 4,
+             .num_rows = 1000,
+             .serialized_size = 1024,
+             .mem_size = 2048,
+             .current_index_version = 15,
+             .current_scalar_index_version = 7,
+             .index_store_path_version = 1,
+             .index_file_keys = {"index.bin", "raw_data.bin"},
              .properties = {{"M", "16"}, {"ef_construction", "128"}}};
 
   Index idx2{.column_name = "id",
@@ -167,16 +178,28 @@ TEST_F(ManifestTest, IndexesRoundTrip) {
   auto read_back = RoundTrip(manifest);
 
   ASSERT_EQ(read_back->indexes().size(), 2);
-  EXPECT_EQ(read_back->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
-
   const Index* found_hnsw = read_back->getIndex("vector", "hnsw");
   ASSERT_NE(found_hnsw, nullptr);
+  EXPECT_EQ(found_hnsw->index_name, idx1.index_name);
   EXPECT_EQ(found_hnsw->path, idx1.path);
+  EXPECT_EQ(found_hnsw->field_id, idx1.field_id);
+  EXPECT_EQ(found_hnsw->index_id, idx1.index_id);
+  EXPECT_EQ(found_hnsw->build_id, idx1.build_id);
+  EXPECT_EQ(found_hnsw->index_version, idx1.index_version);
+  EXPECT_EQ(found_hnsw->num_rows, idx1.num_rows);
+  EXPECT_EQ(found_hnsw->serialized_size, idx1.serialized_size);
+  EXPECT_EQ(found_hnsw->mem_size, idx1.mem_size);
+  EXPECT_EQ(found_hnsw->current_index_version, idx1.current_index_version);
+  EXPECT_EQ(found_hnsw->current_scalar_index_version, idx1.current_scalar_index_version);
+  EXPECT_EQ(found_hnsw->index_store_path_version, idx1.index_store_path_version);
+  EXPECT_EQ(found_hnsw->index_file_keys, idx1.index_file_keys);
   EXPECT_EQ(found_hnsw->properties.at("M"), "16");
   EXPECT_EQ(found_hnsw->properties.at("ef_construction"), "128");
 
   const Index* found_inv = read_back->getIndex("id", "inverted");
   ASSERT_NE(found_inv, nullptr);
+  EXPECT_EQ(found_inv->field_id, 0);
+  EXPECT_TRUE(found_inv->index_file_keys.empty());
   EXPECT_TRUE(found_inv->properties.empty());
 }
 

--- a/cpp/test/manifest_test.cpp
+++ b/cpp/test/manifest_test.cpp
@@ -85,6 +85,7 @@ TEST_F(ManifestTest, EmptyManifestRoundTrip) {
   EXPECT_TRUE(read_back->stats().empty());
   EXPECT_TRUE(read_back->indexes().empty());
   EXPECT_TRUE(read_back->lobFiles().empty());
+  EXPECT_EQ(read_back->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::NONE));
 }
 
 TEST_F(ManifestTest, ColumnGroupsRoundTrip) {
@@ -166,9 +167,11 @@ TEST_F(ManifestTest, IndexesRoundTrip) {
   auto read_back = RoundTrip(manifest);
 
   ASSERT_EQ(read_back->indexes().size(), 2);
+  EXPECT_EQ(read_back->minorVersion(), static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO));
 
   const Index* found_hnsw = read_back->getIndex("vector", "hnsw");
   ASSERT_NE(found_hnsw, nullptr);
+  EXPECT_EQ(found_hnsw->path, idx1.path);
   EXPECT_EQ(found_hnsw->properties.at("M"), "16");
   EXPECT_EQ(found_hnsw->properties.at("ef_construction"), "128");
 

--- a/docs/manifest-index-artifacts-design.md
+++ b/docs/manifest-index-artifacts-design.md
@@ -103,7 +103,7 @@ The Avro schema adds:
 }
 ```
 
-`MANIFEST_VERSION` keeps its existing format-compatibility meaning. It must not be changed solely because a manifest contains an index.
+`MANIFEST_VERSION` keeps its format-compatibility meaning. Version 6 adds the persistent `minor_version` field, which supplements existing `Index` metadata with a marker that index information is present.
 
 ### Invariant
 
@@ -148,31 +148,10 @@ Index index{
 
 ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs, base_path, 42, IndexResolver));
 txn->AddIndexInfo(index);
-ARROW_ASSIGN_OR_RAISE(auto committed, txn->CommitWithInfo());
+ARROW_ASSIGN_OR_RAISE(auto committed, txn->Commit());
 ```
 
 `source_manifest_version` is an engine convention stored in `properties`, not a new `Index` field. It allows DataCoord and the resolver to reject publication of an index built from stale source data.
-
-### Commit result
-
-Keep the existing ABI/API:
-
-```cpp
-arrow::Result<int64_t> Transaction::Commit();
-```
-
-Add an opt-in result for the DataCoord publishing path:
-
-```cpp
-struct ManifestCommitInfo {
-  int64_t manifest_version;
-  int32_t manifest_minor_version;
-};
-
-arrow::Result<ManifestCommitInfo> Transaction::CommitWithInfo();
-```
-
-The new result reports the committed manifest revision and its persistent minor version. It does not include `has_index_info`, which is derivable from the minor version.
 
 ### Conflict rules
 
@@ -249,7 +228,7 @@ If manifest metadata cannot be read, garbage collection must fail closed for tha
 
 The required additive interfaces are:
 
-- C/C++ FFI exposure for `AddIndexInfo` and `CommitWithInfo`;
+- C/C++ FFI exposure for `AddIndexInfo`;
 - manifest metadata export support for existing `Index` entries and `minor_version`;
 - `datapb.SegmentInfo`, manifest-update messages, and load metadata carrying `manifest_minor_version`;
 - Go bindings that forward the completed `Index` information, rather than index bytes, from the build/publish path.

--- a/docs/manifest-index-artifacts-design.md
+++ b/docs/manifest-index-artifacts-design.md
@@ -10,10 +10,22 @@
 
 ```cpp
 struct Index {
-  std::string column_name;
-  std::string index_type;
-  std::string path;
-  std::map<std::string, std::string> properties;
+    std::string column_name;
+    std::string index_name;
+    std::string index_type;
+    std::string path;
+    int64_t field_id;
+    int64_t index_id;
+    int64_t build_id;
+    int64_t index_version;
+    int64_t num_rows;
+    int64_t serialized_size;
+    int64_t mem_size;
+    int32_t current_index_version;
+    int32_t current_scalar_index_version;
+    int32_t index_store_path_version;
+    std::vector<std::string> index_file_keys;
+    std::map<std::string, std::string> properties;
 };
 ```
 
@@ -22,25 +34,26 @@ This design reuses that definition without adding an index-artifact, index-file,
 No index-related API is added to `Manifest`. In particular, `Manifest` does
 not open or read index files. Consumers continue to obtain the metadata they
 need through the existing `getIndex(column_name, index_type)` lookup (or the
-existing index collection) and give `Index::path` and `Index::properties` to
-the engine's established file-manager/index-loader path.
+existing index collection) and give the typed `Index` fields and
+`Index::properties` to the engine's established file-manager/index-loader
+path.
 
-The index-building flow writes its index file before it interacts with the transaction. The transaction's responsibility is only to atomically record or replace that completed index's `Index` information in a new manifest revision. A persistent manifest minor version lets DataCoord determine whether a manifest has index information and persist that fact alongside the manifest reference in etcd.
+The index-building flow writes its index file before it interacts with the transaction. The transaction's responsibility is only to atomically record or replace that completed index's `Index` information in a new manifest revision. Index presence is determined from the manifest's existing `indexes` payload; no separate marker is persisted.
 
 ```text
 IndexNode writes an index file
   -> Transaction::AddIndexInfo(index metadata)
   -> transaction commit writes a new manifest revision
-  -> DataCoord atomically persists manifest revision + minor version in etcd
-  -> QueryNode sees the minor version, reads Index from the manifest, and loads it through its cache layer
+  -> DataCoord publishes only the current manifest path in SegmentInfo etcd metadata
+  -> QueryNode reads Index from that manifest and loads it through its cache layer
 ```
 
 ## Goals
 
 1. Record completed index files in the same immutable manifest revision model used by data files, delta logs, and stats.
-2. Let DataCoord and QueryCoord identify index-bearing StorageV3 manifests without eagerly reading every manifest.
+2. Make the manifest the sole persistent source for completed-index load metadata, minimizing etcd index state.
 3. Keep index-byte ownership in the existing Milvus QueryNode cache layer; do not add a second index-byte cache in `milvus-storage`.
-4. Reuse the existing `Manifest::getIndex` lookup, existing `Index` serialization, and existing `Transaction::AddIndex` callers.
+4. Reuse the existing `Manifest::getIndex` lookup and `Index` serialization; use `Transaction::AddIndexInfo` for publication.
 
 ## Non-goals
 
@@ -67,60 +80,21 @@ Transaction& Transaction::AddIndexInfo(const Index& index);
 
 `AddIndexInfo` is metadata-only. It does not create, write, delete, rename, checksum, or otherwise manage `index.path`. The caller must write the completed index file before calling it.
 
-`AddIndex` remains source-compatible. It may be retained as an alias of `AddIndexInfo`, with `AddIndexInfo` used by the Milvus engine path to distinguish index-metadata publication from index construction.
+The typed fields in `Index` carry the completed artifact identity, name, file
+list, sizes, row count, and engine/path versions. `Index::properties` is reserved for
+open-ended algorithm parameters, such as metric type, dimensions, M, and
+efConstruction. This avoids string parsing for required load metadata while
+retaining an evolution path for index-type-specific options.
 
-`Index::properties` remains the place for engine metadata already needed by the load path, such as `index_id`, `build_id`, `index_version`, metric type, dimensions, and algorithm-specific settings. This proposal adds no new manifest index structure.
+## Manifest format version
 
-## Manifest minor version
+### Manifest version and index metadata
 
-### Problem
+`MANIFEST_VERSION` remains a serialization-format constant. It is bumped to 6 for this transaction index-publication addition, but it is not a persistent per-revision routing signal: an Avro read reports the version compiled into the reader.
 
-`Manifest::version()` and `MANIFEST_VERSION` describe the manifest serialization format. In the current Avro object-container-file implementation, a manifest read sets this value to the compiled format version. It is not a persistent per-manifest marker that DataCoord can use to decide whether index information exists.
+The existing `Index` entries are the only persistent index-presence signal. Readers must inspect `Manifest::indexes()` directly. No `ManifestMinorVersion`, `minor_version` Avro field, or C-FFI minor-version field is added.
 
-### Persistent field
-
-Add a separate persistent field to `Manifest` and its Avro record:
-
-```cpp
-enum class ManifestMinorVersion : int32_t {
-  NONE = 0,
-  INDEX_INFO = 1,
-};
-
-[[nodiscard]] int32_t minorVersion() const;
-[[nodiscard]] bool hasIndexInfo() const {
-  return minorVersion() >= static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO);
-}
-```
-
-The Avro schema adds:
-
-```json
-{
-  "name": "minor_version",
-  "type": "int",
-  "default": 0
-}
-```
-
-`MANIFEST_VERSION` keeps its format-compatibility meaning. Version 6 adds the persistent `minor_version` field, which supplements existing `Index` metadata with a marker that index information is present.
-
-### Invariant
-
-The minor version is derived from the final manifest state:
-
-| Final manifest state | `minor_version` |
-| --- | --- |
-| `indexes()` is empty | `NONE` (`0`) |
-| `indexes()` is non-empty | `INDEX_INFO` (`1`) |
-
-Thus a stats-only transaction preserves `1` when it inherits index information, and dropping the last index writes `0`. A failed transaction does not affect the minor version.
-
-`hasIndexInfo()` is only a derived helper. It is not separately serialized, returned in a commit response, or persisted in etcd, because that would duplicate `minor_version`.
-
-### Compatibility
-
-Old manifests do not contain `minor_version`; Avro schema resolution supplies its default value `0`. Existing index records retain their current schema. No conversion to a new index descriptor is required.
+Existing manifests remain compatible because the pre-existing `indexes` Avro field has an empty-array default. No index-descriptor conversion is required.
 
 ## Transaction and commit API
 
@@ -129,7 +103,7 @@ Old manifests do not contain `minor_version`; Avro schema resolution supplies it
 The engine sequence is:
 
 1. Build and write the index file using the existing index-builder/file-manager path.
-2. Fill an existing `Index` with column name, index type, completed path, and properties.
+2. Fill an existing `Index` with the completed artifact's typed metadata and algorithm properties.
 3. Open a transaction at the manifest revision used by the index build.
 4. Call `AddIndexInfo(index)`.
 5. Commit the manifest.
@@ -137,12 +111,23 @@ The engine sequence is:
 ```cpp
 Index index{
     .column_name = "100",
+    .index_name = "vector_hnsw",
     .index_type = "HNSW",
-    .path = "<segment-base>/_index/<written-file>",
+    .path = "<segment-base>/_index/<artifact-prefix>",
+    .field_id = 100,
+    .index_id = 101,
+    .build_id = 10001,
+    .index_version = 4,
+    .num_rows = 100000,
+    .serialized_size = 1048576,
+    .mem_size = 2097152,
+    .current_index_version = 15,
+    .current_scalar_index_version = 7,
+    .index_store_path_version = 1,
+    .index_file_keys = {"index.bin", "raw_data.bin"},
     .properties = {
-        {"index_id", "101"},
-        {"build_id", "10001"},
-        {"source_manifest_version", "42"},
+        {"metric_type", "COSINE"},
+        {"M", "16"},
     },
 };
 
@@ -151,72 +136,54 @@ txn->AddIndexInfo(index);
 ARROW_ASSIGN_OR_RAISE(auto committed, txn->Commit());
 ```
 
-`source_manifest_version` is an engine convention stored in `properties`, not a new `Index` field. It allows DataCoord and the resolver to reject publication of an index built from stale source data.
+The source manifest revision is transaction state: DataCoord opens the transaction at the revision used by the index build. It is not duplicated in `Index` or `properties`.
 
 ### Conflict rules
 
 `milvus-storage` retains its existing generic resolvers. The Milvus engine integration must not use `OverwriteResolver` to publish an index built from an older manifest: a data append can invalidate it. That integration needs an index-aware resolver which:
 
-1. Read `source_manifest_version` from `Index::properties`.
-2. Require it to equal the transaction's read version.
-3. Commit if the latest manifest revision is the same as the source revision.
-4. Otherwise fail transaction resolution and rebuild the index against the newer data.
+1. Open the transaction at the source manifest revision.
+2. Commit only if the latest manifest revision is still that source revision.
+3. Otherwise fail transaction resolution and rebuild the index against the newer data.
 
 This initial engine rule is deliberately conservative: a concurrent stats or delta-only change may require a rebuild. A later optimization may compare the affected column-group files and safely rebase only when their source data is unchanged. It is not part of the storage-only API change in this document.
 
-`AddIndexInfo` still replaces the matching `(column_name, index_type)` metadata entry, exactly as `AddIndex` does today. The pre-existing file lifecycle is outside this transaction; when a new path replaces an old path, DataCoord garbage collection determines when the no-longer-referenced old file is safe to delete.
+`AddIndexInfo` replaces the matching `(column_name, index_type)` metadata entry. The pre-existing file lifecycle is outside this transaction; when a new path replaces an old path, DataCoord garbage collection determines when the no-longer-referenced old file is safe to delete.
 
 ## DataCoord and etcd publication
 
-### Atomic manifest reference
+### Minimal etcd state
 
-For StorageV3 segments, the following fields form one logical manifest reference:
+`datapb.SegmentInfo.manifest_path` is the only durable StorageV3 reference needed by the load path. The manifest `Index` also carries `index_name`, so it can form the complete QueryNode `FieldIndexInfo`. Every completed-index loading field currently held by etcd `indexpb.SegmentIndex` is persisted in the matching manifest `Index` instead: `field_id`, `index_id`, `build_id`, `index_version`, `num_rows`, `serialized_size`, `mem_size`, current vector/scalar engine versions, path-layout version, and `index_file_keys`.
 
-```text
-manifest_path
-manifest_version
-manifest_minor_version
-```
-
-DataCoord adds `manifest_minor_version` as an additive field on `datapb.SegmentInfo` and persists all three values in the same SegmentInfo etcd write. They must not be written in independent keys or independent updates.
-
-The existing manifest-update payload (`BatchUpdateManifestItem`) and `UpdateManifestVersion` operation must carry the minor version together with the manifest revision and retain base-version validation. A stale index-build publication must not move the manifest pointer backwards or attach a minor version to a different manifest revision.
-
-Old SegmentInfo records decode the new protobuf field as `0`.
-
-### What the minor version means
-
-`manifest_minor_version == 0` means DataCoord and QueryCoord do not need to resolve StorageV3 index information from that manifest.
-
-`manifest_minor_version >= 1` means the referenced immutable manifest contains `Index` metadata. It is a routing signal, not a replacement for the metadata itself. The load or garbage-collection path must still read `Index::path` and `Index::properties` from that manifest.
+`path` is the artifact-directory prefix and `index_file_keys` identifies each file beneath it. QueryCoord constructs the complete file paths from these two fields. `SegmentIndex` may retain transient task state while a build is queued or in progress, but a finished artifact's paths, sizes, identity, and load versions must not be read from etcd.
 
 ## QueryCoord and QueryNode load path
 
-1. QueryCoord propagates the manifest reference and minor version from DataCoord.
-2. For minor version `0`, it skips StorageV3 manifest-index resolution.
-3. For minor version `1`, it opens the exact manifest revision and obtains the existing `Index` metadata with `getIndex`.
-4. QueryNode passes `Index::path` and `Index::properties` to its existing file-manager/index-loader path.
-5. QueryNode continues to use its existing `SealedIndexTranslator` and `CacheSlot<IndexBase>` for loading, warmup, pinning, eviction, and memory/disk accounting.
+1. QueryCoord obtains the segment's current `SegmentInfo.manifest_path` from etcd and opens that immutable manifest revision.
+2. It obtains the matching `Index` metadata with `getIndex` (or scans `indexes()` by `field_id` and `index_id`).
+3. It builds `FieldIndexInfo` entirely from the manifest Index: identity, file paths, sizes, row count, and engine versions are copied directly; index-type parameters come from `properties`.
+4. QueryNode continues to use its existing `SealedIndexTranslator` and `CacheSlot<IndexBase>` for loading, warmup, pinning, eviction, and memory/disk accounting.
 
-Minor version avoids needless manifest index parsing; it does not allow a missing or corrupt index file to be ignored. Such a file remains an index-load error.
+A missing or corrupt matching index file remains an index-load error. A missing matching Index entry in the current manifest is a stale-index condition, not a legacy fallback.
 
 ### Cache and mmap identity
 
 No storage-layer byte cache is introduced. Cache lifecycle remains owned by QueryNode.
 
-When the engine replaces an index path, its QueryNode cache key and mmap local path must distinguish the old and new index. The key should use existing `Index::properties` values where available:
+When the engine replaces an index path, its QueryNode cache key and mmap local path must distinguish the old and new index. The key uses typed Index fields:
 
 ```text
 segment_id + field_id + index_id + build_id + index_version
 ```
 
-If a property is absent for legacy metadata, QueryNode follows its existing cache-key behaviour. For new engine-written index information, `index_id` and `build_id` are required. Replacing an index must retire or cancel the old cache slot before the old local mmap files are reclaimed; existing readers retain their old slot until release.
+For new engine-written index information, `field_id`, `index_id`, and `build_id` are required. Replacing an index must retire or cancel the old cache slot before the old local mmap files are reclaimed; existing readers retain their old slot until release.
 
 ## Index-file lifecycle and garbage collection
 
 Writing index bytes is intentionally outside `Transaction::AddIndexInfo`. The index-builder path is responsible for creating the file before metadata registration, and DataCoord remains responsible for deleting unreferenced files.
 
-For StorageV3 index paths, DataCoord garbage collection must inspect `Index` entries in every live and protected manifest with `minor_version >= 1`. It may delete a file only after it is absent from:
+For StorageV3 index paths, DataCoord garbage collection must inspect `Index` entries in every live and protected manifest. It may delete a file only after it is absent from:
 
 1. the live SegmentInfo manifest reference;
 2. protected snapshots and compaction fallback manifests; and
@@ -229,9 +196,8 @@ If manifest metadata cannot be read, garbage collection must fail closed for tha
 The required additive interfaces are:
 
 - C/C++ FFI exposure for `AddIndexInfo`;
-- manifest metadata export support for existing `Index` entries and `minor_version`;
-- `datapb.SegmentInfo`, manifest-update messages, and load metadata carrying `manifest_minor_version`;
-- Go bindings that forward the completed `Index` information, rather than index bytes, from the build/publish path.
+- manifest metadata export support for existing `Index` entries;
+- Go bindings that forward the completed `Index` information, rather than index bytes, from the build/publish path and use it to form QueryNode load requests.
 
 There is no transaction streaming-write FFI and no index-artifact ABI.
 
@@ -244,25 +210,25 @@ There is no transaction streaming-write FFI and no index-artifact ABI.
 | Engine index publication lacks source revision | DataCoord must reject it before publication; source-version enforcement is an engine integration responsibility. |
 | Manifest conflict after index file exists | Do not publish its metadata; rebuild or later GC the unreferenced file. |
 | Manifest committed but DataCoord publication fails | File and manifest remain invisible to QueryNode until an idempotent publication retry succeeds. |
-| DataCoord receives stale base revision | Reject the update and keep the current manifest reference/minor pair unchanged. |
-| QueryNode sees minor `1` but cannot read file | Fail index load; never silently load a different path or a cached older index. |
+| DataCoord receives stale base revision | Reject the update and keep the current manifest reference unchanged. |
+| QueryNode cannot read the matching manifest index file | Fail index load; never silently load a different path or a cached older index. |
 
 ## Compatibility and rollout
 
-- Older manifests read with `minor_version = 0`.
-- Existing `Index` records and `Transaction::AddIndex` stay valid.
-- Older etcd/protobuf records default the new minor field to `0`.
-- Deploy readers of `minor_version` and `Index` metadata before enabling IndexNode publication through `AddIndexInfo`.
+- Existing `Index` records stay valid.
+- Older manifests with an empty index list continue to represent no manifest-published index metadata.
+- During rollout, completed legacy indexes may use the existing `SegmentIndex` path construction until they are rebuilt and republished into a manifest.
+- Deploy manifest-index readers before enabling IndexNode publication through `AddIndexInfo`.
 - During mixed-version rollout, DataCoord must not publish manifest-index references to QueryNodes that cannot resolve them.
 
 ## Test matrix
 
 | Area | Required tests |
 | --- | --- |
-| Manifest | Avro round-trip for minor `0`/`1`; old manifest defaults to `0`; existing `getIndex` returns the recorded path and properties. No index-file read API is added. |
-| Transaction | `AddIndexInfo` adds/replaces index metadata, preserves/reset minor version as indexes appear/disappear, and leaves `AddIndex` compatible. |
+| Manifest | Version-6 Avro round-trip preserves every typed Index load field, file key, and property; existing manifests without index entries remain readable. No index-file read API is added. |
+| Transaction | `AddIndexInfo` adds or replaces index metadata for the matching `(column_name, index_type)`. |
 | Conflict | Milvus integration test: an index built from a stale source manifest is rejected after a data append; its old file stays unreferenced and is eligible for GC. |
-| DataCoord | Manifest revision and minor version update atomically; stale update rejection; old etcd record defaults to `0`. |
-| QueryNode | Minor `0` skips index resolution; minor `1` loads through the existing file-manager/index-loader path; replacement produces a different cache/mmap identity. |
+| DataCoord | Form QueryNode load metadata entirely from the manifest Index; do not read completed-artifact paths, sizes, or identity from SegmentIndex. |
+| QueryNode | A manifest Index loads through the existing file-manager/index-loader path; replacement produces a different cache/mmap identity. |
 | GC | Live, snapshot, and fallback manifests protect their recorded `Index::path`; unreferenced index files are reclaimed only after protection ends. |
 | End-to-end | Write index file, register via `AddIndexInfo`, publish through DataCoord, load on QueryNode, replace it, and verify old-cache retirement. |

--- a/docs/manifest-index-artifacts-design.md
+++ b/docs/manifest-index-artifacts-design.md
@@ -1,0 +1,289 @@
+# Manifest index-info publication design
+
+**Status:** Proposed
+**Owners:** Milvus Storage and Milvus engine
+**Scope:** StorageV3 / LOON manifests and Milvus DataCoord, IndexNode, QueryCoord, and QueryNode integration
+
+## Summary
+
+`milvus-storage` already defines `Index` in `cpp/include/milvus-storage/manifest.h`:
+
+```cpp
+struct Index {
+  std::string column_name;
+  std::string index_type;
+  std::string path;
+  std::map<std::string, std::string> properties;
+};
+```
+
+This design reuses that definition without adding an index-artifact, index-file, or writer-handle type.
+
+No index-related API is added to `Manifest`. In particular, `Manifest` does
+not open or read index files. Consumers continue to obtain the metadata they
+need through the existing `getIndex(column_name, index_type)` lookup (or the
+existing index collection) and give `Index::path` and `Index::properties` to
+the engine's established file-manager/index-loader path.
+
+The index-building flow writes its index file before it interacts with the transaction. The transaction's responsibility is only to atomically record or replace that completed index's `Index` information in a new manifest revision. A persistent manifest minor version lets DataCoord determine whether a manifest has index information and persist that fact alongside the manifest reference in etcd.
+
+```text
+IndexNode writes an index file
+  -> Transaction::AddIndexInfo(index metadata)
+  -> transaction commit writes a new manifest revision
+  -> DataCoord atomically persists manifest revision + minor version in etcd
+  -> QueryNode sees the minor version, reads Index from the manifest, and loads it through its cache layer
+```
+
+## Goals
+
+1. Record completed index files in the same immutable manifest revision model used by data files, delta logs, and stats.
+2. Let DataCoord and QueryCoord identify index-bearing StorageV3 manifests without eagerly reading every manifest.
+3. Keep index-byte ownership in the existing Milvus QueryNode cache layer; do not add a second index-byte cache in `milvus-storage`.
+4. Reuse the existing `Manifest::getIndex` lookup, existing `Index` serialization, and existing `Transaction::AddIndex` callers.
+
+## Non-goals
+
+- Writing index bytes through `Transaction`.
+- Adding `IndexArtifact`, `IndexFile`, `IndexWriteHandle`, or `BeginIndexWrite` APIs.
+- Returning a write-side file handle from `Transaction`.
+- Adding a new index-file read API to `Manifest`.
+- Changing `Manifest::getIndex` or making `Manifest` own index-file I/O or caching.
+- Making the pre-existing file write and the object-store manifest write a distributed atomic transaction.
+- Replacing QueryNode's `CacheSlot` ownership with a manifest-level byte-buffer cache.
+
+## Existing model
+
+`Manifest::getIndex` already provides the necessary metadata lookup. Its
+return value exposes the existing `Index::path` and `Index::properties`; the
+manifest layer deliberately stops there. This proposal adds no index-specific
+`Manifest` method such as `ReadIndexFile`.
+
+The existing transaction API already stores an `Index` in its update set and replaces an index with the same `(column_name, index_type)` during manifest resolution. The proposed API makes that intent explicit for engine callers:
+
+```cpp
+Transaction& Transaction::AddIndexInfo(const Index& index);
+```
+
+`AddIndexInfo` is metadata-only. It does not create, write, delete, rename, checksum, or otherwise manage `index.path`. The caller must write the completed index file before calling it.
+
+`AddIndex` remains source-compatible. It may be retained as an alias of `AddIndexInfo`, with `AddIndexInfo` used by the Milvus engine path to distinguish index-metadata publication from index construction.
+
+`Index::properties` remains the place for engine metadata already needed by the load path, such as `index_id`, `build_id`, `index_version`, metric type, dimensions, and algorithm-specific settings. This proposal adds no new manifest index structure.
+
+## Manifest minor version
+
+### Problem
+
+`Manifest::version()` and `MANIFEST_VERSION` describe the manifest serialization format. In the current Avro object-container-file implementation, a manifest read sets this value to the compiled format version. It is not a persistent per-manifest marker that DataCoord can use to decide whether index information exists.
+
+### Persistent field
+
+Add a separate persistent field to `Manifest` and its Avro record:
+
+```cpp
+enum class ManifestMinorVersion : int32_t {
+  NONE = 0,
+  INDEX_INFO = 1,
+};
+
+[[nodiscard]] int32_t minorVersion() const;
+[[nodiscard]] bool hasIndexInfo() const {
+  return minorVersion() >= static_cast<int32_t>(ManifestMinorVersion::INDEX_INFO);
+}
+```
+
+The Avro schema adds:
+
+```json
+{
+  "name": "minor_version",
+  "type": "int",
+  "default": 0
+}
+```
+
+`MANIFEST_VERSION` keeps its existing format-compatibility meaning. It must not be changed solely because a manifest contains an index.
+
+### Invariant
+
+The minor version is derived from the final manifest state:
+
+| Final manifest state | `minor_version` |
+| --- | --- |
+| `indexes()` is empty | `NONE` (`0`) |
+| `indexes()` is non-empty | `INDEX_INFO` (`1`) |
+
+Thus a stats-only transaction preserves `1` when it inherits index information, and dropping the last index writes `0`. A failed transaction does not affect the minor version.
+
+`hasIndexInfo()` is only a derived helper. It is not separately serialized, returned in a commit response, or persisted in etcd, because that would duplicate `minor_version`.
+
+### Compatibility
+
+Old manifests do not contain `minor_version`; Avro schema resolution supplies its default value `0`. Existing index records retain their current schema. No conversion to a new index descriptor is required.
+
+## Transaction and commit API
+
+### Registering completed index information
+
+The engine sequence is:
+
+1. Build and write the index file using the existing index-builder/file-manager path.
+2. Fill an existing `Index` with column name, index type, completed path, and properties.
+3. Open a transaction at the manifest revision used by the index build.
+4. Call `AddIndexInfo(index)`.
+5. Commit the manifest.
+
+```cpp
+Index index{
+    .column_name = "100",
+    .index_type = "HNSW",
+    .path = "<segment-base>/_index/<written-file>",
+    .properties = {
+        {"index_id", "101"},
+        {"build_id", "10001"},
+        {"source_manifest_version", "42"},
+    },
+};
+
+ARROW_ASSIGN_OR_RAISE(auto txn, Transaction::Open(fs, base_path, 42, IndexResolver));
+txn->AddIndexInfo(index);
+ARROW_ASSIGN_OR_RAISE(auto committed, txn->CommitWithInfo());
+```
+
+`source_manifest_version` is an engine convention stored in `properties`, not a new `Index` field. It allows DataCoord and the resolver to reject publication of an index built from stale source data.
+
+### Commit result
+
+Keep the existing ABI/API:
+
+```cpp
+arrow::Result<int64_t> Transaction::Commit();
+```
+
+Add an opt-in result for the DataCoord publishing path:
+
+```cpp
+struct ManifestCommitInfo {
+  int64_t manifest_version;
+  int32_t manifest_minor_version;
+};
+
+arrow::Result<ManifestCommitInfo> Transaction::CommitWithInfo();
+```
+
+The new result reports the committed manifest revision and its persistent minor version. It does not include `has_index_info`, which is derivable from the minor version.
+
+### Conflict rules
+
+`milvus-storage` retains its existing generic resolvers. The Milvus engine integration must not use `OverwriteResolver` to publish an index built from an older manifest: a data append can invalidate it. That integration needs an index-aware resolver which:
+
+1. Read `source_manifest_version` from `Index::properties`.
+2. Require it to equal the transaction's read version.
+3. Commit if the latest manifest revision is the same as the source revision.
+4. Otherwise fail transaction resolution and rebuild the index against the newer data.
+
+This initial engine rule is deliberately conservative: a concurrent stats or delta-only change may require a rebuild. A later optimization may compare the affected column-group files and safely rebase only when their source data is unchanged. It is not part of the storage-only API change in this document.
+
+`AddIndexInfo` still replaces the matching `(column_name, index_type)` metadata entry, exactly as `AddIndex` does today. The pre-existing file lifecycle is outside this transaction; when a new path replaces an old path, DataCoord garbage collection determines when the no-longer-referenced old file is safe to delete.
+
+## DataCoord and etcd publication
+
+### Atomic manifest reference
+
+For StorageV3 segments, the following fields form one logical manifest reference:
+
+```text
+manifest_path
+manifest_version
+manifest_minor_version
+```
+
+DataCoord adds `manifest_minor_version` as an additive field on `datapb.SegmentInfo` and persists all three values in the same SegmentInfo etcd write. They must not be written in independent keys or independent updates.
+
+The existing manifest-update payload (`BatchUpdateManifestItem`) and `UpdateManifestVersion` operation must carry the minor version together with the manifest revision and retain base-version validation. A stale index-build publication must not move the manifest pointer backwards or attach a minor version to a different manifest revision.
+
+Old SegmentInfo records decode the new protobuf field as `0`.
+
+### What the minor version means
+
+`manifest_minor_version == 0` means DataCoord and QueryCoord do not need to resolve StorageV3 index information from that manifest.
+
+`manifest_minor_version >= 1` means the referenced immutable manifest contains `Index` metadata. It is a routing signal, not a replacement for the metadata itself. The load or garbage-collection path must still read `Index::path` and `Index::properties` from that manifest.
+
+## QueryCoord and QueryNode load path
+
+1. QueryCoord propagates the manifest reference and minor version from DataCoord.
+2. For minor version `0`, it skips StorageV3 manifest-index resolution.
+3. For minor version `1`, it opens the exact manifest revision and obtains the existing `Index` metadata with `getIndex`.
+4. QueryNode passes `Index::path` and `Index::properties` to its existing file-manager/index-loader path.
+5. QueryNode continues to use its existing `SealedIndexTranslator` and `CacheSlot<IndexBase>` for loading, warmup, pinning, eviction, and memory/disk accounting.
+
+Minor version avoids needless manifest index parsing; it does not allow a missing or corrupt index file to be ignored. Such a file remains an index-load error.
+
+### Cache and mmap identity
+
+No storage-layer byte cache is introduced. Cache lifecycle remains owned by QueryNode.
+
+When the engine replaces an index path, its QueryNode cache key and mmap local path must distinguish the old and new index. The key should use existing `Index::properties` values where available:
+
+```text
+segment_id + field_id + index_id + build_id + index_version
+```
+
+If a property is absent for legacy metadata, QueryNode follows its existing cache-key behaviour. For new engine-written index information, `index_id` and `build_id` are required. Replacing an index must retire or cancel the old cache slot before the old local mmap files are reclaimed; existing readers retain their old slot until release.
+
+## Index-file lifecycle and garbage collection
+
+Writing index bytes is intentionally outside `Transaction::AddIndexInfo`. The index-builder path is responsible for creating the file before metadata registration, and DataCoord remains responsible for deleting unreferenced files.
+
+For StorageV3 index paths, DataCoord garbage collection must inspect `Index` entries in every live and protected manifest with `minor_version >= 1`. It may delete a file only after it is absent from:
+
+1. the live SegmentInfo manifest reference;
+2. protected snapshots and compaction fallback manifests; and
+3. any existing engine metadata that retains the same file reference.
+
+If manifest metadata cannot be read, garbage collection must fail closed for that reference set.
+
+## FFI and protobuf changes
+
+The required additive interfaces are:
+
+- C/C++ FFI exposure for `AddIndexInfo` and `CommitWithInfo`;
+- manifest metadata export support for existing `Index` entries and `minor_version`;
+- `datapb.SegmentInfo`, manifest-update messages, and load metadata carrying `manifest_minor_version`;
+- Go bindings that forward the completed `Index` information, rather than index bytes, from the build/publish path.
+
+There is no transaction streaming-write FFI and no index-artifact ABI.
+
+## Failure handling
+
+| Failure | Required behaviour |
+| --- | --- |
+| Index file write fails before `AddIndexInfo` | Do not start index metadata publication. |
+| `AddIndexInfo` input lacks path | The storage FFI rejects it; native callers must provide a valid completed-file path. |
+| Engine index publication lacks source revision | DataCoord must reject it before publication; source-version enforcement is an engine integration responsibility. |
+| Manifest conflict after index file exists | Do not publish its metadata; rebuild or later GC the unreferenced file. |
+| Manifest committed but DataCoord publication fails | File and manifest remain invisible to QueryNode until an idempotent publication retry succeeds. |
+| DataCoord receives stale base revision | Reject the update and keep the current manifest reference/minor pair unchanged. |
+| QueryNode sees minor `1` but cannot read file | Fail index load; never silently load a different path or a cached older index. |
+
+## Compatibility and rollout
+
+- Older manifests read with `minor_version = 0`.
+- Existing `Index` records and `Transaction::AddIndex` stay valid.
+- Older etcd/protobuf records default the new minor field to `0`.
+- Deploy readers of `minor_version` and `Index` metadata before enabling IndexNode publication through `AddIndexInfo`.
+- During mixed-version rollout, DataCoord must not publish manifest-index references to QueryNodes that cannot resolve them.
+
+## Test matrix
+
+| Area | Required tests |
+| --- | --- |
+| Manifest | Avro round-trip for minor `0`/`1`; old manifest defaults to `0`; existing `getIndex` returns the recorded path and properties. No index-file read API is added. |
+| Transaction | `AddIndexInfo` adds/replaces index metadata, preserves/reset minor version as indexes appear/disappear, and leaves `AddIndex` compatible. |
+| Conflict | Milvus integration test: an index built from a stale source manifest is rejected after a data append; its old file stays unreferenced and is eligible for GC. |
+| DataCoord | Manifest revision and minor version update atomically; stale update rejection; old etcd record defaults to `0`. |
+| QueryNode | Minor `0` skips index resolution; minor `1` loads through the existing file-manager/index-loader path; replacement produces a different cache/mmap identity. |
+| GC | Live, snapshot, and fallback manifests protect their recorded `Index::path`; unreferenced index files are reclaimed only after protection ends. |
+| End-to-end | Write index file, register via `AddIndexInfo`, publish through DataCoord, load on QueryNode, replace it, and verify old-cache retirement. |


### PR DESCRIPTION
## Summary

- publish completed index metadata through `Transaction::AddIndexInfo`
- persist typed artifact identity, index name, file keys, sizes, row count, and engine versions in manifest `Index`
- expose the same metadata through `LoonIndexInfo` and C FFI
- remove `ManifestMinorVersion`; index presence is represented by manifest `indexes`
- document the manifest-first, minimal-etcd QueryCoord/QueryNode load design

## Testing

- builder-container clang-format dry run
- builder-container build of `milvus_test` and `Test_FFI`
- focused manifest / transaction / FFI GTests (5 passed)
- `Test_FFI` (78 tests, 0 failed)