### PR TITLE
fix: preserve manifest indexes by ID

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -855,29 +855,16 @@ FFI_EXPORT LoonFFIResult loon_transaction_update_stat(LoonTransactionHandle hand
 FFI_EXPORT LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, const LoonIndexInfo* index_info);
 
 /**
- * @brief Remove an index from the transaction updates.
+ * @brief Remove all completed artifacts for an index from the transaction updates.
  *
- * This only removes the matching index metadata from the manifest; it does
- * not delete the index artifact files.
+ * This only removes matching index metadata from the manifest; it does not
+ * delete the index artifact files.
  *
  * @param handle Transaction handle
- * @param column_name Name of the indexed column
- * @param index_type Type of the index to remove
+ * @param index_id Stable user index ID
  * @return result of FFI
  */
-FFI_EXPORT LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
-                                                     const char* column_name,
-                                                     const char* index_type);
-
-/**
- * @brief Remove one exact completed index artifact from the transaction updates.
- *
- * Index ID identifies the user index; build ID prevents a stale removal from
- * deleting a newer build of the same index.
- */
-FFI_EXPORT LoonFFIResult loon_transaction_drop_index_by_id(LoonTransactionHandle handle,
-                                                           int64_t index_id,
-                                                           int64_t build_id);
+FFI_EXPORT LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle, int64_t index_id);
 
 /**
  * @brief Add a LOB file info to the transaction updates

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -870,6 +870,16 @@ FFI_EXPORT LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handl
                                                      const char* index_type);
 
 /**
+ * @brief Remove one exact completed index artifact from the transaction updates.
+ *
+ * Index ID identifies the user index; build ID prevents a stale removal from
+ * deleting a newer build of the same index.
+ */
+FFI_EXPORT LoonFFIResult loon_transaction_drop_index_by_id(LoonTransactionHandle handle,
+                                                           int64_t index_id,
+                                                           int64_t build_id);
+
+/**
  * @brief Add a LOB file info to the transaction updates
  * Used during compaction REUSE_ALL mode to merge LOB file references
  *

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -54,6 +54,7 @@ class Updates {
   void AddIndex(const Index& index);
   void DropColumn(const std::string& column_name);
   void DropIndex(const std::string& column_name, const std::string& index_type);
+  void DropIndexByID(int64_t index_id, int64_t build_id);
   void AddLobFile(const LobFileInfo& lob_file);
   [[nodiscard]] const std::vector<std::shared_ptr<ColumnGroup>>& GetAddedColumnGroups() const;
   [[nodiscard]] const std::vector<std::vector<std::shared_ptr<ColumnGroup>>>& GetAppendedFiles() const;
@@ -62,6 +63,7 @@ class Updates {
   [[nodiscard]] const std::vector<Index>& GetAddedIndexes() const;
   [[nodiscard]] const std::vector<std::string>& GetDroppedColumns() const;
   [[nodiscard]] const std::vector<std::pair<std::string, std::string>>& GetDroppedIndexes() const;
+  [[nodiscard]] const std::vector<std::pair<int64_t, int64_t>>& GetDroppedIndexIDs() const;
   [[nodiscard]] const std::vector<LobFileInfo>& GetAddedLobFiles() const;
 
   private:
@@ -81,6 +83,7 @@ class Updates {
   // Index changes
   std::vector<Index> added_indexes_;                                  // Indexes to add or replace
   std::vector<std::pair<std::string, std::string>> dropped_indexes_;  // (column_name, index_type) to drop
+  std::vector<std::pair<int64_t, int64_t>> dropped_index_ids_;        // (index_id, build_id) to drop
 
   // LOB file changes
   std::vector<LobFileInfo> added_lob_files_;  // New LOB files to add
@@ -255,12 +258,18 @@ class Transaction {
   Transaction& AddIndexInfo(const Index& index);
 
   /**
-   * @brief Drop an index by column name and type
+   * @brief Drop all indexes matching column name and type
    * @param column_name Column the index is on
    * @param index_type Type of the index
    * @return Reference to this transaction for method chaining
    */
   Transaction& DropIndex(const std::string& column_name, const std::string& index_type);
+
+  /**
+   * @brief Drop the exact completed index artifact identified by index and build IDs.
+   * @return Reference to this transaction for method chaining
+   */
+  Transaction& DropIndexByID(int64_t index_id, int64_t build_id);
 
   /**
    * @brief Add a LOB file to the transaction updates

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -79,8 +79,8 @@ class Updates {
   std::map<std::string, Statistics> added_stats_;  // New stats to add (key -> Statistics)
 
   // Index changes
-  std::vector<Index> added_indexes_;       // Indexes to add or replace
-  std::vector<int64_t> dropped_indexes_;   // index_id to drop
+  std::vector<Index> added_indexes_;      // Indexes to add or replace
+  std::vector<int64_t> dropped_indexes_;  // index_id to drop
 
   // LOB file changes
   std::vector<LobFileInfo> added_lob_files_;  // New LOB files to add

--- a/cpp/include/milvus-storage/transaction/transaction.h
+++ b/cpp/include/milvus-storage/transaction/transaction.h
@@ -53,8 +53,7 @@ class Updates {
   void UpdateStat(const std::string& key, const Statistics& stat);
   void AddIndex(const Index& index);
   void DropColumn(const std::string& column_name);
-  void DropIndex(const std::string& column_name, const std::string& index_type);
-  void DropIndexByID(int64_t index_id, int64_t build_id);
+  void DropIndex(int64_t index_id);
   void AddLobFile(const LobFileInfo& lob_file);
   [[nodiscard]] const std::vector<std::shared_ptr<ColumnGroup>>& GetAddedColumnGroups() const;
   [[nodiscard]] const std::vector<std::vector<std::shared_ptr<ColumnGroup>>>& GetAppendedFiles() const;
@@ -62,8 +61,7 @@ class Updates {
   [[nodiscard]] const std::map<std::string, Statistics>& GetAddedStats() const;
   [[nodiscard]] const std::vector<Index>& GetAddedIndexes() const;
   [[nodiscard]] const std::vector<std::string>& GetDroppedColumns() const;
-  [[nodiscard]] const std::vector<std::pair<std::string, std::string>>& GetDroppedIndexes() const;
-  [[nodiscard]] const std::vector<std::pair<int64_t, int64_t>>& GetDroppedIndexIDs() const;
+  [[nodiscard]] const std::vector<int64_t>& GetDroppedIndexes() const;
   [[nodiscard]] const std::vector<LobFileInfo>& GetAddedLobFiles() const;
 
   private:
@@ -81,9 +79,8 @@ class Updates {
   std::map<std::string, Statistics> added_stats_;  // New stats to add (key -> Statistics)
 
   // Index changes
-  std::vector<Index> added_indexes_;                                  // Indexes to add or replace
-  std::vector<std::pair<std::string, std::string>> dropped_indexes_;  // (column_name, index_type) to drop
-  std::vector<std::pair<int64_t, int64_t>> dropped_index_ids_;        // (index_id, build_id) to drop
+  std::vector<Index> added_indexes_;       // Indexes to add or replace
+  std::vector<int64_t> dropped_indexes_;   // index_id to drop
 
   // LOB file changes
   std::vector<LobFileInfo> added_lob_files_;  // New LOB files to add
@@ -258,18 +255,10 @@ class Transaction {
   Transaction& AddIndexInfo(const Index& index);
 
   /**
-   * @brief Drop all indexes matching column name and type
-   * @param column_name Column the index is on
-   * @param index_type Type of the index
+   * @brief Drop all completed artifacts for an index.
    * @return Reference to this transaction for method chaining
    */
-  Transaction& DropIndex(const std::string& column_name, const std::string& index_type);
-
-  /**
-   * @brief Drop the exact completed index artifact identified by index and build IDs.
-   * @return Reference to this transaction for method chaining
-   */
-  Transaction& DropIndexByID(int64_t index_id, int64_t build_id);
+  Transaction& DropIndex(int64_t index_id);
 
   /**
    * @brief Add a LOB file to the transaction updates

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -341,6 +341,21 @@ LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
   RETURN_UNREACHABLE();
 }
 
+LoonFFIResult loon_transaction_drop_index_by_id(LoonTransactionHandle handle, int64_t index_id, int64_t build_id) {
+  if (!handle || index_id == 0 || build_id == 0) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, index_id, and build_id must be non-zero");
+  }
+  try {
+    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
+    cpp_transaction->DropIndexByID(index_id, build_id);
+    RETURN_SUCCESS();
+  } catch (std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
 LoonFFIResult loon_transaction_add_lob_file(LoonTransactionHandle handle, const LoonLobFileInfo* lob_file) {
   if (!handle || !lob_file) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and lob_file must not be null");

--- a/cpp/src/ffi/manifest_c.cpp
+++ b/cpp/src/ffi/manifest_c.cpp
@@ -324,30 +324,13 @@ LoonFFIResult loon_transaction_add_index_info(LoonTransactionHandle handle, cons
   RETURN_UNREACHABLE();
 }
 
-LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
-                                          const char* column_name,
-                                          const char* index_type) {
-  if (!handle || !column_name || !index_type) {
-    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, column_name, and index_type must not be null");
+LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle, int64_t index_id) {
+  if (!handle || index_id == 0) {
+    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle and index_id must be non-zero");
   }
   try {
     auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
-    cpp_transaction->DropIndex(column_name, index_type);
-    RETURN_SUCCESS();
-  } catch (std::exception& e) {
-    RETURN_EXCEPTION(e.what());
-  }
-
-  RETURN_UNREACHABLE();
-}
-
-LoonFFIResult loon_transaction_drop_index_by_id(LoonTransactionHandle handle, int64_t index_id, int64_t build_id) {
-  if (!handle || index_id == 0 || build_id == 0) {
-    RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, index_id, and build_id must be non-zero");
-  }
-  try {
-    auto* cpp_transaction = reinterpret_cast<Transaction*>(handle);
-    cpp_transaction->DropIndexByID(index_id, build_id);
+    cpp_transaction->DropIndex(index_id);
     RETURN_SUCCESS();
   } catch (std::exception& e) {
     RETURN_EXCEPTION(e.what());

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -192,9 +192,9 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
                 indexes.end());
 
   for (const auto& dropped : updates.GetDroppedIndexes()) {
-    indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
-                                 [&](const Index& idx) { return idx.index_id == dropped; }),
-                  indexes.end());
+    indexes.erase(
+        std::remove_if(indexes.begin(), indexes.end(), [&](const Index& idx) { return idx.index_id == dropped; }),
+        indexes.end());
   }
 
   for (const auto& new_idx : updates.GetAddedIndexes()) {

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -41,7 +41,7 @@ Updates::~Updates() = default;
 bool Updates::hasChanges() const {
   return !dropped_columns_.empty() || !added_column_groups_.empty() || !appended_files_.empty() ||
          !added_delta_logs_.empty() || !added_stats_.empty() || !added_indexes_.empty() || !dropped_indexes_.empty() ||
-         !added_lob_files_.empty();
+         !dropped_index_ids_.empty() || !added_lob_files_.empty();
 }
 
 void Updates::DropColumn(const std::string& column_name) { dropped_columns_.push_back(column_name); }
@@ -72,9 +72,13 @@ void Updates::DropIndex(const std::string& column_name, const std::string& index
   dropped_indexes_.emplace_back(column_name, index_type);
 }
 
+void Updates::DropIndexByID(int64_t index_id, int64_t build_id) { dropped_index_ids_.emplace_back(index_id, build_id); }
+
 const std::vector<Index>& Updates::GetAddedIndexes() const { return added_indexes_; }
 
 const std::vector<std::pair<std::string, std::string>>& Updates::GetDroppedIndexes() const { return dropped_indexes_; }
+
+const std::vector<std::pair<int64_t, int64_t>>& Updates::GetDroppedIndexIDs() const { return dropped_index_ids_; }
 
 const std::vector<LobFileInfo>& Updates::GetAddedLobFiles() const { return added_lob_files_; }
 
@@ -201,10 +205,25 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
                   indexes.end());
   }
 
+  for (const auto& dropped : updates.GetDroppedIndexIDs()) {
+    const auto [index_id, build_id] = dropped;
+    indexes.erase(
+        std::remove_if(indexes.begin(), indexes.end(),
+                       [&](const Index& idx) { return idx.index_id == index_id && idx.build_id == build_id; }),
+        indexes.end());
+  }
+
   for (const auto& new_idx : updates.GetAddedIndexes()) {
     indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
                                  [&](const Index& idx) {
-                                   return idx.column_name == new_idx.column_name &&
+                                   // index_id is the stable identity of a user index. It
+                                   // lets multiple JSON-path indexes with the same column
+                                   // and type coexist. Keep the legacy key for old entries
+                                   // that did not record an index ID.
+                                   if (new_idx.index_id != 0) {
+                                     return idx.index_id == new_idx.index_id;
+                                   }
+                                   return idx.index_id == 0 && idx.column_name == new_idx.column_name &&
                                           idx.index_type == new_idx.index_type;
                                  }),
                   indexes.end());
@@ -502,6 +521,11 @@ Transaction& Transaction::AddIndexInfo(const Index& index) {
 
 Transaction& Transaction::DropIndex(const std::string& column_name, const std::string& index_type) {
   updates_.DropIndex(column_name, index_type);
+  return *this;
+}
+
+Transaction& Transaction::DropIndexByID(int64_t index_id, int64_t build_id) {
+  updates_.DropIndexByID(index_id, build_id);
   return *this;
 }
 

--- a/cpp/src/transaction/transaction.cpp
+++ b/cpp/src/transaction/transaction.cpp
@@ -41,7 +41,7 @@ Updates::~Updates() = default;
 bool Updates::hasChanges() const {
   return !dropped_columns_.empty() || !added_column_groups_.empty() || !appended_files_.empty() ||
          !added_delta_logs_.empty() || !added_stats_.empty() || !added_indexes_.empty() || !dropped_indexes_.empty() ||
-         !dropped_index_ids_.empty() || !added_lob_files_.empty();
+         !added_lob_files_.empty();
 }
 
 void Updates::DropColumn(const std::string& column_name) { dropped_columns_.push_back(column_name); }
@@ -68,17 +68,11 @@ const std::map<std::string, Statistics>& Updates::GetAddedStats() const { return
 
 void Updates::AddIndex(const Index& index) { added_indexes_.push_back(index); }
 
-void Updates::DropIndex(const std::string& column_name, const std::string& index_type) {
-  dropped_indexes_.emplace_back(column_name, index_type);
-}
-
-void Updates::DropIndexByID(int64_t index_id, int64_t build_id) { dropped_index_ids_.emplace_back(index_id, build_id); }
+void Updates::DropIndex(int64_t index_id) { dropped_indexes_.push_back(index_id); }
 
 const std::vector<Index>& Updates::GetAddedIndexes() const { return added_indexes_; }
 
-const std::vector<std::pair<std::string, std::string>>& Updates::GetDroppedIndexes() const { return dropped_indexes_; }
-
-const std::vector<std::pair<int64_t, int64_t>>& Updates::GetDroppedIndexIDs() const { return dropped_index_ids_; }
+const std::vector<int64_t>& Updates::GetDroppedIndexes() const { return dropped_indexes_; }
 
 const std::vector<LobFileInfo>& Updates::GetAddedLobFiles() const { return added_lob_files_; }
 
@@ -191,26 +185,16 @@ arrow::Result<std::shared_ptr<Manifest>> applyUpdates(const std::shared_ptr<Mani
     }
   }
 
-  // Resolve indexes: drop affected, apply DropIndex, apply AddIndex
+  // Resolve indexes: drop affected, apply DropIndex, apply AddIndex.
   indexes.erase(std::remove_if(
                     indexes.begin(), indexes.end(),
                     [&](const Index& idx) { return affected_columns.find(idx.column_name) != affected_columns.end(); }),
                 indexes.end());
 
   for (const auto& dropped : updates.GetDroppedIndexes()) {
-    const auto& col = dropped.first;
-    const auto& type = dropped.second;
     indexes.erase(std::remove_if(indexes.begin(), indexes.end(),
-                                 [&](const Index& idx) { return idx.column_name == col && idx.index_type == type; }),
+                                 [&](const Index& idx) { return idx.index_id == dropped; }),
                   indexes.end());
-  }
-
-  for (const auto& dropped : updates.GetDroppedIndexIDs()) {
-    const auto [index_id, build_id] = dropped;
-    indexes.erase(
-        std::remove_if(indexes.begin(), indexes.end(),
-                       [&](const Index& idx) { return idx.index_id == index_id && idx.build_id == build_id; }),
-        indexes.end());
   }
 
   for (const auto& new_idx : updates.GetAddedIndexes()) {
@@ -519,13 +503,8 @@ Transaction& Transaction::AddIndexInfo(const Index& index) {
   return *this;
 }
 
-Transaction& Transaction::DropIndex(const std::string& column_name, const std::string& index_type) {
-  updates_.DropIndex(column_name, index_type);
-  return *this;
-}
-
-Transaction& Transaction::DropIndexByID(int64_t index_id, int64_t build_id) {
-  updates_.DropIndexByID(index_id, build_id);
+Transaction& Transaction::DropIndex(int64_t index_id) {
+  updates_.DropIndex(index_id);
   return *this;
 }
 

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -313,7 +313,7 @@ TEST_F(TransactionTest, AddIndexInfoPersistsCompletedIndexMetadata) {
   // Removing the final index removes all manifest-published index metadata.
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
-    transaction->DropIndex("vector", "hnsw");
+    transaction->DropIndex(first_index.index_id);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     EXPECT_EQ(committed_version, 3);
   }
@@ -360,7 +360,7 @@ TEST_F(TransactionTest, IndexesWithTheSameColumnAndTypeHaveIndependentIdentities
 
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
-    transaction->DropIndexByID(category_index.index_id, category_index.build_id);
+    transaction->DropIndex(category_index.index_id);
     ASSERT_OK(transaction->Commit());
   }
 
@@ -649,6 +649,7 @@ TEST_F(TransactionTest, IndexBasicOperationsTest) {
     Index idx;
     idx.column_name = "id";
     idx.index_type = "hnsw";
+    idx.index_id = 100;
     idx.path = base_path_ + "/_index/id_hnsw.idx";
     idx.properties = {{"ef_construction", "128"}, {"M", "16"}};
 
@@ -672,7 +673,7 @@ TEST_F(TransactionTest, IndexBasicOperationsTest) {
   // Drop the index
   {
     ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
-    transaction->DropIndex("id", "hnsw");
+    transaction->DropIndex(100);
     ASSERT_AND_ASSIGN(auto committed_version, transaction->Commit());
     ASSERT_EQ(committed_version, 3);
 

--- a/cpp/test/api_transaction_test.cpp
+++ b/cpp/test/api_transaction_test.cpp
@@ -323,6 +323,54 @@ TEST_F(TransactionTest, AddIndexInfoPersistsCompletedIndexMetadata) {
   EXPECT_TRUE(manifest->indexes().empty());
 }
 
+TEST_F(TransactionTest, IndexesWithTheSameColumnAndTypeHaveIndependentIdentities) {
+  Index category_index{.column_name = "metadata",
+                       .index_name = "idx_category",
+                       .index_type = "inverted",
+                       .path = base_path_ + "/_index/category.idx",
+                       .field_id = 100,
+                       .index_id = 200,
+                       .build_id = 300};
+  Index price_index{.column_name = "metadata",
+                    .index_name = "idx_price",
+                    .index_type = "inverted",
+                    .path = base_path_ + "/_index/price.idx",
+                    .field_id = 100,
+                    .index_id = 201,
+                    .build_id = 301};
+
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    transaction->AddIndexInfo(category_index);
+    transaction->AddIndexInfo(price_index);
+    ASSERT_OK(transaction->Commit());
+  }
+
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
+    ASSERT_EQ(manifest->indexes().size(), 2);
+    EXPECT_TRUE(std::any_of(manifest->indexes().begin(), manifest->indexes().end(), [&](const Index& index) {
+      return index.index_id == category_index.index_id && index.build_id == category_index.build_id;
+    }));
+    EXPECT_TRUE(std::any_of(manifest->indexes().begin(), manifest->indexes().end(), [&](const Index& index) {
+      return index.index_id == price_index.index_id && index.build_id == price_index.build_id;
+    }));
+  }
+
+  {
+    ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+    transaction->DropIndexByID(category_index.index_id, category_index.build_id);
+    ASSERT_OK(transaction->Commit());
+  }
+
+  ASSERT_AND_ASSIGN(auto transaction, Transaction::Open(fs_, base_path_));
+  ASSERT_AND_ASSIGN(auto manifest, transaction->GetManifest());
+  ASSERT_EQ(manifest->indexes().size(), 1);
+  EXPECT_EQ(manifest->indexes().front().index_id, price_index.index_id);
+  EXPECT_EQ(manifest->indexes().front().build_id, price_index.build_id);
+}
+
 TEST_F(TransactionTest, ConflictResolveOverwriteTest) {
   // initial 5 commit with one column group
   for (size_t i = 0; i < 5; ++i) {

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -376,6 +376,8 @@ static void test_drop_index_and_commit(void) {
       .index_name = "vector_hnsw",
       .index_type = "HNSW",
       .path = "vector-hnsw",
+      .index_id = 200,
+      .build_id = 300,
   };
 
   create_test_pp(&pp);
@@ -392,7 +394,7 @@ static void test_drop_index_and_commit(void) {
 
   rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
-  rc = loon_transaction_drop_index(transaction, "vector", "HNSW");
+  rc = loon_transaction_drop_index_by_id(transaction, 200, 300);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   rc = loon_transaction_commit(transaction, &committed_version);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));

--- a/cpp/test/ffi/ffi_manifest_test.c
+++ b/cpp/test/ffi/ffi_manifest_test.c
@@ -394,7 +394,7 @@ static void test_drop_index_and_commit(void) {
 
   rc = loon_transaction_begin(TEST_BASE_PATH, &pp, -1, LOON_TRANSACTION_RESOLVE_FAIL, 1, &transaction);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
-  rc = loon_transaction_drop_index_by_id(transaction, 200, 300);
+  rc = loon_transaction_drop_index(transaction, 200);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
   rc = loon_transaction_commit(transaction, &committed_version);
   ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));

--- a/python/milvus_storage/_ffi.py
+++ b/python/milvus_storage/_ffi.py
@@ -359,8 +359,7 @@ _ffi.cdef(
                                                const char* column_name);
 
     LoonFFIResult loon_transaction_drop_index(LoonTransactionHandle handle,
-                                              const char* column_name,
-                                              const char* index_type);
+                                              int64_t index_id);
 
     LoonFFIResult loon_transaction_add_column_group(LoonTransactionHandle handle,
                                                     const LoonColumnGroup* column_group);


### PR DESCRIPTION
### Summary

- identify manifest index entries by `index_id` so JSON-path indexes sharing a field and type coexist
- add exact `(index_id, build_id)` drop through the C FFI to prevent stale GC from removing a newer build

### Verification

- `TransactionTest.IndexesWithTheSameColumnAndTypeHaveIndependentIdentities`
- `Test_FFI` (79 tests)