### PR TITLE
fix: make the Vortex writer honor backpressure by bounding chunk concurrency

### DIFF
--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -8618,7 +8618,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "vortex-alp 0.1.0",
  "vortex-array 0.1.0",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -8724,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "arrow-buffer 58.3.0",
  "bitvec",
@@ -8930,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "num-traits",
  "vortex-array 0.1.0",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -9023,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "arrow-schema 58.3.0",
  "flatbuffers",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -9112,7 +9112,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9199,7 +9199,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "flatbuffers",
  "vortex-buffer 0.1.0",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "fsst-rs",
  "prost 0.14.1",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -9306,7 +9306,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -9341,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "arcref",
  "arrow-array 58.3.0",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer 0.1.0",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "parking_lot",
  "sketches-ddsketch",
@@ -9466,7 +9466,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "pco",
  "prost 0.14.1",
@@ -9495,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "prost 0.14.1",
  "prost-types",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "arrow-array 58.3.0",
  "itertools 0.14.0",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "async-trait",
  "futures",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "num-traits",
  "prost 0.14.1",
@@ -9613,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "dashmap",
  "lasso",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -9669,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -9690,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "vortex-array 0.1.0",
  "vortex-buffer 0.1.0",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#d971ca99448387b723519a812b45efdb25abf7ab"
+source = "git+https://github.com/zilliztech/vortex?branch=v0.75.0-patched#78803e70307fb7dda97c481f6a6cd60cb4c03baf"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.1",

--- a/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::num::NonZeroUsize;
 use std::ops::{BitAnd, Range};
 use std::sync::{Arc, Mutex};
 
@@ -1471,18 +1472,118 @@ where
     SequentialStreamAdapter::new(dtype, row_group_stream).sendable()
 }
 
-/// Splits a stream of arrays into byte-size row groups without building zonemap side data.
-///
-/// This strategy is a writer-side stream adapter only: it does not serialize a custom layout
-/// node into the Vortex footer. The emitted row-group arrays are passed to `child`, which
-/// builds the normal V2 data layout tree:
-///
-/// ```text
-/// ChunkedLayout                         // one chunk per row group
-///   StructLayout                        // row group payload
-///     field layouts: Chunked -> Compressed -> Flat
-///     validity layouts: Collect -> Compressed -> Flat
-/// ```
+// V2 writer layout-strategy topology.
+//
+// Stream items are `(SequenceId, ArrayRef)`. Arrows below describe the stream passed to the next
+// `LayoutStrategy`; returned `LayoutRef`s flow in the opposite direction. `BtrBlocksCompressor`
+// is compressor configuration, not a `LayoutStrategy`.
+//
+// CORE STREAM TRANSFORMS
+//
+//   singleton stream:
+//     A `SendableSequentialStream` containing exactly one `(SequenceId, ArrayRef)` item.
+//
+//   [ChunkedLayoutStrategy]:
+//     in: stream<chunk>
+//     child input: one singleton stream<chunk> per existing input item
+//     return: ChunkedLayout<child LayoutRef>, or the only child LayoutRef for one input item
+//     role: partition the stream on its existing chunk/row-range axis; it does not slice or merge
+//           an ArrayRef and does not choose row-group boundaries
+//
+//   [TableStrategy]:
+//     in: stream<Struct chunk>
+//     child inputs: one stream per field, plus a validity stream for a nullable Struct
+//     return: StructLayout<field LayoutRef>
+//     role: transpose the Struct stream on its field/column axis; each field stream retains one
+//           item per input Struct chunk, and nested Struct fields recurse through TableStrategy
+//
+//   [ChunkedLayoutStrategy] -> [TableStrategy] means chunks/row ranges first, then columns.
+//   [TableStrategy] -> [ChunkedLayoutStrategy] means columns first, then chunks/row ranges.
+//
+// ROOT
+//
+//   stream<Struct batch>
+//   ├── zone maps disabled
+//   │   └── [RowGroupSplitStrategy]
+//   │       ├── in: stream<Struct batch>
+//   │       ├── child input: stream<canonical Struct row group>
+//   │       │   └── {DATA} -> data LayoutRef
+//   │       └── return: data LayoutRef (no layout node of its own)
+//   │
+//   └── zone maps enabled
+//       └── [RowGroupZoneMapStrategy]
+//           ├── in: stream<Struct batch>
+//           ├── data child input: stream<canonical Struct row group>
+//           │   └── {DATA} -> data LayoutRef
+//           ├── zones child input, after {DATA} completes:
+//           │   singleton stream<Struct {
+//           │     <column>: ZoneMap stats Struct,
+//           │     __rg_boundaries: Struct<__rg_start: u64, __rg_len: u64>
+//           │   }, rows = row-group count>
+//           │   └── {ZONES} -> zones LayoutRef
+//           └── return:
+//               ├── RowGroupZoneMapLayout<data LayoutRef, zones LayoutRef>
+//               └── data LayoutRef when no column has usable ZoneMap statistics
+//
+// DATA
+//
+//   stream<canonical Struct row group>
+//   └── [ChunkedLayoutStrategy] (outer, row-group level; max concurrent children = 1)
+//       ├── child input per row group: singleton stream<Struct row group>
+//       │   └── [TableStrategy]
+//       │       ├── nullable Struct validity: stream<Bool validity>
+//       │       │   └── [CollectStrategy] -> singleton stream<Chunked Bool validity>
+//       │       │       └── [CompressingStrategy] (BtrBlocks defaults minus ALP-RD)
+//       │       │           └── singleton stream<compressed Bool validity>
+//       │       │               └── [FlatLayoutStrategy] (inline array node) -> FlatLayout
+//       │       ├── nested Struct field: stream<Struct field>
+//       │       │   └── [TableStrategy] recursively -> StructLayout
+//       │       ├── non-Struct field: stream<field>
+//       │       │   └── [ChunkedLayoutStrategy] (inner, field-chunk level)
+//       │       │       ├── child input per chunk: singleton stream<field>
+//       │       │       │   └── [PredefinedFlatDataStrategy]
+//       │       │       │       ├── FixedSizeList
+//       │       │       │       │   └── [FlatLayoutStrategy] (inline array node) -> FlatLayout
+//       │       │       │       └── other dtype
+//       │       │       │           └── [CompressingStrategy] (BtrBlocks defaults minus ALP-RD)
+//       │       │       │               └── singleton stream<compressed field>
+//       │       │       │                   └── [FlatLayoutStrategy] (inline array node)
+//       │       │       │                       └── FlatLayout
+//       │       │       └── return: ChunkedLayout, or its only child LayoutRef for one chunk
+//       │       └── return: StructLayout for one row group
+//       └── return: ChunkedLayout<StructLayout per row group>, or the only StructLayout
+//
+// ZONES
+//
+//   singleton stream<zones Struct, rows = row-group count>
+//   └── [TableStrategy]
+//       ├── nested ZoneMap or __rg_boundaries Struct: stream<Struct field>
+//       │   └── [TableStrategy] recursively -> StructLayout
+//       ├── nullable Struct validity, when present: stream<Bool validity>
+//       │   └── [CollectStrategy] -> singleton stream<Chunked Bool validity>
+//       │       └── [CompressingStrategy] (BtrBlocks defaults)
+//       │           └── singleton stream<compressed Bool validity>
+//       │               └── [FlatLayoutStrategy] (array node not inlined) -> FlatLayout
+//       ├── ZoneMap-stat or boundary leaf: stream<leaf>
+//       │   └── [CompressingStrategy] (BtrBlocks defaults)
+//       │       └── singleton stream<compressed leaf>
+//       │           └── [FlatLayoutStrategy] (array node not inlined) -> FlatLayout
+//       └── return: zones StructLayout
+//
+// LAYOUT RESULTS
+//
+//   [RowGroupZoneMapStrategy] -> RowGroupZoneMapLayout
+//   [ChunkedLayoutStrategy]   -> ChunkedLayout, or its only child LayoutRef for one chunk
+//   [TableStrategy]           -> StructLayout
+//   [FlatLayoutStrategy]      -> FlatLayout backed by one segment
+//
+//   [RowGroupSplitStrategy], [CollectStrategy], [CompressingStrategy], and
+//   [PredefinedFlatDataStrategy] only transform or route streams and return their child LayoutRef.
+//   The stats-enabled root writes DATA to completion before ZONES, so all data segments precede
+//   all ZoneMap and row-group-boundary segments.
+
+/// Splits a stream of arrays into byte-size row groups without building ZoneMap side data.
+/// This is a stream adapter and returns its child's layout directly.
 struct RowGroupSplitStrategy {
     child: Arc<dyn LayoutStrategy>,
     options: RowGroupSplitOptions,
@@ -1521,24 +1622,9 @@ impl LayoutStrategy for RowGroupSplitStrategy {
     }
 }
 
-/// Builds the row-group data layout plus a sidecar zonemap layout used for pruning.
-///
-/// Unlike `RowGroupSplitStrategy`, this strategy does serialize a custom root layout. The
-/// root's data child is the same row-grouped V2 data tree produced by `RowGroupSplitStrategy`.
-/// The zones child is a struct with one row per row group: each real column with usable stats
-/// stores a Vortex `ZoneMap` stats table, and `__rg_boundaries` maps row-group pruning results
-/// back to row ranges.
-///
-/// ```text
-/// RowGroupZoneMapLayout                 // encoding: milvus.v2_zoned_row_group
-///   data: ChunkedLayout                 // one chunk per row group
-///     StructLayout
-///       field layouts: Chunked -> Compressed -> Flat
-///       validity layouts: Collect -> Compressed -> Flat
-///   zones: StructLayout                 // one row per row group
-///     <column>: Compressed -> Flat      // per-column ZoneMap stats table
-///     __rg_boundaries: Compressed -> Flat
-/// ```
+/// Builds the row-group data layout and its row-group ZoneMap side data. This strategy writes the
+/// data child first, writes the zones child second, and returns the custom root layout described
+/// in the topology above.
 pub struct RowGroupZoneMapStrategy {
     data_child: Arc<dyn LayoutStrategy>,
     zones_child: Arc<dyn LayoutStrategy>,
@@ -1906,7 +1992,10 @@ fn build_data_strategy() -> Arc<dyn LayoutStrategy> {
     let chunked_inner = ChunkedLayoutStrategy::new(data_child);
     let validity = CollectStrategy::new(compress_flat);
     let struct_inner = TableStrategy::new(Arc::new(validity), Arc::new(chunked_inner));
-    Arc::new(ChunkedLayoutStrategy::new(struct_inner))
+    Arc::new(
+        ChunkedLayoutStrategy::new(struct_inner)
+            .with_max_concurrent_children(NonZeroUsize::MIN),
+    )
 }
 
 fn build_zones_strategy() -> Arc<dyn LayoutStrategy> {

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -305,6 +305,8 @@ class APIWriterReaderTest : public ::testing::TestWithParam<std::tuple<std::stri
   milvus_storage::api::Properties properties_;
 };
 
+class VortexWriterBufferTest : public APIWriterReaderTest {};
+
 TEST_P(APIWriterReaderTest, SingleColumnGroupWriteRead) {
   ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
   auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
@@ -1623,6 +1625,38 @@ TEST_P(APIWriterReaderTest, RowAlignmentWithMultipleRowGroups) {
   EXPECT_GT(batch_count, 1);
 }
 
+TEST_P(VortexWriterBufferTest, V2BoundsRetainedInputBuffers) {
+  ASSERT_EQ(SetValue(properties_, PROPERTY_WRITER_BUFFER_SIZE, "262144"), std::nullopt);
+  ASSERT_EQ(SetValue(properties_, PROPERTY_WRITER_VORTEX_FORMAT_VERSION, "2"), std::nullopt);
+  ASSERT_EQ(SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, "131072"), std::nullopt);
+
+  ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy("id|name,value|vector", format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  ASSERT_NE(writer, nullptr);
+
+  std::vector<std::weak_ptr<arrow::Buffer>> input_buffers;
+  // Exceed one in-flight row group per column group plus the pending input.
+  constexpr int kBatchCount = 6;
+  constexpr int64_t kRowsPerBatch = 8192;
+  for (int batch_index = 0; batch_index < kBatchCount; ++batch_index) {
+    ASSERT_AND_ASSIGN(auto batch, CreateTestData(schema_, batch_index * kRowsPerBatch, false, kRowsPerBatch));
+    input_buffers.emplace_back(batch->column(0)->data()->buffers[1]);
+    input_buffers.emplace_back(
+        std::static_pointer_cast<arrow::ListArray>(batch->column(3))->values()->data()->buffers[1]);
+    ASSERT_STATUS_OK(writer->write(batch));
+    batch.reset();
+  }
+
+  EXPECT_TRUE(input_buffers[0].expired()) << "old input buffers must not remain live until Close";
+  EXPECT_TRUE(input_buffers[1].expired()) << "old input buffers must not remain live until Close";
+
+  ASSERT_AND_ASSIGN(auto column_groups, writer->close());
+  ASSERT_EQ(column_groups->size(), 2);
+  for (const auto& buffer : input_buffers) {
+    EXPECT_TRUE(buffer.expired());
+  }
+}
+
 TEST_P(APIWriterReaderTest, TakeMethodTest) {
   std::string patterns = "id, name, value|vector";
   ASSERT_AND_ASSIGN(auto policy, CreateSchemaBasePolicy(patterns, format, schema_));
@@ -2707,5 +2741,9 @@ INSTANTIATE_TEST_SUITE_P(APIWriterReaderTestP,
                          APIWriterReaderTest,
                          ::testing::Combine(::testing::Values(LOON_FORMAT_PARQUET, LOON_FORMAT_VORTEX),
                                             ::testing::Values(1, 4)));
+
+INSTANTIATE_TEST_SUITE_P(VortexV2,
+                         VortexWriterBufferTest,
+                         ::testing::Values(std::make_tuple(std::string(LOON_FORMAT_VORTEX), size_t{1})));
 
 }  // namespace milvus_storage::test


### PR DESCRIPTION
issue: [#52180](https://github.com/milvus-io/milvus/issues/52180)

After private PR in https://github.com/zilliztech/vortex/pull/3.

Vortex V2 was not propagating writer backpressure correctly because the outer ChunkedLayoutStrategy allowed an unlimited number of row-group children to run concurrently. As the writer kept pulling new row groups into the pipeline, child futures, layout results, and their input Arrow buffers stayed alive until the write finished, causing memory usage to grow with the total amount of data written.

Update the patched Vortex dependency to use the new configurable child-concurrency API, and limit the outer row-group ChunkedLayoutStrategy to one in-flight child. The inner field-level ChunkedLayoutStrategy keeps its default behavior because each invocation already receives a singleton field stream within one row group, so it does not contribute to growth across row groups.

Once the active row-group child is complete, the outer strategy can release its retained RecordBatch buffers before pulling the next row group. This lets backpressure travel back through the layout pipeline and keeps memory tied to the active write window instead of the total number of row groups in the file.

Also document the Vortex V2 layout strategy tree and the stream boundaries between each strategy. The updated diagram explains how ChunkedLayoutStrategy creates singleton child streams, how TableStrategy splits Struct chunks into field streams, and how the data and ZoneMap layouts are assembled.