### PR TITLE
feat: expose cached filesystem metrics

### DIFF
--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -109,6 +109,8 @@
 
     # FilesystemMetrics interface
     loon_filesystem_get_metrics;
+    loon_filesystem_list_metrics;
+    loon_filesystem_free_metrics_list;
     loon_filesystem_reset_metrics;
 
     # Reader interface

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -107,6 +107,8 @@ _loon_close_filesystems
 
 # FilesystemMetrics interface
 _loon_filesystem_get_metrics
+_loon_filesystem_list_metrics
+_loon_filesystem_free_metrics_list
 _loon_filesystem_reset_metrics
 
 # Reader interface

--- a/cpp/include/milvus-storage/common/lrucache.h
+++ b/cpp/include/milvus-storage/common/lrucache.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <list>
 #include <optional>
+#include <vector>
 
 #include <arrow/status.h>
 #include <arrow/result.h>
@@ -85,6 +86,17 @@ class LRUCache {
   [[nodiscard]] size_t size() const {
     std::shared_lock lock(mutex_);
     return cache_.size();
+  }
+
+  // List all cached entries without changing their recency.
+  [[nodiscard]] std::vector<std::pair<K, V>> list() const {
+    std::shared_lock lock(mutex_);
+    std::vector<std::pair<K, V>> entries;
+    entries.reserve(cache_.size());
+    for (const auto& [key, value_and_iterator] : cache_) {
+      entries.emplace_back(key, value_and_iterator.first);
+    }
+    return entries;
   }
 
   // Remove the cache entry by key

--- a/cpp/include/milvus-storage/ffi_filesystem_metrics_c.h
+++ b/cpp/include/milvus-storage/ffi_filesystem_metrics_c.h
@@ -47,6 +47,22 @@ typedef struct LoonFilesystemMetricsSnapshot {  // NOLINT
 } LoonFilesystemMetricsSnapshot;  // NOLINT
 
 /**
+ * Metrics for one cached filesystem.
+ */
+typedef struct LoonFilesystemMetricsEntry {  // NOLINT
+  char* display_key;
+  LoonFilesystemMetricsSnapshot metrics;
+} LoonFilesystemMetricsEntry;  // NOLINT
+
+/**
+ * Metrics for all cached filesystems.
+ */
+typedef struct LoonFilesystemMetricsList {  // NOLINT
+  LoonFilesystemMetricsEntry* entries;
+  uint32_t count;
+} LoonFilesystemMetricsList;  // NOLINT
+
+/**
  * Get metrics from a filesystem handle.
  * Returns metrics if the filesystem is observable, otherwise returns error.
  *
@@ -56,6 +72,22 @@ typedef struct LoonFilesystemMetricsSnapshot {  // NOLINT
  */
 FFI_EXPORT LoonFFIResult loon_filesystem_get_metrics(FileSystemHandle handle,
                                                      LoonFilesystemMetricsSnapshot* out_metrics);
+
+/**
+ * List metrics for all cached filesystems.
+ *
+ * @param out_list The output metrics list. Must be released with
+ *                 loon_filesystem_free_metrics_list.
+ * @return result of FFI
+ */
+FFI_EXPORT LoonFFIResult loon_filesystem_list_metrics(LoonFilesystemMetricsList* out_list);
+
+/**
+ * Release a filesystem metrics list.
+ *
+ * @param list The list returned by loon_filesystem_list_metrics.
+ */
+FFI_EXPORT void loon_filesystem_free_metrics_list(LoonFilesystemMetricsList* list);
 
 /**
  * Reset all metrics for a filesystem.

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -22,6 +22,7 @@
 #include <shared_mutex>
 #include <unordered_map>
 #include <list>
+#include <vector>
 
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/util/uri.h>
@@ -331,6 +332,15 @@ class FilesystemCache {
   [[nodiscard]] size_t size() const;
 
   /**
+   * @brief List all cached filesystems without changing their recency
+   *
+   * Each returned pair is `{display_key, filesystem}`. See MakeDisplayKey()
+   * for the display key composition. The display key is not the internal cache
+   * key accepted by remove().
+   */
+  [[nodiscard]] std::vector<std::pair<std::string, ArrowFileSystemPtr>> list() const;
+
+  /**
    * @brief Remove a cached filesystem by key
    */
   void remove(const std::string& key);
@@ -350,12 +360,27 @@ class FilesystemCache {
   FilesystemCache& operator=(const FilesystemCache&) = delete;
 
   private:
+  struct CacheEntry {
+    std::string display_key;
+    ArrowFileSystemPtr filesystem;
+  };
+
+  /**
+   * @brief Build a display key from the filesystem location and its internal cache key
+   *
+   * Local format: `file://{root_path}#{cache_key}`.
+   * Remote format: `{address}/{bucket_name}#{cache_key}`. An empty remote
+   * address is rendered as `<null>`. `cache_key` is the existing internal LRU
+   * key returned by ArrowFileSystemConfig::GetCacheKey().
+   */
+  [[nodiscard]] static std::string MakeDisplayKey(const ArrowFileSystemConfig& config, const std::string& cache_key);
+
   explicit FilesystemCache(size_t capacity) : cache_(capacity) {}
   ~FilesystemCache() = default;
 
   // Filesystem instance cache (LRU)
   mutable std::mutex mutex_;
-  LRUCache<std::string, ArrowFileSystemPtr> cache_;
+  LRUCache<std::string, std::shared_ptr<CacheEntry>> cache_;
 };
 
 }  // namespace milvus_storage

--- a/cpp/src/ffi/filesystem_metrics_c.cpp
+++ b/cpp/src/ffi/filesystem_metrics_c.cpp
@@ -14,13 +14,35 @@
 
 #include "milvus-storage/ffi_filesystem_metrics_c.h"
 
+#include <cstdlib>
+#include <cstring>
+
 #include "milvus-storage/ffi_internal/result.h"
 #include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/ffi/filesystem_internal.h"
 
 using ::FileSystemWrapper;
+using milvus_storage::FilesystemCache;
+using milvus_storage::FilesystemMetrics;
 using milvus_storage::Observable;
+
+static void FillMetricsSnapshot(const FilesystemMetrics::MetricsSnapshot& snapshot,
+                                LoonFilesystemMetricsSnapshot* out_metrics) {
+  out_metrics->read_count = snapshot.read_count;
+  out_metrics->write_count = snapshot.write_count;
+  out_metrics->read_bytes = snapshot.read_bytes;
+  out_metrics->write_bytes = snapshot.write_bytes;
+  out_metrics->get_file_info_count = snapshot.get_file_info_count;
+  out_metrics->create_dir_count = snapshot.create_dir_count;
+  out_metrics->delete_dir_count = snapshot.delete_dir_count;
+  out_metrics->delete_file_count = snapshot.delete_file_count;
+  out_metrics->move_count = snapshot.move_count;
+  out_metrics->copy_file_count = snapshot.copy_file_count;
+  out_metrics->failed_count = snapshot.failed_count;
+  out_metrics->multi_part_upload_created = snapshot.multi_part_upload_created;
+  out_metrics->multi_part_upload_finished = snapshot.multi_part_upload_finished;
+}
 
 LoonFFIResult loon_filesystem_get_metrics(FileSystemHandle handle, LoonFilesystemMetricsSnapshot* out_metrics) {
   try {
@@ -40,23 +62,79 @@ LoonFFIResult loon_filesystem_get_metrics(FileSystemHandle handle, LoonFilesyste
       RETURN_ERROR(LOON_INVALID_ARGS, "Filesystem metrics are not enabled");
     }
 
-    auto snapshot = metrics->GetSnapshot();
-    out_metrics->read_count = snapshot.read_count;
-    out_metrics->write_count = snapshot.write_count;
-    out_metrics->read_bytes = snapshot.read_bytes;
-    out_metrics->write_bytes = snapshot.write_bytes;
-    out_metrics->get_file_info_count = snapshot.get_file_info_count;
-    out_metrics->create_dir_count = snapshot.create_dir_count;
-    out_metrics->delete_dir_count = snapshot.delete_dir_count;
-    out_metrics->delete_file_count = snapshot.delete_file_count;
-    out_metrics->move_count = snapshot.move_count;
-    out_metrics->copy_file_count = snapshot.copy_file_count;
-    out_metrics->failed_count = snapshot.failed_count;
-    out_metrics->multi_part_upload_created = snapshot.multi_part_upload_created;
-    out_metrics->multi_part_upload_finished = snapshot.multi_part_upload_finished;
+    FillMetricsSnapshot(metrics->GetSnapshot(), out_metrics);
 
     RETURN_SUCCESS();
   } catch (const std::exception& e) {
+    RETURN_EXCEPTION(e.what());
+  }
+
+  RETURN_UNREACHABLE();
+}
+
+void loon_filesystem_free_metrics_list(LoonFilesystemMetricsList* list) {
+  if (!list) {
+    return;
+  }
+  if (list->entries) {
+    for (uint32_t i = 0; i < list->count; ++i) {
+      free(list->entries[i].display_key);
+    }
+    free(list->entries);
+    list->entries = nullptr;
+  }
+  list->count = 0;
+}
+
+LoonFFIResult loon_filesystem_list_metrics(LoonFilesystemMetricsList* out_list) {
+  try {
+    if (!out_list) {
+      RETURN_ERROR(LOON_INVALID_ARGS, "out_list must not be null");
+    }
+
+    out_list->entries = nullptr;
+    out_list->count = 0;
+
+    auto filesystems = FilesystemCache::getInstance().list();
+    if (filesystems.empty()) {
+      RETURN_SUCCESS();
+    }
+
+    auto count = static_cast<uint32_t>(filesystems.size());
+    out_list->entries = static_cast<LoonFilesystemMetricsEntry*>(calloc(count, sizeof(LoonFilesystemMetricsEntry)));
+    if (!out_list->entries) {
+      RETURN_ERROR(LOON_LOGICAL_ERROR, "Failed to allocate memory for filesystem metrics list");
+    }
+    out_list->count = count;
+
+    for (uint32_t i = 0; i < count; ++i) {
+      const auto& [display_key, fs] = filesystems[i];
+      auto observable = std::dynamic_pointer_cast<Observable>(fs);
+      if (!observable) {
+        loon_filesystem_free_metrics_list(out_list);
+        RETURN_ERROR(LOON_LOGICAL_ERROR, "Cached filesystem does not implement Observable interface");
+      }
+
+      auto metrics = observable->GetMetrics();
+      if (!metrics) {
+        loon_filesystem_free_metrics_list(out_list);
+        RETURN_ERROR(LOON_LOGICAL_ERROR, "Cached filesystem metrics are not enabled");
+      }
+
+      auto* entry = &out_list->entries[i];
+      entry->display_key = strdup(display_key.c_str());
+      if (!entry->display_key) {
+        loon_filesystem_free_metrics_list(out_list);
+        RETURN_ERROR(LOON_LOGICAL_ERROR, "Failed to duplicate filesystem display key");
+      }
+      FillMetricsSnapshot(metrics->GetSnapshot(), &entry->metrics);
+    }
+
+    RETURN_SUCCESS();
+  } catch (const std::exception& e) {
+    if (out_list) {
+      loon_filesystem_free_metrics_list(out_list);
+    }
     RETURN_EXCEPTION(e.what());
   }
 

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -191,11 +191,28 @@ FilesystemCache& FilesystemCache::getInstance() {
 
 size_t FilesystemCache::size() const { return cache_.size(); }
 
+std::vector<std::pair<std::string, ArrowFileSystemPtr>> FilesystemCache::list() const {
+  auto cached_entries = cache_.list();
+  std::vector<std::pair<std::string, ArrowFileSystemPtr>> entries;
+  entries.reserve(cached_entries.size());
+  for (const auto& cached_entry : cached_entries) {
+    entries.emplace_back(cached_entry.second->display_key, cached_entry.second->filesystem);
+  }
+  return entries;
+}
+
 void FilesystemCache::remove(const std::string& key) { cache_.remove(key); }
 
 void FilesystemCache::clean() { cache_.clean(); }
 
 void FilesystemCache::set_capacity(size_t capacity) { cache_.set_capacity(capacity); }
+
+std::string FilesystemCache::MakeDisplayKey(const ArrowFileSystemConfig& config, const std::string& cache_key) {
+  if (config.storage_type == "local") {
+    return "file://" + config.root_path + "#" + cache_key;
+  }
+  return (config.address.empty() ? "<null>" : config.address) + "/" + config.bucket_name + "#" + cache_key;
+}
 
 arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_storage::api::Properties& properties_map,
                                                                ArrowFileSystemConfig& result) {
@@ -350,14 +367,14 @@ arrow::Result<ArrowFileSystemPtr> FilesystemCache::get(const api::Properties& pr
   // protects each individual operation, but separate get() and put() calls would
   // still allow concurrent same-key misses to create multiple filesystems.
   std::lock_guard<std::mutex> lock(mutex_);
-  auto cached_fs = cache_.get(cache_key);
-  if (cached_fs.has_value()) {
-    return cached_fs.value();
+  auto cached_entry = cache_.get(cache_key);
+  if (cached_entry.has_value()) {
+    return cached_entry.value()->filesystem;
   }
 
   // Create and cache
   ARROW_ASSIGN_OR_RAISE(auto fs, CreateArrowFileSystem(config));
-  cache_.put(cache_key, fs);
+  cache_.put(cache_key, std::make_shared<CacheEntry>(CacheEntry{MakeDisplayKey(config, cache_key), fs}));
   return fs;
 }
 

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -364,6 +364,67 @@ static void test_filesystem_metrics(void) {
   loon_filesystem_destroy(fs_handle);
 }
 
+static void test_filesystem_metrics_list(void) {
+  if (is_cloud_env()) {
+    return;
+  }
+
+  loon_close_filesystems();
+
+  LoonFilesystemMetricsList metrics_list = {0};
+  LoonFFIResult rc = loon_filesystem_list_metrics(&metrics_list);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_eq(metrics_list.count, 0);
+  ck_assert(metrics_list.entries == NULL);
+
+  FileSystemHandle fs_a;
+  FileSystemHandle fs_b;
+  get_test_filesystem(&fs_a, "test_filesystem_metrics_list_a");
+  get_test_filesystem(&fs_b, "test_filesystem_metrics_list_b");
+  write_single_file(&fs_a);
+  write_single_file(&fs_b);
+
+  rc = loon_filesystem_list_metrics(&metrics_list);
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  ck_assert_int_eq(metrics_list.count, 2);
+  ck_assert(metrics_list.entries != NULL);
+  ck_assert(metrics_list.entries[0].display_key != NULL);
+  ck_assert(metrics_list.entries[1].display_key != NULL);
+  ck_assert(strcmp(metrics_list.entries[0].display_key, metrics_list.entries[1].display_key) != 0);
+
+  bool found_a = false;
+  bool found_b = false;
+  const char* prefix_a = "file://test_filesystem_metrics_list_a#fs:";
+  const char* prefix_b = "file://test_filesystem_metrics_list_b#fs:";
+  for (uint32_t i = 0; i < metrics_list.count; ++i) {
+    found_a = found_a || strncmp(metrics_list.entries[i].display_key, prefix_a, strlen(prefix_a)) == 0;
+    found_b = found_b || strncmp(metrics_list.entries[i].display_key, prefix_b, strlen(prefix_b)) == 0;
+  }
+  ck_assert(found_a);
+  ck_assert(found_b);
+
+  ck_assert_int_gt(metrics_list.entries[0].metrics.write_count, 0);
+  ck_assert_int_gt(metrics_list.entries[1].metrics.write_count, 0);
+
+  loon_filesystem_free_metrics_list(&metrics_list);
+  ck_assert_int_eq(metrics_list.count, 0);
+  ck_assert(metrics_list.entries == NULL);
+
+  rc = loon_filesystem_list_metrics(NULL);
+  ck_assert(!loon_ffi_is_success(&rc));
+  loon_ffi_free_result(&rc);
+
+  rc = loon_filesystem_delete_file(fs_a, TEST_FILE_NAME, strlen(TEST_FILE_NAME));
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  rc = loon_filesystem_delete_file(fs_b, TEST_FILE_NAME, strlen(TEST_FILE_NAME));
+  ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
+  loon_filesystem_destroy(fs_a);
+  loon_filesystem_destroy(fs_b);
+  loon_close_filesystems();
+  ck_assert_int_eq(remove("test_filesystem_metrics_list_a"), 0);
+  ck_assert_int_eq(remove("test_filesystem_metrics_list_b"), 0);
+}
+
 // Test filesystem get_file_stats function
 static void test_filesystem_get_file_stats(void) {
   LoonFFIResult rc;
@@ -930,6 +991,7 @@ void run_filesystem_suite(void) {
   RUN_TEST(test_filesystem_delete_file);
   RUN_TEST(test_filesystem_dir_operator);
   RUN_TEST(test_filesystem_metrics);
+  RUN_TEST(test_filesystem_metrics_list);
   RUN_TEST(test_filesystem_get_file_stats);
   RUN_TEST(test_filesystem_file_not_found);
   RUN_TEST(test_filesystem_write_with_metadata);

--- a/cpp/test/format/fs_cache_test.cpp
+++ b/cpp/test/format/fs_cache_test.cpp
@@ -77,6 +77,30 @@ TEST_F(FileSystemCacheTest, LRUCacheInstantiation) {
   EXPECT_FALSE(s2.has_value());
 }
 
+TEST_F(FileSystemCacheTest, LRUCacheList) {
+  LRUCache<int, std::string> cache(2);
+  cache.put(1, "a");
+  cache.put(2, "b");
+
+  auto entries = cache.list();
+  ASSERT_EQ(entries.size(), 2u);
+
+  bool found_a = false;
+  bool found_b = false;
+  for (const auto& [key, value] : entries) {
+    found_a = found_a || (key == 1 && value == "a");
+    found_b = found_b || (key == 2 && value == "b");
+  }
+  EXPECT_TRUE(found_a);
+  EXPECT_TRUE(found_b);
+
+  // Listing must not update recency. Entry 1 remains the least recently used.
+  cache.put(3, "c");
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_EQ(cache.get(2).value(), "b");
+  EXPECT_EQ(cache.get(3).value(), "c");
+}
+
 TEST_F(FileSystemCacheTest, Basic) {
   auto props1 = MakeProperties("A");
   auto props2 = MakeProperties("B");
@@ -103,6 +127,79 @@ TEST_F(FileSystemCacheTest, Basic) {
 
   cache.clean();
   EXPECT_EQ(cache.size(), 0);
+}
+
+TEST_F(FileSystemCacheTest, List) {
+  auto props1 = MakeProperties("LIST_A");
+  auto props2 = MakeProperties("LIST_B");
+  auto& cache = FilesystemCache::getInstance();
+
+  ASSERT_AND_ASSIGN(auto config1, cache.resolve_config(props1, "s3://localhost_LIST_A/bucket_LIST_A/file.parquet"));
+  ASSERT_AND_ASSIGN(auto config2, cache.resolve_config(props2, "s3://localhost_LIST_B/bucket_LIST_B/file.parquet"));
+
+  ASSERT_AND_ASSIGN(auto fs1, cache.get(props1, "s3://localhost_LIST_A/bucket_LIST_A/file.parquet"));
+  ASSERT_AND_ASSIGN(auto fs2, cache.get(props2, "s3://localhost_LIST_B/bucket_LIST_B/file.parquet"));
+
+  auto entries = cache.list();
+  ASSERT_EQ(entries.size(), 2u);
+
+  bool found_fs1 = false;
+  bool found_fs2 = false;
+  for (const auto& [display_key, fs] : entries) {
+    if (fs == fs1) {
+      EXPECT_EQ(display_key, "file:///tmp/fs_test_LIST_A#" + config1.GetCacheKey());
+      found_fs1 = true;
+    }
+    if (fs == fs2) {
+      EXPECT_EQ(display_key, "file:///tmp/fs_test_LIST_B#" + config2.GetCacheKey());
+      found_fs2 = true;
+    }
+  }
+  EXPECT_TRUE(found_fs1);
+  EXPECT_TRUE(found_fs2);
+
+  cache.remove(config1.GetCacheKey());
+  cache.remove(config2.GetCacheKey());
+  EXPECT_TRUE(cache.list().empty());
+}
+
+TEST_F(FileSystemCacheTest, ListReturnsRemoteDisplayKey) {
+  api::Properties props;
+  props[PROPERTY_FS_STORAGE_TYPE] = std::string("remote");
+  props[PROPERTY_FS_CLOUD_PROVIDER] = std::string(kCloudProviderAWS);
+  props[PROPERTY_FS_ADDRESS] = std::string("minio.example.com:9000");
+  props[PROPERTY_FS_BUCKET_NAME] = std::string("display-bucket");
+  props[PROPERTY_FS_ACCESS_KEY_ID] = std::string("ak");
+  props[PROPERTY_FS_ACCESS_KEY_VALUE] = std::string("sk");
+
+  auto& cache = FilesystemCache::getInstance();
+  ASSERT_AND_ASSIGN(auto config, cache.resolve_config(props));
+  ASSERT_AND_ASSIGN(auto fs, cache.get(props));
+
+  auto entries = cache.list();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].first, "minio.example.com:9000/display-bucket#" + config.GetCacheKey());
+  EXPECT_EQ(entries[0].second, fs);
+}
+
+TEST_F(FileSystemCacheTest, ListUsesNullForEmptyRemoteAddress) {
+  api::Properties props;
+  props[PROPERTY_FS_STORAGE_TYPE] = std::string("remote");
+  props[PROPERTY_FS_CLOUD_PROVIDER] = std::string(kCloudProviderAWS);
+  props[PROPERTY_FS_ADDRESS] = std::string("");
+  props[PROPERTY_FS_BUCKET_NAME] = std::string("display-bucket");
+  props[PROPERTY_FS_ACCESS_KEY_ID] = std::string("ak");
+  props[PROPERTY_FS_ACCESS_KEY_VALUE] = std::string("sk");
+
+  auto& cache = FilesystemCache::getInstance();
+  ASSERT_AND_ASSIGN(auto config, cache.resolve_config(props));
+  ASSERT_TRUE(config.address.empty());
+  ASSERT_AND_ASSIGN(auto fs, cache.get(props));
+
+  auto entries = cache.list();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].first, "<null>/display-bucket#" + config.GetCacheKey());
+  EXPECT_EQ(entries[0].second, fs);
 }
 
 TEST_F(FileSystemCacheTest, CacheKeyIncludesCredentialIdentity) {


### PR DESCRIPTION
Filesystem metrics could previously only be read through an individual filesystem handle, which made it difficult for callers to inspect every filesystem currently held by the global cache. Add a cache-wide listing API so callers can discover active filesystems and collect their latest metrics snapshots in one call.

Keep the existing hashed cache key as the internal LRU identity, while storing a separate human-readable display key alongside each cached filesystem. Local filesystems use file://{root_path}#{cache_key}, while remote filesystems use {address}/{bucket_name}#{cache_key}, with an empty address shown as <null>. The display key is created once when the filesystem enters the cache, and normal cache lookups continue to use the original hash without repeatedly copying the display string.

Expose the cached metrics list through the C FFI with explicit result structures and a matching release function for owned memory. Reuse the existing metrics snapshot conversion logic, clean up partially allocated results when an entry cannot be reported, and publish the new functions through both Linux and macOS symbol export lists.