### PR TITLE
chore: enforce deprecated API checks in the Rust format bridge

### DIFF
--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -130,3 +130,6 @@ lance-arrow = { git = "https://github.com/zilliztech/lance", rev = "b13b89169b28
 lance-core = { git = "https://github.com/zilliztech/lance", rev = "b13b89169b283e47ae9b2dd13e12a6a9863c3908" }
 lance-io = { git = "https://github.com/zilliztech/lance", rev = "b13b89169b283e47ae9b2dd13e12a6a9863c3908" }
 lance-namespace = { git = "https://github.com/zilliztech/lance", rev = "b13b89169b283e47ae9b2dd13e12a6a9863c3908" }
+
+[lints.rust]
+deprecated = "deny"

--- a/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
@@ -1118,7 +1118,10 @@ impl IcebergStorage for AliyunOssStorage {
         } else {
             format!("{rel}/")
         };
-        op.remove_all(&prefixed).await.map_err(from_opendal_error)
+        op.delete_with(&prefixed)
+            .recursive(true)
+            .await
+            .map_err(from_opendal_error)
     }
 
     fn new_input(&self, path: &str) -> IcebergResult<InputFile> {

--- a/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
@@ -397,6 +397,21 @@ impl LayoutChildren for MilvusLayoutChildren {
     }
 }
 
+// Vortex has no non-deprecated public API for reconstructing this schema. This custom layout must
+// know the zones child dtype before deserializing the child, so it cannot derive the dtype from the
+// child itself. Reimplementing the schema here would duplicate Vortex internals and risk silent
+// drift, so keep this compatibility call until Vortex exposes a stable public replacement.
+//
+// TODO: On the next Vortex upgrade, verify that `ZoneMap::dtype_for_stats_table` still matches
+// `StatsAccumulator::as_array()` and remains valid for reading `STATS_VERSION == 1` files.
+#[allow(
+    deprecated,
+    reason = "the zones child dtype is required before deserialization and Vortex has no public replacement"
+)]
+fn zone_map_stats_table_dtype(column_dtype: &DType, present_stats: &[Stat]) -> DType {
+    ZoneMap::dtype_for_stats_table(column_dtype, present_stats)
+}
+
 fn zones_dtype(dtype: &DType, metadata: &RowGroupZoneMapMetadata) -> VortexResult<DType> {
     let struct_fields = dtype
         .as_struct_fields_opt()
@@ -410,7 +425,7 @@ fn zones_dtype(dtype: &DType, metadata: &RowGroupZoneMapMetadata) -> VortexResul
             .field(&column.field_name)
             .ok_or_else(|| vortex_err!("Missing zonemap column {}", column.field_name))?;
         names.push(column.field_name.clone());
-        dtypes.push(ZoneMap::dtype_for_stats_table(
+        dtypes.push(zone_map_stats_table_dtype(
             &column_dtype,
             &column.present_stats,
         ));
@@ -799,13 +814,12 @@ impl RowGroupZoneMapReader {
         .into_array())
     }
 
-    #[allow(deprecated)]
     fn validate_stats_table(
         column_dtype: &DType,
         zone_array: &StructArray,
         present_stats: &[Stat],
     ) -> VortexResult<()> {
-        let expected_dtype = ZoneMap::dtype_for_stats_table(column_dtype, present_stats);
+        let expected_dtype = zone_map_stats_table_dtype(column_dtype, present_stats);
         vortex_ensure!(
             zone_array.dtype() == &expected_dtype,
             "Array dtype does not match expected zone map dtype: {expected_dtype}"


### PR DESCRIPTION
The Rust format bridge had no crate-level guard against deprecated APIs, which meant dependency upgrades could quietly leave outdated calls behind. This change turns deprecated usage into a hard error so every new occurrence has to be migrated or explicitly justified.

Move Aliyun OSS recursive deletion to OpenDAL’s supported delete_with(...).recursive(true) flow. This preserves the existing prefix handling and error mapping while removing the deprecated Operator::remove_all call.

The Vortex V2 layout still needs ZoneMap::dtype_for_stats_table because it must reconstruct the zones child dtype before that child can be deserialized, and Vortex does not currently expose a non-deprecated public replacement. Keep this dependency behind a small zone_map_stats_table_dtype compatibility wrapper with a narrowly scoped allow and an explicit reason, instead of copying Vortex’s internal schema logic and risking silent drift. Leave a clear note for the next Vortex dependency upgrade to confirm that this API still matches StatsAccumulator::as_array() and remains compatible with files using STATS_VERSION == 1.