### PR TITLE
fix: [3.0] size sliced batches by referenced buffers

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,7 +40,6 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     timeout-minutes: 180
-    continue-on-error: true  # Tests may fail due to conan dependency compatibility issues
     strategy:
       matrix:
         python-version: ['3.11']
@@ -98,26 +97,27 @@ jobs:
 
       - name: Set library path
         run: |
-          # Find all conan library directories and add to LD_LIBRARY_PATH
-          CONAN_LIB_PATHS=$(find ~/.conan2/p -name "lib" -type d 2>/dev/null | grep "/p/" | tr '\n' ':')
-          # Remove trailing colon from CONAN_LIB_PATHS if present
-          CONAN_LIB_PATHS="${CONAN_LIB_PATHS%:}"
-          # Put CONAN_LIB_PATHS first to ensure conan-provided libraries (like newer liblzma) are preferred over system ones
-          echo "LD_LIBRARY_PATH=${CONAN_LIB_PATHS}:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          BUILD_DIR="$GITHUB_WORKSPACE/cpp/build/Release"
+          BUILD_LIB_DIR="$BUILD_DIR/libs"
 
-          # Find Conan's liblzma and preload it to override system liblzma
-          CONAN_LZMA=$(find ~/.conan2/p -name "liblzma.so*" -path "*/lib/*" 2>/dev/null | head -n 1)
+          # Use the dependency libraries copied for this build. Scanning the
+          # whole Conan cache can put stale/incompatible libraries before the
+          # ones that match libmilvus-storage.so.
+          echo "LD_LIBRARY_PATH=$BUILD_LIB_DIR:$BUILD_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> $GITHUB_ENV
+
+          # Preload the liblzma copied for this build to override system liblzma.
+          BUILD_LZMA=$(find "$BUILD_LIB_DIR" -name "liblzma.so*" -type f 2>/dev/null | sort | head -n 1)
 
           # Build LD_PRELOAD list for libraries that need to be forced at runtime
           PRELOAD_LIBS=""
 
-          if [ -n "$CONAN_LZMA" ]; then
-            echo "Found Conan liblzma at: $CONAN_LZMA"
-            echo "Checking symbol in $CONAN_LZMA:"
-            nm -D "$CONAN_LZMA" | grep lzma_index_uncompressed_size || echo "Symbol NOT FOUND in Conan lib"
-            PRELOAD_LIBS="$CONAN_LZMA"
+          if [ -n "$BUILD_LZMA" ]; then
+            echo "Found build liblzma at: $BUILD_LZMA"
+            echo "Checking symbol in $BUILD_LZMA:"
+            nm -D "$BUILD_LZMA" | grep lzma_index_uncompressed_size || echo "Symbol NOT FOUND in build lib"
+            PRELOAD_LIBS="$BUILD_LZMA"
           else
-            echo "WARNING: Conan liblzma.so* not found! Verify xz_utils:shared=True"
+            echo "WARNING: build liblzma.so* not found! Verify xz_utils:shared=True"
           fi
 
           echo "Checking system liblzma symbol:"
@@ -144,12 +144,20 @@ jobs:
 
       - name: Verify library dependencies
         run: |
+          set -o pipefail
+
           echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+          echo "libmilvus-storage dependency resolution:"
+          ldd -r cpp/build/Release/libmilvus-storage.so 2>&1 | tee /tmp/libmilvus-storage.ldd
+          if grep -q "not found\\|undefined symbol" /tmp/libmilvus-storage.ldd; then
+            echo "Runtime dependency resolution failed"
+            exit 1
+          fi
           # Check if liblzma is available
           ldconfig -p | grep lzma || echo "liblzma not in ldconfig, checking file system..."
           ls -la /usr/lib/x86_64-linux-gnu/liblzma* || true
           # Check glog dependencies
-          find ~/.conan2/p -name "libglog.so*" -exec ldd {} \; 2>/dev/null | head -20 || true
+          find cpp/build/Release/libs -name "libglog.so*" -exec ldd {} \; 2>/dev/null | head -20 || true
 
       - name: Run tests
         working-directory: ./python

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -18,6 +18,7 @@
 
 #include <arrow/io/buffered.h>
 #include <arrow/io/memory.h>
+#include <arrow/util/byte_size.h>
 #include <parquet/properties.h>
 #include <parquet/metadata.h>
 #include <boost/variant.hpp>
@@ -221,8 +222,9 @@ arrow::Status ParquetFileWriter::Write(const std::shared_ptr<arrow::RecordBatch>
   if (!record) {
     return arrow::Status::OK();
   }
+  ARROW_ASSIGN_OR_RAISE(auto referenced_size, arrow::util::ReferencedBufferSize(*record));
+  auto batch_size = static_cast<size_t>(referenced_size);
   cached_batches_.push_back(record);
-  auto batch_size = milvus_storage::GetRecordBatchMemorySize(record);
   cached_batch_sizes_.push_back(batch_size);
   cached_size_ += batch_size;
   return arrow::Status::OK();

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -146,6 +146,55 @@ TEST_F(ParquetFileWriterTest, LargeRecordBatchSplitting) {
   }
 }
 
+TEST_F(ParquetFileWriterTest, SlicedRecordBatchUsesCompactRowGroupSize) {
+  const int64_t total_rows = 4096;
+  const int64_t slice_rows = 64;
+  const int32_t vector_bytes = 512;
+
+  auto vector_field = arrow::field("vector", arrow::fixed_size_binary(vector_bytes), false,
+                                   arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"101"}));
+  auto schema = arrow::schema({vector_field});
+
+  arrow::FixedSizeBinaryBuilder builder(arrow::fixed_size_binary(vector_bytes));
+  std::vector<uint8_t> vector(vector_bytes, 0);
+  for (int64_t i = 0; i < total_rows; ++i) {
+    vector[0] = static_cast<uint8_t>(i % 256);
+    ASSERT_TRUE(builder.Append(vector.data()).ok());
+  }
+  auto array = builder.Finish().ValueOrDie();
+
+  for (int64_t offset : {int64_t{0}, int64_t{1024}}) {
+    auto sliced = array->Slice(offset, slice_rows);
+    auto record = arrow::RecordBatch::Make(schema, slice_rows, {sliced});
+    ASSERT_GT(GetRecordBatchMemorySize(record), DEFAULT_MAX_ROW_GROUP_SIZE);
+
+    std::string temp_file = "/tmp/test_sliced_batch_" + std::to_string(offset) + ".parquet";
+    StorageConfig config;
+    std::vector<std::string> paths = {temp_file};
+    std::vector<std::vector<int>> column_groups = {{0}};
+    ASSERT_AND_ASSIGN(auto writer,
+                      PackedRecordBatchWriter::Make(fs_, paths, schema, config, column_groups, 2 * 1024 * 1024));
+    ASSERT_TRUE(writer->Write(record).ok());
+    ASSERT_TRUE(writer->Close().ok());
+
+    ASSERT_AND_ASSIGN(auto reader, FileRowGroupReader::Make(fs_, temp_file, schema));
+    auto metadata = reader->file_metadata()->GetRowGroupMetadataVector();
+    ASSERT_EQ(metadata.size(), 1);
+    EXPECT_EQ(metadata.Get(0).row_num(), slice_rows);
+    EXPECT_LT(metadata.Get(0).memory_size(), DEFAULT_MAX_ROW_GROUP_SIZE);
+
+    ASSERT_TRUE(reader->SetRowGroupOffsetAndCount(0, 1).ok());
+    std::shared_ptr<arrow::Table> table;
+    ASSERT_TRUE(reader->ReadNextRowGroup(&table).ok());
+    ASSERT_NE(table, nullptr);
+    ASSERT_AND_ASSIGN(auto actual, table->CombineChunksToBatch());
+    EXPECT_TRUE(actual->Equals(*record));
+    ASSERT_TRUE(reader->Close().ok());
+
+    std::remove(temp_file.c_str());
+  }
+}
+
 TEST_F(ParquetFileWriterTest, EmptyRecordBatch) {
   // Test writing empty record batch
   // Create empty arrays for each column in the schema


### PR DESCRIPTION
Forward-port of #637 to `3.0`.

Related to #633 and alternative implementation to #635.

## What changed

- Use `arrow::util::ReferencedBufferSize` for Parquet row-group sizing.
- Cache the original sliced `RecordBatch` instead of materializing every column.
- Keep `GetRecordBatchMemorySize` unchanged for retained-memory backpressure.

This fixes sliced-batch row-group sizing without an extra full-batch allocation and copy.

## Validation

- Added regression coverage for sliced fixed-size-binary batches at zero and non-zero offsets.
- `git diff --check` passes.
- Full unit test suite: pending CI.