### PR TITLE
feat: expose transaction drop index through FFI

### DIFF
--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -155,6 +155,7 @@
     loon_transaction_add_delta_log;
     loon_transaction_update_stat;
     loon_transaction_add_index_info;
+    loon_transaction_drop_index;
 
     # External table interface
     loon_exttable_explore;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -153,6 +153,7 @@ _loon_transaction_append_files
 _loon_transaction_add_delta_log
 _loon_transaction_update_stat
 _loon_transaction_add_index_info
+_loon_transaction_drop_index
 
 # External table interface
 _loon_exttable_explore

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -855,6 +855,21 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
 FFI_EXPORT LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, const LoonIndexInfo* index_info);
 
 /**
+ * @brief Remove an index from the transaction updates.
+ *
+ * This only removes the matching index metadata from the manifest; it does
+ * not delete the index artifact files.
+ *
+ * @param handle Transaction handle
+ * @param column_name Name of the indexed column
+ * @param index_type Type of the index to remove
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
+                                                     const char* column_name,
+                                                     const char* index_type);
+
+/**
  * @brief Add a LOB file info to the transaction updates
  * Used during compaction REUSE_ALL mode to merge LOB file references
  *

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -324,6 +324,23 @@ LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, cons
   RETURN_UNREACHABLE();
 }
 
+LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
+                                          const char* column_name,
+                                          const char* index_type) {
+  if (!handle || !column_name || !index_type) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, column_name, and index_type must not be null");
+  }
+  try {
+    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
+    cpp_transaction->DropIndex(column_name, index_type);
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
 LoonFFIResult loon_transaction_add_lob_file(LoonTransactionHandle handle, const LoonLobFileInfo* lob_file) {
   if (!handle || !lob_file) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and lob_file must not be null");

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -364,6 +364,53 @@ static void test_add_index_info_and_commit(void) {
   loon_properties_free(&pp);
 }
 
+static void test_drop_index_and_commit(void) {
+  LoonProperties pp;
+  LoonFFIResult rc;
+  LoonTransactionHandle transaction = 0;
+  LoonTransactionHandle read_transaction = 0;
+  LoonManifest* cmanifest = NULL;
+  int64_t committed_version = 0;
+  LoonIndexInfo index_info = {
+      .column_name = "vector",
+      .index_name = "vector_hnsw",
+      .index_type = "HNSW",
+      .path = "vector-hnsw",
+  };
+
+  create_test_pp(&pp);
+  FileSystemHandle fs = get_fs(&pp);
+  recreate_dir(fs, TEST_BASE_PATH);
+
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &transaction);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_transaction_add_index_info(transaction, &index_info);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_transaction_commit(transaction, &committed_version);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  loon_transaction_destroy(transaction);
+
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &transaction);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_transaction_drop_index(transaction, "vector", "HNSW");
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_transaction_commit(transaction, &committed_version);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  loon_transaction_destroy(transaction);
+
+  rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &read_transaction);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_transaction_get_manifest(read_transaction, &cmanifest);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_eq(cmanifest->indexes.num_indexes, 0);
+
+  loon_manifest_destroy(cmanifest);
+  loon_transaction_destroy(read_transaction);
+  clean_test_dir(fs, TEST_BASE_PATH);
+  loon_filesystem_destroy(fs);
+  loon_properties_free(&pp);
+}
+
 // Test loon_transaction_add_delta_log
 static void test_add_delta_log(void) {
   LoonTransactionHandle tranhandle;
@@ -839,6 +886,8 @@ void run_manifest_suite(void) {
   RUN_TEST(test_add_column_group);
   loon_reset_context();
   RUN_TEST(test_add_index_info_and_commit);
+  loon_reset_context();
+  RUN_TEST(test_drop_index_and_commit);
   loon_reset_context();
   RUN_TEST(test_add_delta_log);
   loon_reset_context();

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -358,6 +358,10 @@ _ffi.cdef(
     LoonFFIResult loon_transaction_drop_column(LoonTransactionHandle handle,
                                                const char* column_name);
 
+    LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
+                                              const char* column_name,
+                                              const char* index_type);
+
     LoonFFIResult loon_transaction_add_column_group(LoonTransactionHandle handle,
                                                     const LoonColumnGroup* column_group);
 


### PR DESCRIPTION
## Summary
- expose `Transaction::DropIndex` through the C FFI
- update symbol exports and Python cffi declarations
- add an FFI regression test for dropping an index

## Validation
- `make build` succeeded in the Milvus builder container
- `git diff --check` passed