### PR TITLE
fix: decode index metadata only from manifest v6

### DIFF
--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -104,7 +104,8 @@ struct Index {
   int32_t current_index_version = 0;
   int32_t current_scalar_index_version = 0;
   int32_t index_store_path_version = 0;
-  std::vector<std::string> index_file_keys;  ///< File names relative to path
+  std::vector<std::string>
+      index_file_keys;  ///< File names relative to path
   std::map<std::string, std::string> properties;  ///< Index-specific properties
 };
 

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -104,8 +104,7 @@ struct Index {
   int32_t current_index_version = 0;
   int32_t current_scalar_index_version = 0;
   int32_t index_store_path_version = 0;
-  std::vector<std::string>
-      index_file_keys;  ///< File names relative to path
+  std::vector<std::string> index_file_keys;       ///< File names relative to path
   std::map<std::string, std::string> properties;  ///< Index-specific properties
 };
 

--- a/cpp/include/milvus-storage/manifest.h
+++ b/cpp/include/milvus-storage/manifest.h
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <unordered_map>
 #include <optional>
 
 #include <arrow/status.h>
@@ -106,8 +105,7 @@ struct Index {
   int32_t current_scalar_index_version = 0;
   int32_t index_store_path_version = 0;
   std::vector<std::string> index_file_keys;  ///< File names relative to path
-  std::unordered_map<std::string, std::string>
-      properties;  ///< Index-specific properties; key lookup is the common operation
+  std::map<std::string, std::string> properties;  ///< Index-specific properties
 };
 
 /**

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -37,30 +37,32 @@
 // Specialize codec_traits for custom types in the avro namespace
 namespace avro {
 
-template <>
-struct codec_traits<std::unordered_map<std::string, std::string>> {
-  static void encode(Encoder& e, const std::unordered_map<std::string, std::string>& properties) {
+// Avro natively supports std::map but not std::unordered_map.
+// This codec_traits bridges unordered_map to Avro's map wire format.
+template <typename V>
+struct codec_traits<std::unordered_map<std::string, V>> {
+  static void encode(Encoder& e, const std::unordered_map<std::string, V>& m) {
     e.mapStart();
-    if (!properties.empty()) {
-      e.setItemCount(properties.size());
-      for (const auto& [key, value] : properties) {
+    if (!m.empty()) {
+      e.setItemCount(m.size());
+      for (const auto& [k, v] : m) {
         e.startItem();
-        avro::encode(e, key);
-        avro::encode(e, value);
+        avro::encode(e, k);
+        avro::encode(e, v);
       }
     }
     e.mapEnd();
   }
 
-  static void decode(Decoder& d, std::unordered_map<std::string, std::string>& properties) {
-    properties.clear();
+  static void decode(Decoder& d, std::unordered_map<std::string, V>& m) {
+    m.clear();
     for (size_t n = d.mapStart(); n != 0; n = d.mapNext()) {
       for (size_t i = 0; i < n; ++i) {
         std::string key;
-        std::string value;
         avro::decode(d, key);
-        avro::decode(d, value);
-        properties.emplace(std::move(key), std::move(value));
+        V val;
+        avro::decode(d, val);
+        m[std::move(key)] = std::move(val);
       }
     }
   }

--- a/cpp/src/manifest.cpp
+++ b/cpp/src/manifest.cpp
@@ -37,32 +37,30 @@
 // Specialize codec_traits for custom types in the avro namespace
 namespace avro {
 
-// Avro natively supports std::map but not std::unordered_map.
-// This codec_traits bridges unordered_map to Avro's map wire format.
-template <typename V>
-struct codec_traits<std::unordered_map<std::string, V>> {
-  static void encode(Encoder& e, const std::unordered_map<std::string, V>& m) {
+template <>
+struct codec_traits<std::unordered_map<std::string, std::string>> {
+  static void encode(Encoder& e, const std::unordered_map<std::string, std::string>& properties) {
     e.mapStart();
-    if (!m.empty()) {
-      e.setItemCount(m.size());
-      for (const auto& [k, v] : m) {
+    if (!properties.empty()) {
+      e.setItemCount(properties.size());
+      for (const auto& [key, value] : properties) {
         e.startItem();
-        avro::encode(e, k);
-        avro::encode(e, v);
+        avro::encode(e, key);
+        avro::encode(e, value);
       }
     }
     e.mapEnd();
   }
 
-  static void decode(Decoder& d, std::unordered_map<std::string, V>& m) {
-    m.clear();
+  static void decode(Decoder& d, std::unordered_map<std::string, std::string>& properties) {
+    properties.clear();
     for (size_t n = d.mapStart(); n != 0; n = d.mapNext()) {
       for (size_t i = 0; i < n; ++i) {
         std::string key;
+        std::string value;
         avro::decode(d, key);
-        V val;
-        avro::decode(d, val);
-        m[std::move(key)] = std::move(val);
+        avro::decode(d, value);
+        properties.emplace(std::move(key), std::move(value));
       }
     }
   }
@@ -498,26 +496,10 @@ void Manifest::deserializeLegacy(std::istream& input_stream) {
     }
   }
 
-  if (version >= MANIFEST_VERSION) {
-    // Raw MILV manifests at version 6 or newer use the current typed Index
-    // layout.  This branch is retained for forward compatibility; current
-    // writers use Avro OCF and therefore normally take the path above.
+  if (version >= 6) {
+    // Index metadata was added to the raw MILV format in version 6. Earlier
+    // versions did not publish or consume the index section.
     avro::decode(*decoder, indexes_);
-  } else if (version >= 2) {
-    // Raw MILV manifests from versions 2 through 5 predate the typed Index
-    // load metadata.  Their Index records contain only column_name,
-    // index_type, path, and properties, so decode that layout explicitly.
-    indexes_.clear();
-    for (size_t n = decoder->arrayStart(); n != 0; n = decoder->arrayNext()) {
-      for (size_t i = 0; i < n; ++i) {
-        Index index;
-        avro::decode(*decoder, index.column_name);
-        avro::decode(*decoder, index.index_type);
-        avro::decode(*decoder, index.path);
-        avro::decode(*decoder, index.properties);
-        indexes_.push_back(std::move(index));
-      }
-    }
   } else {
     indexes_.clear();
   }

--- a/cpp/test/column_groups_test.cpp
+++ b/cpp/test/column_groups_test.cpp
@@ -324,13 +324,21 @@ static void encodeDeltaLog(avro::Encoder& e, const DeltaLog& dl) {
 
 static void encodeIndex(avro::Encoder& e, const Index& idx) {
   avro::encode(e, idx.column_name);
+  avro::encode(e, idx.index_name);
   avro::encode(e, idx.index_type);
   avro::encode(e, idx.path);
-  // The legacy test fixture uses the original Avro map representation.  The
-  // public Index now uses unordered_map for lookup efficiency, while the
-  // compatibility encoder remains independent of the implementation type.
-  std::map<std::string, std::string> properties(idx.properties.begin(), idx.properties.end());
-  avro::encode(e, properties);
+  avro::encode(e, idx.field_id);
+  avro::encode(e, idx.index_id);
+  avro::encode(e, idx.build_id);
+  avro::encode(e, idx.index_version);
+  avro::encode(e, idx.num_rows);
+  avro::encode(e, idx.serialized_size);
+  avro::encode(e, idx.mem_size);
+  avro::encode(e, idx.current_index_version);
+  avro::encode(e, idx.current_scalar_index_version);
+  avro::encode(e, idx.index_store_path_version);
+  avro::encode(e, idx.index_file_keys);
+  avro::encode(e, idx.properties);
 }
 
 static void encodeStatistics(avro::Encoder& e, const Statistics& stat) {
@@ -391,7 +399,7 @@ static std::string encodeLegacyManifest(int32_t version,
     avro::encode(*encoder, legacy_stats);
   }
 
-  if (version >= 2) {
+  if (version >= 6) {
     encoder->arrayStart();
     if (!indexes.empty()) {
       encoder->setItemCount(indexes.size());
@@ -400,6 +408,11 @@ static std::string encodeLegacyManifest(int32_t version,
         encodeIndex(*encoder, idx);
       }
     }
+    encoder->arrayEnd();
+  }
+
+  if (version >= 5) {
+    encoder->arrayStart();
     encoder->arrayEnd();
   }
 
@@ -447,16 +460,8 @@ TEST_F(ColumnGroupsTest, LegacyV3Deserialize) {
   stat.metadata = {{"k", "v"}};
   stats["key"] = stat;
 
-  std::vector<Index> indexes;
-  Index idx;
-  idx.column_name = "col";
-  idx.index_type = "hnsw";
-  idx.path = "i.idx";
-  idx.properties = {{"M", "8"}};
-  indexes.push_back(idx);
-
   auto legacy_cgs = MakeLegacyCgs(test_cgs_, base_path_);
-  std::string legacy_bytes = encodeLegacyManifest(3, legacy_cgs, {}, stats, indexes);
+  std::string legacy_bytes = encodeLegacyManifest(3, legacy_cgs, {}, stats, {});
 
   ASSERT_NE(legacy_bytes.substr(0, 4), std::string("Obj\x01", 4));
 
@@ -464,8 +469,7 @@ TEST_F(ColumnGroupsTest, LegacyV3Deserialize) {
 
   EXPECT_EQ(deserialized->columnGroups().size(), 2);
   EXPECT_EQ(deserialized->stats().at("key").metadata.at("k"), "v");
-  EXPECT_EQ(deserialized->indexes().size(), 1);
-  EXPECT_EQ(deserialized->indexes()[0].properties.at("M"), "8");
+  EXPECT_TRUE(deserialized->indexes().empty());
 }
 
 TEST_F(ColumnGroupsTest, LegacyV1Deserialize) {
@@ -485,26 +489,59 @@ TEST_F(ColumnGroupsTest, LegacyV1Deserialize) {
 }
 
 TEST_F(ColumnGroupsTest, LegacyV2Deserialize) {
-  std::vector<Index> indexes;
-  Index idx;
-  idx.column_name = "col";
-  idx.index_type = "ivf";
-  idx.path = "v2.idx";
-  idx.properties = {};
-  indexes.push_back(idx);
-
   auto legacy_cgs = MakeLegacyCgs(test_cgs_, base_path_);
-  std::string legacy_bytes = encodeLegacyManifest(2, legacy_cgs, {}, {}, indexes);
+  std::string legacy_bytes = encodeLegacyManifest(2, legacy_cgs, {}, {}, {});
 
   ASSERT_AND_ASSIGN(auto deserialized, WriteLegacyAndReadBack(fs_, base_path_, legacy_bytes, 3));
 
   EXPECT_EQ(deserialized->columnGroups().size(), 2);
   EXPECT_TRUE(deserialized->stats().empty());
-  EXPECT_EQ(deserialized->indexes().size(), 1);
-  EXPECT_EQ(deserialized->indexes()[0].index_type, "ivf");
-  EXPECT_TRUE(deserialized->indexes()[0].index_name.empty());
-  EXPECT_EQ(deserialized->indexes()[0].field_id, 0);
-  EXPECT_TRUE(deserialized->indexes()[0].index_file_keys.empty());
+  EXPECT_TRUE(deserialized->indexes().empty());
+}
+
+TEST_F(ColumnGroupsTest, LegacyV6Deserialize) {
+  Index index;
+  index.column_name = "embedding";
+  index.index_name = "embedding_hnsw";
+  index.index_type = "HNSW";
+  index.path = "embedding_hnsw";
+  index.field_id = 101;
+  index.index_id = 102;
+  index.build_id = 103;
+  index.index_version = 104;
+  index.num_rows = 105;
+  index.serialized_size = 106;
+  index.mem_size = 107;
+  index.current_index_version = 108;
+  index.current_scalar_index_version = 109;
+  index.index_store_path_version = 110;
+  index.index_file_keys = {"index_params", "data"};
+  index.properties = {{"M", "16"}, {"metric_type", "COSINE"}};
+
+  auto legacy_cgs = MakeLegacyCgs(test_cgs_, base_path_);
+  std::string legacy_bytes = encodeLegacyManifest(6, legacy_cgs, {}, {}, {index});
+
+  ASSERT_AND_ASSIGN(auto deserialized, WriteLegacyAndReadBack(fs_, base_path_, legacy_bytes));
+
+  ASSERT_EQ(deserialized->indexes().size(), 1);
+  const auto& decoded = deserialized->indexes()[0];
+  EXPECT_EQ(decoded.column_name, index.column_name);
+  EXPECT_EQ(decoded.index_name, index.index_name);
+  EXPECT_EQ(decoded.index_type, index.index_type);
+  EXPECT_EQ(decoded.path, base_path_ + "/_index/embedding_hnsw");
+  EXPECT_EQ(decoded.field_id, index.field_id);
+  EXPECT_EQ(decoded.index_id, index.index_id);
+  EXPECT_EQ(decoded.build_id, index.build_id);
+  EXPECT_EQ(decoded.index_version, index.index_version);
+  EXPECT_EQ(decoded.num_rows, index.num_rows);
+  EXPECT_EQ(decoded.serialized_size, index.serialized_size);
+  EXPECT_EQ(decoded.mem_size, index.mem_size);
+  EXPECT_EQ(decoded.current_index_version, index.current_index_version);
+  EXPECT_EQ(decoded.current_scalar_index_version, index.current_scalar_index_version);
+  EXPECT_EQ(decoded.index_store_path_version, index.index_store_path_version);
+  EXPECT_EQ(decoded.index_file_keys, index.index_file_keys);
+  EXPECT_EQ(decoded.properties, index.properties);
+  EXPECT_TRUE(deserialized->lobFiles().empty());
 }
 
 TEST_F(ColumnGroupsTest, IndexRoundTripPreservesData) {


### PR DESCRIPTION
## Summary
- decode raw MILV index metadata only when manifest version is at least 6
- preserve Avro encoding for legacy ColumnGroupFile properties
- add coverage for raw manifest v6 index metadata and legacy v1-v3 behavior

## Validation
- `ColumnGroupsTest.LegacyV*`: 4/4 passed
- `ColumnGroupsTest.Index*`: 3/3 passed
- container build: passed
- `git diff --check`: passed
