### PR TITLE
chore: update OWNERS approvers and reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
 filters:
   ".*":
     approvers:
-      - sunby
-      - tedxu
-      - shaoting-huang
+      - yuruiz
+      - jiaqizho
     reviewers:
-      - sunby
-      - tedxu
-      - shaoting-huang
+      - yuruiz
+      - jiaqizho


### PR DESCRIPTION
The OWNERS file was still pointing at the previous set of maintainers, update to newest.