### PR TITLE
enhance:[2.6] enable `allow_delayed_open` by default (#376)

### DIFF
--- a/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
+++ b/cpp/src/filesystem/s3/multi_part_upload_s3_fs.cpp
@@ -546,7 +546,7 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         background_writes_(options.background_writes),
         use_crc32c_checksum_(options.use_crc32c_checksum),
         part_upload_size_(part_size),
-        allow_delayed_open_(false) {}
+        allow_delayed_open_(true) {}
 
   template <typename ObjectRequest>
   arrow::Status SetMetadataInRequest(ObjectRequest* request) {
@@ -580,8 +580,6 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   arrow::Status CreateMultipartUpload() {
-    DCHECK(ShouldBeMultipartUpload());
-
     ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
 
     // Initiate the multi-part upload


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/52573
After storage cherry-pick the GH-40557, the option `allow_delayed_open` in ObjectOutputStream is always false. The buffer which with small size(less than single part size) will still use the multipart upload.

Current commit enable the `allow_delayed_open` by default(hardcode).


(cherry picked from commit 2912b8a76d38726a2aa518db06c6c75e8e0637bc)