### PR TITLE
fix: normalize GCP credential registry endpoint matching

### DIFF
--- a/cpp/include/milvus-storage/filesystem/gcp/gcp_credential_registry.h
+++ b/cpp/include/milvus-storage/filesystem/gcp/gcp_credential_registry.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -25,34 +27,43 @@
 
 namespace milvus_storage {
 
+// Canonical endpoint identity used for registry lookups. The port is always
+// the effective port, including 80/443 when it was omitted from the address.
+struct GcpEndpointKey {
+  Aws::Http::Scheme scheme;
+  uint16_t port;
+  std::string host;
+
+  bool operator==(const GcpEndpointKey& other) const noexcept {
+    return scheme == other.scheme && port == other.port && host == other.host;
+  }
+};
+
 // Key used to map an outgoing GCP request to a credential provider.
-//
-// endpoint_host is the bare host (scheme stripped, no trailing slash).
-// Examples after normalization:
-//   - "storage.googleapis.com"
-//   - "custom-gcs.internal:8443"
-//
-// bucket_name is the GCS bucket the request targets.
 struct GcpBucketKey {
-  std::string endpoint_host;
+  GcpEndpointKey endpoint;
   std::string bucket_name;
 
   bool operator==(const GcpBucketKey& other) const noexcept {
-    return endpoint_host == other.endpoint_host && bucket_name == other.bucket_name;
+    return endpoint == other.endpoint && bucket_name == other.bucket_name;
   }
 };
 
 struct GcpBucketKeyHash {
   size_t operator()(const GcpBucketKey& k) const noexcept {
-    return std::hash<std::string>{}(k.endpoint_host) ^ (std::hash<std::string>{}(k.bucket_name) << 1);
+    size_t hash = std::hash<int>{}(static_cast<int>(k.endpoint.scheme));
+    hash ^= std::hash<uint16_t>{}(k.endpoint.port) << 1;
+    hash ^= std::hash<std::string>{}(k.endpoint.host) << 2;
+    hash ^= std::hash<std::string>{}(k.bucket_name) << 3;
+    return hash;
   }
 };
 
-// Normalize a filesystem config's `address` field into an endpoint host for
-// use as a GcpBucketKey. Strips scheme (http://, https://) and trailing '/'.
-std::string NormalizeGcpEndpointHost(const std::string& address);
+// Normalize a filesystem config's address using an explicit scheme when
+// present, or use_ssl otherwise.
+GcpEndpointKey NormalizeGcpEndpoint(const std::string& address, bool use_ssl);
 
-// Process-wide registry mapping (endpoint_host, bucket) → credential provider.
+// Process-wide registry mapping (endpoint, bucket) → credential provider.
 //
 // The GCP HTTP client factory and delegator are installed once globally (AWS
 // SDK constraint via InitializeS3 + call_once). They are stateless and look
@@ -74,8 +85,9 @@ class GcpCredentialRegistry {
   void Register(GcpBucketKey key, std::shared_ptr<GcpCredentialProvider> provider);
 
   // Look up the provider for an outgoing request URI. Tries both path-style
-  // (host + first path segment) and virtual-host-style (first subdomain +
-  // remaining host) interpretations. Returns nullptr if no match.
+  // (request endpoint + first path segment) and virtual-host-style (first
+  // subdomain + remaining endpoint host) interpretations. Returns nullptr if
+  // no match.
   std::shared_ptr<GcpCredentialProvider> Lookup(const Aws::Http::URI& uri) const;
 
   private:

--- a/cpp/src/filesystem/gcp/gcp_credential_registry.cpp
+++ b/cpp/src/filesystem/gcp/gcp_credential_registry.cpp
@@ -36,23 +36,18 @@ std::string ToLower(std::string s) {
   return s;
 }
 
+GcpEndpointKey EndpointFromUri(const Aws::Http::URI& uri) {
+  return {uri.GetScheme(), uri.GetPort(), ToLower(uri.GetAuthority().c_str())};
+}
+
 }  // namespace
 
-std::string NormalizeGcpEndpointHost(const std::string& address) {
-  std::string host = address;
-
-  // Strip scheme.
-  auto scheme_pos = host.find("://");
-  if (scheme_pos != std::string::npos) {
-    host.erase(0, scheme_pos + 3);
+GcpEndpointKey NormalizeGcpEndpoint(const std::string& address, bool use_ssl) {
+  std::string endpoint = address;
+  if (!endpoint.starts_with("http://") && !endpoint.starts_with("https://")) {
+    endpoint.insert(0, use_ssl ? "https://" : "http://");
   }
-
-  // Strip trailing slash(es).
-  while (!host.empty() && host.back() == '/') {
-    host.pop_back();
-  }
-
-  return ToLower(host);
+  return EndpointFromUri(Aws::Http::URI(endpoint.c_str()));
 }
 
 GcpCredentialRegistry& GcpCredentialRegistry::Instance() {
@@ -61,13 +56,13 @@ GcpCredentialRegistry& GcpCredentialRegistry::Instance() {
 }
 
 void GcpCredentialRegistry::Register(GcpBucketKey key, std::shared_ptr<GcpCredentialProvider> provider) {
-  key.endpoint_host = ToLower(std::move(key.endpoint_host));
+  key.endpoint.host = ToLower(std::move(key.endpoint.host));
   std::lock_guard<std::mutex> lock(mu_);
   providers_[std::move(key)] = std::move(provider);
 }
 
 std::shared_ptr<GcpCredentialProvider> GcpCredentialRegistry::Lookup(const Aws::Http::URI& uri) const {
-  std::string host = ToLower(uri.GetAuthority().c_str());
+  auto endpoint = EndpointFromUri(uri);
   std::string path = uri.GetPath().c_str();
 
   auto find = [this](const GcpBucketKey& key) -> std::shared_ptr<GcpCredentialProvider> {
@@ -76,20 +71,20 @@ std::shared_ptr<GcpCredentialProvider> GcpCredentialRegistry::Lookup(const Aws::
     return it == providers_.end() ? nullptr : it->second;
   };
 
-  // Path-style: endpoint = host, bucket = first path segment.
+  // Path-style: endpoint = request endpoint, bucket = first path segment.
   auto seg = FirstPathSegment(path);
   if (!seg.empty()) {
-    if (auto p = find({host, seg})) {
+    if (auto p = find({endpoint, seg})) {
       return p;
     }
   }
 
-  // Virtual-host-style: bucket = first subdomain, endpoint = rest of host.
-  auto dot = host.find('.');
+  // Virtual-host-style: bucket = first subdomain, endpoint host = rest of host.
+  auto dot = endpoint.host.find('.');
   if (dot != std::string::npos && dot > 0) {
-    auto subdomain = host.substr(0, dot);
-    auto rest = host.substr(dot + 1);
-    if (auto p = find({rest, subdomain})) {
+    auto subdomain = endpoint.host.substr(0, dot);
+    endpoint.host.erase(0, dot + 1);
+    if (auto p = find({endpoint, subdomain})) {
       return p;
     }
   }

--- a/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
+++ b/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
@@ -202,7 +202,7 @@ arrow::Status GcpFileSystemProducer::InitS3Compat(const ArrowFileSystemConfig& f
 
 arrow::Status GcpFileSystemProducer::RegisterIdentity(const ArrowFileSystemConfig& config) {
   ARROW_ASSIGN_OR_RAISE(auto provider, BuildGcpProviderFromConfig(config));
-  GcpBucketKey key{NormalizeGcpEndpointHost(config.address), config.bucket_name};
+  GcpBucketKey key{NormalizeGcpEndpoint(config.address, config.use_ssl), config.bucket_name};
   GcpCredentialRegistry::Instance().Register(std::move(key), std::move(provider));
   return arrow::Status::OK();
 }

--- a/cpp/test/filesystem/gcp_credential_registry_test.cpp
+++ b/cpp/test/filesystem/gcp_credential_registry_test.cpp
@@ -1,0 +1,114 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <arrow/status.h>
+#include <aws/core/http/URI.h>
+
+#include "milvus-storage/filesystem/gcp/gcp_credential_registry.h"
+
+namespace milvus_storage {
+
+namespace {
+
+class TestGcpCredentialProvider final : public GcpCredentialProvider {
+  public:
+  std::optional<std::pair<std::string, std::string>> AuthorizationHeader() override { return std::nullopt; }
+
+  arrow::Status MaybeSignConditionalWrite(const std::shared_ptr<Aws::Http::HttpRequest>&) override {
+    return arrow::Status::OK();
+  }
+};
+
+}  // namespace
+
+TEST(GcpCredentialRegistryTest, CanonicalizesConfigEndpoints) {
+  auto implicit_https = NormalizeGcpEndpoint("Storage.GoogleApis.com", true);
+  auto explicit_https = NormalizeGcpEndpoint("https://storage.googleapis.com:443/", false);
+  EXPECT_EQ(implicit_https, explicit_https);
+  EXPECT_EQ(implicit_https.scheme, Aws::Http::Scheme::HTTPS);
+  EXPECT_EQ(implicit_https.port, Aws::Http::HTTPS_DEFAULT_PORT);
+  EXPECT_EQ(implicit_https.host, "storage.googleapis.com");
+
+  auto implicit_http = NormalizeGcpEndpoint("example.test", false);
+  auto explicit_http = NormalizeGcpEndpoint("http://example.test:80/", true);
+  EXPECT_EQ(implicit_http, explicit_http);
+  EXPECT_EQ(implicit_http.scheme, Aws::Http::Scheme::HTTP);
+  EXPECT_EQ(implicit_http.port, Aws::Http::HTTP_DEFAULT_PORT);
+
+  auto non_default = NormalizeGcpEndpoint("example.test:8443", true);
+  EXPECT_EQ(non_default.scheme, Aws::Http::Scheme::HTTPS);
+  EXPECT_EQ(non_default.port, 8443);
+  EXPECT_EQ(non_default.host, "example.test");
+
+  auto ipv6 = NormalizeGcpEndpoint("[2001:DB8::1]:443", true);
+  EXPECT_EQ(ipv6.scheme, Aws::Http::Scheme::HTTPS);
+  EXPECT_EQ(ipv6.port, Aws::Http::HTTPS_DEFAULT_PORT);
+  EXPECT_EQ(ipv6.host, "[2001:db8::1]");
+}
+
+TEST(GcpCredentialRegistryTest, LooksUpDefaultHttpsPort) {
+  const std::string bucket = "gcp-registry-default-port-bucket";
+  auto provider = std::make_shared<TestGcpCredentialProvider>();
+  auto& registry = GcpCredentialRegistry::Instance();
+  registry.Register({NormalizeGcpEndpoint("storage.googleapis.com:443", true), bucket}, provider);
+
+  auto implicit_port_uri = Aws::Http::URI(("https://storage.googleapis.com/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(implicit_port_uri), provider);
+
+  auto explicit_port_uri = Aws::Http::URI(("https://storage.googleapis.com:443/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(explicit_port_uri), provider);
+}
+
+TEST(GcpCredentialRegistryTest, PreservesNonDefaultPortAndScheme) {
+  const std::string host = "gcp-registry-port.example";
+  const std::string bucket = "gcp-registry-port-bucket";
+  auto provider = std::make_shared<TestGcpCredentialProvider>();
+  auto& registry = GcpCredentialRegistry::Instance();
+  registry.Register({NormalizeGcpEndpoint(host + ":8443", true), bucket}, provider);
+
+  auto matching_uri = Aws::Http::URI(("https://" + host + ":8443/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(matching_uri), provider);
+
+  auto different_port_uri = Aws::Http::URI(("https://" + host + ":9443/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(different_port_uri), nullptr);
+
+  auto different_scheme_uri = Aws::Http::URI(("http://" + host + ":8443/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(different_scheme_uri), nullptr);
+}
+
+TEST(GcpCredentialRegistryTest, LooksUpVirtualHostAndIpv6Endpoints) {
+  auto& registry = GcpCredentialRegistry::Instance();
+
+  const std::string virtual_host = "gcp-registry-vhost.example";
+  const std::string virtual_bucket = "gcp-registry-vhost-bucket";
+  auto virtual_provider = std::make_shared<TestGcpCredentialProvider>();
+  registry.Register({NormalizeGcpEndpoint(virtual_host + ":8443", true), virtual_bucket}, virtual_provider);
+  auto virtual_uri = Aws::Http::URI(("https://" + virtual_bucket + "." + virtual_host + ":8443/key").c_str());
+  EXPECT_EQ(registry.Lookup(virtual_uri), virtual_provider);
+
+  const std::string ipv6_bucket = "gcp-registry-ipv6-bucket";
+  auto ipv6_provider = std::make_shared<TestGcpCredentialProvider>();
+  registry.Register({NormalizeGcpEndpoint("[2001:db8::7]:80", false), ipv6_bucket}, ipv6_provider);
+  auto ipv6_uri = Aws::Http::URI(("http://[2001:db8::7]/" + ipv6_bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(ipv6_uri), ipv6_provider);
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
issue: #623

GCP credential providers were registered from filesystem configuration, while outgoing requests were matched from an AWS URI. The two paths could describe the same endpoint differently—for example, one side could include an explicit default port while the other omitted it—so the registry failed to find the provider even though the request was going to the configured bucket.

The registry now uses a structured endpoint key made up of the scheme, effective port, and lowercased host. Both registration and lookup build that key through the same URI-based normalization path, with an explicit HTTP or HTTPS scheme taking precedence and use_ssl filling it in when the address does not include one.

Path-style and virtual-host-style requests now reuse the same endpoint identity, including default ports, non-default ports, and IPv6 hosts. This makes equivalent endpoint forms resolve to the same credential provider while still keeping genuinely different schemes or ports isolated.