### PR TITLE
fix: harden cloud filesystem errors and lifecycle

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -30,7 +30,7 @@ jobs:
       # Conan 2.x CMakeDeps doesn't propagate system_libs through shared library targets,
       # so libaio (required by folly) must be explicitly installed and linked.
       - name: Install system libraries
-        run: sudo apt-get update && sudo apt-get install -y libaio-dev
+        run: sudo apt-get update && sudo apt-get install -y libaio-dev protobuf-compiler
 
       - name: Setup Rust
         id: rust-toolchain
@@ -40,8 +40,12 @@ jobs:
         id: rust-cache
         uses: actions/cache/restore@v4
         with:
+          # The second path is `cargo test`'s own target dir -- the CMake bridge
+          # build above does not share it, so without caching it the test step
+          # cold-builds the whole vortex dependency tree every run.
           path: |
             cpp/build/Release/cargo/build
+            cpp/src/format/bridge/rust/target
           key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
           restore-keys: |
             storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
@@ -67,6 +71,17 @@ jobs:
         run: |
           make build USE_ASAN=True BUILD_TYPE=Release
 
+      # The bridge's own unit tests. Until this step existed, `cargo test` ran
+      # nowhere in CI, so anything asserted on the Rust side was a gate that
+      # never fired -- which is why the vortex classifier's guarantees were
+      # pinned only from C++, where the interesting inputs (a layout metadata
+      # buffer damaged in a specific way) are not reachable.
+      #
+      # --lib only: the integration tests reach for object storage.
+      - name: Rust bridge unit tests
+        working-directory: ./cpp/src/format/bridge/rust
+        run: cargo test --lib
+
       - name: Save rust build cache
         if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -74,6 +89,7 @@ jobs:
         with:
           path: |
             cpp/build/Release/cargo/build
+            cpp/src/format/bridge/rust/target
           key: ${{ steps.rust-cache.outputs.cache-primary-key }}
 
       - name: Save conan package cache
@@ -94,6 +110,47 @@ jobs:
             cpp/build/Release/libs/
             cpp/build/Release/libmilvus-storage.so*
             cpp/build/Release/**/*.gcno
+
+  build-crt:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: aminya/setup-cpp@v1
+        with:
+          conan: 2.25.1
+          cmake: true
+
+      - name: Install system libraries
+        run: sudo apt-get update && sudo apt-get install -y libaio-dev protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore conan package cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.conan2
+          key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
+          restore-keys: |
+            conan-cpp-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: setup conan
+        run: |
+          conan profile detect --force
+          conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
+          conan remote list
+
+      - name: Build with CRT
+        working-directory: ./cpp
+        run: |
+          make build USE_ASAN=True BUILD_TYPE=Release WITH_CRT=True
+
+      - name: Run CRT footer regression test
+        working-directory: ./cpp
+        run: ./build/Release/test/milvus_test --gtest_filter='*ParquetFooterFastPathUsesCrtReadAtAsyncInto*'
 
   lint:
     runs-on: ubuntu-22.04

--- a/cpp/ffi_exports.map
+++ b/cpp/ffi_exports.map
@@ -49,7 +49,6 @@
     loon_errcode_aws_precondition_failed;
     loon_errcode_aws_not_found;
     loon_errcode_aws_access_denied;
-    loon_errcode_aws_non_retryable;
 
     # Properties interface
     loon_properties_create;

--- a/cpp/ffi_exports_mac.map
+++ b/cpp/ffi_exports_mac.map
@@ -47,7 +47,6 @@ _loon_errcode_aws_conflict
 _loon_errcode_aws_precondition_failed
 _loon_errcode_aws_not_found
 _loon_errcode_aws_access_denied
-_loon_errcode_aws_non_retryable
 
 # Properties interface
 _loon_properties_create

--- a/cpp/include/milvus-storage/common/writer_status.h
+++ b/cpp/include/milvus-storage/common/writer_status.h
@@ -1,0 +1,45 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mutex>
+#include <utility>
+
+#include <arrow/status.h>
+
+namespace milvus_storage {
+
+/// Thread-safe first-failure state for writers with asynchronous work.
+class WriterStatus {
+  public:
+  [[nodiscard]] arrow::Status Check() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return status_;
+  }
+
+  [[nodiscard]] arrow::Status RecordFirstFailure(arrow::Status status) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!status.ok() && status_.ok()) {
+      status_ = std::move(status);
+    }
+    return status_.ok() ? status : status_;
+  }
+
+  private:
+  mutable std::mutex mutex_;
+  arrow::Status status_ = arrow::Status::OK();
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/ffi_internal/ffi_error_code.h
+++ b/cpp/include/milvus-storage/ffi_internal/ffi_error_code.h
@@ -73,7 +73,7 @@
 #define LOON_AWS_ERROR_PRECONDITION_FAILED LOON_STORAGE_PRECONDITION_FAILED
 #define LOON_AWS_ERROR_NOT_FOUND LOON_STORAGE_NOT_FOUND
 #define LOON_AWS_ERROR_ACCESS_DENIED LOON_STORAGE_ACCESS_DENIED
-#define LOON_AWS_ERROR_NON_RETRYABLE 106
+// 106 retired (was LOON_AWS_ERROR_NON_RETRYABLE). Never reuse.
 #define LOON_TRANSIENT_NETWORK 107
 #define LOON_TRANSIENT_TIMEOUT 108
 #define LOON_TRANSIENT_THROTTLING 109
@@ -201,7 +201,6 @@
     LOON_ERROR_CATEGORY_CONFLICT)                                                                               \
   X(StorageNotFound, LOON_STORAGE_NOT_FOUND, storage_not_found, LOON_ERROR_CATEGORY_SYSTEM)                     \
   X(StorageAccessDenied, LOON_STORAGE_ACCESS_DENIED, storage_access_denied, LOON_ERROR_CATEGORY_SYSTEM)         \
-  X(AwsErrorNonRetryable, LOON_AWS_ERROR_NON_RETRYABLE, aws_non_retryable, LOON_ERROR_CATEGORY_SYSTEM)          \
   X(StorageTransientNetwork, LOON_TRANSIENT_NETWORK, transient_network, LOON_ERROR_CATEGORY_RETRYABLE)          \
   X(StorageTransientTimeout, LOON_TRANSIENT_TIMEOUT, transient_timeout, LOON_ERROR_CATEGORY_RETRYABLE)          \
   X(StorageTransientThrottling, LOON_TRANSIENT_THROTTLING, transient_throttling, LOON_ERROR_CATEGORY_RETRYABLE) \

--- a/cpp/include/milvus-storage/filesystem/azure/azurefs_internal.h
+++ b/cpp/include/milvus-storage/filesystem/azure/azurefs_internal.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include "arrow/result.h"
@@ -29,6 +31,10 @@ class DataLakeFileSystemClient;
 class DataLakeServiceClient;
 }  // namespace Azure::Storage::Files::DataLake
 
+namespace Azure::Core {
+class RequestFailedException;
+}  // namespace Azure::Core
+
 namespace milvus_storage::fs {
 
 using arrow::Result;
@@ -37,13 +43,18 @@ struct AzureOptions;
 
 namespace internal {
 
+enum class AzureResourceKind : uint8_t {
+  Unknown,
+  Container,
+};
+
 /// \brief Map an Azure failure onto the shared ExtendStatusCode taxonomy.
 ///
 /// Producer owns classification: the Azure filesystem is the only layer that
-/// still has the typed `RequestFailedException`, so the transient-vs-permanent
+/// still has the typed `RequestFailedException`, so the retryable-vs-system
 /// verdict has to be made here. Anything this returns `nullopt` for stays an
-/// untagged `Status::IOError` and reaches segcore as StorageError/2044 --
-/// permanent and non-retriable, the same conservative default the S3 path uses.
+/// untagged `Status::IOError` and reaches segcore as the conservative,
+/// non-retryable StorageError/2044 fallback used by the S3 path too.
 ///
 /// Takes the raw HTTP status rather than the SDK enum so it can be unit-tested
 /// without an Azure account or a synthesized SDK exception.
@@ -59,9 +70,79 @@ namespace internal {
 /// \param transport_failure true only for `Azure::Core::Http::TransportException`
 ///        -- the request never reached the service (connection refused/reset,
 ///        DNS, TLS). `http_status` is ignored when this is set.
-std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(int http_status,
-                                                                   std::string_view error_code,
-                                                                   bool transport_failure);
+/// \param reason_phrase the exception's ReasonPhrase, used only to tell a
+///        missing CONTAINER from a missing blob on a 404. Azure sometimes
+///        leaves ErrorCode empty and says it there instead -- the same reason
+///        IsContainerNotFound checks both. Defaulted so the many call sites
+///        that only have a status and an error code keep compiling; omitting it
+///        costs nothing but the container/blob distinction.
+/// \param resource_kind identifies container-level operations when a proxy has
+///        removed both ErrorCode and ReasonPhrase from a 404 response.
+std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(
+    int http_status,
+    std::string_view error_code,
+    bool transport_failure,
+    std::string_view reason_phrase = {},
+    AzureResourceKind resource_kind = AzureResourceKind::Unknown);
+
+/// TODO(stringly-typed): the LoonBroker* error codes are stringly-typed. A
+/// broker failure travels through Azure's HTTP-only policy interface as a magic
+/// string in `x-ms-error-code`, then is matched back by string comparison in
+/// BrokerErrorCodeToExtendStatus. A typo or a drift between the producer
+/// (azure_sas_token_policy.cpp) and the consumer silently degrades the
+/// classification to "unclassified / non-retriable" with no compile-time
+/// protection. Replace with a typed code once the SDK pipeline exposes a
+/// channel that carries an ExtendStatusCode end to end.
+///
+/// Every synthetic response the SAS policy stamps when it cannot obtain a token
+/// carries an error code under this prefix. The prefix is what lets
+/// ClassifyAzureError short-circuit: a LoonBroker* code means "this failure
+/// came from the local credential broker, not from Azure Storage", so it is
+/// decoded by BrokerErrorCodeToExtendStatus instead of the HTTP-status switch
+/// that handles real Azure responses.
+inline constexpr const char* kSyntheticBrokerErrorCodePrefix = "LoonBroker";
+
+/// The broker rejected our credentials (401/403). A genuine verdict, not a
+/// fallback: only a broker that actually rejected us reaches this code.
+inline constexpr const char* kSyntheticBrokerAccessDeniedErrorCode = "LoonBrokerAccessDenied";
+
+/// The broker request timed out or its context deadline fired.
+inline constexpr const char* kSyntheticBrokerTimeoutErrorCode = "LoonBrokerTimeout";
+
+/// The broker throttled us.
+inline constexpr const char* kSyntheticBrokerThrottlingErrorCode = "LoonBrokerThrottling";
+
+/// The broker answered 5xx or is otherwise transiently unwell.
+inline constexpr const char* kSyntheticBrokerServiceUnavailableErrorCode = "LoonBrokerServiceUnavailable";
+
+/// The broker could not be reached at all (connection refused/reset, DNS, TLS).
+inline constexpr const char* kSyntheticBrokerNetworkErrorCode = "LoonBrokerNetworkFailure";
+
+/// Carries an unclassified broker-side failure through Azure's HTTP-only
+/// policy interface without relabelling it as authentication or service
+/// availability. Deliberately System, not retryable: the only producer left is
+/// `catch (...)`, i.e. an exception we did not anticipate, which is almost
+/// always our bug -- replaying a bug only reproduces it, and the taxonomy never
+/// invents retriability.
+inline constexpr const char* kSyntheticBrokerUnexpectedErrorCode = "LoonBrokerUnexpectedFailure";
+
+/// Carries an allocation failure through Azure's HTTP-only policy interface.
+/// AzureExceptionToStatus restores it to arrow::Status::OutOfMemory so the
+/// direct C++ boundary can map it to MemAllocateFailed.
+inline constexpr const char* kSyntheticBrokerOutOfMemoryErrorCode = "LoonBrokerOutOfMemory";
+
+/// Map a LoonBroker* error code back to the ExtendStatusCode the SAS policy
+/// started from. Returns nullopt for the OOM/unexpected codes, which are not
+/// ExtendStatusCode conditions -- AzureExceptionToStatus handles them before
+/// the general classifier is reached.
+std::optional<milvus_storage::ExtendStatusCode> BrokerErrorCodeToExtendStatus(std::string_view error_code);
+
+/// Translate the typed Azure exception while its ErrorCode and dynamic type
+/// are still available. Public only for unit tests; production call sites use
+/// the variadic ExceptionToStatus wrapper in azurefs.cc.
+arrow::Status AzureExceptionToStatus(const Azure::Core::RequestFailedException& exception,
+                                     std::string prefix,
+                                     AzureResourceKind resource_kind = AzureResourceKind::Unknown);
 
 enum class HierarchicalNamespaceSupport {
   kUnknown = 0,

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <string_view>
+#include <cctype>
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <mutex>
@@ -123,6 +126,43 @@ bool IsLocalFileSystem(const ArrowFileSystemPtr& fs);
  * - Absolute URIs: s3://[endpoint/]bucket/key
  * - Relative paths: path/to/file
  */
+/// \brief Does this string name a location, or is it a path relative to
+/// whatever filesystem the deployment is configured with?
+///
+/// Cheap and syntactic on purpose -- no parse, no allocation. It exists so a
+/// caller can answer "is this location the user's?" before deciding whose
+/// fault a configuration failure is: an absolute URI is the user's, a relative
+/// path is resolved by the deployment's own fs.* settings.
+///
+/// Same RFC 3986 test StorageUri::Parse uses to decide a malformed URI is a
+/// malformed URI rather than a filename; the two must agree or a string could
+/// be "user-supplied" to one and "relative" to the other.
+[[nodiscard]] inline bool HasUriScheme(std::string_view text) {
+  const auto colon = text.find(':');
+  if (colon == std::string_view::npos || colon <= 1 || std::isalpha(static_cast<unsigned char>(text.front())) == 0) {
+    return false;
+  }
+  return std::all_of(text.begin(), text.begin() + static_cast<std::ptrdiff_t>(colon),
+                     [](unsigned char c) { return std::isalnum(c) != 0 || c == '+' || c == '-' || c == '.'; });
+}
+
+/// \brief Does this string parse as a URI at all?
+///
+/// Purely syntactic (RFC 3986), and deliberately narrower than
+/// StorageUri::Parse: it answers "are these bytes a URI", not "is this a
+/// location this build can open". "s3://bucket/%ZZ" is false here -- a
+/// percent-escape that is not one is a mangled string, whoever wrote it.
+/// "s3://bucket/key" is TRUE here even though StorageUri::Parse rejects it,
+/// because that rejection is about an addressing convention this build does
+/// not support, not about the bytes being damaged.
+///
+/// The distinction exists because the two failures have different owners: a
+/// manifest that has stored an unparseable location holds bad content, while a
+/// manifest holding a well-formed URI in an unsupported form is a
+/// configuration/compatibility problem. Only the first may be called
+/// corruption.
+[[nodiscard]] bool IsParseableUri(const std::string& text);
+
 struct StorageUri {
   std::string scheme;       // URI scheme (e.g., "s3"), or "" for relative paths
   std::string address;      // Optional endpoint/host, or "" for relative paths

--- a/cpp/include/milvus-storage/filesystem/gcp/gcp_credential_provider.h
+++ b/cpp/include/milvus-storage/filesystem/gcp/gcp_credential_provider.h
@@ -30,10 +30,12 @@ struct ArrowFileSystemConfig;
 // GcpCredentialProvider abstracts the identity attached to GCP requests.
 //
 // A provider is looked up per-request by (endpoint, bucket) via
-// GcpCredentialRegistry. The GCP HTTP factory calls AuthorizationHeader() at
-// request creation to inject OAuth2 Bearer (IAM modes), and the HTTP delegator
-// calls MaybeSignConditionalWrite() to re-sign conditional writes with
-// GOOG4-HMAC-SHA256 (HMAC mode).
+// GcpCredentialRegistry. Immediately before sending, the GCP HTTP delegator
+// calls AuthorizationHeader() to inject OAuth2 Bearer (IAM modes), then calls
+// MaybeSignConditionalWrite() to re-sign conditional writes with
+// GOOG4-HMAC-SHA256 (HMAC mode). Keeping token resolution and its Result in the
+// same send call makes failures request-local: a failed token lookup can never
+// be mistaken for another request's successful lookup.
 //
 // Concrete implementations (VM IAM / Impersonation / HMAC) live entirely in
 // the .cpp — callers only ever see this interface and the factory below.
@@ -43,12 +45,20 @@ class GcpCredentialProvider {
 
   // Returns {header_name, header_value} for IAM/Impersonation modes, or
   // std::nullopt for HMAC (AWS SDK's SigV4 will sign the request itself).
-  virtual std::optional<std::pair<std::string, std::string>> AuthorizationHeader() = 0;
+  // A token-fetch failure is returned directly to the delegator; it must not
+  // be stored on the provider or converted into an anonymous request.
+  virtual arrow::Result<std::optional<std::pair<std::string, std::string>>> AuthorizationHeader() = 0;
 
   // Re-signs conditional writes using GOOG4-HMAC-SHA256 (HMAC mode only).
   // No-op for IAM/Impersonation modes.
   virtual arrow::Status MaybeSignConditionalWrite(const std::shared_ptr<Aws::Http::HttpRequest>& request) = 0;
 };
+
+// Resolve and attach the authorization header for exactly this request.
+// HMAC providers return OK without changing the request. OAuth2 failures are
+// returned to the caller before the underlying HTTP client is invoked.
+arrow::Status ApplyGcpAuthorizationHeader(const std::shared_ptr<GcpCredentialProvider>& provider,
+                                          const std::shared_ptr<Aws::Http::HttpRequest>& request);
 
 // Build the appropriate provider from a filesystem config. Returns
 // arrow::Status::Invalid when the config doesn't match any supported credential

--- a/cpp/include/milvus-storage/filesystem/gcp/gcp_credential_registry.h
+++ b/cpp/include/milvus-storage/filesystem/gcp/gcp_credential_registry.h
@@ -20,7 +20,9 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
+#include <arrow/result.h>
 #include <aws/core/http/URI.h>
 
 #include "milvus-storage/filesystem/gcp/gcp_credential_provider.h"
@@ -63,7 +65,24 @@ struct GcpBucketKeyHash {
 // present, or use_ssl otherwise.
 GcpEndpointKey NormalizeGcpEndpoint(const std::string& address, bool use_ssl);
 
-// Process-wide registry mapping (endpoint, bucket) → credential provider.
+// One live registration for a GCP identity. The identity string is an opaque,
+// exact comparison key and is never logged. A registration is retained by the
+// S3 credentials provider owned by the filesystem/client; the process-wide
+// registry below keeps only a weak reference.
+class GcpCredentialRegistration {
+  public:
+  GcpCredentialRegistration(std::string identity, std::shared_ptr<GcpCredentialProvider> provider)
+      : identity_(std::move(identity)), provider_(std::move(provider)) {}
+
+  private:
+  friend class GcpCredentialRegistry;
+
+  std::string identity_;
+  std::shared_ptr<GcpCredentialProvider> provider_;
+};
+
+// Process-wide registry mapping (endpoint, bucket) → live credential
+// registration.
 //
 // The GCP HTTP client factory and delegator are installed once globally (AWS
 // SDK constraint via InitializeS3 + call_once). They are stateless and look
@@ -75,14 +94,11 @@ class GcpCredentialRegistry {
   public:
   static GcpCredentialRegistry& Instance();
 
-  // Register or replace the provider for a (endpoint, bucket) pair.
-  //
-  // Registration is idempotent: a second Register with the same key silently
-  // replaces the prior provider. In practice this only happens when the same
-  // bucket is configured via both `fs.*` and an `extfs.<ns>.*` slot, or when
-  // the same config Make()s twice — in both cases the identity is identical.
-  // Same bucket + different identity is not a supported configuration.
-  void Register(GcpBucketKey key, std::shared_ptr<GcpCredentialProvider> provider);
+  // Register an identity for a (endpoint, bucket) pair. An equivalent live
+  // registration is reused. A different live identity is rejected instead of
+  // changing the credentials used by an already-created filesystem.
+  arrow::Result<std::shared_ptr<GcpCredentialRegistration>> Register(
+      GcpBucketKey key, std::shared_ptr<GcpCredentialRegistration> registration);
 
   // Look up the provider for an outgoing request URI. Tries both path-style
   // (request endpoint + first path segment) and virtual-host-style (first
@@ -94,7 +110,7 @@ class GcpCredentialRegistry {
   GcpCredentialRegistry() = default;
 
   mutable std::mutex mu_;
-  std::unordered_map<GcpBucketKey, std::shared_ptr<GcpCredentialProvider>, GcpBucketKeyHash> providers_;
+  std::unordered_map<GcpBucketKey, std::weak_ptr<GcpCredentialRegistration>, GcpBucketKeyHash> registrations_;
 };
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/gcp/gcp_filesystem_producer.h
+++ b/cpp/include/milvus-storage/filesystem/gcp/gcp_filesystem_producer.h
@@ -21,6 +21,8 @@
 
 namespace milvus_storage {
 
+class GcpCredentialRegistration;
+
 // GCS access through the S3-compatible XML API, using the AWS SDK S3Client.
 // Authentication is layered via a custom HttpClientFactory:
 //   - IAM mode: OAuth2 Bearer token from ComputeEngineCredentials (GCE metadata).
@@ -43,10 +45,11 @@ class GcpFileSystemProducer : public FileSystemProducer {
   static arrow::Status InitS3Compat(const ArrowFileSystemConfig& first_config);
 
   // Per-Make: build a credential provider from the given config and register
-  // it in GcpCredentialRegistry under (endpoint, bucket). Must be called
-  // after InitS3Compat. Returns Status::Invalid when the config doesn't
-  // match any supported credential mode.
-  static arrow::Status RegisterIdentity(const ArrowFileSystemConfig& config);
+  // it in GcpCredentialRegistry under (endpoint, bucket). Must be called after
+  // InitS3Compat. An equivalent live identity is reused; a conflicting live
+  // identity is rejected.
+  static arrow::Result<std::shared_ptr<GcpCredentialRegistration>> RegisterIdentity(
+      const ArrowFileSystemConfig& config);
 
   arrow::Result<S3Options> CreateS3Options();
 

--- a/cpp/include/milvus-storage/filesystem/observable.h
+++ b/cpp/include/milvus-storage/filesystem/observable.h
@@ -26,6 +26,8 @@
 #include <arrow/status.h>
 #include <arrow/util/future.h>
 
+#include "milvus-storage/common/writer_status.h"
+
 namespace milvus_storage {
 
 /// \brief Metrics collection for filesystem operations
@@ -311,34 +313,55 @@ class MetricsOutputStream : public arrow::io::OutputStream {
   MetricsOutputStream(std::shared_ptr<arrow::io::OutputStream> stream, std::shared_ptr<FilesystemMetrics> metrics)
       : stream_(std::move(stream)), metrics_(std::move(metrics)) {}
 
+  ~MetricsOutputStream() override = default;
+
   // FileInterface
-  arrow::Status Close() override { return stream_->Close(); }
-  arrow::Status Abort() override { return stream_->Abort(); }
-  arrow::Result<int64_t> Tell() const override { return stream_->Tell(); }
+  arrow::Status Close() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(stream_->Close());
+  }
+  arrow::Status Abort() override {
+    (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+    return stream_->Abort();
+  }
+  arrow::Result<int64_t> Tell() const override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    auto result = stream_->Tell();
+    if (!result.ok()) {
+      return writer_status_.RecordFirstFailure(result.status());
+    }
+    return result;
+  }
   bool closed() const override { return stream_->closed(); }
 
   // Writable
   arrow::Status Write(const void* data, int64_t nbytes) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
     auto status = stream_->Write(data, nbytes);
     if (status.ok() && nbytes > 0) {
       metrics_->IncrementWriteBytes(nbytes);
     }
-    return status;
+    return writer_status_.RecordFirstFailure(std::move(status));
   }
 
   arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
     auto status = stream_->Write(data);
     if (status.ok() && data && data->size() > 0) {
       metrics_->IncrementWriteBytes(data->size());
     }
-    return status;
+    return writer_status_.RecordFirstFailure(std::move(status));
   }
 
-  arrow::Status Flush() override { return stream_->Flush(); }
+  arrow::Status Flush() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(stream_->Flush());
+  }
 
   private:
   std::shared_ptr<arrow::io::OutputStream> stream_;
   std::shared_ptr<FilesystemMetrics> metrics_;
+  mutable WriterStatus writer_status_;
 };
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include "AliyunSTSClient.h"
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
 namespace milvus_storage {
 
 /**
@@ -31,7 +33,8 @@ namespace milvus_storage {
  * Note that STS accepts request with protocol of queryxml. Calling GetAWSCredentials() will trigger (if expired)
  * a query request using AWSHttpResourceClient under the hood.
  */
-class AWS_CORE_API AliyunSTSAssumeRoleWebIdentityCredentialsProvider : public ::Aws::Auth::AWSCredentialsProvider {
+class AWS_CORE_API AliyunSTSAssumeRoleWebIdentityCredentialsProvider : public ::Aws::Auth::AWSCredentialsProvider,
+                                                                       public RequestCredentialsResolver {
   public:
   // Reads role_arn, session_name, and OIDC token file from ALIBABA_CLOUD_* env
   // vars, with profile-config fallback.
@@ -46,6 +49,7 @@ class AWS_CORE_API AliyunSTSAssumeRoleWebIdentityCredentialsProvider : public ::
    * Retrieves the credentials if found, otherwise returns empty credential set.
    */
   ::Aws::Auth::AWSCredentials GetAWSCredentials() override;
+  [[nodiscard]] arrow::Result<::Aws::Auth::AWSCredentials> ResolveForRequest() override;
 
   protected:
   void Reload() override;
@@ -57,6 +61,9 @@ class AWS_CORE_API AliyunSTSAssumeRoleWebIdentityCredentialsProvider : public ::
 
   ::Aws::UniquePtr<AliyunSTSCredentialsClient> m_client;
   ::Aws::Auth::AWSCredentials m_credentials;
+  // Guarded by m_reloadLock, like m_credentials.
+  arrow::Status m_lastResolution;
+
   ::Aws::String m_roleArn;
   ::Aws::String m_tokenFile;
   ::Aws::String m_sessionName;

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h
@@ -22,6 +22,8 @@
 #include "AliyunCredentialsProvider.h"
 #include "AliyunRAMSTSClient.h"
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
 namespace milvus_storage {
 
 // Two-step OIDC chain for cross-account OSS access:
@@ -43,7 +45,8 @@ namespace milvus_storage {
 // Mirrors the structure of AliyunRAMCredentialsProvider (IMDS step 1, same
 // step 2). Selected for OIDC deployments at the dispatch layer; RAM mode
 // (ALIYUN_ROLE_ARN_AUTH_MODE=ram) keeps using AliyunRAMCredentialsProvider.
-class AWS_CORE_API AliyunOIDCAssumeRoleChainProvider : public ::Aws::Auth::AWSCredentialsProvider {
+class AWS_CORE_API AliyunOIDCAssumeRoleChainProvider : public ::Aws::Auth::AWSCredentialsProvider,
+                                                       public RequestCredentialsResolver {
   public:
   // `target_external_id` is forwarded to step 2 (sts:AssumeRole). Aliyun's
   // AssumeRoleWithOIDC API itself has no ExternalId concept, so step 1 never
@@ -54,6 +57,7 @@ class AWS_CORE_API AliyunOIDCAssumeRoleChainProvider : public ::Aws::Auth::AWSCr
                                     const ::Aws::String& target_external_id = "");
 
   ::Aws::Auth::AWSCredentials GetAWSCredentials() override;
+  [[nodiscard]] arrow::Result<::Aws::Auth::AWSCredentials> ResolveForRequest() override;
 
   protected:
   void Reload() override;
@@ -71,6 +75,9 @@ class AWS_CORE_API AliyunOIDCAssumeRoleChainProvider : public ::Aws::Auth::AWSCr
   ::Aws::UniquePtr<AliyunRAMSTSClient> m_stsClient;
 
   ::Aws::Auth::AWSCredentials m_credentials;
+  // Guarded by m_reloadLock, like m_credentials.
+  arrow::Status m_lastResolution;
+
   ::Aws::String m_targetRoleArn;
   ::Aws::String m_targetSessionName;
   ::Aws::String m_targetExternalId;

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h
@@ -20,6 +20,7 @@
 #include <aws/core/utils/memory/stl/AWSString.h>
 
 #include "AliyunRAMSTSClient.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 
 namespace milvus_storage {
 
@@ -33,13 +34,16 @@ namespace milvus_storage {
 // ALIYUN_ROLE_ARN_AUTH_MODE=ram at the dispatch layer; the
 // existing OIDC (AssumeRoleWithOIDC) provider is used otherwise so OIDC
 // deployments are unaffected.
-class AWS_CORE_API AliyunRAMCredentialsProvider : public ::Aws::Auth::AWSCredentialsProvider {
+class AWS_CORE_API AliyunRAMCredentialsProvider : public ::Aws::Auth::AWSCredentialsProvider,
+                                                  public RequestCredentialsResolver {
   public:
   AliyunRAMCredentialsProvider(const ::Aws::String& role_arn,
                                const ::Aws::String& role_session_name,
                                const ::Aws::String& external_id = "");
 
   ::Aws::Auth::AWSCredentials GetAWSCredentials() override;
+
+  [[nodiscard]] arrow::Result<::Aws::Auth::AWSCredentials> ResolveForRequest() override;
 
   protected:
   void Reload() override;
@@ -50,6 +54,8 @@ class AWS_CORE_API AliyunRAMCredentialsProvider : public ::Aws::Auth::AWSCredent
 
   ::Aws::UniquePtr<AliyunRAMSTSClient> m_stsClient;
   ::Aws::Auth::AWSCredentials m_credentials;
+  // Guarded by m_reloadLock, like m_credentials.
+  arrow::Status m_lastResolution;
   ::Aws::String m_roleArn;
   ::Aws::String m_roleSessionName;
   ::Aws::String m_externalId;

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h
@@ -20,6 +20,8 @@
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/internal/AWSHttpResourceClient.h>
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
 namespace milvus_storage {
 
 // STS client for Aliyun sts:AssumeRole using POP v1 (HMAC-SHA1) signing.
@@ -53,12 +55,17 @@ class AWS_CORE_API AliyunRAMSTSClient : public ::Aws::Internal::AWSHttpResourceC
 
   struct AssumeRoleResult {
     ::Aws::Auth::AWSCredentials creds;
+    // Why creds is empty. OK when credentials were produced. Carried out rather
+    // than logged and dropped, because "STS was unreachable" and "STS refused
+    // us" need opposite handling and the caller cannot tell them apart from an
+    // empty credential set.
+    arrow::Status status;
   };
 
-  // Returns empty credentials on failure; errors are logged.
   AssumeRoleResult GetAssumeRoleCredentials(const AssumeRoleRequest& request);
 
   private:
+  std::shared_ptr<::Aws::Http::HttpClient> m_rawHttpClient;
   ::Aws::String m_endpoint;
 };
 

--- a/cpp/include/milvus-storage/filesystem/s3/provider/AliyunSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/AliyunSTSClient.h
@@ -24,7 +24,9 @@
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/AmazonWebServiceResult.h>
 #include <aws/core/utils/DateTime.h>
-#include <aws/core/internal/AWSHttpResourceClient.h>  // [aliyun] import original http client
+#include <aws/core/internal/AWSHttpResourceClient.h>
+
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"  // [aliyun] import original http client
 #include <memory>
 #include <mutex>
 
@@ -56,6 +58,10 @@ class AWS_CORE_API AliyunSTSCredentialsClient : public ::Aws::Internal::AWSHttpR
   };
 
   struct STSAssumeRoleWithWebIdentityResult {
+    // Why creds is empty. OK when credentials were produced. "STS was
+    // unreachable" and "STS refused us" need opposite handling upstream and
+    // both otherwise arrive as an empty credential set.
+    arrow::Status status;
     ::Aws::Auth::AWSCredentials creds;
   };
 
@@ -63,6 +69,7 @@ class AWS_CORE_API AliyunSTSCredentialsClient : public ::Aws::Internal::AWSHttpR
       const STSAssumeRoleWithWebIdentityRequest& request);
 
   private:
+  std::shared_ptr<::Aws::Http::HttpClient> m_rawHttpClient;
   ::Aws::String m_endpoint;
   ::Aws::String m_aliyunOidcProviderArn;  // [aliyun]
 };

--- a/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h
@@ -6,16 +6,21 @@
 
 #include "HuaweiCloudSTSClient.h"
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
 namespace milvus_storage {
 
 class HuaweiCloudCredentialsProviderTestHelper;
 
-class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
+class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth::AWSCredentialsProvider,
+                                                               public RequestCredentialsResolver {
   friend class HuaweiCloudCredentialsProviderTestHelper;
 
   public:
   HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider();
   Aws::Auth::AWSCredentials GetAWSCredentials() override;
+
+  [[nodiscard]] arrow::Result<Aws::Auth::AWSCredentials> ResolveForRequest() override;
 
   protected:
   void Reload() override;
@@ -25,6 +30,8 @@ class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth:
 
   Aws::UniquePtr<HuaweiCloudSTSCredentialsClient> m_client;
   Aws::Auth::AWSCredentials m_credentials;
+  // Guarded by m_reloadLock, like m_credentials.
+  arrow::Status m_lastResolution;
   Aws::String m_region;
   Aws::String m_providerId;
   Aws::String m_roleArn;
@@ -32,15 +39,10 @@ class HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth:
   Aws::String m_sessionName;
   Aws::String m_token;
   bool m_initialized;
-  bool m_lastReloadFailed = false;
-  std::chrono::steady_clock::time_point m_lastFailedReloadTime;
   std::atomic<int64_t> m_stsSuccessCount{0};
   std::atomic<int64_t> m_stsFailureCount{0};
-  static constexpr int RELOAD_COOLDOWN_SECONDS = 30;
-  static constexpr int RELOAD_COOLDOWN_SECONDS_URGENT = 5;
 
   bool ExpiresSoon() const;
-  bool IsInCooldown() const;
 };
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/HuaweiCloudSTSClient.h
@@ -2,6 +2,8 @@
 
 #include <aws/core/internal/AWSHttpResourceClient.h>
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
 namespace milvus_storage {
 
 class AWS_CORE_API HuaweiCloudSTSCredentialsClient : public ::Aws::Internal::AWSHttpResourceClient {
@@ -26,6 +28,8 @@ class AWS_CORE_API HuaweiCloudSTSCredentialsClient : public ::Aws::Internal::AWS
   struct STSAssumeRoleWithWebIdentityResult {
     bool success = false;
     Aws::Auth::AWSCredentials creds;
+    // Why success is false; see AliyunSTSClient.h.
+    arrow::Status status;
   };
 
   virtual STSAssumeRoleWithWebIdentityResult GetAssumeRoleWithWebIdentityCredentials(
@@ -39,6 +43,7 @@ class AWS_CORE_API HuaweiCloudSTSCredentialsClient : public ::Aws::Internal::AWS
     bool success = false;
     Aws::Auth::AWSCredentials credentials;
     Aws::String errorMessage;
+    arrow::Status status;
   };
 
   STSCallResult callHuaweiCloudSTS(const Aws::String& userToken, const STSAssumeRoleWithWebIdentityRequest& request);

--- a/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h
@@ -24,6 +24,8 @@
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include "TencentCloudSTSClient.h"
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
 namespace milvus_storage {
 
 /**
@@ -31,7 +33,8 @@ namespace milvus_storage {
  * Note that STS accepts request with protocol of queryxml. Calling GetAWSCredentials() will trigger (if expired)
  * a query request using AWSHttpResourceClient under the hood.
  */
-class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
+class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : public Aws::Auth::AWSCredentialsProvider,
+                                                                             public RequestCredentialsResolver {
   public:
   TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider();
 
@@ -39,6 +42,7 @@ class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : pub
    * Retrieves the credentials if found, otherwise returns empty credential set.
    */
   Aws::Auth::AWSCredentials GetAWSCredentials() override;
+  [[nodiscard]] arrow::Result<Aws::Auth::AWSCredentials> ResolveForRequest() override;
 
   protected:
   void Reload() override;
@@ -49,6 +53,9 @@ class AWS_CORE_API TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider : pub
 
   Aws::UniquePtr<TencentCloudSTSCredentialsClient> m_client;
   Aws::Auth::AWSCredentials m_credentials;
+  // Guarded by m_reloadLock, like m_credentials.
+  arrow::Status m_lastResolution;
+
   Aws::String m_region;
   Aws::String m_roleArn;
   Aws::String m_tokenFile;

--- a/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h
@@ -25,6 +25,8 @@
 #include <aws/core/AmazonWebServiceResult.h>
 #include <aws/core/utils/DateTime.h>
 #include <aws/core/internal/AWSHttpResourceClient.h>
+
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include <memory>
 #include <mutex>
 
@@ -59,6 +61,8 @@ class AWS_CORE_API TencentCloudSTSCredentialsClient : public Aws::Internal::AWSH
   };
 
   struct STSAssumeRoleWithWebIdentityResult {
+    // Why creds is empty; see AliyunSTSClient.h.
+    arrow::Status status;
     Aws::Auth::AWSCredentials creds;
   };
 
@@ -66,6 +70,7 @@ class AWS_CORE_API TencentCloudSTSCredentialsClient : public Aws::Internal::AWSH
       const STSAssumeRoleWithWebIdentityRequest& request);
 
   private:
+  std::shared_ptr<Aws::Http::HttpClient> m_rawHttpClient;
   Aws::String m_endpoint;
 };
 

--- a/cpp/include/milvus-storage/filesystem/s3/provider/credential_resolution.h
+++ b/cpp/include/milvus-storage/filesystem/s3/provider/credential_resolution.h
@@ -1,0 +1,170 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <string_view>
+
+#include <arrow/status.h>
+#include <arrow/result.h>
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+
+namespace milvus_storage {
+
+/// How many times a credential client retries before giving up.
+///
+/// One number for every provider, because the layering is: this library makes a
+/// bounded attempt and then reports what happened; deciding whether to try
+/// again later belongs to the caller, which knows what the operation was worth.
+/// Before this was uniform the same repository ran three different policies --
+/// IMDS retried zero times, the web identity clients three, and the remaining
+/// STS clients whatever AWS_MAX_ATTEMPTS happened to say -- so how long a
+/// credential failure took to surface depended on which cloud you were on.
+inline constexpr long kCredentialRetryAttempts = 3;
+inline constexpr long kCredentialConnectTimeoutMs = 2000;
+inline constexpr long kCredentialRequestTimeoutMs = 5000;
+// IMDS is link-local and answers in milliseconds on a healthy instance, so it
+// gets a much tighter cap: with the retry budget above, 5s per attempt made a
+// single failing refresh hold the credentials lock for tens of seconds, which
+// is exactly what the original short caps existed to prevent.
+inline constexpr long kImdsRequestTimeoutMs = 1500;
+
+/// A request-local credential resolution gate.
+///
+/// `AWSCredentialsProvider::GetAWSCredentials()` is the SDK's interface: it
+/// hands back credentials and nothing else. A provider that could not reach
+/// STS therefore answers with an empty set and the reason dies with the call.
+///
+/// ResolveForRequest returns the credentials and their typed failure as one
+/// value. S3's Standard and CRT holders call it before handing a client to an
+/// object request, so an expired credential whose refresh failed never falls
+/// through as an anonymous request and later masquerades as AccessDenied.
+class RequestCredentialsResolver {
+  public:
+  virtual ~RequestCredentialsResolver() = default;
+
+  [[nodiscard]] virtual arrow::Result<Aws::Auth::AWSCredentials> ResolveForRequest() = 0;
+};
+
+/// Validate caller-supplied long-lived credentials as one identity.
+///
+/// Supplying no static credential at all is valid: the caller may explicitly
+/// choose anonymous access or let a default provider chain continue. Once any
+/// static credential field is present, however, both AK and SK are required so
+/// a partial source cannot be treated as anonymous or skipped in favor of a
+/// later identity.
+arrow::Status ValidateStaticCredentials(std::string_view access_key,
+                                        std::string_view secret_key,
+                                        std::string_view session_token,
+                                        std::string_view source);
+
+/// Apply the same zero-or-complete rule to the AWS environment credential
+/// source before the SDK default chain can fall through to another identity.
+arrow::Status ValidateAwsEnvironmentCredentials();
+
+/// Validate a short-lived credential set as one indivisible value.
+///
+/// AWSCredentials::IsEmpty() only checks that both AK and SK are empty. It
+/// accepts half-filled credentials and treats a missing expiration as "never
+/// expires", which is unsafe for STS responses. Every temporary credential
+/// cache must pass this check before publishing the new value.
+arrow::Status ValidateTemporaryCredentials(const Aws::Auth::AWSCredentials& credentials, std::string_view source);
+
+/// How long a caller keeps trying to resolve credentials before deciding the
+/// attempt belongs to someone else.
+inline constexpr std::chrono::milliseconds kCredentialResolutionBudget{100};
+
+/// Whether a caller that entered credential resolution at `started` still has
+/// budget left to make an attempt of its own.
+///
+/// Asked AFTER the writer lock is acquired, because acquiring it can take as
+/// long as another thread's entire reload.
+///
+/// The double-check that precedes this already covers the case where that
+/// thread SUCCEEDED -- the credentials are fresh, everyone returns them, and
+/// nobody reloads. What it cannot cover is that thread having FAILED: the
+/// credentials are still empty, so the condition is false for every queued
+/// caller and they each replay the same outage in series, with the queue as
+/// long as the thread pool. Asking "do I still have budget" ends that without
+/// anyone having to record whose failure it was.
+bool CredentialAttemptStillWorthMaking(std::chrono::steady_clock::time_point started);
+
+/// Send a request through a raw HttpClient with the shared retry budget.
+///
+/// `HttpClient::MakeRequest` does NOT consume
+/// `ClientConfiguration::retryStrategy` -- the SDK's retry loop lives in
+/// `AWSHttpResourceClient::GetResourceWithAWSWebServiceResult`, and the call
+/// sites that talk to IMDS or to Huawei's second stage bypass it. Setting the
+/// strategy on the config was therefore decoration on those paths: they stayed
+/// one-shot no matter what the number said.
+///
+/// Retries only what a retry can fix -- no response at all, or a 5xx/429/408
+/// from the service. A 4xx means the request was refused on its merits and
+/// repeating it just delays the answer.
+std::shared_ptr<Aws::Http::HttpResponse> MakeRequestWithCredentialRetry(
+    Aws::Http::HttpClient& client, const std::shared_ptr<Aws::Http::HttpRequest>& request);
+
+/// Classify a credential request from the HTTP outcome it actually got.
+///
+/// The point of separating these is NOT to make the SDK retry again -- the
+/// credential clients already have their own bounded retry, and by the time a
+/// status reaches a caller that budget is spent. It is to let the layer above
+/// re-run the whole operation later. Collapsing every cause into
+/// StorageAccessDenied made that impossible: the code is SYSTEM-category, it
+/// lands on segcore's ConfigInvalid, and the operation is never attempted
+/// again -- so a metadata service that was restarting failed a query exactly as
+/// permanently as a role ARN that does not exist.
+///
+/// Order matters: the SDK's sentinels sit inside ordinary numeric ranges.
+/// NO_RESPONSE is 444 and the network timeouts are 598/599, so classifying by
+/// range first would call a dead network a bad configuration.
+arrow::Status ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode code, std::string_view what);
+
+/// Aliyun STS may report throttling as HTTP 302. Only its XML producer can
+/// distinguish that response from an unrelated redirect, so inspect <Code>
+/// here and otherwise retain the generic HTTP classification.
+arrow::Status ClassifyAliyunStsHttpFailure(Aws::Http::HttpResponseCode code,
+                                           std::string_view payload,
+                                           std::string_view what);
+
+/// Pre-I/O deployment configuration is missing something this process needs,
+/// such as a token file that is not mounted. Not retryable, and naming it points
+/// whoever is paged at the thing to change.
+arrow::Status MakeCredentialConfigError(std::string_view what);
+
+/// The service answered, and we could not use the answer: an unparseable body,
+/// a response with no credentials in it.
+///
+/// Deliberately left unclassified rather than mapped to AccessDenied. It is
+/// neither a transport fault we can wait out nor a refusal on the merits, and
+/// dressing it as either would be a guess -- the conservative unclassified
+/// landing is non-retryable without claiming to know why.
+arrow::Status MakeCredentialResponseError(std::string_view what);
+
+/// Turn a dependency exception into the Status contract used by credential
+/// resolvers. Allocation failures remain Arrow OOM statuses, so the direct
+/// C++ boundary can report MemAllocateFailed. Other exceptions are deliberately
+/// unclassified: no HTTP or provider verdict was observed.
+arrow::Status MakeCredentialOutOfMemoryError(std::string_view what);
+arrow::Status MakeCredentialExceptionError(std::string_view what, const std::exception& exception);
+arrow::Status MakeCredentialUnknownExceptionError(std::string_view what);
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_client.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_client.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -35,6 +36,8 @@
 namespace milvus_storage {
 
 using ::milvus_storage::S3Options;
+
+class RequestCredentialsResolver;
 
 class S3Client : public Aws::S3::S3Client {
   public:
@@ -97,7 +100,10 @@ class S3ClientHolder {
   /// An error is returned if S3 is already finalized.
   arrow::Result<S3ClientLock> Lock();
 
-  S3ClientHolder(std::weak_ptr<S3ClientFinalizer> finalizer, std::shared_ptr<S3Client> client);
+  S3ClientHolder(std::weak_ptr<S3ClientFinalizer> finalizer,
+                 std::shared_ptr<S3Client> client,
+                 std::shared_ptr<RequestCredentialsResolver> credentials_resolver = nullptr,
+                 std::function<void()> release_resources = nullptr);
 
   void Finalize();
 
@@ -105,13 +111,23 @@ class S3ClientHolder {
   std::mutex mutex_;
   std::weak_ptr<S3ClientFinalizer> finalizer_;
   std::shared_ptr<S3Client> client_;
+  std::shared_ptr<RequestCredentialsResolver> credentials_resolver_;
+  std::function<void()> release_resources_;
 };
 
 class S3ClientFinalizer : public std::enable_shared_from_this<S3ClientFinalizer> {
   using ClientHolderList = std::vector<std::weak_ptr<S3ClientHolder>>;
 
   public:
-  arrow::Result<std::shared_ptr<S3ClientHolder>> AddClient(std::shared_ptr<S3Client> client);
+  using ClientFactory = std::function<arrow::Result<std::shared_ptr<S3Client>>()>;
+
+  // Construct and register the client under the process-wide shutdown
+  // barrier. Finalize() closes admission, waits for any running factory and
+  // its cleanup, then drains every successfully published holder.
+  arrow::Result<std::shared_ptr<S3ClientHolder>> AddClient(
+      ClientFactory make_client,
+      std::shared_ptr<RequestCredentialsResolver> credentials_resolver = nullptr,
+      std::function<void()> release_resources = nullptr);
 
   void Finalize();
   std::shared_lock<std::shared_mutex> LockShared();
@@ -119,6 +135,9 @@ class S3ClientFinalizer : public std::enable_shared_from_this<S3ClientFinalizer>
   protected:
   friend class S3ClientHolder;
 
+  // Serializes client construction with process-wide finalization without
+  // blocking ordinary S3 operations, which use mutex_ in shared mode.
+  std::mutex construction_mutex_;
   std::shared_mutex mutex_;
   ClientHolderList holders_;
   bool finalized_ = false;

--- a/cpp/include/milvus-storage/filesystem/s3/s3_client_builder.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_client_builder.h
@@ -14,8 +14,10 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 #include <arrow/result.h>
@@ -58,12 +60,17 @@ class ClientBuilderBase {
 
   const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& credentials_provider() const;
 
+  const std::string& region() const;
+
+  void ReleaseAwsResources();
+
   protected:
   arrow::Status PrepareClientConfig(Aws::Client::ClientConfiguration* client_config,
                                     std::optional<arrow::io::IOContext> io_context);
 
   S3Options options_;
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider_;
+  std::string region_;
 };
 
 template <typename ClientT>
@@ -74,21 +81,30 @@ class ClientBuilder : public ClientBuilderBase {
 
   explicit ClientBuilder(S3Options options)
       : ClientBuilderBase(std::move(options)),
-        client_config_(client_builder_internal::MakeClientConfigurationInitValues(options_)) {}
+        client_config_(std::in_place, client_builder_internal::MakeClientConfigurationInitValues(options_)) {}
 
-  const ConfigType& config() const { return client_config_; }
+  const ConfigType& config() const { return *client_config_; }
 
-  ConfigType* mutable_config() { return &client_config_; }
+  ConfigType* mutable_config() { return &*client_config_; }
 
   arrow::Status PrepareClientConfig(std::optional<arrow::io::IOContext> io_context) {
-    return ClientBuilderBase::PrepareClientConfig(&client_config_, io_context);
+    if (!client_config_) {
+      return arrow::Status::Invalid("S3 client builder has released its AWS resources");
+    }
+    return ClientBuilderBase::PrepareClientConfig(&*client_config_, io_context);
   }
 
   arrow::Result<std::shared_ptr<HolderType>> BuildClient(std::optional<arrow::io::IOContext> io_context = std::nullopt,
-                                                         std::shared_ptr<FilesystemMetrics> metrics = nullptr);
+                                                         std::shared_ptr<FilesystemMetrics> metrics = nullptr,
+                                                         std::function<void()> release_resources = nullptr);
+
+  void ReleaseAwsResources() {
+    client_config_.reset();
+    ClientBuilderBase::ReleaseAwsResources();
+  }
 
   private:
-  ConfigType client_config_;
+  std::optional<ConfigType> client_config_;
 };
 
 ClientBuilder(S3Options) -> ClientBuilder<S3Client>;
@@ -105,6 +121,8 @@ struct ClientBuilderTraits<S3Client> {
 
 template <>
 arrow::Result<std::shared_ptr<S3ClientHolder>> ClientBuilder<S3Client>::BuildClient(
-    std::optional<arrow::io::IOContext> io_context, std::shared_ptr<FilesystemMetrics> metrics);
+    std::optional<arrow::io::IOContext> io_context,
+    std::shared_ptr<FilesystemMetrics> metrics,
+    std::function<void()> release_resources);
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/s3/s3_crt_client.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_crt_client.h
@@ -35,6 +35,7 @@
 namespace milvus_storage {
 
 class S3CrtClientHolder;
+class RequestCredentialsResolver;
 
 template <>
 struct ClientBuilderTraits<Aws::S3Crt::S3CrtClient> {
@@ -44,7 +45,9 @@ struct ClientBuilderTraits<Aws::S3Crt::S3CrtClient> {
 
 template <>
 arrow::Result<std::shared_ptr<S3CrtClientHolder>> ClientBuilder<Aws::S3Crt::S3CrtClient>::BuildClient(
-    std::optional<arrow::io::IOContext> io_context, std::shared_ptr<FilesystemMetrics> metrics);
+    std::optional<arrow::io::IOContext> io_context,
+    std::shared_ptr<FilesystemMetrics> metrics,
+    std::function<void()> release_resources);
 
 class S3CrtClientOperationState;
 class S3CrtClientFinalizer;
@@ -192,7 +195,10 @@ class S3CrtClientHolder {
 
   protected:
   friend class S3CrtClientFinalizer;
-  S3CrtClientHolder(std::shared_ptr<S3CrtClientFinalizer> finalizer, std::shared_ptr<FilesystemMetrics> metrics);
+  S3CrtClientHolder(std::shared_ptr<S3CrtClientFinalizer> finalizer,
+                    std::shared_ptr<FilesystemMetrics> metrics,
+                    std::shared_ptr<RequestCredentialsResolver> credentials_resolver = nullptr,
+                    std::function<void()> release_resources = nullptr);
   void Finalize();
 
   std::shared_ptr<S3CrtClientFinalizer> finalizer_;
@@ -204,6 +210,8 @@ class S3CrtClientHolder {
   // never copy this shared_ptr.
   std::shared_ptr<Aws::S3Crt::S3CrtClient> client_;
   std::shared_ptr<FilesystemMetrics> metrics_;
+  std::shared_ptr<RequestCredentialsResolver> credentials_resolver_;
+  std::function<void()> release_resources_;
 };
 
 /// Coordinates construction and destruction of every CRT client in the process.
@@ -234,8 +242,11 @@ class S3CrtClientFinalizer : public std::enable_shared_from_this<S3CrtClientFina
 
   /// Reserve construction before invoking the factory, then register its
   /// client. The factory is not invoked after finalization starts.
-  arrow::Result<std::shared_ptr<S3CrtClientHolder>> AddClient(ClientFactory make_client,
-                                                              std::shared_ptr<FilesystemMetrics> metrics);
+  arrow::Result<std::shared_ptr<S3CrtClientHolder>> AddClient(
+      ClientFactory make_client,
+      std::shared_ptr<FilesystemMetrics> metrics,
+      std::shared_ptr<RequestCredentialsResolver> credentials_resolver = nullptr,
+      std::function<void()> release_resources = nullptr);
   /// Wait for client construction, then close all holders and wait until every
   /// CRT client destructor has returned.
   /// This is an S3 lifecycle operation and must not be called from a CRT

--- a/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_internal.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -45,6 +46,66 @@ namespace internal {
 // XXX Should we expose this at some point?
 enum class S3Backend { Amazon, Minio, Other };
 
+enum class S3ResourceKind : uint8_t {
+  /// The operation does not identify one resource kind, or the caller has not
+  /// carried that fact. Generic RESOURCE_NOT_FOUND keeps the conservative
+  /// object-missing behavior for compatibility.
+  Unknown,
+  /// The request addressed an object/key.
+  Object,
+  /// The request addressed the bucket itself (HeadBucket, ListObjects, etc.).
+  Bucket,
+  /// The request addressed multipart-upload state rather than an object that
+  /// could independently be absent. A generic 404 here is reported as
+  /// NoSuchUpload; a vanished bucket is indistinguishable without extra IO,
+  /// which is deliberately not spent.
+  MultipartUpload,
+};
+
+/// \brief Which kind of resource the failed request addressed.
+struct S3ErrorProvenance {
+  constexpr explicit S3ErrorProvenance(S3ResourceKind resource_kind = S3ResourceKind::Unknown)
+      : resource_kind(resource_kind) {}
+
+  /// \brief Which resource a bodyless/generic 404 was answering about.
+  ///
+  /// S3's RESOURCE_NOT_FOUND value is used for both a missing object and a
+  /// missing bucket. Use only the failed operation's resource kind; do not
+  /// issue a follow-up request to disambiguate an already failed operation.
+  S3ResourceKind resource_kind;
+};
+
+/// \brief Keep a message useful without letting it grow unbounded.
+///
+/// The tail of an S3 error message is whatever the endpoint felt like sending
+/// -- a proxy in front of a misconfigured store answers a signed GET with a
+/// full HTML page, and that lands verbatim in a Status that is then logged,
+/// wrapped and carried across the FFI boundary. The head is where the useful
+/// part is.
+inline std::string BoundedDetail(const std::string& text, size_t limit = 512) {
+  if (text.size() <= limit) {
+    return text;
+  }
+  return text.substr(0, limit) + "...(+" + ::arrow::internal::ToChars(text.size() - limit) + " bytes)";
+}
+
+inline bool IsExpiredCredentialError(std::string_view exception_name) {
+  return exception_name == "ExpiredToken" || exception_name == "ExpiredTokenException" ||
+         exception_name == "TokenRefreshRequired";
+}
+
+/// \brief Does the service error name identify rejected credentials or access?
+///
+/// DeleteObjects reports per-key failures as strings inside an otherwise
+/// successful response, so those errors bypass AWSError and its enum/HTTP
+/// classification. Keep the accepted spellings in one place so request-level
+/// and per-key failures retain the same structured verdict.
+inline bool IsAccessDeniedErrorName(std::string_view exception_name) {
+  return IsExpiredCredentialError(exception_name) || exception_name == "AccessDenied" ||
+         exception_name == "InvalidToken" || exception_name == "InvalidAccessKeyId" ||
+         exception_name == "SignatureDoesNotMatch" || exception_name == "InvalidSecurity";
+}
+
 // Detect the S3 backend type from the S3 server's response headers
 inline S3Backend DetectS3Backend(const Aws::Http::HeaderValueCollection& headers) {
   const auto it = headers.find("server");
@@ -65,24 +126,6 @@ inline S3Backend DetectS3Backend(const Aws::Client::AWSError<Error>& error) {
   return DetectS3Backend(error.GetResponseHeaders());
 }
 
-template <typename Error>
-inline bool IsConnectError(const Aws::Client::AWSError<Error>& error) {
-  if (error.ShouldRetry()) {
-    return true;
-  }
-  // Sometimes Minio may fail with a 503 error
-  // (exception name: XMinioServerNotInitialized,
-  //  message: "Server not initialized, please try again")
-  // Handle MinIO SlowDown errors (rate limiting)
-  if (error.GetExceptionName() == "SlowDownWrite" || error.GetExceptionName() == "SlowDown") {
-    return true;
-  }
-  if (error.GetExceptionName() == "XMinioServerNotInitialized") {
-    return true;
-  }
-  return false;
-}
-
 template <typename ErrorType>
 inline std::optional<std::string> BucketRegionFromError(const Aws::Client::AWSError<ErrorType>& error) {
   if constexpr (std::is_same_v<ErrorType, Aws::S3::S3Errors>) {
@@ -96,9 +139,27 @@ inline std::optional<std::string> BucketRegionFromError(const Aws::Client::AWSEr
   return std::nullopt;
 }
 
-inline bool IsNotFound(const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
+/// \brief Does this error mean the object/key is absent?
+///
+/// RESOURCE_NOT_FOUND is intentionally accepted here because object HEADs on
+/// AWS are bodyless and commonly lose the more precise NoSuchKey spelling. It
+/// is ambiguous with a missing bucket; the ambiguity is accepted and reported
+/// as a missing key -- resolving it would cost an extra RPC on every miss.
+inline bool IsObjectNotFound(const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
   const auto error_type = error.GetErrorType();
-  return (error_type == Aws::S3::S3Errors::NO_SUCH_BUCKET || error_type == Aws::S3::S3Errors::RESOURCE_NOT_FOUND);
+  return error_type == Aws::S3::S3Errors::NO_SUCH_KEY || error_type == Aws::S3::S3Errors::RESOURCE_NOT_FOUND;
+}
+
+/// \brief Does a bucket-level operation say the bucket is absent?
+inline bool IsBucketNotFound(const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
+  const auto error_type = error.GetErrorType();
+  return error_type == Aws::S3::S3Errors::NO_SUCH_BUCKET || error_type == Aws::S3::S3Errors::RESOURCE_NOT_FOUND;
+}
+
+/// \brief Is the response unambiguously about a missing bucket even on an
+/// object-level operation?
+inline bool IsExplicitBucketNotFound(const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
+  return error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_BUCKET;
 }
 
 inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
@@ -163,24 +224,89 @@ inline std::string S3ErrorToString(Aws::S3::S3Errors error_type) {
   }
 }
 
-inline std::optional<arrow::Status> tryMakePermanentExtendArrowError(Aws::S3::S3Errors error_type,
-                                                                     Aws::Http::HttpResponseCode response_code,
-                                                                     const std::string& message) {
+inline std::optional<arrow::Status> tryMakeClassifiedExtendArrowError(Aws::S3::S3Errors error_type,
+                                                                      Aws::Http::HttpResponseCode response_code,
+                                                                      const std::string& message,
+                                                                      std::string_view exception_name,
+                                                                      const std::string& extra_info,
+                                                                      S3ErrorProvenance provenance) {
+  // GCP OAuth token resolution happens inside the process-global HTTP client
+  // factory, after the S3 call has begun. These internal XML names carry its
+  // typed Result across the AWS SDK marshalling boundary without pretending a
+  // malformed token response was an access-control decision.
+  if (exception_name == "LoonGcpCredentialConfigInvalid") {
+    return MakeExtendError(ExtendStatusCode::StorageConfigInvalid, arrow::StatusCode::IOError, message, extra_info);
+  }
+  if (exception_name == "LoonGcpCredentialResponseInvalid") {
+    return arrow::Status::IOError(message);
+  }
+
+  // Some SDK/parser combinations preserve the service's exception name while
+  // normalizing the enum to ACCESS_DENIED; others leave it UNKNOWN. By the
+  // time this error escapes the SDK, its credential provider has already been
+  // asked for credentials. This layer cannot promise that replaying the same
+  // operation will obtain a different token (explicit and default-chain
+  // credentials may be static), so report the observed authentication failure
+  // instead of inventing a retry guarantee.
+  if (IsAccessDeniedErrorName(exception_name)) {
+    return MakeExtendError(ExtendStatusCode::StorageAccessDenied, message, extra_info);
+  }
+
   switch (error_type) {
+    case Aws::S3::S3Errors::NO_SUCH_UPLOAD:
+      // A dead upload id cannot be repaired by replaying the same multipart
+      // request. The owner of the upload may choose to start a new one.
+      return MakeExtendError(ExtendStatusCode::StorageNoSuchUpload, message, extra_info);
     case Aws::S3::S3Errors::NO_SUCH_BUCKET:
+      // Split out of the not-found group on purpose. A missing bucket is not
+      // data loss and re-reading the manifest cannot conjure one -- the
+      // deployment points somewhere that does not exist, which is a
+      // configuration fix, not an object to go looking for.
+      return MakeExtendError(ExtendStatusCode::StorageBucketNotFound, message, extra_info);
     case Aws::S3::S3Errors::NO_SUCH_KEY:
+      return MakeExtendError(ExtendStatusCode::StorageNotFound, message, extra_info);
     case Aws::S3::S3Errors::RESOURCE_NOT_FOUND:
-      return MakeExtendError(ExtendStatusCode::AwsErrorNotFound, message, message /* extra_info */);
+      if (provenance.resource_kind == S3ResourceKind::Bucket) {
+        return MakeExtendError(ExtendStatusCode::StorageBucketNotFound, message, extra_info);
+      }
+      if (provenance.resource_kind == S3ResourceKind::MultipartUpload) {
+        return MakeExtendError(ExtendStatusCode::StorageNoSuchUpload, message, extra_info);
+      }
+      return MakeExtendError(ExtendStatusCode::StorageNotFound, message, extra_info);
     case Aws::S3::S3Errors::ACCESS_DENIED:
     case Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID:
     case Aws::S3::S3Errors::SIGNATURE_DOES_NOT_MATCH:
-      return MakeExtendError(ExtendStatusCode::AwsErrorAccessDenied, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageAccessDenied, message, extra_info);
     case Aws::S3::S3Errors::UNKNOWN:
+      // The SDK models only a fraction of what a store can answer, and
+      // everything it does not model arrives here nameless. Credential
+      // failures are the ones that matter: ExpiredToken and its relatives left
+      // as bare IOErrors reached an external-table caller as LOON_ARROW_ERROR
+      // -- a generic internal failure -- when the caller's own credentials
+      // were the thing at fault and they are the only one who can fix them.
+      //
+      // Matched on the error NAME as well as the status, because
+      // S3-compatible stores spell 401/403 inconsistently while the token
+      // names are stable across them.
+      if (IsAccessDeniedErrorName(exception_name) || response_code == Aws::Http::HttpResponseCode::UNAUTHORIZED ||
+          response_code == Aws::Http::HttpResponseCode::FORBIDDEN) {
+        return MakeExtendError(ExtendStatusCode::StorageAccessDenied, message, extra_info);
+      }
       switch (response_code) {
         case Aws::Http::HttpResponseCode::PRECONDITION_FAILED:
-          return MakeExtendError(ExtendStatusCode::AwsErrorPreConditionFailed, message, message /* extra_info */);
+          return MakeExtendError(ExtendStatusCode::StoragePreConditionFailed, message, extra_info);
         case Aws::Http::HttpResponseCode::CONFLICT:
-          return MakeExtendError(ExtendStatusCode::AwsErrorConflict, message, message /* extra_info */);
+          // 409 is overloaded. A lost race (conditional write, concurrent
+          // commit) is Conflict: re-read state and re-submit. BucketNotEmpty
+          // and InvalidBucketState are 409s too, but they are answers about
+          // the bucket, not about a race -- replaying cannot change either.
+          // Exclude the known non-conflict shapes rather than allowlist the
+          // races, so the transaction commit path keeps its Conflict verdict
+          // across S3-compatible stores whose race spellings differ.
+          if (exception_name == "BucketNotEmpty" || exception_name == "InvalidBucketState") {
+            return std::nullopt;
+          }
+          return MakeExtendError(ExtendStatusCode::StorageConflict, message, extra_info);
         default:
           return std::nullopt;
       }
@@ -192,61 +318,117 @@ inline std::optional<arrow::Status> tryMakePermanentExtendArrowError(Aws::S3::S3
 template <typename ErrorType>
 std::optional<arrow::Status> tryMakeRetryableExtendArrowError(const Aws::Client::AWSError<ErrorType>& error,
                                                               Aws::S3::S3Errors error_type,
-                                                              const std::string& message) {
+                                                              const std::string& message,
+                                                              const std::string& extra_info = {}) {
   switch (error_type) {
-    case Aws::S3::S3Errors::NO_SUCH_UPLOAD:
-      return MakeExtendError(ExtendStatusCode::AwsErrorNoSuchUpload, message, message /* extra_info */);
+    case Aws::S3::S3Errors::INTERNAL_FAILURE:
+      return MakeExtendError(ExtendStatusCode::StorageTransientService, message, extra_info);
     case Aws::S3::S3Errors::REQUEST_TIMEOUT:
-      return MakeExtendError(ExtendStatusCode::StorageTransientTimeout, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientTimeout, message, extra_info);
     case Aws::S3::S3Errors::THROTTLING:
     case Aws::S3::S3Errors::SLOW_DOWN:
-      return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, message, extra_info);
     case Aws::S3::S3Errors::SERVICE_UNAVAILABLE:
-      return MakeExtendError(ExtendStatusCode::StorageTransientService, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientService, message, extra_info);
     case Aws::S3::S3Errors::NETWORK_CONNECTION:
-      return MakeExtendError(ExtendStatusCode::StorageTransientNetwork, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientNetwork, message, extra_info);
     default:
       break;
   }
 
   switch (error.GetResponseCode()) {
     case Aws::Http::HttpResponseCode::REQUEST_TIMEOUT:
-      return MakeExtendError(ExtendStatusCode::StorageTransientTimeout, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientTimeout, message, extra_info);
     case Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS:
-      return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, message, extra_info);
     case Aws::Http::HttpResponseCode::INTERNAL_SERVER_ERROR:
     case Aws::Http::HttpResponseCode::BAD_GATEWAY:
     case Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE:
     case Aws::Http::HttpResponseCode::GATEWAY_TIMEOUT:
-      return MakeExtendError(ExtendStatusCode::StorageTransientService, message, message /* extra_info */);
+      return MakeExtendError(ExtendStatusCode::StorageTransientService, message, extra_info);
     default:
       break;
   }
 
   const auto exception_name = error.GetExceptionName();
   if (exception_name == "SlowDown" || exception_name == "SlowDownWrite") {
-    return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, message, message /* extra_info */);
+    return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, message, extra_info);
   }
   if (exception_name == "XMinioServerNotInitialized") {
-    return MakeExtendError(ExtendStatusCode::StorageTransientService, message, message /* extra_info */);
-  }
-  if (error.ShouldRetry()) {
-    return MakeExtendError(ExtendStatusCode::StorageTransientNetwork, message, message /* extra_info */);
+    return MakeExtendError(ExtendStatusCode::StorageTransientService, message, extra_info);
   }
 
+  // ShouldRetry is the SDK retry policy, not a diagnosis. If no error type,
+  // HTTP status or backend exception name identifies the condition, leave the
+  // status unclassified instead of inventing a network failure.
   return std::nullopt;
 }
 
-// TODO qualify error messages with a prefix indicating context
-// (e.g. "When completing multipart upload to bucket 'xxx', key 'xxx': ...")
 template <typename ErrorType>
 arrow::Status ErrorToStatus(const std::string& prefix,
                             const std::string& operation,
                             const Aws::Client::AWSError<ErrorType>& error,
+                            S3ErrorProvenance provenance,
                             const std::optional<std::string>& region = std::nullopt) {
+  const std::string exception_name(error.GetExceptionName().data(), error.GetExceptionName().size());
+  const std::string aws_message(error.GetMessage().data(), error.GetMessage().size());
+  const std::string bounded_operation = BoundedDetail(operation, 128);
+  const std::string bounded_exception = exception_name.empty() ? "(none)" : BoundedDetail(exception_name, 128);
+
   // XXX Handle fine-grained error types
   // See
   // https://sdk.amazonaws.com/cpp/api/LATEST/namespace_aws_1_1_s3.html#ae3f82f8132b619b6e91c88a9f1bde371
+  // CoreErrors and S3Errors share a numeric space only by accident: the S3
+  // enum continues where the core one stops, so casting a core code into it
+  // names whichever S3 error happens to sit at that number. Answer core errors
+  // on their own terms before that cast.
+  //
+  // The bound is SERVICE_EXTENSION_START_RANGE (128), which is where the SDK
+  // stops numbering core errors and service enums begin -- not VALIDATION (14),
+  // which is merely one core code among many. Gating on VALIDATION made this
+  // whole block unreachable for the three codes it exists for
+  // (UNRECOGNIZED_CLIENT=17, INVALID_SIGNATURE=21, MEMORY_ALLOCATION=26): they
+  // sit above it, so every one still fell through to the S3 cast.
+  if (static_cast<int>(error.GetErrorType()) <
+      static_cast<int>(Aws::Client::CoreErrors::SERVICE_EXTENSION_START_RANGE)) {
+    const auto core = static_cast<Aws::Client::CoreErrors>(error.GetErrorType());
+    // Carries the prefix for the same reason the classified messages below do:
+    // this is where the bucket and key are named.
+    std::string core_message = BoundedDetail(prefix, 768) + "AWS core error " + bounded_exception + " during " +
+                               bounded_operation + " operation: " + BoundedDetail(aws_message);
+    core_message = BoundedDetail(core_message, 2048);
+    const std::string core_extra_info =
+        BoundedDetail("operation=" + bounded_operation +
+                          " core_error=" + ::arrow::internal::ToChars(static_cast<int>(error.GetErrorType())) +
+                          " exception=" + bounded_exception +
+                          " http_status=" + ::arrow::internal::ToChars(static_cast<int>(error.GetResponseCode())),
+                      512);
+    // The provider was already consulted before the signed request failed.
+    // Without a provider-specific invalidation signal, an immediate replay may
+    // reuse the same expired credential, so keep this as authentication failure.
+    if (IsExpiredCredentialError(exception_name)) {
+      return MakeExtendError(ExtendStatusCode::StorageAccessDenied, core_message, core_extra_info);
+    }
+    switch (core) {
+      case Aws::Client::CoreErrors::MEMORY_ALLOCATION:
+        return arrow::Status::OutOfMemory(core_message);
+      case Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE:
+        // The SDK credential interface reports only an empty credential set,
+        // not the reason resolution failed. Keep that unknown cause generic
+        // and non-retryable instead of guessing timeout, throttling, or denial.
+        return arrow::Status::IOError(core_message);
+      case Aws::Client::CoreErrors::UNRECOGNIZED_CLIENT:
+      case Aws::Client::CoreErrors::MISSING_AUTHENTICATION_TOKEN:
+      case Aws::Client::CoreErrors::INVALID_CLIENT_TOKEN_ID:
+      case Aws::Client::CoreErrors::INVALID_SIGNATURE:
+        // Credentials the deployment supplied are not accepted. An operator
+        // fixes this; it is not the caller's request and not our bug.
+        return MakeExtendError(ExtendStatusCode::StorageAccessDenied, core_message, core_extra_info);
+      default:
+        break;
+    }
+  }
+
   auto error_type = static_cast<Aws::S3::S3Errors>(error.GetErrorType());
   std::stringstream ss;
   ss << S3ErrorToString(error_type);
@@ -259,92 +441,132 @@ arrow::Status ErrorToStatus(const std::string& prefix,
   if (region.has_value()) {
     const auto maybe_region = BucketRegionFromError(error);
     if (maybe_region.has_value() && maybe_region.value() != region.value()) {
-      wrong_region_msg = " Looks like the configured region is '" + region.value() +
-                         "' while the bucket is located in '" + maybe_region.value() + "'.";
+      wrong_region_msg = " Looks like the configured region is '" + BoundedDetail(region.value(), 128) +
+                         "' while the bucket is located in '" + BoundedDetail(maybe_region.value(), 128) + "'.";
     }
   }
-  std::string message = "AWS Error " + ss.str() + " during " + operation + " operation: " + error.GetMessage() +
-                        wrong_region_msg.value_or("");
+  // Built ONCE, with the prefix, and used for every arm below.
+  //
+  // The prefix is where the bucket and the key are ("When reading information
+  // for key 'k' in bucket 'b': "). It used to be glued on only by the trailing
+  // IOError, so every CLASSIFIED status -- the ones that reach an operator with
+  // a verdict attached, and the ones that get paged on -- named the operation
+  // and nothing it operated on: "AccessDenied during HeadObject", with no way
+  // to tell which bucket rejected which key.
+  std::string message = BoundedDetail(prefix, 768) + "AWS Error " + ss.str() + " during " + bounded_operation +
+                        " operation: " + BoundedDetail(aws_message) + wrong_region_msg.value_or("");
+  message = BoundedDetail(message, 2048);
   LOG_STORAGE_WARNING_ << message;
 
-  if (auto permanent_status = tryMakePermanentExtendArrowError(error_type, error.GetResponseCode(), message);
-      permanent_status.has_value()) {
-    return permanent_status.value();
+  // extra_info used to be the message a second time, which cost a copy of an
+  // unbounded string per failure and told a reader nothing the message had not
+  // already said. What is here instead is the part a human message renders
+  // badly: the store's own name for the condition (S3-compatible backends put
+  // their real answer there and nowhere else -- "SlowDownWrite",
+  // "XMinioServerNotInitialized", "ExpiredToken") and the HTTP status the
+  // verdict was derived from.
+  std::string extra_info = "operation=" + bounded_operation + " s3_error=" + ss.str() +
+                           " exception=" + bounded_exception +
+                           " http_status=" + ::arrow::internal::ToChars(static_cast<int>(error.GetResponseCode()));
+  if (wrong_region_msg.has_value()) {
+    const auto actual_region = BucketRegionFromError(error).value();
+    extra_info += " configured_region=" + BoundedDetail(region.value(), 128) +
+                  " actual_region=" + BoundedDetail(actual_region, 128);
+  }
+  extra_info = BoundedDetail(extra_info, 512);
+
+  if (auto classified_status = tryMakeClassifiedExtendArrowError(
+          error_type, error.GetResponseCode(), message, std::string_view(exception_name), extra_info, provenance);
+      classified_status.has_value()) {
+    return classified_status.value();
   }
 
-  if (auto retryable_status = tryMakeRetryableExtendArrowError(error, error_type, message);
+  if (auto retryable_status = tryMakeRetryableExtendArrowError(error, error_type, message, extra_info);
       retryable_status.has_value()) {
     return retryable_status.value();
   }
 
-  // The AWS SDK carries its own retryability verdict (the same one its internal
-  // retry loop used). An escaped error the SDK itself would not retry is
-  // permanent -- tag it so consumers do not infer retryability from a generic
-  // storage error.
+  // x-amz-bucket-region is the service's authoritative answer. When it differs
+  // from the region used to sign the request, replaying the same configuration
+  // cannot help.
   //
-  // BUT only trust that verdict for error types the SDK actually recognized:
-  // S3-compatible backends (e.g. MinIO) return genuine transients as UNKNOWN
-  // with the non-retryable flag set -- "SlowDown" rate limiting arrives exactly
-  // this way. Recognized transient names and HTTP codes were handled above.
-  // Unknown/connect-style leftovers stay plain IOError instead of being tagged
-  // as permanent.
-  if (error_type != Aws::S3::S3Errors::UNKNOWN && !IsConnectError(error) && !error.ShouldRetry()) {
-    return MakeExtendError(ExtendStatusCode::AwsErrorNonRetryable, message, message /* extra_info */);
+  // Checked LAST, not first. The header is an attribute of the response, not a
+  // diagnosis of the failure: a store is free to echo it on a 503 or a 429, and
+  // a request that was throttled while pointed at the wrong region was still
+  // throttled. Judging it ahead of the identified condition let one true fact
+  // erase a sharper one, which is the downgrade R2.3 forbids. The mismatch
+  // stays in the message and extra_info on every arm above, so a misconfigured
+  // region is still visible in whichever verdict actually applies. It becomes
+  // THE verdict only when nothing else identified the failure -- which is the
+  // redirect/malformed-authorization shape it exists for, since the SDK reports
+  // those as UNKNOWN with a 301/400 that no other arm claims.
+  if (wrong_region_msg.has_value()) {
+    return MakeExtendError(ExtendStatusCode::StorageConfigInvalid, arrow::StatusCode::IOError, message, extra_info);
   }
 
-  // Backend-specific UNKNOWN errors without a recognizable permanent or
-  // transient signal remain plain IOError.
-  return arrow::Status::IOError(prefix, "AWS Error ", ss.str(), " during ", operation,
-                                " operation: ", error.GetMessage(), wrong_region_msg.value_or(""));
+  // ShouldRetry is an SDK policy decision, not an observed cause.  If the
+  // error type, HTTP response, transport condition, or backend name above did
+  // not identify the condition, leave it unclassified instead of publishing
+  // either a transient or permanent verdict derived from that policy.
+  return arrow::Status::IOError(message);
 }
 
 template <typename ErrorType, typename... Args>
 arrow::Status ErrorToStatus(const std::tuple<Args&...>& prefix,
                             const std::string& operation,
-                            const Aws::Client::AWSError<ErrorType>& error) {
+                            const Aws::Client::AWSError<ErrorType>& error,
+                            S3ErrorProvenance provenance) {
   std::stringstream ss;
   ::arrow::internal::PrintTuple(&ss, prefix);
-  return ErrorToStatus(ss.str(), operation, error);
+  return ErrorToStatus(ss.str(), operation, error, provenance);
 }
 
 template <typename ErrorType>
-arrow::Status ErrorToStatus(const std::string& operation, const Aws::Client::AWSError<ErrorType>& error) {
-  return ErrorToStatus(std::string(), operation, error);
+arrow::Status ErrorToStatus(const std::string& operation,
+                            const Aws::Client::AWSError<ErrorType>& error,
+                            S3ErrorProvenance provenance) {
+  return ErrorToStatus(std::string(), operation, error, provenance);
 }
 
 template <typename AwsResult, typename Error>
 arrow::Status OutcomeToStatus(const std::string& prefix,
                               const std::string& operation,
-                              const Aws::Utils::Outcome<AwsResult, Error>& outcome) {
+                              const Aws::Utils::Outcome<AwsResult, Error>& outcome,
+                              S3ErrorProvenance provenance) {
   if (outcome.IsSuccess()) {
     return arrow::Status::OK();
   } else {
-    return ErrorToStatus(prefix, operation, outcome.GetError());
+    return ErrorToStatus(prefix, operation, outcome.GetError(), provenance);
   }
 }
 
 template <typename AwsResult, typename Error, typename... Args>
 arrow::Status OutcomeToStatus(const std::tuple<Args&...>& prefix,
                               const std::string& operation,
-                              const Aws::Utils::Outcome<AwsResult, Error>& outcome) {
+                              const Aws::Utils::Outcome<AwsResult, Error>& outcome,
+                              S3ErrorProvenance provenance) {
   if (outcome.IsSuccess()) {
     return arrow::Status::OK();
   } else {
-    return ErrorToStatus(prefix, operation, outcome.GetError());
+    return ErrorToStatus(prefix, operation, outcome.GetError(), provenance);
   }
 }
 
 template <typename AwsResult, typename Error>
-arrow::Status OutcomeToStatus(const std::string& operation, const Aws::Utils::Outcome<AwsResult, Error>& outcome) {
-  return OutcomeToStatus(std::string(), operation, outcome);
+arrow::Status OutcomeToStatus(const std::string& operation,
+                              const Aws::Utils::Outcome<AwsResult, Error>& outcome,
+                              S3ErrorProvenance provenance) {
+  return OutcomeToStatus(std::string(), operation, outcome, provenance);
 }
 
 template <typename AwsResult, typename Error>
-arrow::Result<AwsResult> OutcomeToResult(const std::string& operation, Aws::Utils::Outcome<AwsResult, Error> outcome) {
+arrow::Result<AwsResult> OutcomeToResult(const std::string& operation,
+                                         Aws::Utils::Outcome<AwsResult, Error> outcome,
+                                         S3ErrorProvenance provenance) {
   if (outcome.IsSuccess()) {
     return std::move(outcome).GetResultWithOwnership();
   } else {
-    return ErrorToStatus(operation, outcome.GetError());
+    return ErrorToStatus(operation, outcome.GetError(), provenance);
   }
 }
 
@@ -375,8 +597,13 @@ class ConnectRetryStrategy : public Aws::Client::RetryStrategy {
 
   bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors>& error,
                    long attempted_retries) const override {  // NOLINT runtime/int
-    if (!IsConnectError(error)) {
-      // Not a connect error, don't retry
+    // This class is itself an AWS SDK retry policy. It may consult the SDK's
+    // eligibility flag, but that flag must never escape through ErrorToStatus
+    // as a storage diagnosis or public retry contract.
+    const auto exception_name = error.GetExceptionName();
+    const bool retry_eligible = error.ShouldRetry() || exception_name == "SlowDownWrite" ||
+                                exception_name == "SlowDown" || exception_name == "XMinioServerNotInitialized";
+    if (!retry_eligible) {
       return false;
     }
     return attempted_retries * retry_interval_ < max_retry_duration_;

--- a/cpp/include/milvus-storage/filesystem/util_internal.h
+++ b/cpp/include/milvus-storage/filesystem/util_internal.h
@@ -1,10 +1,16 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <memory>
+#include <new>
+#include <stdexcept>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/io/interfaces.h"
@@ -12,6 +18,9 @@
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/uri.h"
 #include "arrow/util/visibility.h"
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/common/writer_status.h"
 
 namespace arrow {
 using util::Uri;
@@ -111,12 +120,121 @@ arrow::Status PathNotFound(std::string_view path);
 namespace io {
 namespace internal {
 
+/// Record a background I/O failure on the writer and return the writer's
+/// terminal status.
+///
+/// Recording allocates. If that allocation fails the exception propagates and
+/// the process dies, by design: the alternative -- swallowing it so the caller
+/// can carry on -- is what used to leave the aggregate future unfinished with
+/// its publish slot already consumed, hanging every waiter forever.
+inline arrow::Status ObserveBackgroundIOStatus(milvus_storage::WriterStatus* writer_status,
+                                               const arrow::Status& status) {
+  if (status.ok()) {
+    return arrow::Status::OK();
+  }
+  (void)writer_status->RecordFirstFailure(status);
+  return writer_status->Check();
+}
+
 template <typename... SubmitArgs>
 auto SubmitIO(arrow::io::IOContext io_context, SubmitArgs&&... submit_args)
     -> decltype(std::declval<::arrow::internal::Executor*>()->Submit(submit_args...)) {
   arrow::internal::TaskHints hints;
   hints.external_id = io_context.external_id();
   return io_context.executor()->Submit(hints, io_context.stop_token(), std::forward<SubmitArgs>(submit_args)...);
+}
+
+/// Submit a background I/O task and invoke `completion` exactly once for every
+/// recoverable outcome: executor rejection, a returned task failure, or an
+/// exception before the task can report its status. Allocation failure is
+/// fail-stop once the caller has registered the operation, because recovery
+/// could strand its completion slot. Pre-execution cancellation is handled by
+/// the executor stop callback; every other recoverable path settles here.
+template <typename Task, typename Completion>
+arrow::Status SubmitIOWithCompletion(arrow::io::IOContext io_context, Task&& task, Completion&& completion) noexcept {
+  using CompletionType = std::decay_t<Completion>;
+  static_assert(std::is_copy_constructible_v<CompletionType>, "The completion callback must be copyable");
+
+  struct CompletionState {
+    explicit CompletionState(const CompletionType& callback) : callback(callback) {}
+
+    void Complete(const arrow::Status& status) noexcept {
+      if (!completed.exchange(true, std::memory_order_acq_rel)) {
+        callback(status);
+      }
+    }
+
+    std::atomic<bool> completed{false};
+    CompletionType callback;
+  };
+
+  std::shared_ptr<CompletionState> completion_state;
+  try {
+    // Copy the named callback only after make_shared has allocated storage, so
+    // allocation/construction failure leaves the caller's callback usable.
+    completion_state = std::make_shared<CompletionState>(completion);
+  } catch (const std::bad_alloc&) {
+    // Callers register the background operation before entering this helper.
+    // Returning or unwinding here would leave that completion slot unresolved.
+    std::terminate();
+  } catch (const std::exception& e) {
+    auto status = milvus_storage::MakeExtendErrorMsg(milvus_storage::ExtendStatusCode::InternalInvariantViolated,
+                                                     "Failed to prepare background I/O completion: ", e.what());
+    completion(status);
+    return status;
+  } catch (...) {
+    auto status = milvus_storage::MakeExtendErrorMsg(
+        milvus_storage::ExtendStatusCode::InternalInvariantViolated,
+        "Failed to prepare background I/O completion due to a non-standard exception");
+    completion(status);
+    return status;
+  }
+
+  try {
+    auto deferred = [task = std::forward<Task>(task), completion_state]() mutable noexcept {
+      arrow::Status task_status;
+      try {
+        task_status = task();
+      } catch (const std::bad_alloc&) {
+        // A waiter already owns this task's completion slot. There is no safe
+        // recoverable status to publish while allocation itself is failing.
+        std::terminate();
+      } catch (const std::exception& e) {
+        task_status = milvus_storage::MakeExtendErrorMsg(milvus_storage::ExtendStatusCode::InternalInvariantViolated,
+                                                         "Background I/O task threw an exception: ", e.what());
+      } catch (...) {
+        task_status = milvus_storage::MakeExtendErrorMsg(milvus_storage::ExtendStatusCode::InternalInvariantViolated,
+                                                         "Background I/O task threw a non-standard exception");
+      }
+      completion_state->Complete(task_status);
+    };
+
+    arrow::internal::TaskHints hints;
+    hints.external_id = io_context.external_id();
+    auto stop_callback = [completion_state](const arrow::Status& status) { completion_state->Complete(status); };
+    auto submit_status =
+        io_context.executor()->Spawn(hints, std::move(deferred), io_context.stop_token(), std::move(stop_callback));
+    if (!submit_status.ok()) {
+      completion_state->Complete(submit_status);
+      return submit_status;
+    }
+  } catch (const std::bad_alloc&) {
+    // Executor submission may have accepted the task before throwing. Failing
+    // stop is the only verdict that cannot strand or double-set completion.
+    std::terminate();
+  } catch (const std::exception& e) {
+    auto status = milvus_storage::MakeExtendErrorMsg(milvus_storage::ExtendStatusCode::InternalInvariantViolated,
+                                                     "Failed to submit background I/O: ", e.what());
+    completion_state->Complete(status);
+    return status;
+  } catch (...) {
+    auto status = milvus_storage::MakeExtendErrorMsg(milvus_storage::ExtendStatusCode::InternalInvariantViolated,
+                                                     "Failed to submit background I/O due to a non-standard exception");
+    completion_state->Complete(status);
+    return status;
+  }
+
+  return arrow::Status::OK();
 }
 
 }  // namespace internal

--- a/cpp/src/common/extend_status.cpp
+++ b/cpp/src/common/extend_status.cpp
@@ -287,8 +287,6 @@ milvus::ErrorCode ToSegcoreErrorCode(ExtendStatusCode code) {
       // Non-retriable either way, but it must page whoever owns the config
       // rather than be filed as a generic storage failure.
       return milvus::ConfigInvalid;  // 2006
-    case ExtendStatusCode::AwsErrorNonRetryable:
-      return milvus::StorageError;
   }
   return milvus::StorageError;  // out-of-range value: safe non-retriable fallback
 }

--- a/cpp/src/filesystem/azure/azure_fs_producer.cpp
+++ b/cpp/src/filesystem/azure/azure_fs_producer.cpp
@@ -17,6 +17,7 @@
 
 #include "milvus-storage/filesystem/azure/azurefs.h"
 #include "milvus-storage/filesystem/azure/azure_sas_token_policy.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/log.h"
 
 #include "milvus-storage/common/macro.h"
@@ -32,7 +33,10 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
   }
 
   milvus_storage::fs::AzureOptions options;
-  assert(!config_.access_key_id.empty());
+  if (config_.access_key_id.empty()) {
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                              "Azure filesystem requires fs.access_key_id (the storage account name)");
+  }
   options.account_name = config_.access_key_id;
 
   if (!config_.address.empty()) {
@@ -66,27 +70,38 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
     ARROW_RETURN_NOT_OK(
         options.ConfigureSASTokenPolicy(std::make_shared<fs::AzureSasTokenPolicy>(std::move(broker_config))));
   } else if (config_.use_iam) {
+    if (!config_.use_ssl) {
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Azure IAM authentication requires fs.use_ssl=true because bearer tokens "
+                                "cannot be sent over HTTP");
+    }
     const char* federated_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
     if (federated_token != nullptr && strlen(federated_token) > 0) {
       // Workload Identity
       if (std::getenv("AZURE_CLIENT_ID") == nullptr) {
-        return arrow::Status::Invalid("AZURE_CLIENT_ID environment variable is not set");
+        return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                  "AZURE_CLIENT_ID environment variable is not set");
       }
       if (std::getenv("AZURE_TENANT_ID") == nullptr) {
-        return arrow::Status::Invalid("AZURE_TENANT_ID environment variable is not set");
+        return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                  "AZURE_TENANT_ID environment variable is not set");
       }
       ARROW_RETURN_NOT_OK(options.ConfigureWorkloadIdentityCredential());
     } else {
       // Managed Identity
       const char* client_id = std::getenv("AZURE_CLIENT_ID");
       if (client_id == nullptr) {
-        return arrow::Status::Invalid("AZURE_CLIENT_ID environment variable is not set");
+        return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                  "AZURE_CLIENT_ID environment variable is not set");
       }
       ARROW_RETURN_NOT_OK(options.ConfigureManagedIdentityCredential(std::string(client_id)));
     }
   } else {
     // need azure secret key without iam
-    assert(!config_.access_key_value.empty());
+    if (config_.access_key_value.empty()) {
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Azure account-key authentication requires fs.access_key_value");
+    }
     ARROW_RETURN_NOT_OK(options.ConfigureAccountKeyCredential(config_.access_key_value));
   }
 

--- a/cpp/src/filesystem/azure/azure_sas_token_policy.cpp
+++ b/cpp/src/filesystem/azure/azure_sas_token_policy.cpp
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "milvus-storage/filesystem/azure/azurefs_internal.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/azure/azure_sas_token_policy.h"
 
 #include <cstdint>
 #include <exception>
 #include <iomanip>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -27,6 +30,7 @@
 #include <azure/core/http/http.hpp>
 #include <azure/core/io/body_stream.hpp>
 #include <azure/core/url.hpp>
+#include <arrow/util/value_parsing.h>
 #include <nlohmann/json.hpp>
 
 #include "milvus-storage/common/log.h"
@@ -92,25 +96,23 @@ AzureSasTokenPolicy::AzureSasTokenPolicy(AzureSasBrokerConfig config,
 bool AzureSasTokenPolicy::IsFresh(TimePoint expires_at, TimePoint now) { return expires_at - now > kRefreshOffset; }
 
 arrow::Result<std::string> AzureSasTokenPolicy::FetchSasToken(TimePoint now, TimePoint* expires_at) const {
-  const nlohmann::json request_json = {
-      {"csp", "azure"},
-      {"region", state_->config.region},
-      {"bucket", state_->config.bucket},
-      {"durationSeconds", state_->config.duration_seconds},
-      {"azureClientId", state_->config.client_id},
-      {"azureTenantId", state_->config.tenant_id},
-      {"azureAccountName", state_->config.account_name},
-  };
-
-  const auto request_body = request_json.dump();
-  const std::vector<uint8_t> request_bytes(request_body.begin(), request_body.end());
-  Azure::Core::IO::MemoryBodyStream body_stream(request_bytes);
-
-  bool request_completed = false;
-  bool response_body_read_completed = false;
   size_t response_size = 0;
   AzureSasBrokerResponse broker_response;
   try {
+    const nlohmann::json request_json = {
+        {"csp", "azure"},
+        {"region", state_->config.region},
+        {"bucket", state_->config.bucket},
+        {"durationSeconds", state_->config.duration_seconds},
+        {"azureClientId", state_->config.client_id},
+        {"azureTenantId", state_->config.tenant_id},
+        {"azureAccountName", state_->config.account_name},
+    };
+
+    const auto request_body = request_json.dump();
+    const std::vector<uint8_t> request_bytes(request_body.begin(), request_body.end());
+    Azure::Core::IO::MemoryBodyStream body_stream(request_bytes);
+
     Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Post, Azure::Core::Url(state_->config.endpoint),
                                        &body_stream);
     request.SetHeader("Content-Type", "application/json");
@@ -122,13 +124,48 @@ arrow::Result<std::string> AzureSasTokenPolicy::FetchSasToken(TimePoint now, Tim
                                           std::chrono::milliseconds(state_->config.request_timeout_ms));
     const auto context = Azure::Core::Context().WithDeadline(deadline);
     auto response = state_->transport->Send(request, context);
-    request_completed = true;
     if (!response) {
-      return arrow::Status::IOError("Azure SAS credential broker returned no HTTP response: endpoint=",
-                                    state_->config.endpoint);
+      // Classified HERE, at the producer. The policy downstream cannot tell a
+      // broker that never answered from a broker that rejected us, and an
+      // unclassified failure there defaulted to "credentials are wrong" --
+      // permanent, when this is the textbook retriable case.
+      return MakeExtendErrorMsg(
+          ExtendStatusCode::StorageTransientNetwork,
+          "Azure SAS credential broker returned no HTTP response: endpoint=", state_->config.endpoint);
     }
     const int status_code = static_cast<int>(response->GetStatusCode());
     if (status_code < 200 || status_code >= 300) {
+      // 408/429/5xx are the broker being unwell, not a verdict about our
+      // credentials; only a 401/403 is that. Same split the S3 and Azure
+      // filesystems already make on their own responses.
+      std::optional<ExtendStatusCode> transient;
+      if (status_code == 408) {
+        transient = ExtendStatusCode::StorageTransientTimeout;
+      } else if (status_code == 429) {
+        transient = ExtendStatusCode::StorageTransientThrottling;
+      } else if (status_code >= 500) {
+        transient = ExtendStatusCode::StorageTransientService;
+      }
+      if (transient.has_value()) {
+        return MakeExtendErrorMsg(
+            *transient, "Azure SAS credential broker returned an HTTP error: endpoint=", state_->config.endpoint,
+            ", status_code=", status_code, ", reason=", response->GetReasonPhrase());
+      }
+      if (status_code == 401 || status_code == 403) {
+        // The other half of the rule stated above, which used to be a comment
+        // only: the broker rejecting US is the one answer that is genuinely
+        // about credentials. Saying so HERE is what lets the policy below stop
+        // guessing -- without this code, a 400 or a 404 arrived downstream
+        // indistinguishable from a real rejection and was reported as one.
+        return MakeExtendErrorMsg(
+            ExtendStatusCode::StorageAccessDenied,
+            "Azure SAS credential broker rejected the request: endpoint=", state_->config.endpoint,
+            ", status_code=", status_code, ", reason=", response->GetReasonPhrase());
+      }
+      // 400, 404, and anything else the broker invents: a real failure whose
+      // owner we cannot name. Left unclassified on purpose (R1.2) -- it is not
+      // transient and it is not a credential verdict, and inventing either one
+      // sends somebody to fix the wrong thing.
       return arrow::Status::IOError(
           "Azure SAS credential broker returned an HTTP error: endpoint=", state_->config.endpoint,
           ", status_code=", status_code, ", reason=", response->GetReasonPhrase());
@@ -138,7 +175,6 @@ arrow::Result<std::string> AzureSasTokenPolicy::FetchSasToken(TimePoint now, Tim
     if (auto body_stream = response->ExtractBodyStream()) {
       response_body = body_stream->ReadToEnd(context);
     }
-    response_body_read_completed = true;
     response_size = response_body.size();
     const auto response_json = nlohmann::json::parse(response_body.begin(), response_body.end());
     response_json.get_to(broker_response);
@@ -168,9 +204,24 @@ arrow::Result<std::string> AzureSasTokenPolicy::FetchSasToken(TimePoint now, Tim
           "query parameter");
     }
 
-    const auto parsed = Azure::DateTime::Parse(broker_response.token.expired_at, Azure::DateTime::DateFormat::Rfc3339);
-    const auto expiration = static_cast<std::chrono::system_clock::time_point>(parsed);
+    // Parse at NANO so fractional seconds up to 9 digits are accepted: Azure /
+    // .NET brokers emit 7-digit ticks (e.g. ...T12:00:00.1234567Z), which a
+    // MILLI-precision parse rejects outright.
+    static const auto iso8601_parser = arrow::TimestampParser::MakeISO8601();
+    int64_t expiration_nanos = 0;
+    bool zone_offset_present = false;
+    if (!(*iso8601_parser)(broker_response.token.expired_at.data(), broker_response.token.expired_at.size(),
+                           arrow::TimeUnit::NANO, &expiration_nanos, &zone_offset_present) ||
+        !zone_offset_present) {
+      return arrow::Status::IOError("Azure SAS credential broker returned an invalid expiration time: expiredAt=",
+                                    broker_response.token.expired_at);
+    }
+    const auto expiration =
+        TimePoint{std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::nanoseconds{expiration_nanos})};
     if (expiration <= now) {
+      // The broker returned a structurally valid but unusable credential. It
+      // did not provide a transient verdict, so do not turn this broad
+      // dependency failure into a retry that performs another broker request.
       return arrow::Status::IOError(
           "Azure SAS credential broker returned an expired token: expiredAt=", broker_response.token.expired_at,
           ", current_time=", Azure::DateTime(now).ToString(Azure::DateTime::DateFormat::Rfc3339));
@@ -184,17 +235,23 @@ arrow::Result<std::string> AzureSasTokenPolicy::FetchSasToken(TimePoint now, Tim
         ", parse_error_byte=", error.byte, ", response_size=", response_size);
   } catch (const nlohmann::json::exception& error) {
     return arrow::Status::IOError("Azure SAS credential broker response schema is invalid: ", error.what());
-  } catch (const std::exception& error) {
-    if (!request_completed) {
-      return arrow::Status::IOError("Azure SAS credential broker request failed: endpoint=", state_->config.endpoint,
-                                    ", error=", error.what());
-    }
-    if (!response_body_read_completed) {
-      return arrow::Status::IOError("Azure SAS credential broker response body read failed: endpoint=",
-                                    state_->config.endpoint, ", error=", error.what());
-    }
-    return arrow::Status::IOError("Azure SAS credential broker returned an invalid expiration time: expiredAt=",
-                                  broker_response.token.expired_at, ", error=", error.what());
+  } catch (const Azure::Core::Http::TransportException& error) {
+    // The request never reached the broker -- connection refused/reset, DNS,
+    // TLS. Classified here because the policy downstream can only see the
+    // synthetic response it builds, and an unclassified failure there became a
+    // 401, i.e. "your credentials are wrong" for a cable that came loose.
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientNetwork,
+                              "Azure SAS credential broker request failed at the transport: endpoint=",
+                              state_->config.endpoint, ", error=", error.what());
+  } catch (const Azure::Core::OperationCancelledException& error) {
+    // The deadline set on the context above fired.
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientTimeout,
+                              "Azure SAS credential broker request timed out: endpoint=", state_->config.endpoint,
+                              ", error=", error.what());
+  } catch (const std::bad_alloc&) {
+    return arrow::Status::OutOfMemory("Azure SAS credential broker ran out of memory");
+  } catch (...) {
+    return arrow::Status::UnknownError("Azure SAS credential broker failed unexpectedly");
   }
 }
 
@@ -218,13 +275,6 @@ arrow::Result<std::string> AzureSasTokenPolicy::GetSasToken() const {
     return state_->cached->sas_token;
   }
 
-  const bool cached_expired = had_cached_sas && state_->cached->expires_at <= now;
-  LOG_STORAGE_WARNING_ << "Azure SAS credential broker refresh failed: " << fetched.status().ToString()
-                       << ", has_cached_sas=" << std::boolalpha << had_cached_sas
-                       << ", cached_expired=" << std::boolalpha << cached_expired;
-  if (had_cached_sas) {
-    return state_->cached->sas_token;
-  }
   return fetched.status();
 }
 
@@ -244,13 +294,71 @@ std::unique_ptr<Azure::Core::Http::RawResponse> AzureSasTokenPolicy::Send(
     const Azure::Core::Context& context) const {
   auto sas_token = GetSasToken();
   if (!sas_token.ok()) {
-    // Stop the Azure pipeline before it sends an unauthenticated request. The
-    // Broker errors are kept in the reason phrase so callers can see the SAS
-    // token failure through Azure's RequestFailedException.
+    // Stop the Azure pipeline before it sends an unauthenticated request.
+    //
+    // This policy sits inside the SDK pipeline and cannot return a Status: its
+    // only channel is a synthesised HTTP response. The classification therefore
+    // travels in the error code under the LoonBroker prefix -- the full verdict
+    // (retriable subtype or credential rejection) is carried there, and
+    // ClassifyAzureError decodes it back via BrokerErrorCodeToExtendStatus. The
+    // HTTP status is only a coarse fallback for consumers that read status codes
+    // without understanding the marker: 401 = rejection, 408/429/503 = the
+    // retriable subtype that status happens to name, 500 = System.
+    //
+    // A broker that timed out, was throttled, or answered 5xx is NOT a rejected
+    // credential; reporting both as 401 made them share code 105, so one of the
+    // two owners was always wrong -- and it was the retriable one being denied
+    // a retry.
+    const auto broker_detail = ExtendStatusDetail::UnwrapStatus(sas_token.status());
+    // The DEFAULT is now "we do not know", not "your credentials are wrong".
+    //
+    // 401 is a specific verdict, and it used to be the fallback for everything
+    // the broker could do wrong: a 400, a 404, an unknown account, a malformed
+    // JSON body, a schema that did not match. Downstream turned every one of
+    // them into StorageAccessDenied and then ConfigInvalid, so an operator was
+    // sent to rotate a credential that was never the problem. Only a broker that
+    // actually rejected us reaches the Unauthorized arm below, and it does so
+    // because GetSasToken() said so with a code rather than because nothing else
+    // matched.
+    auto status_code = Azure::Core::Http::HttpStatusCode::InternalServerError;
+    const char* error_code = internal::kSyntheticBrokerUnexpectedErrorCode;
+    if (sas_token.status().IsOutOfMemory()) {
+      status_code = Azure::Core::Http::HttpStatusCode::InternalServerError;
+      error_code = internal::kSyntheticBrokerOutOfMemoryErrorCode;
+    } else if (sas_token.status().IsUnknownError()) {
+      status_code = Azure::Core::Http::HttpStatusCode::InternalServerError;
+      error_code = internal::kSyntheticBrokerUnexpectedErrorCode;
+    } else if (broker_detail != nullptr && broker_detail->code() == ExtendStatusCode::StorageAccessDenied) {
+      status_code = Azure::Core::Http::HttpStatusCode::Unauthorized;
+      error_code = internal::kSyntheticBrokerAccessDeniedErrorCode;
+    } else if (broker_detail != nullptr && broker_detail->retryable()) {
+      switch (broker_detail->code()) {
+        case ExtendStatusCode::StorageTransientTimeout:
+          status_code = Azure::Core::Http::HttpStatusCode::RequestTimeout;
+          error_code = internal::kSyntheticBrokerTimeoutErrorCode;
+          break;
+        case ExtendStatusCode::StorageTransientThrottling:
+          status_code = Azure::Core::Http::HttpStatusCode::TooManyRequests;
+          error_code = internal::kSyntheticBrokerThrottlingErrorCode;
+          break;
+        case ExtendStatusCode::StorageTransientNetwork:
+          // HTTP has no status meaning "the connection dropped", so the
+          // subtype rides in the error code instead: ClassifyAzureError
+          // recognises this marker and restores 107 rather than flattening the
+          // failure into a service blip. Reported as a 503 so any downstream
+          // that only reads status codes still treats it as retriable.
+          status_code = Azure::Core::Http::HttpStatusCode::ServiceUnavailable;
+          error_code = internal::kSyntheticBrokerNetworkErrorCode;
+          break;
+        default:
+          status_code = Azure::Core::Http::HttpStatusCode::ServiceUnavailable;
+          error_code = internal::kSyntheticBrokerServiceUnavailableErrorCode;
+          break;
+      }
+    }
     auto response = std::make_unique<Azure::Core::Http::RawResponse>(
-        1, 1, Azure::Core::Http::HttpStatusCode::Unauthorized,
-        "Azure SAS token unavailable: " + sas_token.status().ToString());
-    response->SetHeader("x-ms-error-code", "AuthenticationFailed");
+        1, 1, status_code, "Azure SAS token unavailable: " + sas_token.status().ToString());
+    response->SetHeader("x-ms-error-code", error_code);
     response->SetHeader("Content-Length", "0");
     return response;
   }

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -17,26 +17,30 @@
 
 #include <atomic>
 #include <chrono>
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 
 #include "milvus-storage/filesystem/azure/azurefs.h"
 #include "milvus-storage/filesystem/azure/azure_sas_token_policy.h"
 #include "milvus-storage/filesystem/azure/azurefs_internal.h"
 #include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/common/writer_status.h"
 #include "arrow/io/memory.h"
 
 // idenfity.hpp triggers -Wattributes warnings cause -Werror builds to fail,
 // so disable it for this file with pragmas.
 #if defined(__GNUC__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wattributes"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #endif
 #include <azure/identity.hpp>
 #if defined(__GNUC__)
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/files/datalake.hpp>
@@ -112,11 +116,38 @@ using arrow::fs::internal::ValidateAbstractPathParts;
 
 // Declared in azurefs_internal.h. Kept out of the anonymous namespace so it can
 // be unit-tested without an Azure account.
-//
-// The codes are cloud-neutral despite the `AwsError*` prefix (see the naming
-// discussion in #574): they carry the meaning, not the vendor.
-std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(
-    int http_status, std::string_view error_code, bool transport_failure) {
+
+// The inverse of what AzureSasTokenPolicy::Send stamps: a broker failure was
+// smuggled through the HTTP-only policy interface as a LoonBroker* error code,
+// and this restores the ExtendStatusCode the policy started from. Kept in one
+// place so the producer and consumer share a single mapping table; the OOM and
+// unexpected codes are absent on purpose -- they are not ExtendStatusCode
+// conditions and are handled by AzureExceptionToStatus before the general
+// classifier is reached.
+std::optional<milvus_storage::ExtendStatusCode> BrokerErrorCodeToExtendStatus(std::string_view error_code) {
+  if (error_code == internal::kSyntheticBrokerAccessDeniedErrorCode) {
+    return milvus_storage::ExtendStatusCode::StorageAccessDenied;
+  }
+  if (error_code == internal::kSyntheticBrokerTimeoutErrorCode) {
+    return milvus_storage::ExtendStatusCode::StorageTransientTimeout;
+  }
+  if (error_code == internal::kSyntheticBrokerThrottlingErrorCode) {
+    return milvus_storage::ExtendStatusCode::StorageTransientThrottling;
+  }
+  if (error_code == internal::kSyntheticBrokerServiceUnavailableErrorCode) {
+    return milvus_storage::ExtendStatusCode::StorageTransientService;
+  }
+  if (error_code == internal::kSyntheticBrokerNetworkErrorCode) {
+    return milvus_storage::ExtendStatusCode::StorageTransientNetwork;
+  }
+  return std::nullopt;
+}
+
+std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(int http_status,
+                                                                   std::string_view error_code,
+                                                                   bool transport_failure,
+                                                                   std::string_view reason_phrase,
+                                                                   AzureResourceKind resource_kind) {
   // The request never reached the service: connection refused/reset, DNS
   // failure, TLS handshake failure. The textbook retriable case.
   //
@@ -125,6 +156,15 @@ std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(
   // PollUntilDone raises exactly that when a copy operation ends in a failed
   // state -- treating that as a network blip would turn a definitively failed
   // copy into an infinitely retriable one.
+  // A LoonBroker* code means the failure came from the local credential broker,
+  // not from Azure Storage: the SAS policy already classified it, and the code
+  // carries the full verdict. Short-circuit before the HTTP-status switch below,
+  // which is only meaningful for real Azure responses -- the broker's synthetic
+  // status (408/429/503/500) is a coarse fallback for HTTP-only consumers, not
+  // the classification channel.
+  if (error_code.starts_with(internal::kSyntheticBrokerErrorCodePrefix)) {
+    return BrokerErrorCodeToExtendStatus(error_code);
+  }
   if (transport_failure) {
     return milvus_storage::ExtendStatusCode::StorageTransientNetwork;
   }
@@ -135,24 +175,50 @@ std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(
 
   switch (http_status) {
     case 412:  // Precondition Failed
-      return milvus_storage::ExtendStatusCode::AwsErrorPreConditionFailed;
+      // Same discipline as the 409 below, which this used to ignore: classify
+      // only the flavour we positively identify. Azure answers 412 for a
+      // genuine etag/condition mismatch AND for lease problems
+      // (LeaseIdMismatch..., LeaseNotPresent...), which are a different
+      // condition. Calling every 412 a precondition conflict was a guess.
+      return error_code == "ConditionNotMet"
+                 ? std::optional{milvus_storage::ExtendStatusCode::StoragePreConditionFailed}
+                 : std::nullopt;
     case 409:  // Conflict
       // Only the "blob already exists" flavour is the precondition-style
       // conflict this maps to. Other 409s (lease held, container being deleted)
       // are a different condition and stay unclassified rather than guessed at.
       return error_code == "BlobAlreadyExists"
-                 ? std::optional{
-                       milvus_storage::ExtendStatusCode::AwsErrorPreConditionFailed}
+                 ? std::optional{milvus_storage::ExtendStatusCode::StoragePreConditionFailed}
                  : std::nullopt;
     case 404:  // Not Found
-      // The blob/container is gone. Permanent: a retry, or a reroute to another
-      // replica, reaches the same storage account and fails identically.
-      return milvus_storage::ExtendStatusCode::AwsErrorNotFound;
+      // A missing CONTAINER is not a missing blob, and the two need opposite
+      // things from the consumer. Re-reading the manifest can resolve a missing
+      // blob -- it was collected, or it moved. No amount of re-reading produces
+      // a container: the deployment points at one that is not there, which an
+      // operator fixes. Same split S3 already makes between NO_SUCH_BUCKET and
+      // NO_SUCH_KEY; Azure just reports it differently.
+      //
+      // Both signals are checked because Azure sometimes leaves ErrorCode empty
+      // and puts it in the ReasonPhrase -- see IsContainerNotFound, which is
+      // where these strings come from.
+      // Blob and Data Lake are the same container reached through two APIs and
+      // they spell its absence differently -- FilesystemNotFound is the ADLS
+      // Gen2 code. Omitting either spelling sends an operator's problem to the
+      // caller as a missing object.
+      if (resource_kind == AzureResourceKind::Container || error_code == "ContainerNotFound" ||
+          error_code == "FilesystemNotFound" || reason_phrase == "The specified container does not exist." ||
+          reason_phrase == "The specified filesystem does not exist.") {
+        return milvus_storage::ExtendStatusCode::StorageBucketNotFound;
+      }
+      // The blob is gone. This layer will not say whether that is a GC race or
+      // lost data -- the consumer decides. Replaying the same request reaches
+      // the same storage account and fails identically.
+      return milvus_storage::ExtendStatusCode::StorageNotFound;
     case 401:  // Unauthorized
     case 403:  // Forbidden
-      // Bad or expired credentials, or the SAS/RBAC grant does not cover this
-      // operation. Permanent until an operator fixes the configuration.
-      return milvus_storage::ExtendStatusCode::AwsErrorAccessDenied;
+      // Bad credentials, or the SAS/RBAC grant does not cover this operation.
+      // This remains a System failure until an operator fixes the deployment.
+      return milvus_storage::ExtendStatusCode::StorageAccessDenied;
     case 408:  // Request Timeout
       return milvus_storage::ExtendStatusCode::StorageTransientTimeout;
     case 429:  // Too Many Requests
@@ -162,9 +228,8 @@ std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(
       // throttling, anything else is a genuine availability blip. Both are
       // retriable, but keeping them apart lets a consumer apply throttle-aware
       // backoff to the one that calls for it.
-      return error_code == "ServerBusy"
-                 ? milvus_storage::ExtendStatusCode::StorageTransientThrottling
-                 : milvus_storage::ExtendStatusCode::StorageTransientService;
+      return error_code == "ServerBusy" ? milvus_storage::ExtendStatusCode::StorageTransientThrottling
+                                        : milvus_storage::ExtendStatusCode::StorageTransientService;
     case 500:  // Internal Server Error
     case 502:  // Bad Gateway
     case 504:  // Gateway Timeout
@@ -175,6 +240,50 @@ std::optional<milvus_storage::ExtendStatusCode> ClassifyAzureError(
       return std::nullopt;
   }
 }
+
+static std::string BoundedAzureDetail(std::string_view text, size_t limit = 512) {
+  if (text.size() <= limit) {
+    return std::string(text);
+  }
+  return std::string(text.substr(0, limit)) + "...(+" + std::to_string(text.size() - limit) + " bytes)";
+}
+
+arrow::Status AzureExceptionToStatus(const Azure::Core::RequestFailedException& exception,
+                                     std::string prefix,
+                                     AzureResourceKind resource_kind) {
+  if (exception.ErrorCode == kSyntheticBrokerOutOfMemoryErrorCode) {
+    return arrow::Status::OutOfMemory(
+        std::move(prefix), " Azure credential broker allocation failed: ", BoundedAzureDetail(exception.what()));
+  }
+  if (exception.ErrorCode == kSyntheticBrokerUnexpectedErrorCode) {
+    return arrow::Status::UnknownError(
+        std::move(prefix), " Azure credential broker failed unexpectedly: ", BoundedAzureDetail(exception.what()));
+  }
+
+  // Discriminate on the dynamic type: TransportException means the request
+  // never reached the service. Its StatusCode is None, but so is that of a
+  // plain RequestFailedException(std::string), which PollUntilDone raises for
+  // a failed copy -- see ClassifyAzureError.
+  const bool transport_failure = dynamic_cast<const Azure::Core::Http::TransportException*>(&exception) != nullptr;
+  auto code = ClassifyAzureError(static_cast<int>(exception.StatusCode), exception.ErrorCode, transport_failure,
+                                 exception.ReasonPhrase, resource_kind);
+  const auto error_code =
+      exception.ErrorCode.empty() ? std::string("(none)") : BoundedAzureDetail(exception.ErrorCode, 128);
+  const auto exception_message = BoundedAzureDetail(exception.what());
+  if (!code.has_value()) {
+    return arrow::Status::IOError(std::move(prefix), " Azure Error: [", error_code, "] ", exception_message);
+  }
+
+  auto message = std::move(prefix) + " Azure Error: [" + error_code + "] " + exception_message;
+  auto extra_info = "azure_error=" + error_code +
+                    " http_status=" + std::to_string(static_cast<int>(exception.StatusCode)) +
+                    " transport_failure=" + (transport_failure ? std::string("true") : std::string("false"));
+  if (!exception.ReasonPhrase.empty()) {
+    extra_info += " reason=" + BoundedAzureDetail(exception.ReasonPhrase, 128);
+  }
+  return milvus_storage::MakeExtendError(*code, std::move(message), std::move(extra_info));
+}
+
 }  // namespace internal
 // --- End namespace bridge ---
 
@@ -193,8 +302,7 @@ AzureOptions::AzureOptions() = default;
 
 AzureOptions::~AzureOptions() = default;
 
-void AzureOptions::ExtractFromUriSchemeAndHierPart(const Uri& uri,
-                                                   std::string* out_path) {
+void AzureOptions::ExtractFromUriSchemeAndHierPart(const Uri& uri, std::string* out_path) {
   const auto host = uri.host();
   std::string path;
   if (arrow::internal::EndsWith(host, blob_storage_authority)) {
@@ -240,9 +348,8 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
   // (excluding parameters for table storage only)
   // https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#construct-a-user-delegation-sas
   static const std::set<std::string> sas_token_query_parameters = {
-      "sv",    "ss",    "sr",  "st",  "se",   "sp",   "si",   "sip",   "spr",
-      "skoid", "sktid", "srt", "skt", "ske",  "skv",  "sks",  "saoid", "suoid",
-      "scid",  "sdd",   "ses", "sig", "rscc", "rscd", "rsce", "rscl",  "rsct",
+      "sv",  "ss",  "sr",    "st",    "se",   "sp",  "si",  "sip", "spr",  "skoid", "sktid", "srt",  "skt",  "ske",
+      "skv", "sks", "saoid", "suoid", "scid", "sdd", "ses", "sig", "rscc", "rscd",  "rsce",  "rscl", "rsct",
   };
 
   ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
@@ -284,29 +391,23 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
         dfs_storage_scheme = "http";
       }
     } else if (kv.first == "background_writes") {
-      ARROW_ASSIGN_OR_RAISE(background_writes,
-                            ::arrow::internal::ParseBoolean(kv.second));
-    } else if (sas_token_query_parameters.find(kv.first) !=
-               sas_token_query_parameters.end()) {
+      ARROW_ASSIGN_OR_RAISE(background_writes, ::arrow::internal::ParseBoolean(kv.second));
+    } else if (sas_token_query_parameters.find(kv.first) != sas_token_query_parameters.end()) {
       credential_kind = CredentialKind::kSASToken;
     } else {
-      return Status::Invalid(
-          "Unexpected query parameter in Azure Blob File System URI: '", kv.first, "'");
+      return Status::Invalid("Unexpected query parameter in Azure Blob File System URI: '", kv.first, "'");
     }
   }
 
   if (credential_kind) {
     if (!tenant_id.empty()) {
-      return Status::Invalid("tenant_id must not be specified with credential_kind=",
-                             *credential_kind_value);
+      return Status::Invalid("tenant_id must not be specified with credential_kind=", *credential_kind_value);
     }
     if (!client_id.empty()) {
-      return Status::Invalid("client_id must not be specified with credential_kind=",
-                             *credential_kind_value);
+      return Status::Invalid("client_id must not be specified with credential_kind=", *credential_kind_value);
     }
     if (!client_secret.empty()) {
-      return Status::Invalid("client_secret must not be specified with credential_kind=",
-                             *credential_kind_value);
+      return Status::Invalid("client_secret must not be specified with credential_kind=", *credential_kind_value);
     }
 
     switch (*credential_kind) {
@@ -349,8 +450,7 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
       if (tenant_id.empty() && client_secret.empty()) {
         RETURN_NOT_OK(ConfigureManagedIdentityCredential(client_id));
       } else if (!tenant_id.empty() && !client_secret.empty()) {
-        RETURN_NOT_OK(
-            ConfigureClientSecretCredential(tenant_id, client_id, client_secret));
+        RETURN_NOT_OK(ConfigureClientSecretCredential(tenant_id, client_id, client_secret));
       } else {
         return Status::Invalid("Both of tenant_id and client_secret must be specified");
       }
@@ -366,8 +466,7 @@ Result<AzureOptions> AzureOptions::FromUri(const Uri& uri, std::string* out_path
   return options;
 }
 
-Result<AzureOptions> AzureOptions::FromUri(const std::string& uri_string,
-                                           std::string* out_path) {
+Result<AzureOptions> AzureOptions::FromUri(const std::string& uri_string, std::string* out_path) {
   Uri uri;
   RETURN_NOT_OK(uri.Parse(uri_string));
   return FromUri(uri, out_path);
@@ -377,10 +476,8 @@ bool AzureOptions::Equals(const AzureOptions& other) const {
   const bool equals = blob_storage_authority == other.blob_storage_authority &&
                       dfs_storage_authority == other.dfs_storage_authority &&
                       blob_storage_scheme == other.blob_storage_scheme &&
-                      dfs_storage_scheme == other.dfs_storage_scheme &&
-                      default_metadata == other.default_metadata &&
-                      account_name == other.account_name &&
-                      credential_kind_ == other.credential_kind_;
+                      dfs_storage_scheme == other.dfs_storage_scheme && default_metadata == other.default_metadata &&
+                      account_name == other.account_name && credential_kind_ == other.credential_kind_;
   if (!equals) {
     return false;
   }
@@ -389,8 +486,7 @@ bool AzureOptions::Equals(const AzureOptions& other) const {
     case CredentialKind::kAnonymous:
       return true;
     case CredentialKind::kStorageSharedKey:
-      return storage_shared_key_credential_->AccountName ==
-             other.storage_shared_key_credential_->AccountName;
+      return storage_shared_key_credential_->AccountName == other.storage_shared_key_credential_->AccountName;
     case CredentialKind::kSASToken:
       return sas_token_ == other.sas_token_;
     case CredentialKind::kDynamicSASToken:
@@ -400,16 +496,14 @@ bool AzureOptions::Equals(const AzureOptions& other) const {
     case CredentialKind::kManagedIdentity:
     case CredentialKind::kWorkloadIdentity:
     case CredentialKind::kEnvironment:
-      return token_credential_->GetCredentialName() ==
-             other.token_credential_->GetCredentialName();
+      return token_credential_->GetCredentialName() == other.token_credential_->GetCredentialName();
   }
   DCHECK(false);
   return false;
 }
 
 namespace {
-std::string BuildBaseUrl(const std::string& scheme, const std::string& authority,
-                         const std::string& account_name) {
+std::string BuildBaseUrl(const std::string& scheme, const std::string& authority, const std::string& account_name) {
   std::string url;
   url += scheme + "://";
   if (!authority.empty()) {
@@ -427,26 +521,17 @@ std::string BuildBaseUrl(const std::string& scheme, const std::string& authority
 }
 
 template <typename... PrefixArgs>
-Status ExceptionToStatus(const Azure::Core::RequestFailedException& exception,
-                         PrefixArgs&&... prefix_args) {
-  // Discriminate on the dynamic type: TransportException means the request
-  // never reached the service. Its StatusCode is None, but so is that of a
-  // plain RequestFailedException(std::string), which PollUntilDone raises for
-  // a failed copy -- see internal::ClassifyAzureError.
-  const bool transport_failure =
-      dynamic_cast<const Azure::Core::Http::TransportException*>(&exception) != nullptr;
-  auto code = internal::ClassifyAzureError(static_cast<int>(exception.StatusCode),
-                                           exception.ErrorCode, transport_failure);
-  if (!code.has_value()) {
-    return Status::IOError(std::forward<PrefixArgs>(prefix_args)..., " Azure Error: [",
-                           exception.ErrorCode, "] ", exception.what());
-  }
-
+Status ExceptionToStatus(const Azure::Core::RequestFailedException& exception, PrefixArgs&&... prefix_args) {
   std::stringstream ss;
   (ss << ... << std::forward<PrefixArgs>(prefix_args));
-  ss << " Azure Error: [" << exception.ErrorCode << "] " << exception.what();
-  auto message = ss.str();
-  return milvus_storage::MakeExtendError(*code, message, message);
+  return internal::AzureExceptionToStatus(exception, ss.str());
+}
+
+template <typename... PrefixArgs>
+Status ContainerExceptionToStatus(const Azure::Core::RequestFailedException& exception, PrefixArgs&&... prefix_args) {
+  std::stringstream ss;
+  (ss << ... << std::forward<PrefixArgs>(prefix_args));
+  return internal::AzureExceptionToStatus(exception, ss.str(), internal::AzureResourceKind::Container);
 }
 }  // namespace
 
@@ -474,8 +559,7 @@ Status AzureOptions::ConfigureAccountKeyCredential(const std::string& account_ke
   if (account_name.empty()) {
     return Status::Invalid("AzureOptions doesn't contain a valid account name");
   }
-  storage_shared_key_credential_ =
-      std::make_shared<Storage::StorageSharedKeyCredential>(account_name, account_key);
+  storage_shared_key_credential_ = std::make_shared<Storage::StorageSharedKeyCredential>(account_name, account_key);
   return Status::OK();
 }
 
@@ -504,15 +588,13 @@ Status AzureOptions::ConfigureClientSecretCredential(const std::string& tenant_i
                                                      const std::string& client_id,
                                                      const std::string& client_secret) {
   credential_kind_ = CredentialKind::kClientSecret;
-  token_credential_ = std::make_shared<Azure::Identity::ClientSecretCredential>(
-      tenant_id, client_id, client_secret);
+  token_credential_ = std::make_shared<Azure::Identity::ClientSecretCredential>(tenant_id, client_id, client_secret);
   return Status::OK();
 }
 
 Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& client_id) {
   credential_kind_ = CredentialKind::kManagedIdentity;
-  token_credential_ =
-      std::make_shared<Azure::Identity::ManagedIdentityCredential>(client_id);
+  token_credential_ = std::make_shared<Azure::Identity::ManagedIdentityCredential>(client_id);
   return Status::OK();
 }
 
@@ -534,14 +616,12 @@ Status AzureOptions::ConfigureEnvironmentCredential() {
   return Status::OK();
 }
 
-Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceClient()
-    const {
+Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceClient() const {
   if (account_name.empty()) {
     return Status::Invalid("AzureOptions doesn't contain a valid account name");
   }
   if (!(blob_storage_scheme == "http" || blob_storage_scheme == "https")) {
-    return Status::Invalid("AzureOptions::blob_storage_scheme must be http or https: ",
-                           blob_storage_scheme);
+    return Status::Invalid("AzureOptions::blob_storage_scheme must be http or https: ", blob_storage_scheme);
   }
   switch (credential_kind_) {
     case CredentialKind::kAnonymous:
@@ -556,14 +636,11 @@ Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceC
     case CredentialKind::kCLI:
     case CredentialKind::kWorkloadIdentity:
     case CredentialKind::kEnvironment:
-      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name),
-                                                        token_credential_);
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name), token_credential_);
     case CredentialKind::kStorageSharedKey:
-      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name),
-                                                        storage_shared_key_credential_);
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name), storage_shared_key_credential_);
     case CredentialKind::kSASToken:
-      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name) +
-                                                        sas_token_);
+      return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name) + sas_token_);
     case CredentialKind::kDynamicSASToken: {
       Blobs::BlobClientOptions options;
       options.PerOperationPolicies.emplace_back(sas_token_policy_->Clone());
@@ -573,19 +650,16 @@ Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceC
   return Status::Invalid("AzureOptions doesn't contain a valid auth configuration");
 }
 
-Result<std::unique_ptr<DataLake::DataLakeServiceClient>>
-AzureOptions::MakeDataLakeServiceClient() const {
+Result<std::unique_ptr<DataLake::DataLakeServiceClient>> AzureOptions::MakeDataLakeServiceClient() const {
   if (account_name.empty()) {
     return Status::Invalid("AzureOptions doesn't contain a valid account name");
   }
   if (!(dfs_storage_scheme == "http" || dfs_storage_scheme == "https")) {
-    return Status::Invalid("AzureOptions::dfs_storage_scheme must be http or https: ",
-                           dfs_storage_scheme);
+    return Status::Invalid("AzureOptions::dfs_storage_scheme must be http or https: ", dfs_storage_scheme);
   }
   switch (credential_kind_) {
     case CredentialKind::kAnonymous:
-      return std::make_unique<DataLake::DataLakeServiceClient>(
-          AccountDfsUrl(account_name));
+      return std::make_unique<DataLake::DataLakeServiceClient>(AccountDfsUrl(account_name));
     case CredentialKind::kDefault:
       if (!token_credential_) {
         token_credential_ = std::make_shared<Azure::Identity::DefaultAzureCredential>();
@@ -596,14 +670,12 @@ AzureOptions::MakeDataLakeServiceClient() const {
     case CredentialKind::kCLI:
     case CredentialKind::kWorkloadIdentity:
     case CredentialKind::kEnvironment:
-      return std::make_unique<DataLake::DataLakeServiceClient>(
-          AccountDfsUrl(account_name), token_credential_);
+      return std::make_unique<DataLake::DataLakeServiceClient>(AccountDfsUrl(account_name), token_credential_);
     case CredentialKind::kStorageSharedKey:
-      return std::make_unique<DataLake::DataLakeServiceClient>(
-          AccountDfsUrl(account_name), storage_shared_key_credential_);
+      return std::make_unique<DataLake::DataLakeServiceClient>(AccountDfsUrl(account_name),
+                                                               storage_shared_key_credential_);
     case CredentialKind::kSASToken:
-      return std::make_unique<DataLake::DataLakeServiceClient>(
-          AccountBlobUrl(account_name) + sas_token_);
+      return std::make_unique<DataLake::DataLakeServiceClient>(AccountBlobUrl(account_name) + sas_token_);
     case CredentialKind::kDynamicSASToken: {
       DataLake::DataLakeClientOptions options;
       options.PerOperationPolicies.emplace_back(sas_token_policy_->Clone());
@@ -672,32 +744,30 @@ struct AzureLocation {
 
   bool empty() const { return container.empty() && path.empty(); }
 
-  bool operator==(const AzureLocation& other) const {
-    return container == other.container && path == other.path;
-  }
+  bool operator==(const AzureLocation& other) const { return container == other.container && path == other.path; }
 
- private:
+  private:
   Status Validate() {
     auto status = internal::ValidateAbstractPathParts(path_parts);
     return status.ok() ? status : Status::Invalid(status.message(), " in location ", all);
   }
 };
 
-Status PathNotFound(const AzureLocation& location) {
-  return ::arrow::fs::internal::PathNotFound(location.all);
+Status PathNotFound(const AzureLocation& location) { return ::arrow::fs::internal::PathNotFound(location.all); }
+
+Status ContainerNotFoundStatus(const AzureLocation& location, std::string_view operation) {
+  DCHECK(!location.container.empty());
+  return milvus_storage::MakeExtendError(
+      milvus_storage::ExtendStatusCode::StorageBucketNotFound,
+      std::string(operation) + " failed because Azure container '" + location.container + "' does not exist",
+      "container=" + location.container);
 }
 
-Status NotADir(const AzureLocation& location) {
-  return ::arrow::fs::internal::NotADir(location.all);
-}
+Status NotADir(const AzureLocation& location) { return ::arrow::fs::internal::NotADir(location.all); }
 
-Status NotAFile(const AzureLocation& location) {
-  return ::arrow::fs::internal::NotAFile(location.all);
-}
+Status NotAFile(const AzureLocation& location) { return ::arrow::fs::internal::NotAFile(location.all); }
 
-Status NotEmpty(const AzureLocation& location) {
-  return ::arrow::fs::internal::NotEmpty(location.all);
-}
+Status NotEmpty(const AzureLocation& location) { return ::arrow::fs::internal::NotEmpty(location.all); }
 
 Status ValidateFileLocation(const AzureLocation& location) {
   if (location.container.empty()) {
@@ -710,28 +780,37 @@ Status ValidateFileLocation(const AzureLocation& location) {
 }
 
 Status InvalidDirMoveToSubdir(const AzureLocation& src, const AzureLocation& dest) {
-  return Status::Invalid("Cannot Move to '", dest.all, "' and make '", src.all,
-                         "' a sub-directory of itself.");
+  return Status::Invalid("Cannot Move to '", dest.all, "' and make '", src.all, "' a sub-directory of itself.");
 }
 
 Status DestinationParentPathNotFound(const AzureLocation& dest) {
-  return Status::IOError("The parent directory of the destination path '", dest.all,
-                         "' does not exist.");
+  return Status::IOError("The parent directory of the destination path '", dest.all, "' does not exist.");
 }
 
-Status CrossContainerMoveNotImplemented(const AzureLocation& src,
-                                        const AzureLocation& dest) {
-  return Status::NotImplemented(
-      "Move of '", src.all, "' to '", dest.all,
-      "' requires moving data between containers, which is not implemented.");
+Status CrossContainerMoveNotImplemented(const AzureLocation& src, const AzureLocation& dest) {
+  return Status::NotImplemented("Move of '", src.all, "' to '", dest.all,
+                                "' requires moving data between containers, which is not implemented.");
 }
 
-bool IsContainerNotFound(const Storage::StorageException& e) {
-  // In some situations, only the ReasonPhrase is set and the
-  // ErrorCode is empty, so we check both.
-  if (e.ErrorCode == "ContainerNotFound" ||
-      e.ReasonPhrase == "The specified container does not exist." ||
-      e.ReasonPhrase == "The specified filesystem does not exist.") {
+// Takes the BASE exception type on purpose: every try block in this file
+// ultimately catches Core::RequestFailedException -- directly, or as the
+// trailing clause of a pair -- so that a TransportException, a sibling of
+// StorageException that the SDK rethrows after its retries are exhausted,
+// reaches ExceptionToStatus and classifies as transient network instead of
+// escaping as an uncaught exception (and, on the paths Rust drives through the
+// read callbacks, undefined behaviour across the C ABI). All three members
+// read here live on the base.
+bool IsContainerNotFound(const Core::RequestFailedException& e) {
+  if (e.ErrorCode == "ContainerNotFound" || e.ErrorCode == "FilesystemNotFound") {
+    DCHECK_EQ(e.StatusCode, Http::HttpStatusCode::NotFound);
+    return true;
+  }
+  // In some situations only the ReasonPhrase is set and ErrorCode is empty. To
+  // keep an SDK upgrade or a locale change from silently changing the
+  // classification, fall back to the exact phrase only when the SDK gave us no
+  // structured code to branch on.
+  if (e.ErrorCode.empty() && (e.ReasonPhrase == "The specified container does not exist." ||
+                              e.ReasonPhrase == "The specified filesystem does not exist.")) {
     DCHECK_EQ(e.StatusCode, Http::HttpStatusCode::NotFound);
     return true;
   }
@@ -744,14 +823,12 @@ const auto kFlatNamespaceIsDirectoryMetadataKey = "is_directory";
 bool MetadataIndicatesIsDirectory(const Storage::Metadata& metadata) {
   // Inspired by
   // https://github.com/Azure/azure-sdk-for-cpp/blob/12407e8bfcb9bc1aa43b253c1d0ec93bf795ae3b/sdk/storage/azure-storage-files-datalake/src/datalake_utilities.cpp#L86-L91
-  auto hierarchical_directory_metadata =
-      metadata.find(kHierarchicalNamespaceIsDirectoryMetadataKey);
+  auto hierarchical_directory_metadata = metadata.find(kHierarchicalNamespaceIsDirectoryMetadataKey);
   if (hierarchical_directory_metadata != metadata.end()) {
     return hierarchical_directory_metadata->second == "true";
   }
   auto flat_directory_metadata = metadata.find(kFlatNamespaceIsDirectoryMetadataKey);
-  return flat_directory_metadata != metadata.end() &&
-         flat_directory_metadata->second == "true";
+  return flat_directory_metadata != metadata.end() && flat_directory_metadata->second == "true";
 }
 
 template <typename ArrowType>
@@ -768,8 +845,7 @@ std::string FormatValue(typename TypeTraits<ArrowType>::CType value) {
   return appender.string;
 }
 
-std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
-    const Blobs::Models::BlobProperties& properties) {
+std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(const Blobs::Models::BlobProperties& properties) {
   auto metadata = std::make_shared<KeyValueMetadata>();
   // Not supported yet:
   // * properties.ObjectReplicationSourceProperties
@@ -781,10 +857,8 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
   // users can use all values by using KeyValueMetadata::keys() and
   // KeyValueMetadata::values().
   if (properties.ImmutabilityPolicy.HasValue()) {
-    metadata->Append("Immutability-Policy-Expires-On",
-                     properties.ImmutabilityPolicy.Value().ExpiresOn.ToString());
-    metadata->Append("Immutability-Policy-Mode",
-                     properties.ImmutabilityPolicy.Value().PolicyMode.ToString());
+    metadata->Append("Immutability-Policy-Expires-On", properties.ImmutabilityPolicy.Value().ExpiresOn.ToString());
+    metadata->Append("Immutability-Policy-Mode", properties.ImmutabilityPolicy.Value().PolicyMode.ToString());
   }
   metadata->Append("Content-Type", properties.HttpHeaders.ContentType);
   metadata->Append("Content-Encoding", properties.HttpHeaders.ContentEncoding);
@@ -819,12 +893,10 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
     metadata->Append("Copy-Status", properties.CopyStatus.Value().ToString());
   }
   if (properties.IsIncrementalCopy.HasValue()) {
-    metadata->Append("Is-Incremental-Copy",
-                     FormatValue<BooleanType>(properties.IsIncrementalCopy.Value()));
+    metadata->Append("Is-Incremental-Copy", FormatValue<BooleanType>(properties.IsIncrementalCopy.Value()));
   }
   if (properties.IncrementalCopyDestinationSnapshot.HasValue()) {
-    metadata->Append("Incremental-Copy-Destination-Snapshot",
-                     properties.IncrementalCopyDestinationSnapshot.Value());
+    metadata->Append("Incremental-Copy-Destination-Snapshot", properties.IncrementalCopyDestinationSnapshot.Value());
   }
   if (properties.LeaseDuration.HasValue()) {
     metadata->Append("Lease-Duration", properties.LeaseDuration.Value().ToString());
@@ -840,15 +912,12 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
     metadata->Append("ETag", properties.ETag.ToString());
   }
   if (properties.SequenceNumber.HasValue()) {
-    metadata->Append("Sequence-Number",
-                     FormatValue<Int64Type>(properties.SequenceNumber.Value()));
+    metadata->Append("Sequence-Number", FormatValue<Int64Type>(properties.SequenceNumber.Value()));
   }
   if (properties.CommittedBlockCount.HasValue()) {
-    metadata->Append("Committed-Block-Count",
-                     FormatValue<Int32Type>(properties.CommittedBlockCount.Value()));
+    metadata->Append("Committed-Block-Count", FormatValue<Int32Type>(properties.CommittedBlockCount.Value()));
   }
-  metadata->Append("IsServerEncrypted",
-                   FormatValue<BooleanType>(properties.IsServerEncrypted));
+  metadata->Append("IsServerEncrypted", FormatValue<BooleanType>(properties.IsServerEncrypted));
   if (properties.EncryptionKeySha256.HasValue()) {
     const auto& sha256 = properties.EncryptionKeySha256.Value();
     metadata->Append("Encryption-Key-Sha-256", HexEncode(sha256.data(), sha256.size()));
@@ -860,22 +929,19 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
     metadata->Append("Access-Tier", properties.AccessTier.Value().ToString());
   }
   if (properties.IsAccessTierInferred.HasValue()) {
-    metadata->Append("Is-Access-Tier-Inferred",
-                     FormatValue<BooleanType>(properties.IsAccessTierInferred.Value()));
+    metadata->Append("Is-Access-Tier-Inferred", FormatValue<BooleanType>(properties.IsAccessTierInferred.Value()));
   }
   if (properties.ArchiveStatus.HasValue()) {
     metadata->Append("Archive-Status", properties.ArchiveStatus.Value().ToString());
   }
   if (properties.AccessTierChangedOn.HasValue()) {
-    metadata->Append("Access-Tier-Changed-On",
-                     properties.AccessTierChangedOn.Value().ToString());
+    metadata->Append("Access-Tier-Changed-On", properties.AccessTierChangedOn.Value().ToString());
   }
   if (properties.VersionId.HasValue()) {
     metadata->Append("Version-Id", properties.VersionId.Value());
   }
   if (properties.IsCurrentVersion.HasValue()) {
-    metadata->Append("Is-Current-Version",
-                     FormatValue<BooleanType>(properties.IsCurrentVersion.Value()));
+    metadata->Append("Is-Current-Version", FormatValue<BooleanType>(properties.IsCurrentVersion.Value()));
   }
   if (properties.TagCount.HasValue()) {
     metadata->Append("Tag-Count", FormatValue<Int32Type>(properties.TagCount.Value()));
@@ -887,8 +953,7 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
     metadata->Append("Is-Sealed", FormatValue<BooleanType>(properties.IsSealed.Value()));
   }
   if (properties.RehydratePriority.HasValue()) {
-    metadata->Append("Rehydrate-Priority",
-                     properties.RehydratePriority.Value().ToString());
+    metadata->Append("Rehydrate-Priority", properties.RehydratePriority.Value().ToString());
   }
   if (properties.LastAccessedOn.HasValue()) {
     metadata->Append("Last-Accessed-On", properties.LastAccessedOn.Value().ToString());
@@ -900,9 +965,8 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
   return metadata;
 }
 
-void ArrowMetadataToCommitBlockListOptions(
-    const std::shared_ptr<const KeyValueMetadata>& arrow_metadata,
-    Blobs::CommitBlockListOptions& options) {
+void ArrowMetadataToCommitBlockListOptions(const std::shared_ptr<const KeyValueMetadata>& arrow_metadata,
+                                           Blobs::CommitBlockListOptions& options) {
   using ::arrow::internal::AsciiEqualsCaseInsensitive;
   for (auto& [key, value] : arrow_metadata->sorted_pairs()) {
     if (AsciiEqualsCaseInsensitive(key, "Content-Type")) {
@@ -924,9 +988,10 @@ void ArrowMetadataToCommitBlockListOptions(
 }
 
 class ObjectInputFile final : public io::RandomAccessFile {
- public:
+  public:
   ObjectInputFile(std::shared_ptr<Blobs::BlobClient> blob_client,
-                  const io::IOContext& io_context, AzureLocation location,
+                  const io::IOContext& io_context,
+                  AzureLocation location,
                   int64_t size = kNoSize)
       : blob_client_(std::move(blob_client)),
         io_context_(io_context),
@@ -970,8 +1035,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
     return metadata_;
   }
 
-  Future<std::shared_ptr<const KeyValueMetadata>> ReadMetadataAsync(
-      const io::IOContext& io_context) override {
+  Future<std::shared_ptr<const KeyValueMetadata>> ReadMetadataAsync(const io::IOContext& io_context) override {
     return Future<std::shared_ptr<const KeyValueMetadata>>::MakeFinished(ReadMetadata());
   }
 
@@ -1014,22 +1078,17 @@ class ObjectInputFile final : public io::RandomAccessFile {
     Storage::Blobs::DownloadBlobToOptions download_options;
     download_options.Range = range;
     try {
-      auto result =
-          blob_client_->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes,
-                                   download_options);
+      auto result = blob_client_->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options);
       const auto bytes_read = result.Value.ContentRange.Length.Value();
       if (bytes_read < 0 || bytes_read > nbytes) {
-        return Status::IOError("Unexpected DownloadTo Content-Range length ",
-                               bytes_read, " for range read of ", nbytes,
+        return Status::IOError("Unexpected DownloadTo Content-Range length ", bytes_read, " for range read of ", nbytes,
                                " bytes");
       }
       RETURN_NOT_OK(CacheContentLengthFromRead(result.Value));
       return bytes_read;
-    } catch (const Storage::StorageException& exception) {
-      return ExceptionToStatus(
-          exception, "DownloadTo from '", blob_client_->GetUrl(), "' at position ",
-          position, " for ", nbytes,
-          " bytes failed. ReadAt failed to read the required byte range.");
+    } catch (const Core::RequestFailedException& exception) {
+      return ExceptionToStatus(exception, "DownloadTo from '", blob_client_->GetUrl(), "' at position ", position,
+                               " for ", nbytes, " bytes failed. ReadAt failed to read the required byte range.");
     }
   }
 
@@ -1037,11 +1096,9 @@ class ObjectInputFile final : public io::RandomAccessFile {
     RETURN_NOT_OK(CheckClosed("read"));
     ARROW_ASSIGN_OR_RAISE(nbytes, GetReadSize(position, nbytes));
 
-    ARROW_ASSIGN_OR_RAISE(auto buffer,
-                          AllocateResizableBuffer(nbytes, io_context_.pool()));
+    ARROW_ASSIGN_OR_RAISE(auto buffer, AllocateResizableBuffer(nbytes, io_context_.pool()));
     if (nbytes > 0) {
-      ARROW_ASSIGN_OR_RAISE(int64_t bytes_read,
-                            ReadAt(position, nbytes, buffer->mutable_data()));
+      ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(position, nbytes, buffer->mutable_data()));
       DCHECK_LE(bytes_read, nbytes);
       RETURN_NOT_OK(buffer->Resize(bytes_read));
     }
@@ -1095,17 +1152,25 @@ class ObjectInputFile final : public io::RandomAccessFile {
       }
       SetCachedContentLength(content_length);
       return Status::OK();
-    } catch (const Storage::StorageException& exception) {
-      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+    } catch (const Core::RequestFailedException& exception) {
+      // Two different 404s. A missing BLOB is ENOENT: the caller re-reads its
+      // metadata and decides (GC race vs data loss). A missing CONTAINER must
+      // not report as ENOENT-style absence -- no amount of re-reading metadata
+      // produces a container, someone pointed the deployment at one that is
+      // not there. Falling through lets ExceptionToStatus classify it as
+      // StorageBucketNotFound (System), the same split S3 makes between
+      // NO_SUCH_KEY and NO_SUCH_BUCKET. This is the read path, so it is where
+      // that difference reaches milvus. The same rule now applies to
+      // GetFileInfo/list/delete control paths: a missing blob may be represented
+      // as ordinary absence, but a missing configured container must keep 118.
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound && !IsContainerNotFound(exception)) {
         return PathNotFound(location_);
       }
-      return ExceptionToStatus(exception, "GetProperties failed for '",
-                               blob_client_->GetUrl(), "'.");
+      return ExceptionToStatus(exception, "GetProperties failed for '", blob_client_->GetUrl(), "'.");
     }
   }
 
-  Status CacheContentLengthFromRead(
-      const Blobs::Models::DownloadBlobToResult& result) {
+  Status CacheContentLengthFromRead(const Blobs::Models::DownloadBlobToResult& result) {
     if (MetadataIndicatesIsDirectory(result.Details.Metadata)) {
       return NotAFile(location_);
     }
@@ -1116,9 +1181,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
     return Status::OK();
   }
 
-  int64_t GetCachedContentLength() const {
-    return content_length_.load(std::memory_order_acquire);
-  }
+  int64_t GetCachedContentLength() const { return content_length_.load(std::memory_order_acquire); }
 
   void SetCachedContentLength(int64_t content_length) {
     content_length_.store(content_length, std::memory_order_release);
@@ -1126,8 +1189,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
   void SetCachedContentLengthIfAbsent(int64_t content_length) {
     int64_t expected = kNoSize;
-    content_length_.compare_exchange_strong(expected, content_length,
-                                            std::memory_order_acq_rel,
+    content_length_.compare_exchange_strong(expected, content_length, std::memory_order_acq_rel,
                                             std::memory_order_acquire);
   }
 
@@ -1136,7 +1198,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
     return metadata_ != nullptr;
   }
 
- private:
+  private:
   std::shared_ptr<Blobs::BlobClient> blob_client_;
   const io::IOContext io_context_;
   AzureLocation location_;
@@ -1155,14 +1217,13 @@ Status CreateEmptyBlockBlob(const Blobs::BlockBlobClient& block_blob_client,
   }
   try {
     block_blob_client.UploadFrom(nullptr, 0);
-  } catch (const Storage::StorageException& exception) {
+  } catch (const Core::RequestFailedException& exception) {
     if (metrics) {
       metrics->IncrementFailedCount();
     }
-    return ExceptionToStatus(
-        exception, "UploadFrom failed for '", block_blob_client.GetUrl(),
-        "'. There is no existing blob at this location or the existing blob must be "
-        "replaced so ObjectAppendStream must create a new empty block blob.");
+    return ContainerExceptionToStatus(exception, "UploadFrom failed for '", block_blob_client.GetUrl(),
+                                      "'. There is no existing blob at this location or the existing blob must be "
+                                      "replaced so ObjectAppendStream must create a new empty block blob.");
   }
   return Status::OK();
 }
@@ -1177,25 +1238,22 @@ Status CreateEmptyBlockBlobConditional(Blobs::BlockBlobClient& block_blob_client
     options.AccessConditions.IfNoneMatch = Azure::ETag::Any();
     auto body = Core::IO::MemoryBodyStream(nullptr, 0);
     block_blob_client.Upload(body, options);
-  } catch (const Storage::StorageException& exception) {
+  } catch (const Core::RequestFailedException& exception) {
     if (metrics) {
       metrics->IncrementFailedCount();
     }
-    return ExceptionToStatus(
-        exception, "Conditional upload failed for '", block_blob_client.GetUrl(),
-        "'. The blob may already exist.");
+    return ContainerExceptionToStatus(exception, "Conditional upload failed for '", block_blob_client.GetUrl(),
+                                      "'. The blob may already exist.");
   }
   return Status::OK();
 }
 
-Result<Blobs::Models::GetBlockListResult> GetBlockList(
-    std::shared_ptr<Blobs::BlockBlobClient> block_blob_client) {
+Result<Blobs::Models::GetBlockListResult> GetBlockList(std::shared_ptr<Blobs::BlockBlobClient> block_blob_client) {
   try {
     return block_blob_client->GetBlockList().Value;
-  } catch (Storage::StorageException& exception) {
-    return ExceptionToStatus(
-        exception, "GetBlockList failed for '", block_blob_client->GetUrl(),
-        "'. Cannot write to a file without first fetching the existing block list.");
+  } catch (const Core::RequestFailedException& exception) {
+    return ExceptionToStatus(exception, "GetBlockList failed for '", block_blob_client->GetUrl(),
+                             "'. Cannot write to a file without first fetching the existing block list.");
   }
 }
 
@@ -1212,33 +1270,33 @@ Status CommitBlockList(std::shared_ptr<Storage::Blobs::BlockBlobClient> block_bl
     // previously committed blocks.
     // https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-list?tabs=microsoft-entra-id#request-body
     block_blob_client->CommitBlockList(block_ids, options);
-  } catch (const Storage::StorageException& exception) {
+  } catch (const Core::RequestFailedException& exception) {
     if (metrics) {
       metrics->IncrementFailedCount();
     }
-    return ExceptionToStatus(
-        exception, "CommitBlockList failed for '", block_blob_client->GetUrl(),
-        "'. Committing is required to flush an output/append stream.");
+    return ContainerExceptionToStatus(exception, "CommitBlockList failed for '", block_blob_client->GetUrl(),
+                                      "'. Committing is required to flush an output/append stream.");
   }
   return Status::OK();
 }
 
-Status StageBlock(Blobs::BlockBlobClient* block_blob_client, const std::string& id,
-                  Core::IO::MemoryBodyStream& content, int64_t content_length,
+Status StageBlock(Blobs::BlockBlobClient* block_blob_client,
+                  const std::string& id,
+                  Core::IO::MemoryBodyStream& content,
+                  int64_t content_length,
                   const std::shared_ptr<milvus_storage::FilesystemMetrics>& metrics) {
   if (metrics) {
     metrics->IncrementWriteCount();
   }
   try {
     block_blob_client->StageBlock(id, content);
-  } catch (const Storage::StorageException& exception) {
+  } catch (const Core::RequestFailedException& exception) {
     if (metrics) {
       metrics->IncrementFailedCount();
     }
-    return ExceptionToStatus(
-        exception, "StageBlock failed for '", block_blob_client->GetUrl(),
-        "' new_block_id: '", id,
-        "'. Staging new blocks is fundamental to streaming writes to blob storage.");
+    return ContainerExceptionToStatus(exception, "StageBlock failed for '", block_blob_client->GetUrl(),
+                                      "' new_block_id: '", id,
+                                      "'. Staging new blocks is fundamental to streaming writes to blob storage.");
   }
   if (metrics) {
     metrics->IncrementWriteBytes(content_length);
@@ -1253,16 +1311,17 @@ static constexpr int64_t kMaxBlockSizeBytes = 4UL * 1024 * 1024 * 1024;
 
 /// This output stream, similar to other arrow OutputStreams, is not thread-safe.
 class ObjectAppendStream final : public io::OutputStream {
- private:
+  private:
   struct UploadState;
 
   std::shared_ptr<ObjectAppendStream> Self() {
     return std::dynamic_pointer_cast<ObjectAppendStream>(shared_from_this());
   }
 
- public:
+  public:
   ObjectAppendStream(std::shared_ptr<Blobs::BlockBlobClient> block_blob_client,
-                     const io::IOContext& io_context, const AzureLocation& location,
+                     const io::IOContext& io_context,
+                     const AzureLocation& location,
                      const std::shared_ptr<const KeyValueMetadata>& metadata,
                      const AzureOptions& options,
                      std::shared_ptr<milvus_storage::FilesystemMetrics> metrics,
@@ -1274,17 +1333,22 @@ class ObjectAppendStream final : public io::OutputStream {
         background_writes_(options.background_writes),
         block_upload_size_(block_upload_size),
         conditional_write_(conditional_write),
-        metrics_(std::move(metrics)) {
+        metrics_(std::move(metrics)),
+        writer_status_(std::make_shared<milvus_storage::WriterStatus>()) {
     if (metadata && metadata->size() != 0) {
       ArrowMetadataToCommitBlockListOptions(metadata, commit_block_list_options_);
     } else if (options.default_metadata && options.default_metadata->size() != 0) {
-      ArrowMetadataToCommitBlockListOptions(options.default_metadata,
-                                            commit_block_list_options_);
+      ArrowMetadataToCommitBlockListOptions(options.default_metadata, commit_block_list_options_);
     }
   }
 
-  Status Init(const bool truncate,
-              std::function<Status()> ensure_not_flat_namespace_directory) {
+  ~ObjectAppendStream() override {
+    if (!closed_) {
+      DiscardAfterFailure();
+    }
+  }
+
+  Status Init(const bool truncate, std::function<Status()> ensure_not_flat_namespace_directory) {
     if (truncate) {
       content_length_ = 0;
       pos_ = 0;
@@ -1306,7 +1370,7 @@ class ObjectAppendStream final : public io::OutputStream {
         }
         content_length_ = properties.Value.BlobSize;
         pos_ = content_length_;
-      } catch (const Storage::StorageException& exception) {
+      } catch (const Core::RequestFailedException& exception) {
         if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
           // No file exists but on flat namespace its possible there is a directory
           // marker or an implied directory. Ensure there is no directory before starting
@@ -1314,10 +1378,9 @@ class ObjectAppendStream final : public io::OutputStream {
           RETURN_NOT_OK(ensure_not_flat_namespace_directory());
           RETURN_NOT_OK(CreateEmptyBlockBlob(*block_blob_client_, metrics_));
         } else {
-          return ExceptionToStatus(
-              exception, "GetProperties failed for '", block_blob_client_->GetUrl(),
-              "'. Cannot initialise an ObjectAppendStream without knowing whether a "
-              "file already exists at this path, and if it exists, its size.");
+          return ExceptionToStatus(exception, "GetProperties failed for '", block_blob_client_->GetUrl(),
+                                   "'. Cannot initialise an ObjectAppendStream without knowing whether a "
+                                   "file already exists at this path, and if it exists, its size.");
         }
         content_length_ = 0;
       }
@@ -1336,15 +1399,38 @@ class ObjectAppendStream final : public io::OutputStream {
   }
 
   Status Abort() override {
-    if (closed_) {
+    // A successfully committed block list is already final. Abort after that
+    // is an idempotent no-op and must not poison the writer with Cancelled.
+    if (closed_ && writer_status_->Check().ok()) {
       return Status::OK();
     }
-    block_blob_client_ = nullptr;
-    closed_ = true;
+    (void)writer_status_->RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+    // Local-only on purpose, unlike the S3 stream's Abort. A block blob has no
+    // "abort the upload" call: blocks that were staged but never committed are
+    // not part of any blob, they are not billed as one, and the service drops
+    // them on its own if no Put Block List ever names them (a week, per Azure's
+    // uncommitted-block rules). There is nothing to release, so issuing a
+    // request here would be cleanup I/O that buys nothing.
+    DiscardAfterFailure();
     return Status::OK();
   }
 
   Status Close() override {
+    if (!writer_status_->Check().ok()) {
+      return CloseAfterFailure();
+    }
+    RETURN_NOT_OK(writer_status_->Check());
+    auto status = CloseImpl();
+    if (!status.ok()) {
+      return CloseAfterFailure(std::move(status));
+    }
+    return writer_status_->RecordFirstFailure(std::move(status));
+  }
+
+  Status CloseImpl() {
+    if (!writer_status_->Check().ok()) {
+      return CloseAfterFailure();
+    }
     if (closed_) {
       return Status::OK();
     }
@@ -1354,13 +1440,29 @@ class ObjectAppendStream final : public io::OutputStream {
       RETURN_NOT_OK(AppendCurrentBlock());
     }
 
-    RETURN_NOT_OK(Flush());
+    RETURN_NOT_OK(FlushImpl());
     block_blob_client_ = nullptr;
     closed_ = true;
     return Status::OK();
   }
 
   Future<> CloseAsync() override {
+    if (!writer_status_->Check().ok()) {
+      return CloseAfterFailureAsync();
+    }
+    auto check_status = writer_status_->Check();
+    if (!check_status.ok()) {
+      return check_status;
+    }
+    auto future = CloseAsyncImpl();
+    return future.Then([]() { return Status::OK(); },
+                       [self = Self()](const Status& status) { return self->CloseAfterFailureAsync(status); });
+  }
+
+  Future<> CloseAsyncImpl() {
+    if (!writer_status_->Check().ok()) {
+      return CloseAfterFailureAsync();
+    }
     if (closed_) {
       return Status::OK();
     }
@@ -1370,7 +1472,7 @@ class ObjectAppendStream final : public io::OutputStream {
       RETURN_NOT_OK(AppendCurrentBlock());
     }
 
-    return FlushAsync().Then([self = Self()]() {
+    return FlushAsyncImpl().Then([self = Self()]() {
       self->block_blob_client_ = nullptr;
       self->closed_ = true;
     });
@@ -1386,7 +1488,11 @@ class ObjectAppendStream final : public io::OutputStream {
   }
 
   Result<int64_t> Tell() const override {
-    RETURN_NOT_OK(CheckClosed("tell"));
+    RETURN_NOT_OK(writer_status_->Check());
+    auto status = CheckClosed("tell");
+    if (!status.ok()) {
+      return writer_status_->RecordFirstFailure(std::move(status));
+    }
     return pos_;
   }
 
@@ -1394,11 +1500,20 @@ class ObjectAppendStream final : public io::OutputStream {
     return DoWrite(buffer->data(), buffer->size(), buffer);
   }
 
-  Status Write(const void* data, int64_t nbytes) override {
-    return DoWrite(data, nbytes);
-  }
+  Status Write(const void* data, int64_t nbytes) override { return DoWrite(data, nbytes); }
 
   Status Flush() override {
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
+    RETURN_NOT_OK(writer_status_->Check());
+    return writer_status_->RecordFirstFailure(FlushImpl());
+  }
+
+  Status FlushImpl() {
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
     RETURN_NOT_OK(CheckClosed("flush"));
     if (!initialised_) {
       // If the stream has not been successfully initialized then there is nothing to
@@ -1414,11 +1529,27 @@ class ObjectAppendStream final : public io::OutputStream {
 
     RETURN_NOT_OK(pending_blocks_completed.status());
     std::unique_lock<std::mutex> lock(upload_state_->mutex);
-    return CommitBlockList(block_blob_client_, upload_state_->block_ids,
-                           commit_block_list_options_, metrics_);
+    return CommitBlockList(block_blob_client_, upload_state_->block_ids, commit_block_list_options_, metrics_);
   }
 
   Future<> FlushAsync() {
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
+    auto check_status = writer_status_->Check();
+    if (!check_status.ok()) {
+      return check_status;
+    }
+    auto future = FlushAsyncImpl();
+    future.AddCallback(
+        [writer_status = writer_status_](const Status& status) { (void)writer_status->RecordFirstFailure(status); });
+    return future;
+  }
+
+  Future<> FlushAsyncImpl() {
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
     RETURN_NOT_OK(CheckClosed("flush async"));
     if (!initialised_) {
       // If the stream has not been successfully initialized then there is nothing to
@@ -1433,13 +1564,63 @@ class ObjectAppendStream final : public io::OutputStream {
     }
 
     return pending_blocks_completed.Then([self = Self()] {
+      auto writer_status = self->writer_status_->Check();
+      if (!writer_status.ok()) {
+        return writer_status;
+      }
       std::unique_lock<std::mutex> lock(self->upload_state_->mutex);
-      return CommitBlockList(self->block_blob_client_, self->upload_state_->block_ids,
-                             self->commit_block_list_options_, self->metrics_);
+      return CommitBlockList(self->block_blob_client_, self->upload_state_->block_ids, self->commit_block_list_options_,
+                             self->metrics_);
     });
   }
 
- private:
+#ifdef BUILD_GTEST
+  void InitializeForBackgroundRegistrationTest() {
+    upload_state_ = std::make_shared<UploadState>();
+    initialised_ = true;
+    closed_ = false;
+  }
+
+  int64_t BlocksInProgressForTest() const {
+    std::unique_lock<std::mutex> lock(upload_state_->mutex);
+    return upload_state_->blocks_in_progress;
+  }
+
+  void CompleteRegisteredBlockForTest(const Status& status) {
+    {
+      std::unique_lock<std::mutex> lock(upload_state_->mutex);
+      upload_state_->pending_blocks_completed = Future<>::Make();
+      upload_state_->pending_completion_published = false;
+      upload_state_->blocks_in_progress = 1;
+    }
+    HandleUploadOutcome(upload_state_, writer_status_, status);
+  }
+
+  Future<> PendingBlocksCompletedForTest() const {
+    std::unique_lock<std::mutex> lock(upload_state_->mutex);
+    return upload_state_->pending_blocks_completed;
+  }
+#endif
+
+  private:
+  Status CloseAfterFailure(Status primary_status = Status::OK()) {
+    (void)writer_status_->RecordFirstFailure(primary_status);
+    auto first_status = writer_status_->Check();
+    DiscardAfterFailure();
+    return first_status;
+  }
+
+  void DiscardAfterFailure() {
+    current_block_.reset();
+    current_block_size_ = 0;
+    block_blob_client_ = nullptr;
+    closed_ = true;
+  }
+
+  Future<> CloseAfterFailureAsync(Status primary_status = Status::OK()) {
+    return CloseAfterFailure(std::move(primary_status));
+  }
+
   Status AppendCurrentBlock() {
     ARROW_ASSIGN_OR_RAISE(auto buf, current_block_->Finish());
     current_block_.reset();
@@ -1447,8 +1628,12 @@ class ObjectAppendStream final : public io::OutputStream {
     return AppendBlock(buf);
   }
 
-  Status DoWrite(const void* data, int64_t nbytes,
-                 std::shared_ptr<Buffer> owned_buffer = nullptr) {
+  Status DoWrite(const void* data, int64_t nbytes, std::shared_ptr<Buffer> owned_buffer = nullptr) {
+    RETURN_NOT_OK(writer_status_->Check());
+    return writer_status_->RecordFirstFailure(DoWriteImpl(data, nbytes, std::move(owned_buffer)));
+  }
+
+  Status DoWriteImpl(const void* data, int64_t nbytes, std::shared_ptr<Buffer> owned_buffer = nullptr) {
     if (closed_) {
       return Status::Invalid("Operation on closed stream");
     }
@@ -1464,8 +1649,7 @@ class ObjectAppendStream final : public io::OutputStream {
     // Handle case where we have some bytes buffered from prior calls.
     if (current_block_size_ > 0) {
       // Try to fill current buffer
-      const int64_t to_copy =
-          std::min(nbytes, block_upload_size_ - current_block_size_);
+      const int64_t to_copy = std::min(nbytes, block_upload_size_ - current_block_size_);
       RETURN_NOT_OK(current_block_->Write(data_ptr, to_copy));
       current_block_size_ += to_copy;
       advance_ptr(to_copy);
@@ -1491,9 +1675,7 @@ class ObjectAppendStream final : public io::OutputStream {
       current_block_size_ = nbytes;
 
       if (current_block_ == nullptr) {
-        ARROW_ASSIGN_OR_RAISE(
-            current_block_,
-            io::BufferOutputStream::Create(block_upload_size_, io_context_.pool()));
+        ARROW_ASSIGN_OR_RAISE(current_block_, io::BufferOutputStream::Create(block_upload_size_, io_context_.pool()));
       } else {
         // Re-use the allocation from before.
         RETURN_NOT_OK(current_block_->Reset(block_upload_size_, io_context_.pool()));
@@ -1507,49 +1689,57 @@ class ObjectAppendStream final : public io::OutputStream {
     return Status::OK();
   }
 
-  std::string CreateBlock() {
-    std::unique_lock<std::mutex> lock(upload_state_->mutex);
-    const auto n_block_ids = upload_state_->block_ids.size();
+  Result<std::string> CreateBlock() {
+    try {
+      std::unique_lock<std::mutex> lock(upload_state_->mutex);
+      const auto n_block_ids = upload_state_->block_ids.size();
 
-    // New block ID must always be distinct from the existing block IDs. Otherwise we
-    // will accidentally replace the content of existing blocks, causing corruption.
-    // We will use monotonically increasing integers.
-    auto new_block_id = std::to_string(n_block_ids);
+      // New block ID must always be distinct from the existing block IDs. Otherwise we
+      // will accidentally replace the content of existing blocks, causing corruption.
+      // We will use monotonically increasing integers.
+      auto new_block_id = std::to_string(n_block_ids);
 
-    // Pad to 5 digits, because Azure allows a maximum of 50,000 blocks.
-    const size_t target_number_of_digits = 5;
-    const auto required_padding_digits =
-        target_number_of_digits - std::min(target_number_of_digits, new_block_id.size());
-    new_block_id.insert(0, required_padding_digits, '0');
-    // There is a small risk when appending to a blob created by another client that
-    // `new_block_id` may overlapping with an existing block id. Adding the `-arrow`
-    // suffix significantly reduces the risk, but does not 100% eliminate it. For
-    // example if the blob was previously created with one block, with id `00001-arrow`
-    // then the next block we append will conflict with that, and cause corruption.
-    new_block_id += "-arrow";
-    new_block_id = Core::Convert::Base64Encode(
-        std::vector<uint8_t>(new_block_id.begin(), new_block_id.end()));
+      // Pad to 5 digits, because Azure allows a maximum of 50,000 blocks.
+      const size_t target_number_of_digits = 5;
+      const auto required_padding_digits =
+          target_number_of_digits - std::min(target_number_of_digits, new_block_id.size());
+      new_block_id.insert(0, required_padding_digits, '0');
+      // There is a small risk when appending to a blob created by another client that
+      // `new_block_id` may overlapping with an existing block id. Adding the `-arrow`
+      // suffix significantly reduces the risk, but does not 100% eliminate it. For
+      // example if the blob was previously created with one block, with id `00001-arrow`
+      // then the next block we append will conflict with that, and cause corruption.
+      new_block_id += "-arrow";
+      new_block_id = Core::Convert::Base64Encode(std::vector<uint8_t>(new_block_id.begin(), new_block_id.end()));
 
-    upload_state_->block_ids.push_back(new_block_id);
-
-    // We only use the future if we have background writes enabled. Without background
-    // writes the future is initialized as finished and not mutated any more.
-    if (background_writes_ && upload_state_->blocks_in_progress++ == 0) {
-      upload_state_->pending_blocks_completed = Future<>::Make();
+      upload_state_->block_ids.push_back(new_block_id);
+      return new_block_id;
+    } catch (const std::bad_alloc& e) {
+      // Recoverable: this helper owns no shared state to settle, so returning
+      // beats dying. The classification chain maps OOM to MemAllocateFailed.
+      return arrow::Status::OutOfMemory("Failed to prepare an Azure block ID: ", e.what());
+    } catch (const std::exception& e) {
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Failed to prepare an Azure block ID: ", e.what());
+    } catch (...) {
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Failed to prepare an Azure block ID due to a non-standard exception");
     }
-
-    return new_block_id;
   }
 
-  Status AppendBlock(const void* data, int64_t nbytes,
-                     std::shared_ptr<Buffer> owned_buffer = nullptr) {
+  Status AppendBlock(const void* data, int64_t nbytes, std::shared_ptr<Buffer> owned_buffer = nullptr) {
+    // Close/Flush may be admitted before a background callback reports a
+    // failure. Do not enqueue another StageBlock after the writer has been
+    // poisoned; the caller will take the terminal drain/discard path.
+    auto writer_status = writer_status_->Check();
+    if (!writer_status.ok()) {
+      return writer_status;
+    }
     RETURN_NOT_OK(CheckClosed("append"));
 
     if (nbytes == 0) {
       return Status::OK();
     }
-
-    const auto block_id = CreateBlock();
 
     if (background_writes_) {
       if (owned_buffer == nullptr) {
@@ -1559,18 +1749,48 @@ class ObjectAppendStream final : public io::OutputStream {
         DCHECK_EQ(data, owned_buffer->data());
         DCHECK_EQ(nbytes, owned_buffer->size());
       }
+    }
 
-      // The closure keeps the buffer and the upload state alive
-      auto deferred = [owned_buffer, block_id, block_blob_client = block_blob_client_,
-                       state = upload_state_, metrics = metrics_]() mutable -> Status {
-        Core::IO::MemoryBodyStream block_content(owned_buffer->data(),
-                                                 owned_buffer->size());
-        auto status = StageBlock(block_blob_client.get(), block_id, block_content,
-                                 static_cast<int64_t>(owned_buffer->size()), metrics);
-        HandleUploadOutcome(state, status);
-        return Status::OK();
+    ARROW_ASSIGN_OR_RAISE(auto block_id, CreateBlock());
+
+    if (background_writes_) {
+      auto make_task = [&]() {
+        return [owned_buffer, block_id, block_blob_client = block_blob_client_, metrics = metrics_]() mutable {
+          Core::IO::MemoryBodyStream block_content(owned_buffer->data(), owned_buffer->size());
+          return StageBlock(block_blob_client.get(), block_id, block_content,
+                            static_cast<int64_t>(owned_buffer->size()), metrics);
+        };
       };
-      RETURN_NOT_OK(io::internal::SubmitIO(io_context_, std::move(deferred)));
+      auto make_completion = [&]() {
+        return [state = upload_state_, writer_status = writer_status_](const Status& status) {
+          HandleUploadOutcome(state, writer_status, status);
+        };
+      };
+
+      using Task = decltype(make_task());
+      using Completion = decltype(make_completion());
+      std::optional<Task> task;
+      std::optional<Completion> completion;
+      // Create every object that may allocate before this block owns a
+      // counter slot. From registration onward SubmitIOWithCompletion owns
+      // settling that slot on every exit; before it, an exception unwinds
+      // without leaving a phantom block behind, so it is left to propagate.
+      task.emplace(make_task());
+      completion.emplace(make_completion());
+
+      {
+        std::unique_lock<std::mutex> lock(upload_state_->mutex);
+        // Serialize admission with completion failure observation. If the
+        // completion got this lock first, no later block may register.
+        RETURN_NOT_OK(writer_status_->Check());
+        if (upload_state_->blocks_in_progress == 0) {
+          upload_state_->pending_blocks_completed = Future<>::Make();
+          upload_state_->pending_completion_published = false;
+        }
+        ++upload_state_->blocks_in_progress;
+      }
+
+      RETURN_NOT_OK(io::internal::SubmitIOWithCompletion(io_context_, std::move(*task), std::move(*completion)));
     } else {
       auto append_data = reinterpret_cast<const uint8_t*>(data);
       Core::IO::MemoryBodyStream block_content(append_data, nbytes);
@@ -1581,21 +1801,38 @@ class ObjectAppendStream final : public io::OutputStream {
     return Status::OK();
   }
 
-  Status AppendBlock(std::shared_ptr<Buffer> buffer) {
-    return AppendBlock(buffer->data(), buffer->size(), buffer);
-  }
+  Status AppendBlock(std::shared_ptr<Buffer> buffer) { return AppendBlock(buffer->data(), buffer->size(), buffer); }
 
   static void HandleUploadOutcome(const std::shared_ptr<UploadState>& state,
+                                  const std::shared_ptr<milvus_storage::WriterStatus>& writer_status,
                                   const Status& status) {
+    Future<> future;
+    bool publish = false;
     std::unique_lock<std::mutex> lock(state->mutex);
+    DCHECK_GT(state->blocks_in_progress, 0);
+    --state->blocks_in_progress;
     if (!status.ok()) {
-      state->status &= status;
+      // Counter settlement comes first. Observe while holding the admission
+      // lock so a foreground Write cannot register a new block after this
+      // failure has won the ordering race.
+      (void)writer_status->RecordFirstFailure(status);
     }
-    // Notify completion
-    if (--state->blocks_in_progress == 0) {
-      auto fut = state->pending_blocks_completed;
-      lock.unlock();
-      fut.MarkFinished(state->status);
+    if (!state->pending_completion_published && (!status.ok() || state->blocks_in_progress == 0)) {
+      state->pending_completion_published = true;
+      future = state->pending_blocks_completed;
+      publish = true;
+    }
+    lock.unlock();
+
+    // Publishing may allocate. If it fails the exception propagates and the
+    // process dies. That is deliberate: the publish slot above has already been
+    // consumed, so anything that swallows the failure here leaves
+    // pending_blocks_completed unfinished with no later completion able to
+    // claim it, and every FlushAsync/CloseAsync waiter blocks forever. A crash
+    // is restartable; that hang is not.
+    auto completion_status = io::internal::ObserveBackgroundIOStatus(writer_status.get(), status);
+    if (publish) {
+      future.MarkFinished(std::move(completion_status));
     }
   }
 
@@ -1614,6 +1851,7 @@ class ObjectAppendStream final : public io::OutputStream {
   bool closed_ = false;
   bool initialised_ = false;
   int64_t pos_ = 0;
+  std::shared_ptr<milvus_storage::WriterStatus> writer_status_;
 
   // This struct is kept alive through background writes to avoid problems
   // in the completion handler.
@@ -1621,7 +1859,7 @@ class ObjectAppendStream final : public io::OutputStream {
     std::mutex mutex;
     std::vector<std::string> block_ids;
     int64_t blocks_in_progress = 0;
-    Status status;
+    bool pending_completion_published = true;
     Future<> pending_blocks_completed = Future<>::MakeFinished(Status::OK());
   };
   std::shared_ptr<UploadState> upload_state_;
@@ -1629,9 +1867,7 @@ class ObjectAppendStream final : public io::OutputStream {
   Blobs::CommitBlockListOptions commit_block_list_options_;
 };
 
-bool IsDfsEmulator(const AzureOptions& options) {
-  return options.dfs_storage_authority != ".dfs.core.windows.net";
-}
+bool IsDfsEmulator(const AzureOptions& options) { return options.dfs_storage_authority != ".dfs.core.windows.net"; }
 
 }  // namespace
 
@@ -1640,8 +1876,54 @@ bool IsDfsEmulator(const AzureOptions& options) {
 
 namespace internal {
 
-Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
-    const DataLake::DataLakeFileSystemClient& adlfs_client, const AzureOptions& options) {
+#ifdef BUILD_GTEST
+std::vector<Status> RunHealthyCloseAbortCloseForTest() {
+  AzureOptions options;
+  auto block_blob_client =
+      std::make_shared<Blobs::BlockBlobClient>("http://account.blob.core.windows.net/container/blob");
+  auto location = AzureLocation::FromString("container/blob").ValueOrDie();
+  auto stream = std::make_shared<ObjectAppendStream>(block_blob_client, io::default_io_context(), location, nullptr,
+                                                     options, nullptr);
+
+  std::vector<Status> statuses;
+  statuses.reserve(3);
+  statuses.emplace_back(stream->Close());
+  statuses.emplace_back(stream->Abort());
+  statuses.emplace_back(stream->Close());
+  return statuses;
+}
+
+std::vector<Status> RunBackgroundUploadOutcomeFailureForTest(int64_t* blocks_in_progress, bool* future_finished) {
+  AzureOptions options;
+  options.background_writes = true;
+  auto block_blob_client =
+      std::make_shared<Blobs::BlockBlobClient>("http://account.blob.core.windows.net/container/blob");
+  auto location = AzureLocation::FromString("container/blob").ValueOrDie();
+  auto stream = std::make_shared<ObjectAppendStream>(block_blob_client, io::default_io_context(), location, nullptr,
+                                                     options, nullptr, /*block_upload_size=*/1);
+  stream->InitializeForBackgroundRegistrationTest();
+  stream->CompleteRegisteredBlockForTest(Status::IOError("injected Azure child upload failure"));
+  *blocks_in_progress = stream->BlocksInProgressForTest();
+  auto pending_blocks_completed = stream->PendingBlocksCompletedForTest();
+  *future_finished = pending_blocks_completed.Wait(1.0);
+  auto completion_status = *future_finished ? pending_blocks_completed.status()
+                                            : Status::Cancelled("Azure completion remained pending in test");
+  auto flush_status = stream->Flush();
+  auto close_status = stream->Close();
+  auto abort_status = stream->Abort();
+  std::vector<Status> statuses;
+  statuses.reserve(4);
+  statuses.emplace_back(std::move(completion_status));
+  statuses.emplace_back(std::move(flush_status));
+  statuses.emplace_back(std::move(close_status));
+  statuses.emplace_back(std::move(abort_status));
+  return statuses;
+}
+
+#endif
+
+Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                                                         const AzureOptions& options) {
   try {
     auto directory_client = adlfs_client.GetDirectoryClient("");
     // GetAccessControlList will fail on storage accounts
@@ -1652,7 +1934,7 @@ Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
     // Azurite issue detected.
     DCHECK(IsDfsEmulator(options));
     return HNSSupport::kDisabled;
-  } catch (const Storage::StorageException& exception) {
+  } catch (const Core::RequestFailedException& exception) {
     // Flat namespace storage accounts with "soft delete" enabled return
     //
     //   "Conflict - This endpoint does not support BlobStorageEvents
@@ -1673,26 +1955,20 @@ Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
         if (IsDfsEmulator(options)) {
           return HNSSupport::kDisabled;
         }
-        // Did we get an error because of the container not existing?
-        if (IsContainerNotFound(exception)) {
-          return HNSSupport::kContainerNotFound;
-        }
-        [[fallthrough]];
+        // This request addresses the root of one filesystem/container. A 404
+        // cannot be a missing child path, even when an emulator or proxy drops
+        // Azure's ErrorCode and ReasonPhrase.
+        return HNSSupport::kContainerNotFound;
       default:
         if (exception.ErrorCode == "HierarchicalNamespaceNotEnabled") {
           return HNSSupport::kDisabled;
         }
-        return ExceptionToStatus(exception,
-                                 "Check for Hierarchical Namespace support on '",
-                                 adlfs_client.GetUrl(), "' failed.");
+        return ExceptionToStatus(exception, "Check for Hierarchical Namespace support on '", adlfs_client.GetUrl(),
+                                 "' failed.");
     }
-  } catch (const Azure::Core::Http::TransportException& exception) {
-    return ExceptionToStatus(exception, "Check for Hierarchical Namespace support on '",
-                             adlfs_client.GetUrl(), "' failed.");
   } catch (const std::exception& exception) {
-    return Status::UnknownError(
-        "Check for Hierarchical Namespace support on '", adlfs_client.GetUrl(),
-        "' failed: ", typeid(exception).name(), ": ", exception.what());
+    return Status::UnknownError("Check for Hierarchical Namespace support on '", adlfs_client.GetUrl(),
+                                "' failed: ", typeid(exception).name(), ": ", exception.what());
   }
 }
 
@@ -1714,7 +1990,8 @@ const char kDelimiter[] = {internal::kSep, '\0'};
 /// \pre location.container is not empty.
 template <class ContainerClient>
 Result<FileInfo> GetContainerPropsAsFileInfo(const AzureLocation& location,
-                                             const ContainerClient& container_client) {
+                                             const ContainerClient& container_client,
+                                             bool allow_not_found = false) {
   DCHECK(!location.container.empty());
   FileInfo info{location.path.empty() ? location.all : location.container};
   try {
@@ -1722,30 +1999,30 @@ Result<FileInfo> GetContainerPropsAsFileInfo(const AzureLocation& location,
     info.set_type(FileType::Directory);
     info.set_mtime(std::chrono::system_clock::time_point{properties.Value.LastModified});
     return info;
-  } catch (const Storage::StorageException& exception) {
-    if (IsContainerNotFound(exception)) {
-      info.set_type(FileType::NotFound);
-      return info;
+  } catch (const Core::RequestFailedException& exception) {
+    if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+      if (allow_not_found) {
+        info.set_type(FileType::NotFound);
+        return info;
+      }
+      return ContainerExceptionToStatus(exception, "GetProperties for '", container_client.GetUrl(), "' failed.");
     }
-    return ExceptionToStatus(exception, "GetProperties for '", container_client.GetUrl(),
-                             "' failed.");
+    return ContainerExceptionToStatus(exception, "GetProperties for '", container_client.GetUrl(), "' failed.");
   }
 }
 
 template <class ContainerClient>
-Status CreateContainerIfNotExists(const std::string& container_name,
-                                  const ContainerClient& container_client) {
+Status CreateContainerIfNotExists(const std::string& container_name, const ContainerClient& container_client) {
   try {
     container_client.CreateIfNotExists();
     return Status::OK();
-  } catch (const Storage::StorageException& exception) {
-    return ExceptionToStatus(exception, "Failed to create a container: ", container_name,
-                             ": ", container_client.GetUrl());
+  } catch (const Core::RequestFailedException& exception) {
+    return ContainerExceptionToStatus(exception, "Failed to create a container: ", container_name, ": ",
+                                      container_client.GetUrl());
   }
 }
 
-FileInfo FileInfoFromPath(std::string_view container,
-                          const DataLake::Models::PathItem& path) {
+FileInfo FileInfoFromPath(std::string_view container, const DataLake::Models::PathItem& path) {
   FileInfo info{internal::ConcatAbstractPath(container, path.Name),
                 path.IsDirectory ? FileType::Directory : FileType::File};
   info.set_size(path.FileSize);
@@ -1757,8 +2034,7 @@ FileInfo DirectoryFileInfoFromPath(std::string_view path) {
   return FileInfo{std::string{internal::RemoveTrailingSlash(path)}, FileType::Directory};
 }
 
-FileInfo FileInfoFromBlob(std::string_view container,
-                          const Blobs::Models::BlobItem& blob) {
+FileInfo FileInfoFromBlob(std::string_view container, const Blobs::Models::BlobItem& blob) {
   auto path = internal::ConcatAbstractPath(container, blob.Name);
   if (internal::HasTrailingSlash(blob.Name)) {
     return DirectoryFileInfoFromPath(path);
@@ -1782,10 +2058,10 @@ FileInfo FileInfoFromBlob(std::string_view container,
 /// Learn more about leases at
 /// https://learn.microsoft.com/en-us/rest/api/storageservices/lease-blob
 class LeaseGuard {
- public:
+  public:
   using SteadyClock = std::chrono::steady_clock;
 
- private:
+  private:
   /// \brief The time when the lease expires or is broken.
   ///
   /// The lease is not guaranteed to be valid until this time, but it is guaranteed to
@@ -1795,18 +2071,12 @@ class LeaseGuard {
   const std::unique_ptr<Blobs::BlobLeaseClient> lease_client_;
   bool release_attempt_pending_ = true;
 
-  /// \brief The latest known expiry time of a lease guarded by this class
-  /// that failed to be released or was forgotten by calling Forget().
-  static std::atomic<SteadyClock::time_point> latest_known_expiry_time_;
-
   /// \brief The maximum lease duration supported by Azure Storage.
   static constexpr std::chrono::seconds kMaxLeaseDuration{60};
 
- public:
-  LeaseGuard(std::unique_ptr<Blobs::BlobLeaseClient> lease_client,
-             std::chrono::seconds lease_duration)
-      : break_or_expires_at_(SteadyClock::now() +
-                             std::min(kMaxLeaseDuration, lease_duration)),
+  public:
+  LeaseGuard(std::unique_ptr<Blobs::BlobLeaseClient> lease_client, std::chrono::seconds lease_duration)
+      : break_or_expires_at_(SteadyClock::now() + std::min(kMaxLeaseDuration, lease_duration)),
         lease_client_(std::move(lease_client)) {
     DCHECK(lease_duration <= kMaxLeaseDuration);
     DCHECK(this->lease_client_);
@@ -1822,23 +2092,20 @@ class LeaseGuard {
     LOG_STORAGE_DEBUG_ << status.ToString();
   }
 
-  bool PendingRelease() const {
-    return release_attempt_pending_ && SteadyClock::now() <= break_or_expires_at_;
-  }
+  bool PendingRelease() const { return release_attempt_pending_ && SteadyClock::now() <= break_or_expires_at_; }
 
- private:
+  private:
   Status DoRelease() {
     DCHECK(release_attempt_pending_);
     try {
       lease_client_->Release();
-    } catch (const Storage::StorageException& exception) {
-      return ExceptionToStatus(exception, "Failed to release the ",
-                               lease_client_->GetLeaseId(), " lease");
+    } catch (const Core::RequestFailedException& exception) {
+      return ExceptionToStatus(exception, "Failed to release the ", lease_client_->GetLeaseId(), " lease");
     }
     return Status::OK();
   }
 
- public:
+  public:
   std::string LeaseId() const { return lease_client_->GetLeaseId(); }
 
   bool StillValidFor(SteadyClock::duration expected_time_left) const {
@@ -1859,12 +2126,11 @@ class LeaseGuard {
     };
 #ifndef NDEBUG
     if (break_period.HasValue() && !StillValidFor(*break_period)) {
-      LOG_STORAGE_WARNING_
-          << "Azure Storage: requested break_period ("
-          << break_period.ValueOr(std::chrono::seconds{0}).count()
-          << "s) is too long or lease duration is too short for all the operations "
-             "performed so far (lease expires in "
-          << remaining_time_ms().count() << "ms)";
+      LOG_STORAGE_WARNING_ << "Azure Storage: requested break_period ("
+                           << break_period.ValueOr(std::chrono::seconds{0}).count()
+                           << "s) is too long or lease duration is too short for all the operations "
+                              "performed so far (lease expires in "
+                           << remaining_time_ms().count() << "ms)";
     }
 #endif
     Blobs::BreakLeaseOptions options;
@@ -1872,11 +2138,9 @@ class LeaseGuard {
     try {
       lease_client_->Break(options);
       break_or_expires_at_ =
-          std::min(break_or_expires_at_,
-                   SteadyClock::now() + break_period.ValueOr(std::chrono::seconds{0}));
-    } catch (const Storage::StorageException& exception) {
-      return ExceptionToStatus(exception, "Failed to break the ",
-                               lease_client_->GetLeaseId(), " lease expiring in ",
+          std::min(break_or_expires_at_, SteadyClock::now() + break_period.ValueOr(std::chrono::seconds{0}));
+    } catch (const Core::RequestFailedException& exception) {
+      return ExceptionToStatus(exception, "Failed to break the ", lease_client_->GetLeaseId(), " lease expiring in ",
                                remaining_time_ms().count(), "ms");
     }
     return Status::OK();
@@ -1897,9 +2161,7 @@ class LeaseGuard {
   /// and if it's too large the only consequence is that a lease on a non-existent
   /// resource will remain in the "Breaking" state for a while blocking others
   /// from recreating the resource.
-  void BreakBeforeDeletion(std::chrono::seconds break_period) {
-    ARROW_CHECK_OK(Break(break_period));
-  }
+  void BreakBeforeDeletion(std::chrono::seconds break_period) { ARROW_CHECK_OK(Break(break_period)); }
 
   // These functions are marked ARROW_NOINLINE because they are called from
   // multiple locations, but are not performance-critical.
@@ -1921,62 +2183,30 @@ class LeaseGuard {
   ///
   /// When it's known they would certainly fail.
   /// \see LeaseGuard::BreakBeforeDeletion()
-  ARROW_NOINLINE void Forget() {
-    if (!PendingRelease()) {
-      release_attempt_pending_ = false;
-      return;
-    }
-    release_attempt_pending_ = false;
-    // Remember the latest known expiry time so we can gracefully handle lease
-    // acquisition failures by waiting until the latest forgotten lease.
-    auto latest = latest_known_expiry_time_.load(std::memory_order_relaxed);
-    while (
-        latest < break_or_expires_at_ &&
-        !latest_known_expiry_time_.compare_exchange_weak(latest, break_or_expires_at_)) {
-    }
-    DCHECK_GE(latest_known_expiry_time_.load(), break_or_expires_at_);
-  }
-
-  ARROW_NOINLINE static void WaitUntilLatestKnownExpiryTime() {
-    auto remaining_time = latest_known_expiry_time_.load() - SteadyClock::now();
-#ifndef NDEBUG
-    int64_t remaining_time_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(remaining_time).count();
-    LOG_STORAGE_WARNING_ << "LeaseGuard::WaitUntilLatestKnownExpiryTime for "
-                       << remaining_time_ms << "ms...";
-#endif
-    DCHECK(remaining_time <= kMaxLeaseDuration);
-    if (remaining_time > SteadyClock::duration::zero()) {
-      std::this_thread::sleep_for(remaining_time);
-    }
-  }
+  ARROW_NOINLINE void Forget() { release_attempt_pending_ = false; }
 };
 
 }  // namespace
 
 class AzureFileSystem::Impl {
- private:
+  private:
   io::IOContext io_context_;
   AzureOptions options_;
 
   std::unique_ptr<DataLake::DataLakeServiceClient> datalake_service_client_;
   std::unique_ptr<Blobs::BlobServiceClient> blob_service_client_;
   HNSSupport cached_hns_support_ = HNSSupport::kUnknown;
-  std::shared_ptr<milvus_storage::FilesystemMetrics> metrics_ =
-      std::make_shared<milvus_storage::FilesystemMetrics>();
+  std::shared_ptr<milvus_storage::FilesystemMetrics> metrics_ = std::make_shared<milvus_storage::FilesystemMetrics>();
 
   Impl(AzureOptions options, io::IOContext io_context)
       : io_context_(std::move(io_context)), options_(std::move(options)) {}
 
- public:
-  static Result<std::unique_ptr<AzureFileSystem::Impl>> Make(AzureOptions options,
-                                                             io::IOContext io_context) {
-    auto self = std::unique_ptr<AzureFileSystem::Impl>(
-        new AzureFileSystem::Impl(std::move(options), std::move(io_context)));
-    ARROW_ASSIGN_OR_RAISE(self->blob_service_client_,
-                          self->options_.MakeBlobServiceClient());
-    ARROW_ASSIGN_OR_RAISE(self->datalake_service_client_,
-                          self->options_.MakeDataLakeServiceClient());
+  public:
+  static Result<std::unique_ptr<AzureFileSystem::Impl>> Make(AzureOptions options, io::IOContext io_context) {
+    auto self =
+        std::unique_ptr<AzureFileSystem::Impl>(new AzureFileSystem::Impl(std::move(options), std::move(io_context)));
+    ARROW_ASSIGN_OR_RAISE(self->blob_service_client_, self->options_.MakeBlobServiceClient());
+    ARROW_ASSIGN_OR_RAISE(self->datalake_service_client_, self->options_.MakeDataLakeServiceClient());
     return self;
   }
 
@@ -1988,22 +2218,19 @@ class AzureFileSystem::Impl {
     return blob_service_client_->GetBlobContainerClient(container_name);
   }
 
-  Blobs::BlobClient GetBlobClient(const std::string& container_name,
-                                  const std::string& blob_name) {
+  Blobs::BlobClient GetBlobClient(const std::string& container_name, const std::string& blob_name) {
     return GetBlobContainerClient(container_name).GetBlobClient(blob_name);
   }
 
   /// \param container_name Also known as "filesystem" in the ADLS Gen2 API.
-  DataLake::DataLakeFileSystemClient GetFileSystemClient(
-      const std::string& container_name) {
+  DataLake::DataLakeFileSystemClient GetFileSystemClient(const std::string& container_name) {
     return datalake_service_client_->GetFileSystemClient(container_name);
   }
 
   /// \brief Memoized version of CheckIfHierarchicalNamespaceIsEnabled.
   ///
   /// \return kEnabled/kDisabled/kContainerNotFound (kUnknown is never returned).
-  Result<HNSSupport> HierarchicalNamespaceSupport(
-      const DataLake::DataLakeFileSystemClient& adlfs_client) {
+  Result<HNSSupport> HierarchicalNamespaceSupport(const DataLake::DataLakeFileSystemClient& adlfs_client) {
     switch (cached_hns_support_) {
       case HNSSupport::kEnabled:
       case HNSSupport::kDisabled:
@@ -2014,9 +2241,7 @@ class AzureFileSystem::Impl {
         // that didn't exist before may exist now.
         break;
     }
-    ARROW_ASSIGN_OR_RAISE(
-        auto hns_support,
-        internal::CheckIfHierarchicalNamespaceIsEnabled(adlfs_client, options_));
+    ARROW_ASSIGN_OR_RAISE(auto hns_support, internal::CheckIfHierarchicalNamespaceIsEnabled(adlfs_client, options_));
     DCHECK_NE(hns_support, HNSSupport::kUnknown);
     if (hns_support == HNSSupport::kContainerNotFound) {
       // Caller should handle kContainerNotFound case appropriately as it knows the
@@ -2069,16 +2294,14 @@ class AzureFileSystem::Impl {
         info.set_type(FileType::File);
         info.set_size(properties.Value.FileSize);
       }
-      info.set_mtime(
-          std::chrono::system_clock::time_point{properties.Value.LastModified});
+      info.set_mtime(std::chrono::system_clock::time_point{properties.Value.LastModified});
       return info;
-    } catch (const Storage::StorageException& exception) {
-      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+    } catch (const Core::RequestFailedException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound && !IsContainerNotFound(exception)) {
         return FileInfo{location.all, FileType::NotFound};
       }
-      return ExceptionToStatus(
-          exception, "GetProperties for '", file_client.GetUrl(),
-          "' failed. GetFileInfo is unable to determine whether the path exists.");
+      return ExceptionToStatus(exception, "GetProperties for '", file_client.GetUrl(),
+                               "' failed. GetFileInfo is unable to determine whether the path exists.");
     }
   }
 
@@ -2087,8 +2310,7 @@ class AzureFileSystem::Impl {
   /// being blobs with names starting with the directory path.
   ///
   /// \pre location.path is not empty.
-  Result<FileInfo> GetFileInfo(const Blobs::BlobContainerClient& container_client,
-                               const AzureLocation& location) {
+  Result<FileInfo> GetFileInfo(const Blobs::BlobContainerClient& container_client, const AzureLocation& location) {
     DCHECK(!location.path.empty());
     Blobs::ListBlobsOptions options;
     options.Prefix = internal::RemoveTrailingSlash(location.path);
@@ -2121,8 +2343,7 @@ class AzureFileSystem::Impl {
         if (blob.Name == location.path) {
           info.set_type(FileType::File);
           info.set_size(blob.BlobSize);
-          info.set_mtime(
-              std::chrono::system_clock::time_point{blob.Details.LastModified});
+          info.set_mtime(std::chrono::system_clock::time_point{blob.Details.LastModified});
           return info;
         } else if (blob.Name[options.Prefix.Value().length()] < internal::kSep) {
           // First list result did not indicate a directory and there is definitely no
@@ -2147,13 +2368,9 @@ class AzureFileSystem::Impl {
       }
       info.set_type(FileType::NotFound);
       return info;
-    } catch (const Storage::StorageException& exception) {
-      if (IsContainerNotFound(exception)) {
-        return FileInfo{location.all, FileType::NotFound};
-      }
-      return ExceptionToStatus(
-          exception, "ListBlobsByHierarchy failed for prefix='", *options.Prefix,
-          "'. GetFileInfo is unable to determine whether the path exists.");
+    } catch (const Core::RequestFailedException& exception) {
+      return ContainerExceptionToStatus(exception, "ListBlobsByHierarchy failed for prefix='", *options.Prefix,
+                                        "'. GetFileInfo is unable to determine whether the path exists.");
     }
   }
 
@@ -2163,7 +2380,7 @@ class AzureFileSystem::Impl {
     auto adlfs_client = GetFileSystemClient(location.container);
     ARROW_ASSIGN_OR_RAISE(auto hns_support, HierarchicalNamespaceSupport(adlfs_client));
     if (hns_support == HNSSupport::kContainerNotFound) {
-      return FileInfo{location.all, FileType::NotFound};
+      return ContainerNotFoundStatus(location, "GetFileInfo");
     }
     if (hns_support == HNSSupport::kEnabled) {
       return GetFileInfo(adlfs_client, location);
@@ -2173,16 +2390,14 @@ class AzureFileSystem::Impl {
     return GetFileInfo(container_client, location);
   }
 
- private:
+  private:
   /// \pre location.container is not empty.
   template <typename ContainerClient>
-  Status CheckDirExists(const ContainerClient& container_client,
-                        const AzureLocation& location) {
+  Status CheckDirExists(const ContainerClient& container_client, const AzureLocation& location) {
     DCHECK(!location.container.empty());
     FileInfo info;
     if (location.path.empty()) {
-      ARROW_ASSIGN_OR_RAISE(info,
-                            GetContainerPropsAsFileInfo(location, container_client));
+      ARROW_ASSIGN_OR_RAISE(info, GetContainerPropsAsFileInfo(location, container_client));
     } else {
       ARROW_ASSIGN_OR_RAISE(info, GetFileInfo(container_client, location));
     }
@@ -2199,15 +2414,13 @@ class AzureFileSystem::Impl {
   Status VisitContainers(const Core::Context& context, OnContainer&& on_container) const {
     Blobs::ListBlobContainersOptions options;
     try {
-      auto container_list_response =
-          blob_service_client_->ListBlobContainers(options, context);
-      for (; container_list_response.HasPage();
-           container_list_response.MoveToNextPage(context)) {
+      auto container_list_response = blob_service_client_->ListBlobContainers(options, context);
+      for (; container_list_response.HasPage(); container_list_response.MoveToNextPage(context)) {
         for (const auto& container : container_list_response.BlobContainers) {
           RETURN_NOT_OK(on_container(container));
         }
       }
-    } catch (const Storage::StorageException& exception) {
+    } catch (const Core::RequestFailedException& exception) {
       return ExceptionToStatus(exception, "Failed to list account containers.");
     }
     return Status::OK();
@@ -2225,10 +2438,11 @@ class AzureFileSystem::Impl {
   ///
   /// \pre adlfs_client is the client for the filesystem named like the first
   /// segment of select.base_dir. The filesystem is know to exist.
-  Status GetFileInfoWithSelectorFromFileSystem(
-      const DataLake::DataLakeFileSystemClient& adlfs_client,
-      const Core::Context& context, Azure::Nullable<int32_t> page_size_hint,
-      const FileSelector& select, FileInfoVector* acc_results) {
+  Status GetFileInfoWithSelectorFromFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                                               const Core::Context& context,
+                                               Azure::Nullable<int32_t> page_size_hint,
+                                               const FileSelector& select,
+                                               FileInfoVector* acc_results) {
     ARROW_ASSIGN_OR_RAISE(auto base_location, AzureLocation::FromString(select.base_dir));
 
     // The filesystem a.k.a. the container is known to exist so if the path is empty then
@@ -2256,35 +2470,36 @@ class AzureFileSystem::Impl {
           // NOTE: `select.max_recursion` + anything will cause integer overflows because
           // `select.max_recursion` defaults to `INT32_MAX`. Therefore, options to
           // rewrite this condition in a more readable way are limited.
-          if (internal::GetAbstractPathDepth(path.Name) - base_path_depth - 1 <=
-              select.max_recursion) {
+          if (internal::GetAbstractPathDepth(path.Name) - base_path_depth - 1 <= select.max_recursion) {
             acc_results->push_back(FileInfoFromPath(base_location.container, path));
           }
         }
       }
-    } catch (const Storage::StorageException& exception) {
-      if (IsContainerNotFound(exception) || exception.ErrorCode == "PathNotFound") {
+    } catch (const Core::RequestFailedException& exception) {
+      if (IsContainerNotFound(exception)) {
+        return ContainerExceptionToStatus(exception, "Failed to list paths in Azure container '",
+                                          base_location.container, "': ", directory_client.GetUrl());
+      }
+      if (exception.ErrorCode == "PathNotFound") {
         found = false;
       } else {
-        return ExceptionToStatus(exception,
-                                 "Failed to list paths in a directory: ", select.base_dir,
-                                 ": ", directory_client.GetUrl());
+        return ExceptionToStatus(exception, "Failed to list paths in a directory: ", select.base_dir, ": ",
+                                 directory_client.GetUrl());
       }
     }
 
-    return found || select.allow_not_found
-               ? Status::OK()
-               : ::arrow::fs::internal::PathNotFound(select.base_dir);
+    return found || select.allow_not_found ? Status::OK() : ::arrow::fs::internal::PathNotFound(select.base_dir);
   }
 
   /// \brief List the blobs at the root of a container or some dir in a container.
   ///
   /// \pre container_client is the client for the container named like the first
   /// segment of select.base_dir.
-  Status GetFileInfoWithSelectorFromContainer(
-      const Blobs::BlobContainerClient& container_client, const Core::Context& context,
-      Azure::Nullable<int32_t> page_size_hint, const FileSelector& select,
-      FileInfoVector* acc_results) {
+  Status GetFileInfoWithSelectorFromContainer(const Blobs::BlobContainerClient& container_client,
+                                              const Core::Context& context,
+                                              Azure::Nullable<int32_t> page_size_hint,
+                                              const FileSelector& select,
+                                              FileInfoVector* acc_results) {
     ARROW_ASSIGN_OR_RAISE(auto base_location, AzureLocation::FromString(select.base_dir));
 
     bool found = false;
@@ -2304,13 +2519,12 @@ class AzureFileSystem::Impl {
     auto recurse = [&](const std::string& blob_prefix) noexcept -> Status {
       if (select.recursive && select.max_recursion > 0) {
         FileSelector sub_select;
-        sub_select.base_dir = internal::ConcatAbstractPath(
-            base_location.container, internal::RemoveTrailingSlash(blob_prefix));
+        sub_select.base_dir =
+            internal::ConcatAbstractPath(base_location.container, internal::RemoveTrailingSlash(blob_prefix));
         sub_select.allow_not_found = true;
         sub_select.recursive = true;
         sub_select.max_recursion = select.max_recursion - 1;
-        return GetFileInfoWithSelectorFromContainer(
-            container_client, context, page_size_hint, sub_select, acc_results);
+        return GetFileInfoWithSelectorFromContainer(container_client, context, page_size_hint, sub_select, acc_results);
       }
       return Status::OK();
     };
@@ -2330,8 +2544,7 @@ class AzureFileSystem::Impl {
     };
 
     try {
-      auto list_response =
-          container_client.ListBlobsByHierarchy(/*delimiter=*/"/", options, context);
+      auto list_response = container_client.ListBlobsByHierarchy(/*delimiter=*/"/", options, context);
       for (; list_response.HasPage(); list_response.MoveToNextPage(context)) {
         if (list_response.Blobs.empty() && list_response.BlobPrefixes.empty()) {
           continue;
@@ -2341,8 +2554,7 @@ class AzureFileSystem::Impl {
         // them to ensure returned results are all sorted.
         size_t blob_index = 0;
         size_t blob_prefix_index = 0;
-        while (blob_index < list_response.Blobs.size() &&
-               blob_prefix_index < list_response.BlobPrefixes.size()) {
+        while (blob_index < list_response.Blobs.size() && blob_prefix_index < list_response.BlobPrefixes.size()) {
           const auto& blob = list_response.Blobs[blob_index];
           const auto& prefix = list_response.BlobPrefixes[blob_prefix_index];
           const int cmp = blob.Name.compare(prefix);
@@ -2363,34 +2575,25 @@ class AzureFileSystem::Impl {
             // code above is kept just in case, but if this DCHECK(false) is ever reached,
             // we should refactor this loop to ensure no duplicate entries are ever
             // reported.
-            DCHECK(false)
-                << "Unexpected blob/prefix name collision on the same listing request";
+            DCHECK(false) << "Unexpected blob/prefix name collision on the same listing request";
           }
         }
         for (; blob_index < list_response.Blobs.size(); blob_index++) {
           process_blob(list_response.Blobs[blob_index]);
         }
-        for (; blob_prefix_index < list_response.BlobPrefixes.size();
-             blob_prefix_index++) {
+        for (; blob_prefix_index < list_response.BlobPrefixes.size(); blob_prefix_index++) {
           RETURN_NOT_OK(process_prefix(list_response.BlobPrefixes[blob_prefix_index]));
         }
       }
-    } catch (const Storage::StorageException& exception) {
-      if (IsContainerNotFound(exception)) {
-        found = false;
-      } else {
-        return ExceptionToStatus(exception,
-                                 "Failed to list blobs in a directory: ", select.base_dir,
-                                 ": ", container_client.GetUrl());
-      }
+    } catch (const Core::RequestFailedException& exception) {
+      return ContainerExceptionToStatus(exception, "Failed to list blobs in a directory: ", select.base_dir, ": ",
+                                        container_client.GetUrl());
     }
 
-    return found || select.allow_not_found
-               ? Status::OK()
-               : ::arrow::fs::internal::PathNotFound(select.base_dir);
+    return found || select.allow_not_found ? Status::OK() : ::arrow::fs::internal::PathNotFound(select.base_dir);
   }
 
- public:
+  public:
   Status GetFileInfoWithSelector(const Core::Context& context,
                                  Azure::Nullable<int32_t> page_size_hint,
                                  const FileSelector& select,
@@ -2407,8 +2610,7 @@ class AzureFileSystem::Impl {
 
         // Every container is considered a directory.
         FileInfo info{container.Name, FileType::Directory};
-        info.set_mtime(
-            std::chrono::system_clock::time_point{container.Details.LastModified});
+        info.set_mtime(std::chrono::system_clock::time_point{container.Details.LastModified});
         acc_results->push_back(std::move(info));
 
         // Recurse into containers (subdirectories) if requested.
@@ -2418,8 +2620,7 @@ class AzureFileSystem::Impl {
           sub_select.allow_not_found = true;
           sub_select.recursive = true;
           sub_select.max_recursion = select.max_recursion - 1;
-          ARROW_RETURN_NOT_OK(
-              GetFileInfoWithSelector(context, page_size_hint, sub_select, acc_results));
+          ARROW_RETURN_NOT_OK(GetFileInfoWithSelector(context, page_size_hint, sub_select, acc_results));
         }
         return Status::OK();
       };
@@ -2429,37 +2630,26 @@ class AzureFileSystem::Impl {
     auto adlfs_client = GetFileSystemClient(base_location.container);
     ARROW_ASSIGN_OR_RAISE(auto hns_support, HierarchicalNamespaceSupport(adlfs_client));
     if (hns_support == HNSSupport::kContainerNotFound) {
-      if (select.allow_not_found) {
-        return Status::OK();
-      } else {
-        return ::arrow::fs::internal::PathNotFound(select.base_dir);
-      }
+      return ContainerNotFoundStatus(base_location, "List");
     }
     if (hns_support == HNSSupport::kEnabled) {
-      return GetFileInfoWithSelectorFromFileSystem(adlfs_client, context, page_size_hint,
-                                                   select, acc_results);
+      return GetFileInfoWithSelectorFromFileSystem(adlfs_client, context, page_size_hint, select, acc_results);
     }
     DCHECK_EQ(hns_support, HNSSupport::kDisabled);
-    auto container_client =
-        blob_service_client_->GetBlobContainerClient(base_location.container);
-    return GetFileInfoWithSelectorFromContainer(container_client, context, page_size_hint,
-                                                select, acc_results);
+    auto container_client = blob_service_client_->GetBlobContainerClient(base_location.container);
+    return GetFileInfoWithSelectorFromContainer(container_client, context, page_size_hint, select, acc_results);
   }
 
-  Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const AzureLocation& location,
-                                                         AzureFileSystem* fs) {
+  Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const AzureLocation& location, AzureFileSystem* fs) {
     RETURN_NOT_OK(ValidateFileLocation(location));
-    auto blob_client = std::make_shared<Blobs::BlobClient>(
-        GetBlobClient(location.container, location.path));
+    auto blob_client = std::make_shared<Blobs::BlobClient>(GetBlobClient(location.container, location.path));
 
-    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(),
-                                                 std::move(location));
+    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), std::move(location));
     RETURN_NOT_OK(ptr->Init());
     return ptr;
   }
 
-  Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const FileInfo& info,
-                                                         AzureFileSystem* fs) {
+  Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const FileInfo& info, AzureFileSystem* fs) {
     if (info.type() == FileType::NotFound) {
       return ::arrow::fs::internal::PathNotFound(info.path());
     }
@@ -2468,16 +2658,14 @@ class AzureFileSystem::Impl {
     }
     ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(info.path()));
     RETURN_NOT_OK(ValidateFileLocation(location));
-    auto blob_client = std::make_shared<Blobs::BlobClient>(
-        GetBlobClient(location.container, location.path));
+    auto blob_client = std::make_shared<Blobs::BlobClient>(GetBlobClient(location.container, location.path));
 
-    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(),
-                                                 std::move(location), info.size());
+    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), std::move(location), info.size());
     RETURN_NOT_OK(ptr->Init());
     return ptr;
   }
 
- private:
+  private:
   /// This function cannot assume the filesystem/container already exists.
   ///
   /// \pre location.container is not empty.
@@ -2485,7 +2673,8 @@ class AzureFileSystem::Impl {
   template <class ContainerClient, class CreateDirIfNotExists>
   Status CreateDirTemplate(const ContainerClient& container_client,
                            CreateDirIfNotExists&& create_if_not_exists,
-                           const AzureLocation& location, bool recursive) {
+                           const AzureLocation& location,
+                           bool recursive) {
     DCHECK(!location.container.empty());
     DCHECK(!location.path.empty());
     if (recursive) {
@@ -2507,16 +2696,15 @@ class AzureFileSystem::Impl {
         }
       }
       // Ensure container exists
-      ARROW_ASSIGN_OR_RAISE(auto container,
-                            AzureLocation::FromString(location.container));
+      ARROW_ASSIGN_OR_RAISE(auto container, AzureLocation::FromString(location.container));
       ARROW_ASSIGN_OR_RAISE(auto container_info,
-                            GetContainerPropsAsFileInfo(container, container_client));
+                            GetContainerPropsAsFileInfo(container, container_client, /*allow_not_found=*/true));
       if (container_info.type() == FileType::NotFound) {
         try {
           container_client.CreateIfNotExists();
-        } catch (const Storage::StorageException& exception) {
-          return ExceptionToStatus(exception, "Failed to create directory '",
-                                   location.all, "': ", container_client.GetUrl());
+        } catch (const Core::RequestFailedException& exception) {
+          return ContainerExceptionToStatus(exception, "Failed to create directory '", location.all,
+                                            "': ", container_client.GetUrl());
         }
       }
       // Create nonexistent directories from shorter to longer:
@@ -2541,9 +2729,9 @@ class AzureFileSystem::Impl {
         const auto& nonexistent_location = nonexistent_locations[i - 1];
         try {
           create_if_not_exists(container_client, nonexistent_location);
-        } catch (const Storage::StorageException& exception) {
-          return ExceptionToStatus(exception, "Failed to create directory '",
-                                   location.all, "': ", container_client.GetUrl());
+        } catch (const Core::RequestFailedException& exception) {
+          return ExceptionToStatus(exception, "Failed to create directory '", location.all,
+                                   "': ", container_client.GetUrl());
         }
       }
       return Status::OK();
@@ -2559,10 +2747,10 @@ class AzureFileSystem::Impl {
       try {
         create_if_not_exists(container_client, location);
         return Status::OK();
-      } catch (const Storage::StorageException& exception) {
+      } catch (const Core::RequestFailedException& exception) {
         if (IsContainerNotFound(exception)) {
           auto parent = location.parent();
-          return PathNotFound(parent);
+          return ContainerNotFoundStatus(parent, "CreateDir");
         }
         return ExceptionToStatus(exception, "Failed to create directory '", location.all,
                                  "': ", container_client.GetUrl());
@@ -2570,18 +2758,19 @@ class AzureFileSystem::Impl {
     }
   }
 
- public:
+  public:
   /// This function cannot assume the filesystem already exists.
   ///
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
   Status CreateDirOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
-                               const AzureLocation& location, bool recursive) {
+                               const AzureLocation& location,
+                               bool recursive) {
     return CreateDirTemplate(
         adlfs_client,
         [](const auto& adlfs_client, const auto& location) {
-          auto directory_client = adlfs_client.GetDirectoryClient(
-              std::string(internal::RemoveTrailingSlash(location.path)));
+          auto directory_client =
+              adlfs_client.GetDirectoryClient(std::string(internal::RemoveTrailingSlash(location.path)));
           directory_client.CreateIfNotExists();
         },
         location, recursive);
@@ -2592,7 +2781,8 @@ class AzureFileSystem::Impl {
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
   Status CreateDirOnContainer(const Blobs::BlobContainerClient& container_client,
-                              const AzureLocation& location, bool recursive) {
+                              const AzureLocation& location,
+                              bool recursive) {
     return CreateDirTemplate(
         container_client,
         [this](const auto& container_client, const auto& location) {
@@ -2601,23 +2791,20 @@ class AzureFileSystem::Impl {
         location, recursive);
   }
 
-  Result<std::shared_ptr<ObjectAppendStream>> OpenAppendStream(
-      const AzureLocation& location,
-      const std::shared_ptr<const KeyValueMetadata>& metadata, const bool truncate,
-      AzureFileSystem* fs,
-      int64_t block_upload_size = kBlockUploadSizeBytes,
-      bool conditional_write = false) {
+  Result<std::shared_ptr<ObjectAppendStream>> OpenAppendStream(const AzureLocation& location,
+                                                               const std::shared_ptr<const KeyValueMetadata>& metadata,
+                                                               const bool truncate,
+                                                               AzureFileSystem* fs,
+                                                               int64_t block_upload_size = kBlockUploadSizeBytes,
+                                                               bool conditional_write = false) {
     RETURN_NOT_OK(ValidateFileLocation(location));
 
     const auto blob_container_client = GetBlobContainerClient(location.container);
-    auto block_blob_client = std::make_shared<Blobs::BlockBlobClient>(
-        blob_container_client.GetBlockBlobClient(location.path));
+    auto block_blob_client =
+        std::make_shared<Blobs::BlockBlobClient>(blob_container_client.GetBlockBlobClient(location.path));
 
-    auto ensure_not_flat_namespace_directory = [this, location,
-                                                blob_container_client]() -> Status {
-      ARROW_ASSIGN_OR_RAISE(
-          auto hns_support,
-          HierarchicalNamespaceSupport(GetFileSystemClient(location.container)));
+    auto ensure_not_flat_namespace_directory = [this, location, blob_container_client]() -> Status {
+      ARROW_ASSIGN_OR_RAISE(auto hns_support, HierarchicalNamespaceSupport(GetFileSystemClient(location.container)));
       if (hns_support == HNSSupport::kDisabled) {
         // Flat namespace so we need to GetFileInfo in-case its a directory.
         ARROW_ASSIGN_OR_RAISE(auto status, GetFileInfo(blob_container_client, location))
@@ -2632,21 +2819,17 @@ class AzureFileSystem::Impl {
     };
 
     std::shared_ptr<ObjectAppendStream> stream;
-    stream = std::make_shared<ObjectAppendStream>(block_blob_client, fs->io_context(),
-                                                  location, metadata, options_,
-                                                  metrics_,
-                                                  block_upload_size, conditional_write);
+    stream = std::make_shared<ObjectAppendStream>(block_blob_client, fs->io_context(), location, metadata, options_,
+                                                  metrics_, block_upload_size, conditional_write);
     RETURN_NOT_OK(stream->Init(truncate, ensure_not_flat_namespace_directory));
     return stream;
   }
 
- private:
-  void EnsureEmptyDirExistsImplThatThrows(
-      const Blobs::BlobContainerClient& container_client,
-      const std::string& path_within_container) {
+  private:
+  void EnsureEmptyDirExistsImplThatThrows(const Blobs::BlobContainerClient& container_client,
+                                          const std::string& path_within_container) {
     auto dir_marker_blob_path = internal::EnsureTrailingSlash(path_within_container);
-    auto block_blob_client =
-        container_client.GetBlobClient(dir_marker_blob_path).AsBlockBlobClient();
+    auto block_blob_client = container_client.GetBlobClient(dir_marker_blob_path).AsBlockBlobClient();
     // Attach metadata that other filesystem implementations expect to be present
     // on directory marker blobs.
     // https://github.com/fsspec/adlfs/blob/32132c4094350fca2680155a5c236f2e9f991ba5/adlfs/spec.py#L855-L870
@@ -2655,14 +2838,15 @@ class AzureFileSystem::Impl {
     block_blob_client.UploadFrom(nullptr, 0, blob_options);
   }
 
- public:
+  public:
   /// This function assumes the container already exists. So it can only be
   /// called after that has been verified.
   ///
   /// \pre location.container is not empty.
   /// \pre The location.container container already exists.
   Status EnsureEmptyDirExists(const Blobs::BlobContainerClient& container_client,
-                              const AzureLocation& location, const char* operation_name) {
+                              const AzureLocation& location,
+                              const char* operation_name) {
     DCHECK(!location.container.empty());
     if (location.path.empty()) {
       // Nothing to do. The container already exists per the preconditions.
@@ -2671,17 +2855,15 @@ class AzureFileSystem::Impl {
     try {
       EnsureEmptyDirExistsImplThatThrows(container_client, location.path);
       return Status::OK();
-    } catch (const Storage::StorageException& exception) {
-      return ExceptionToStatus(
-          exception, operation_name, " failed to ensure empty directory marker '",
-          location.path, "' exists in container: ", container_client.GetUrl());
+    } catch (const Core::RequestFailedException& exception) {
+      return ContainerExceptionToStatus(exception, operation_name, " failed to ensure empty directory marker '",
+                                        location.path, "' exists in container: ", container_client.GetUrl());
     }
   }
 
   /// \pre location.container is not empty.
   /// \pre location.path is empty.
-  Status DeleteContainer(const Blobs::BlobContainerClient& container_client,
-                         const AzureLocation& location) {
+  Status DeleteContainer(const Blobs::BlobContainerClient& container_client, const AzureLocation& location) {
     DCHECK(!location.container.empty());
     DCHECK(location.path.empty());
     try {
@@ -2689,13 +2871,9 @@ class AzureFileSystem::Impl {
       // Only the "*IfExists" functions ever set Deleted to false.
       // All the others either succeed or throw an exception.
       DCHECK(response.Value.Deleted);
-    } catch (const Storage::StorageException& exception) {
-      if (IsContainerNotFound(exception)) {
-        return PathNotFound(location);
-      }
-      return ExceptionToStatus(exception,
-                               "Failed to delete a container: ", location.container, ": ",
-                               container_client.GetUrl());
+    } catch (const Core::RequestFailedException& exception) {
+      return ContainerExceptionToStatus(exception, "Failed to delete a container: ", location.container, ": ",
+                                        container_client.GetUrl());
     }
     return Status::OK();
   }
@@ -2756,8 +2934,7 @@ class AzureFileSystem::Impl {
         std::vector<std::pair<std::string_view, DeleteBlobResponse>> deferred_responses;
         for (const auto& blob_item : list_response.Blobs) {
           if (preserve_dir_marker_blob && !found_dir_marker_blob) {
-            const bool is_dir_marker_blob =
-                options.Prefix.HasValue() && blob_item.Name == *options.Prefix;
+            const bool is_dir_marker_blob = options.Prefix.HasValue() && blob_item.Name == *options.Prefix;
             if (is_dir_marker_blob) {
               // Skip deletion of the existing directory marker blob,
               // but take note that it exists.
@@ -2765,8 +2942,7 @@ class AzureFileSystem::Impl {
               continue;
             }
           }
-          deferred_responses.emplace_back(blob_item.Name,
-                                          batch.DeleteBlob(blob_item.Name));
+          deferred_responses.emplace_back(blob_item.Name, batch.DeleteBlob(blob_item.Name));
         }
         try {
           // Before submitting the batch deleting directory contents, ensure
@@ -2778,74 +2954,39 @@ class AzureFileSystem::Impl {
             // existence is implied by the existence of blobs with names
             // starting with the directory path.
             if (!deferred_responses.empty()) {
-              RETURN_NOT_OK(
-                  EnsureEmptyDirExists(container_client, location, operation_name));
+              RETURN_NOT_OK(EnsureEmptyDirExists(container_client, location, operation_name));
             }
           }
           if (!deferred_responses.empty()) {
             container_client.SubmitBatch(batch);
           }
-        } catch (const Storage::StorageException& exception) {
-          return ExceptionToStatus(exception, "Failed to delete blobs in a directory: ",
-                                   location.path, ": ", container_client.GetUrl());
+        } catch (const Core::RequestFailedException& exception) {
+          return ContainerExceptionToStatus(exception, "Failed to delete blobs in a directory: ", location.path, ": ",
+                                            container_client.GetUrl());
         }
-        std::vector<std::string> failed_blob_names;
-        // Keep the first per-blob failure as a classified Status. Discarding
-        // the exception and synthesizing a plain IOError below would drop the
-        // classification of every sub-response, so a 429/503 inside a batch
-        // delete would still be reported as a permanent storage error.
-        std::optional<Status> first_failure_status;
         for (auto& [blob_name_view, deferred_response] : deferred_responses) {
-          bool success = true;
           try {
             auto delete_result = deferred_response.GetResponse();
-            success = delete_result.Value.Deleted;
-          } catch (const Storage::StorageException& exception) {
-            success = false;
-            if (!first_failure_status.has_value()) {
-              first_failure_status = ExceptionToStatus(exception, "Failed to delete blob: ",
-                                                       blob_name_view, ": ");
+            if (!delete_result.Value.Deleted) {
+              return Status::IOError("Azure batch response reported Deleted=false without a failure reason");
             }
+          } catch (const Core::RequestFailedException& exception) {
+            return ExceptionToStatus(exception, "Failed to delete blob: ", blob_name_view, ": ");
           }
-          if (!success) {
-            failed_blob_names.emplace_back(blob_name_view);
-          }
-        }
-        if (!failed_blob_names.empty()) {
-          std::stringstream message_stream;
-          if (failed_blob_names.size() == 1) {
-            message_stream << "Failed to delete a blob: " << failed_blob_names[0] << ": "
-                           << container_client.GetUrl();
-          } else {
-            message_stream << "Failed to delete blobs: ["
-                           << arrow::internal::JoinStrings(failed_blob_names, ", ")
-                           << "]: " << container_client.GetUrl();
-          }
-          auto message = message_stream.str();
-          if (first_failure_status.has_value()) {
-            // Reuse the cause's code and detail so the classification survives;
-            // the message still names every blob that failed. A sub-response
-            // that reports Deleted=false without throwing carries nothing to
-            // preserve, so those fall back to the plain IOError below.
-            return Status(first_failure_status->code(),
-                          message + " " + first_failure_status->message(),
-                          first_failure_status->detail());
-          }
-          return Status::IOError(message);
         }
       }
       return Status::OK();
-    } catch (const Storage::StorageException& exception) {
-      return ExceptionToStatus(exception,
-                               "Failed to list blobs in a directory: ", location.path,
-                               ": ", container_client.GetUrl());
+    } catch (const Core::RequestFailedException& exception) {
+      return ContainerExceptionToStatus(exception, "Failed to list blobs in a directory: ", location.path, ": ",
+                                        container_client.GetUrl());
     }
   }
 
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
   Status DeleteDirOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
-                               const AzureLocation& location, bool recursive,
+                               const AzureLocation& location,
+                               bool recursive,
                                bool require_dir_to_exist,
                                Azure::Nullable<std::string> lease_id = {}) {
     DCHECK(!location.container.empty());
@@ -2861,34 +3002,35 @@ class AzureFileSystem::Impl {
     if (file_info.type() != FileType::Directory) {
       return NotADir(location);
     }
-    auto directory_client = adlfs_client.GetDirectoryClient(
-        std::string(internal::RemoveTrailingSlash(location.path)));
+    auto directory_client = adlfs_client.GetDirectoryClient(std::string(internal::RemoveTrailingSlash(location.path)));
     DataLake::DeleteDirectoryOptions options;
     options.AccessConditions.LeaseId = std::move(lease_id);
     try {
-      auto response = recursive ? directory_client.DeleteRecursive(options)
-                                : directory_client.DeleteEmpty(options);
+      auto response = recursive ? directory_client.DeleteRecursive(options) : directory_client.DeleteEmpty(options);
       // Only the "*IfExists" functions ever set Deleted to false.
       // All the others either succeed or throw an exception.
       DCHECK(response.Value.Deleted);
-    } catch (const Storage::StorageException& exception) {
-      if (exception.ErrorCode == "FilesystemNotFound" ||
-          exception.ErrorCode == "PathNotFound") {
+    } catch (const Core::RequestFailedException& exception) {
+      if (exception.ErrorCode == "FilesystemNotFound" || IsContainerNotFound(exception)) {
+        return ContainerExceptionToStatus(exception, "Failed to delete a directory from Azure container '",
+                                          location.container, "': ", directory_client.GetUrl());
+      }
+      if (exception.ErrorCode == "PathNotFound") {
         if (require_dir_to_exist) {
           return PathNotFound(location);
         }
         return Status::OK();
       }
-      return ExceptionToStatus(exception, "Failed to delete a directory: ", location.path,
-                               ": ", directory_client.GetUrl());
+      return ExceptionToStatus(exception, "Failed to delete a directory: ", location.path, ": ",
+                               directory_client.GetUrl());
     }
     return Status::OK();
   }
 
   /// \pre location.container is not empty.
-  Status DeleteDirContentsOnFileSystem(
-      const DataLake::DataLakeFileSystemClient& adlfs_client,
-      const AzureLocation& location, bool missing_dir_ok) {
+  Status DeleteDirContentsOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                                       const AzureLocation& location,
+                                       bool missing_dir_ok) {
     auto directory_client = adlfs_client.GetDirectoryClient(location.path);
     try {
       auto list_response = directory_client.ListPaths(false);
@@ -2898,10 +3040,9 @@ class AzureFileSystem::Impl {
             auto sub_directory_client = adlfs_client.GetDirectoryClient(path.Name);
             try {
               sub_directory_client.DeleteRecursive();
-            } catch (const Storage::StorageException& exception) {
-              return ExceptionToStatus(
-                  exception, "Failed to delete a sub directory: ", location.container,
-                  kDelimiter, path.Name, ": ", sub_directory_client.GetUrl());
+            } catch (const Core::RequestFailedException& exception) {
+              return ExceptionToStatus(exception, "Failed to delete a sub directory: ", location.container, kDelimiter,
+                                       path.Name, ": ", sub_directory_client.GetUrl());
             }
           } else {
             if (path.Name == location.path) {
@@ -2910,60 +3051,55 @@ class AzureFileSystem::Impl {
             auto sub_file_client = adlfs_client.GetFileClient(path.Name);
             try {
               sub_file_client.Delete();
-            } catch (const Storage::StorageException& exception) {
-              return ExceptionToStatus(
-                  exception, "Failed to delete a sub file: ", location.container,
-                  kDelimiter, path.Name, ": ", sub_file_client.GetUrl());
+            } catch (const Core::RequestFailedException& exception) {
+              return ExceptionToStatus(exception, "Failed to delete a sub file: ", location.container, kDelimiter,
+                                       path.Name, ": ", sub_file_client.GetUrl());
             }
           }
         }
       }
       return Status::OK();
-    } catch (const Storage::StorageException& exception) {
+    } catch (const Core::RequestFailedException& exception) {
+      if (IsContainerNotFound(exception) || location.path.empty()) {
+        return ContainerExceptionToStatus(exception, "Failed to delete contents from Azure container '",
+                                          location.container, "': ", directory_client.GetUrl());
+      }
       if (missing_dir_ok && exception.StatusCode == Http::HttpStatusCode::NotFound) {
         return Status::OK();
       }
-      return ExceptionToStatus(exception,
-                               "Failed to delete directory contents: ", location.path,
-                               ": ", directory_client.GetUrl());
+      return ExceptionToStatus(exception, "Failed to delete directory contents: ", location.path, ": ",
+                               directory_client.GetUrl());
     }
   }
 
- private:
+  private:
   /// \brief Create a BlobLeaseClient and acquire a lease on the container.
   ///
   /// \param allow_missing_container if true, a nullptr may be returned when the container
   /// doesn't exist, otherwise a PathNotFound(location) error is produced right away
   /// \return A BlobLeaseClient is wrapped as a unique_ptr so it's moveable and
   /// optional (nullptr denotes container not found)
-  Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireContainerLease(
-      const AzureLocation& location, std::chrono::seconds lease_duration,
-      bool allow_missing_container = false, bool retry_allowed = true) {
+  Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireContainerLease(const AzureLocation& location,
+                                                                        std::chrono::seconds lease_duration,
+                                                                        bool allow_missing_container = false) {
     DCHECK(!location.container.empty());
     auto container_client = GetBlobContainerClient(location.container);
     auto lease_id = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
     auto container_url = container_client.GetUrl();
-    auto lease_client = std::make_unique<Blobs::BlobLeaseClient>(
-        std::move(container_client), std::move(lease_id));
+    auto lease_client = std::make_unique<Blobs::BlobLeaseClient>(std::move(container_client), std::move(lease_id));
     try {
       [[maybe_unused]] auto result = lease_client->Acquire(lease_duration);
       DCHECK_EQ(result.Value.LeaseId, lease_client->GetLeaseId());
-    } catch (const Storage::StorageException& exception) {
-      if (IsContainerNotFound(exception)) {
+    } catch (const Core::RequestFailedException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
         if (allow_missing_container) {
           return nullptr;
         }
-        return PathNotFound(location);
-      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict &&
-                 exception.ErrorCode == "LeaseAlreadyPresent") {
-        if (retry_allowed) {
-          LeaseGuard::WaitUntilLatestKnownExpiryTime();
-          return AcquireContainerLease(location, lease_duration, allow_missing_container,
-                                       /*retry_allowed=*/false);
-        }
+        return ContainerExceptionToStatus(exception, "Failed to acquire a lease on missing Azure container '",
+                                          location.container, "': ", container_url);
       }
-      return ExceptionToStatus(exception, "Failed to acquire a lease on container '",
-                               location.container, "': ", container_url);
+      return ContainerExceptionToStatus(exception, "Failed to acquire a lease on container '", location.container,
+                                        "': ", container_url);
     }
     return lease_client;
   }
@@ -2975,35 +3111,30 @@ class AzureFileSystem::Impl {
   /// doesn't exist, otherwise a PathNotFound(location) error is produced right away
   /// \return A BlobLeaseClient is wrapped as a unique_ptr so it's moveable and
   /// optional (nullptr denotes blob not found)
-  Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireBlobLease(
-      const AzureLocation& location, std::chrono::seconds lease_duration,
-      bool allow_missing, bool retry_allowed = true) {
+  Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireBlobLease(const AzureLocation& location,
+                                                                   std::chrono::seconds lease_duration,
+                                                                   bool allow_missing) {
     DCHECK(!location.container.empty() && !location.path.empty());
     auto path = std::string{internal::RemoveTrailingSlash(location.path)};
     auto blob_client = GetBlobClient(location.container, std::move(path));
     auto lease_id = Blobs::BlobLeaseClient::CreateUniqueLeaseId();
     auto blob_url = blob_client.GetUrl();
-    auto lease_client = std::make_unique<Blobs::BlobLeaseClient>(std::move(blob_client),
-                                                                 std::move(lease_id));
+    auto lease_client = std::make_unique<Blobs::BlobLeaseClient>(std::move(blob_client), std::move(lease_id));
     try {
       [[maybe_unused]] auto result = lease_client->Acquire(lease_duration);
       DCHECK_EQ(result.Value.LeaseId, lease_client->GetLeaseId());
-    } catch (const Storage::StorageException& exception) {
+    } catch (const Core::RequestFailedException& exception) {
       if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        if (IsContainerNotFound(exception)) {
+          return ContainerExceptionToStatus(exception, "Failed to acquire a lease in missing Azure container '",
+                                            location.container, "': ", blob_url);
+        }
         if (allow_missing) {
           return nullptr;
         }
         return PathNotFound(location);
-      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict &&
-                 exception.ErrorCode == "LeaseAlreadyPresent") {
-        if (retry_allowed) {
-          LeaseGuard::WaitUntilLatestKnownExpiryTime();
-          return AcquireBlobLease(location, lease_duration, allow_missing,
-                                  /*retry_allowed=*/false);
-        }
       }
-      return ExceptionToStatus(exception, "Failed to acquire a lease on file '",
-                               location.all, "': ", blob_url);
+      return ExceptionToStatus(exception, "Failed to acquire a lease on file '", location.all, "': ", blob_url);
     }
     return lease_client;
   }
@@ -3039,7 +3170,7 @@ class AzureFileSystem::Impl {
   static constexpr auto kTimeNeededForContainerRename = std::chrono::seconds{3};
   static constexpr auto kTimeNeededForFileOrDirectoryRename = std::chrono::seconds{3};
 
- public:
+  public:
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
   Status DeleteFileOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
@@ -3047,8 +3178,7 @@ class AzureFileSystem::Impl {
                                 bool require_file_to_exist) {
     DCHECK(!location.container.empty());
     DCHECK(!location.path.empty());
-    auto path_no_trailing_slash =
-        std::string{internal::RemoveTrailingSlash(location.path)};
+    auto path_no_trailing_slash = std::string{internal::RemoveTrailingSlash(location.path)};
     auto file_client = adlfs_client.GetFileClient(path_no_trailing_slash);
     try {
       // This is necessary to avoid deletion of directories via DeleteFile.
@@ -3063,16 +3193,18 @@ class AzureFileSystem::Impl {
       // Only the "*IfExists" functions ever set Deleted to false.
       // All the others either succeed or throw an exception.
       DCHECK(response.Value.Deleted);
-    } catch (const Storage::StorageException& exception) {
+    } catch (const Core::RequestFailedException& exception) {
       if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
-        // ErrorCode can be "FilesystemNotFound", "PathNotFound"...
+        if (IsContainerNotFound(exception)) {
+          return ContainerExceptionToStatus(exception, "Failed to delete a file from missing Azure container '",
+                                            location.container, "': ", file_client.GetUrl());
+        }
         if (require_file_to_exist) {
           return PathNotFound(location);
         }
         return Status::OK();
       }
-      return ExceptionToStatus(exception, "Failed to delete a file: ", location.path,
-                               ": ", file_client.GetUrl());
+      return ExceptionToStatus(exception, "Failed to delete a file: ", location.path, ": ", file_client.GetUrl());
     }
     return Status::OK();
   }
@@ -3080,7 +3212,8 @@ class AzureFileSystem::Impl {
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
   Status DeleteFileOnContainer(const Blobs::BlobContainerClient& container_client,
-                               const AzureLocation& location, bool require_file_to_exist,
+                               const AzureLocation& location,
+                               bool require_file_to_exist,
                                const char* operation) {
     DCHECK(!location.container.empty());
     DCHECK(!location.path.empty());
@@ -3092,8 +3225,7 @@ class AzureFileSystem::Impl {
       auto no_trailing_slash = location;
       no_trailing_slash.path = internal::RemoveTrailingSlash(location.path);
       no_trailing_slash.all = internal::RemoveTrailingSlash(location.all);
-      ARROW_ASSIGN_OR_RAISE(auto file_info,
-                            GetFileInfo(container_client, no_trailing_slash));
+      ARROW_ASSIGN_OR_RAISE(auto file_info, GetFileInfo(container_client, no_trailing_slash));
       if (file_info.type() == FileType::NotFound) {
         return require_file_to_exist ? PathNotFound(location) : Status::OK();
       }
@@ -3123,12 +3255,10 @@ class AzureFileSystem::Impl {
       // We have to check the existence of the file before checking the
       // existence of the parent directory marker, so we acquire a lease on the
       // file first.
-      ARROW_ASSIGN_OR_RAISE(auto file_blob_lease_client,
-                            AcquireBlobLease(location, kFileBlobLeaseTime,
-                                             /*allow_missing=*/true));
+      ARROW_ASSIGN_OR_RAISE(auto file_blob_lease_client, AcquireBlobLease(location, kFileBlobLeaseTime,
+                                                                          /*allow_missing=*/true));
       if (file_blob_lease_client) {
-        file_blob_lease_guard.emplace(std::move(file_blob_lease_client),
-                                      kFileBlobLeaseTime);
+        file_blob_lease_guard.emplace(std::move(file_blob_lease_client), kFileBlobLeaseTime);
         // Ensure the empty directory marker blob of the parent exists before the file is
         // deleted.
         //
@@ -3155,12 +3285,15 @@ class AzureFileSystem::Impl {
       // Only the "*IfExists" functions ever set Deleted to false.
       // All the others either succeed or throw an exception.
       DCHECK(response.Value.Deleted);
-    } catch (const Storage::StorageException& exception) {
+    } catch (const Core::RequestFailedException& exception) {
       if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        if (IsContainerNotFound(exception)) {
+          return ContainerExceptionToStatus(exception, "Failed to delete a file from missing Azure container '",
+                                            location.container, "': ", blob_client.GetUrl());
+        }
         return check_if_location_exists_as_dir();
       }
-      return ExceptionToStatus(exception, "Failed to delete a file: ", location.all, ": ",
-                               blob_client.GetUrl());
+      return ExceptionToStatus(exception, "Failed to delete a file: ", location.all, ": ", blob_client.GetUrl());
     }
     return Status::OK();
   }
@@ -3186,8 +3319,7 @@ class AzureFileSystem::Impl {
 
     // If src and dest are the same, we only have to check src exists.
     if (src.container == dest.container) {
-      ARROW_ASSIGN_OR_RAISE(auto info,
-                            GetContainerPropsAsFileInfo(src, src_container_client));
+      ARROW_ASSIGN_OR_RAISE(auto info, GetContainerPropsAsFileInfo(src, src_container_client));
       if (info.type() == FileType::NotFound) {
         return PathNotFound(src);
       }
@@ -3197,17 +3329,15 @@ class AzureFileSystem::Impl {
 
     // Acquire a lease on the source container because (1) we need the lease
     // before rename and (2) it works as a way of checking the container exists.
-    ARROW_ASSIGN_OR_RAISE(auto src_lease_client,
-                          AcquireContainerLease(src, kLeaseDuration));
+    ARROW_ASSIGN_OR_RAISE(auto src_lease_client, AcquireContainerLease(src, kLeaseDuration));
     LeaseGuard src_lease_guard{std::move(src_lease_client), kLeaseDuration};
     // Check dest.container doesn't exist or is empty.
     auto dest_container_client = GetBlobContainerClient(dest.container);
     std::optional<LeaseGuard> dest_lease_guard;
     bool dest_exists = false;
     bool dest_is_empty = false;
-    ARROW_ASSIGN_OR_RAISE(
-        auto dest_lease_client,
-        AcquireContainerLease(dest, kLeaseDuration, /*allow_missing_container*/ true));
+    ARROW_ASSIGN_OR_RAISE(auto dest_lease_client,
+                          AcquireContainerLease(dest, kLeaseDuration, /*allow_missing_container*/ true));
     if (dest_lease_client) {
       dest_lease_guard.emplace(std::move(dest_lease_client), kLeaseDuration);
       dest_exists = true;
@@ -3220,9 +3350,9 @@ class AzureFileSystem::Impl {
         if (!dest_is_empty) {
           return NotEmpty(dest);
         }
-      } catch (const Storage::StorageException& exception) {
-        return ExceptionToStatus(exception, "Failed to check that '", dest.container,
-                                 "' is empty: ", dest_container_client.GetUrl());
+      } catch (const Core::RequestFailedException& exception) {
+        return ContainerExceptionToStatus(exception, "Failed to check that '", dest.container,
+                                          "' is empty: ", dest_container_client.GetUrl());
       }
     }
     DCHECK(!dest_exists || dest_is_empty);
@@ -3235,21 +3365,19 @@ class AzureFileSystem::Impl {
         src_lease_guard.BreakBeforeDeletion(kTimeNeededForContainerRename);
         blob_service_client_->RenameBlobContainer(src.container, dest.container, options);
         src_lease_guard.Forget();
-      } catch (const Storage::StorageException& exception) {
-        if (exception.StatusCode == Http::HttpStatusCode::BadRequest &&
+      } catch (const Core::RequestFailedException& exception) {
+        const auto* storage_exception = dynamic_cast<const Storage::StorageException*>(&exception);
+        if (storage_exception && exception.StatusCode == Http::HttpStatusCode::BadRequest &&
             exception.ErrorCode == "InvalidQueryParameterValue") {
-          auto param_name = exception.AdditionalInformation.find("QueryParameterName");
-          if (param_name != exception.AdditionalInformation.end() &&
-              param_name->second == "comp") {
-            return ExceptionToStatus(
-                exception, "The 'rename' operation is not supported on containers. ",
-                "Attempting a rename of '", src.container, "' to '", dest.container,
-                "': ", blob_service_client_->GetUrl());
+          auto param_name = storage_exception->AdditionalInformation.find("QueryParameterName");
+          if (param_name != storage_exception->AdditionalInformation.end() && param_name->second == "comp") {
+            return ContainerExceptionToStatus(exception, "The 'rename' operation is not supported on containers. ",
+                                              "Attempting a rename of '", src.container, "' to '", dest.container,
+                                              "': ", blob_service_client_->GetUrl());
           }
         }
-        return ExceptionToStatus(exception, "Failed to rename container '", src.container,
-                                 "' to '", dest.container,
-                                 "': ", blob_service_client_->GetUrl());
+        return ContainerExceptionToStatus(exception, "Failed to rename container '", src.container, "' to '",
+                                          dest.container, "': ", blob_service_client_->GetUrl());
       }
     } else if (dest_is_empty) {
       // Even if we deleted the empty dest.container, RenameBlobContainer() would still
@@ -3286,13 +3414,13 @@ class AzureFileSystem::Impl {
           src_lease_guard.BreakBeforeDeletion(kTimeNeededForContainerDeletion);
           src_container_client.Delete(options);
           src_lease_guard.Forget();
-        } catch (const Storage::StorageException& exception) {
-          return ExceptionToStatus(exception, "Failed to delete empty container: '",
-                                   src.container, "': ", src_container_client.GetUrl());
+        } catch (const Core::RequestFailedException& exception) {
+          return ContainerExceptionToStatus(exception, "Failed to delete empty container: '", src.container,
+                                            "': ", src_container_client.GetUrl());
         }
-      } catch (const Storage::StorageException& exception) {
-        return ExceptionToStatus(exception, "Unable to replace empty container: '",
-                                 dest.all, "': ", dest_container_client.GetUrl());
+      } catch (const Core::RequestFailedException& exception) {
+        return ContainerExceptionToStatus(exception, "Unable to replace empty container: '", dest.all,
+                                          "': ", src_container_client.GetUrl());
       }
     }
     return Status::OK();
@@ -3303,8 +3431,7 @@ class AzureFileSystem::Impl {
     DCHECK(!dest.container.empty() && !dest.path.empty());
     // Check Move pre-condition 1 -- `src` must exist.
     auto container_client = GetBlobContainerClient(src.container);
-    ARROW_ASSIGN_OR_RAISE(auto src_info,
-                          GetContainerPropsAsFileInfo(src, container_client));
+    ARROW_ASSIGN_OR_RAISE(auto src_info, GetContainerPropsAsFileInfo(src, container_client));
     if (src_info.type() == FileType::NotFound) {
       return PathNotFound(src);
     }
@@ -3326,8 +3453,7 @@ class AzureFileSystem::Impl {
       case FileType::NotFound:
         return PathNotFound(src);
       case FileType::File:
-        return Status::Invalid(
-            "Creating files at '/' is not possible, only directories.");
+        return Status::Invalid("Creating files at '/' is not possible, only directories.");
       case FileType::Directory:
         break;
     }
@@ -3337,17 +3463,16 @@ class AzureFileSystem::Impl {
     return CrossContainerMoveNotImplemented(src, dest);
   }
 
-  Status MovePathWithDataLakeAPI(
-      const DataLake::DataLakeFileSystemClient& src_adlfs_client,
-      const AzureLocation& src, const AzureLocation& dest) {
+  Status MovePathWithDataLakeAPI(const DataLake::DataLakeFileSystemClient& src_adlfs_client,
+                                 const AzureLocation& src,
+                                 const AzureLocation& dest) {
     DCHECK(!src.container.empty() && !src.path.empty());
     DCHECK(!dest.container.empty() && !dest.path.empty());
     const auto src_path = std::string{internal::RemoveTrailingSlash(src.path)};
     const auto dest_path = std::string{internal::RemoveTrailingSlash(dest.path)};
 
     // Ensure that src exists and, if path has a trailing slash, that it's a directory.
-    ARROW_ASSIGN_OR_RAISE(auto src_lease_client,
-                          AcquireBlobLease(src, kLeaseDuration, /*allow_missing=*/false));
+    ARROW_ASSIGN_OR_RAISE(auto src_lease_client, AcquireBlobLease(src, kLeaseDuration, /*allow_missing=*/false));
     LeaseGuard src_lease_guard{std::move(src_lease_client), kLeaseDuration};
     // It might be necessary to check src is a directory 0-3 times in this function,
     // so we use a lazy evaluation function to avoid redundant calls to GetFileInfo().
@@ -3356,8 +3481,7 @@ class AzureFileSystem::Impl {
       if (src_is_dir_opt.has_value()) {
         return *src_is_dir_opt;
       }
-      ARROW_ASSIGN_OR_RAISE(
-          auto src_info, GetFileInfo(src_adlfs_client, src, src_lease_guard.LeaseId()));
+      ARROW_ASSIGN_OR_RAISE(auto src_info, GetFileInfo(src_adlfs_client, src, src_lease_guard.LeaseId()));
       src_is_dir_opt = src_info.type() == FileType::Directory;
       return *src_is_dir_opt;
     };
@@ -3373,15 +3497,13 @@ class AzureFileSystem::Impl {
     // storage account, if the destination is an empty directory, the rename operation
     // will most likely fail due to a timeout. Providing both leases -- to source and
     // destination -- seems to have made things work.
-    ARROW_ASSIGN_OR_RAISE(auto dest_lease_client,
-                          AcquireBlobLease(dest, kLeaseDuration, /*allow_missing=*/true));
+    ARROW_ASSIGN_OR_RAISE(auto dest_lease_client, AcquireBlobLease(dest, kLeaseDuration, /*allow_missing=*/true));
     std::optional<LeaseGuard> dest_lease_guard;
     if (dest_lease_client) {
       dest_lease_guard.emplace(std::move(dest_lease_client), kLeaseDuration);
       // Perform all the checks on dest (and src) before proceeding with the rename.
       auto dest_adlfs_client = GetFileSystemClient(dest.container);
-      ARROW_ASSIGN_OR_RAISE(auto dest_info, GetFileInfo(dest_adlfs_client, dest,
-                                                        dest_lease_guard->LeaseId()));
+      ARROW_ASSIGN_OR_RAISE(auto dest_info, GetFileInfo(dest_adlfs_client, dest, dest_lease_guard->LeaseId()));
       if (dest_info.type() == FileType::Directory) {
         ARROW_ASSIGN_OR_RAISE(auto src_is_dir, src_is_dir_lazy());
         if (!src_is_dir) {
@@ -3431,7 +3553,7 @@ class AzureFileSystem::Impl {
       src_lease_guard.BreakBeforeDeletion(kTimeNeededForFileOrDirectoryRename);
       src_adlfs_client.RenameFile(src_path, dest_path, options);
       src_lease_guard.Forget();
-    } catch (const Storage::StorageException& exception) {
+    } catch (const Core::RequestFailedException& exception) {
       // https://learn.microsoft.com/en-gb/rest/api/storageservices/datalakestoragegen2/path/create
       if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
         if (exception.ErrorCode == "PathNotFound") {
@@ -3445,14 +3567,13 @@ class AzureFileSystem::Impl {
             exception.ErrorCode == "RenameDestinationParentPathNotFound") {
           return DestinationParentPathNotFound(dest);
         }
-      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict &&
-                 exception.ErrorCode == "PathAlreadyExists") {
+      } else if (exception.StatusCode == Http::HttpStatusCode::Conflict && exception.ErrorCode == "PathAlreadyExists") {
         // "PathAlreadyExists" is only produced when the destination exists and is a
         // non-empty directory, so we produce the appropriate error.
         return NotEmpty(dest);
       }
-      return ExceptionToStatus(exception, "Failed to rename '", src.all, "' to '",
-                               dest.all, "': ", src_adlfs_client.GetUrl());
+      return ExceptionToStatus(exception, "Failed to rename '", src.all, "' to '", dest.all,
+                               "': ", src_adlfs_client.GetUrl());
     }
     return Status::OK();
   }
@@ -3476,10 +3597,9 @@ class AzureFileSystem::Impl {
     DCHECK(!src.container.empty() && !src.path.empty());
     DCHECK(!dest.container.empty() && !dest.path.empty());
     auto src_adlfs_client = GetFileSystemClient(src.container);
-    ARROW_ASSIGN_OR_RAISE(auto hns_support,
-                          HierarchicalNamespaceSupport(src_adlfs_client));
+    ARROW_ASSIGN_OR_RAISE(auto hns_support, HierarchicalNamespaceSupport(src_adlfs_client));
     if (hns_support == HNSSupport::kContainerNotFound) {
-      return PathNotFound(src);
+      return ContainerNotFoundStatus(src, "Move");
     }
     if (hns_support == HNSSupport::kEnabled) {
       return MovePathWithDataLakeAPI(src_adlfs_client, src, dest);
@@ -3516,20 +3636,16 @@ class AzureFileSystem::Impl {
       copy_operation.PollUntilDone(std::chrono::milliseconds(1000));
     } catch (const Storage::StorageException& exception) {
       // StartCopyFromUri failed or a GetProperties call inside PollUntilDone failed.
-      return ExceptionToStatus(
-          exception, "Failed to start blob copy or poll status of ongoing copy. (",
-          src_url, " -> ", dest_blob_client.GetUrl(), ")");
-    } catch (const Azure::Core::RequestFailedException& exception) {
-      // A GetProperties call inside PollUntilDone returned a failed CopyStatus.
-      return ExceptionToStatus(exception, "Failed to copy blob. (", src_url, " -> ",
-                               dest_blob_client.GetUrl(), ")");
+      return ExceptionToStatus(exception, "Failed to start blob copy or poll status of ongoing copy. (", src_url,
+                               " -> ", dest_blob_client.GetUrl(), ")");
+    } catch (const Core::RequestFailedException& exception) {
+      // A GetProperties call inside PollUntilDone returned a failed CopyStatus --
+      // or, since this is the trailing base-type clause, a TransportException.
+      return ExceptionToStatus(exception, "Failed to copy blob. (", src_url, " -> ", dest_blob_client.GetUrl(), ")");
     }
     return Status::OK();
   }
 };
-
-std::atomic<LeaseGuard::SteadyClock::time_point> LeaseGuard::latest_known_expiry_time_ =
-    SteadyClock::time_point{SteadyClock::duration::zero()};
 
 AzureFileSystem::AzureFileSystem(std::unique_ptr<Impl>&& impl)
     : FileSystem(impl->io_context()), impl_(std::move(impl)) {
@@ -3540,8 +3656,8 @@ void AzureFileSystem::ForceCachedHierarchicalNamespaceSupport(int hns_support) {
   impl_->ForceCachedHierarchicalNamespaceSupport(hns_support);
 }
 
-Result<std::shared_ptr<AzureFileSystem>> AzureFileSystem::Make(
-    const AzureOptions& options, const io::IOContext& io_context) {
+Result<std::shared_ptr<AzureFileSystem>> AzureFileSystem::Make(const AzureOptions& options,
+                                                               const io::IOContext& io_context) {
   ARROW_ASSIGN_OR_RAISE(auto impl, AzureFileSystem::Impl::Make(options, io_context));
   return std::shared_ptr<AzureFileSystem>(new AzureFileSystem(std::move(impl)));
 }
@@ -3581,8 +3697,7 @@ Result<FileInfoVector> AzureFileSystem::GetFileInfo(const FileSelector& select) 
   Core::Context context;
   Azure::Nullable<int32_t> page_size_hint;  // unspecified
   FileInfoVector results;
-  RETURN_NOT_OK(
-      impl_->GetFileInfoWithSelector(context, page_size_hint, select, &results));
+  RETURN_NOT_OK(impl_->GetFileInfoWithSelector(context, page_size_hint, select, &results));
   return {std::move(results)};
 }
 
@@ -3601,8 +3716,7 @@ Status AzureFileSystem::CreateDir(const std::string& path, bool recursive) {
   }
 
   auto adlfs_client = impl_->GetFileSystemClient(location.container);
-  ARROW_ASSIGN_OR_RAISE(auto hns_support,
-                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  ARROW_ASSIGN_OR_RAISE(auto hns_support, impl_->HierarchicalNamespaceSupport(adlfs_client));
   if (hns_support == HNSSupport::kContainerNotFound) {
     if (!recursive) {
       auto parent = location.parent();
@@ -3615,8 +3729,8 @@ Status AzureFileSystem::CreateDir(const std::string& path, bool recursive) {
       // We only get kContainerNotFound if we are unable to read the properties of the
       // container we just created. This is very unlikely, but theoretically possible in
       // a concurrent system, so the error is handled to avoid infinite recursion.
-      return Status::IOError("Unable to read properties of a newly created container: ",
-                             location.container, ": " + container_client.GetUrl());
+      return Status::IOError("Unable to read properties of a newly created container: ", location.container,
+                             ": " + container_client.GetUrl());
     }
   }
   // CreateDirOnFileSystem and CreateDirOnContainer can handle the container
@@ -3642,10 +3756,9 @@ Status AzureFileSystem::DeleteDir(const std::string& path) {
   }
 
   auto adlfs_client = impl_->GetFileSystemClient(location.container);
-  ARROW_ASSIGN_OR_RAISE(auto hns_support,
-                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  ARROW_ASSIGN_OR_RAISE(auto hns_support, impl_->HierarchicalNamespaceSupport(adlfs_client));
   if (hns_support == HNSSupport::kContainerNotFound) {
-    return PathNotFound(location);
+    return ContainerNotFoundStatus(location, "DeleteDir");
   }
   if (hns_support == HNSSupport::kEnabled) {
     return impl_->DeleteDirOnFileSystem(adlfs_client, location, /*recursive=*/true,
@@ -3655,8 +3768,7 @@ Status AzureFileSystem::DeleteDir(const std::string& path) {
   auto container_client = impl_->GetBlobContainerClient(location.container);
   return impl_->DeleteDirContentsOnContainer(container_client, location,
                                              /*require_dir_to_exist=*/true,
-                                             /*preserve_dir_marker_blob=*/false,
-                                             "DeleteDir");
+                                             /*preserve_dir_marker_blob=*/false, "DeleteDir");
 }
 
 Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_dir_ok) {
@@ -3667,10 +3779,9 @@ Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_
   }
 
   auto adlfs_client = impl_->GetFileSystemClient(location.container);
-  ARROW_ASSIGN_OR_RAISE(auto hns_support,
-                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  ARROW_ASSIGN_OR_RAISE(auto hns_support, impl_->HierarchicalNamespaceSupport(adlfs_client));
   if (hns_support == HNSSupport::kContainerNotFound) {
-    return missing_dir_ok ? Status::OK() : PathNotFound(location);
+    return ContainerNotFoundStatus(location, "DeleteDirContents");
   }
 
   if (hns_support == HNSSupport::kEnabled) {
@@ -3679,8 +3790,7 @@ Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_
   auto container_client = impl_->GetBlobContainerClient(location.container);
   return impl_->DeleteDirContentsOnContainer(container_client, location,
                                              /*require_dir_to_exist=*/!missing_dir_ok,
-                                             /*preserve_dir_marker_blob=*/true,
-                                             "DeleteDirContents");
+                                             /*preserve_dir_marker_blob=*/true, "DeleteDirContents");
 }
 
 Status AzureFileSystem::DeleteRootDirContents() {
@@ -3696,15 +3806,13 @@ Status AzureFileSystem::DeleteFile(const std::string& path) {
   auto container_client = impl_->GetBlobContainerClient(location.container);
   if (location.path.empty()) {
     // Container paths (locations w/o path) are either not found or represent directories.
-    ARROW_ASSIGN_OR_RAISE(auto container_info,
-                          GetContainerPropsAsFileInfo(location, container_client));
+    ARROW_ASSIGN_OR_RAISE(auto container_info, GetContainerPropsAsFileInfo(location, container_client));
     return container_info.IsDirectory() ? NotAFile(location) : PathNotFound(location);
   }
   auto adlfs_client = impl_->GetFileSystemClient(location.container);
-  ARROW_ASSIGN_OR_RAISE(auto hns_support,
-                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  ARROW_ASSIGN_OR_RAISE(auto hns_support, impl_->HierarchicalNamespaceSupport(adlfs_client));
   if (hns_support == HNSSupport::kContainerNotFound) {
-    return PathNotFound(location);
+    return ContainerNotFoundStatus(location, "DeleteFile");
   }
   if (hns_support == HNSSupport::kEnabled) {
     return impl_->DeleteFileOnFileSystem(adlfs_client, location,
@@ -3744,49 +3852,39 @@ Status AzureFileSystem::CopyFile(const std::string& src, const std::string& dest
   return impl_->CopyFile(src_location, dest_location);
 }
 
-Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
-    const std::string& path) {
+Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(const std::string& path) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenInputFile(location, this));
-  return std::make_shared<milvus_storage::MetricsInputStream>(std::move(stream),
-                                                              impl_->metrics());
+  return std::make_shared<milvus_storage::MetricsInputStream>(std::move(stream), impl_->metrics());
 }
 
-Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
-    const FileInfo& info) {
+Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(const FileInfo& info) {
   ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenInputFile(info, this));
-  return std::make_shared<milvus_storage::MetricsInputStream>(std::move(stream),
-                                                              impl_->metrics());
+  return std::make_shared<milvus_storage::MetricsInputStream>(std::move(stream), impl_->metrics());
 }
 
-Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
-    const std::string& path) {
+Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(const std::string& path) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
   ARROW_ASSIGN_OR_RAISE(auto file, impl_->OpenInputFile(location, this));
-  return std::make_shared<milvus_storage::MetricsRandomAccessFile>(std::move(file),
-                                                                   impl_->metrics());
+  return std::make_shared<milvus_storage::MetricsRandomAccessFile>(std::move(file), impl_->metrics());
 }
 
-Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
-    const FileInfo& info) {
+Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(const FileInfo& info) {
   ARROW_ASSIGN_OR_RAISE(auto file, impl_->OpenInputFile(info, this));
-  return std::make_shared<milvus_storage::MetricsRandomAccessFile>(std::move(file),
-                                                                   impl_->metrics());
+  return std::make_shared<milvus_storage::MetricsRandomAccessFile>(std::move(file), impl_->metrics());
 }
 
 Result<std::shared_ptr<io::OutputStream>> AzureFileSystem::OpenOutputStream(
     const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
-  ARROW_ASSIGN_OR_RAISE(auto stream,
-                        impl_->OpenAppendStream(location, metadata, true, this));
+  ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenAppendStream(location, metadata, true, this));
   return stream;
 }
 
 Result<std::shared_ptr<io::OutputStream>> AzureFileSystem::OpenAppendStream(
     const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
-  ARROW_ASSIGN_OR_RAISE(auto stream,
-                        impl_->OpenAppendStream(location, metadata, false, this));
+  ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenAppendStream(location, metadata, false, this));
   return stream;
 }
 
@@ -3806,40 +3904,29 @@ Result<std::string> AzureFileSystem::PathFromUri(const std::string& uri_string) 
 
   std::vector<std::string> supported_schemes = {"abfs", "abfss"};
   const auto scheme = uri.scheme();
-  if (std::find(supported_schemes.begin(), supported_schemes.end(), scheme) ==
-      supported_schemes.end()) {
-    std::string expected_schemes =
-        ::arrow::internal::JoinStrings(supported_schemes, ", ");
-    return Status::Invalid("The filesystem expected a URI with one of the schemes (",
-                           expected_schemes, ") but received ", uri_string);
+  if (std::find(supported_schemes.begin(), supported_schemes.end(), scheme) == supported_schemes.end()) {
+    std::string expected_schemes = ::arrow::internal::JoinStrings(supported_schemes, ", ");
+    return Status::Invalid("The filesystem expected a URI with one of the schemes (", expected_schemes,
+                           ") but received ", uri_string);
   }
 
   return path;
 }
 
-arrow::Result<std::shared_ptr<arrow::io::OutputStream>>
-AzureFileSystem::OpenConditionalOutputStream(
+arrow::Result<std::shared_ptr<arrow::io::OutputStream>> AzureFileSystem::OpenConditionalOutputStream(
     const std::string& path, std::shared_ptr<arrow::KeyValueMetadata> metadata) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
-  ARROW_ASSIGN_OR_RAISE(
-      auto stream,
-      impl_->OpenAppendStream(location, metadata, true, this, kBlockUploadSizeBytes,
-                              true));
+  ARROW_ASSIGN_OR_RAISE(auto stream,
+                        impl_->OpenAppendStream(location, metadata, true, this, kBlockUploadSizeBytes, true));
   return stream;
 }
 
-std::shared_ptr<milvus_storage::FilesystemMetrics> AzureFileSystem::GetMetrics() const {
-  return impl_->metrics();
-}
+std::shared_ptr<milvus_storage::FilesystemMetrics> AzureFileSystem::GetMetrics() const { return impl_->metrics(); }
 
-arrow::Result<std::shared_ptr<arrow::io::OutputStream>>
-AzureFileSystem::OpenOutputStreamWithUploadSize(
-    const std::string& path,
-    const std::shared_ptr<const arrow::KeyValueMetadata>& metadata,
-    int64_t upload_size) {
+arrow::Result<std::shared_ptr<arrow::io::OutputStream>> AzureFileSystem::OpenOutputStreamWithUploadSize(
+    const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t upload_size) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
-  ARROW_ASSIGN_OR_RAISE(auto stream,
-                        impl_->OpenAppendStream(location, metadata, true, this, upload_size));
+  ARROW_ASSIGN_OR_RAISE(auto stream, impl_->OpenAppendStream(location, metadata, true, this, upload_size));
   return stream;
 }
 

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -14,6 +14,8 @@
 
 #include "milvus-storage/filesystem/fs.h"
 
+#include <cctype>
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -24,6 +26,7 @@
 #include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
 #include "milvus-storage/filesystem/gcp/gcp_filesystem_producer.h"
 #include "milvus-storage/filesystem/local_fs_producer.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/common/lrucache.h"
 
@@ -165,12 +168,14 @@ arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemCon
           return S3FileSystemProducer(config).Make();
         }
         default: {
-          return arrow::Status::Invalid("Unsupported cloud provider: " + config.cloud_provider);
+          return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                    "Unsupported cloud provider: " + config.cloud_provider);
         }
       }
     }
     default: {
-      return arrow::Status::Invalid("Unsupported storage type: " + config.storage_type);
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Unsupported storage type: " + config.storage_type);
     }
   }
 }
@@ -273,17 +278,18 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
     if (result.azure_client_id.empty() || result.azure_tenant_id.empty() || result.azure_credential_endpoint.empty() ||
         result.access_key_id.empty() || result.bucket_name.empty() || result.region.empty() ||
         result.request_timeout_ms <= 0) {
-      return arrow::Status::Invalid(
-          "Azure credential broker mode requires fs.azure_client_id, fs.azure_tenant_id, "
-          "fs.azure_credential_endpoint, fs.access_key_id, fs.bucket_name, fs.region, and a positive "
-          "fs.request_timeout_ms");
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Azure credential broker mode requires fs.azure_client_id, fs.azure_tenant_id, "
+                                "fs.azure_credential_endpoint, fs.access_key_id, fs.bucket_name, fs.region, and a "
+                                "positive fs.request_timeout_ms");
     }
 
     arrow::util::Uri endpoint;
     auto endpoint_status = endpoint.Parse(result.azure_credential_endpoint);
     if (!endpoint_status.ok() || endpoint.host().empty() ||
         (endpoint.scheme() != "http" && endpoint.scheme() != "https")) {
-      return arrow::Status::Invalid("fs.azure_credential_endpoint must be a valid HTTP(S) URL");
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "fs.azure_credential_endpoint must be a valid HTTP(S) URL");
     }
   }
   return arrow::Status::OK();
@@ -316,19 +322,22 @@ arrow::Result<std::unordered_map<std::string, api::Properties>> ExtractExternalF
     std::string remainder = key.substr(prefix.size());
     size_t dot_pos = remainder.find('.');
     if (dot_pos == std::string::npos) {
-      return arrow::Status::Invalid("Invalid external filesystem property format: '", key,
-                                    "'. Expected format: extfs.<name>.<property>");
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Invalid external filesystem property format: '", key,
+                                "'. Expected format: extfs.<name>.<property>");
     }
 
     std::string fs_name = remainder.substr(0, dot_pos);
     std::string fs_property = remainder.substr(dot_pos + 1);
 
     if (fs_name.empty()) {
-      return arrow::Status::Invalid("Empty external filesystem name in property: '", key, "'");
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "Empty external filesystem name in property: '",
+                                key, "'");
     }
 
     if (fs_property.empty()) {
-      return arrow::Status::Invalid("Empty property name in external filesystem property: '", key, "'");
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Empty property name in external filesystem property: '", key, "'");
     }
 
     // Map to standard fs.* property name, convert through SetValue for proper type resolution
@@ -336,7 +345,8 @@ arrow::Result<std::unordered_map<std::string, api::Properties>> ExtractExternalF
     if (auto err =
             api::SetValue(external_fs_map[fs_name], standard_key.c_str(), std::get<std::string>(value).c_str(), false);
         err) {
-      return arrow::Status::Invalid("Failed to set external fs property '", standard_key, "': ", *err);
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "Failed to set external fs property '",
+                                standard_key, "': ", *err);
     }
   }
 
@@ -384,6 +394,36 @@ arrow::Result<ArrowFileSystemConfig> FilesystemCache::resolve_config(const api::
     ARROW_ASSIGN_OR_RAISE(auto uri, StorageUri::Parse(path));
 
     if (uri.IsAbsoluteUri()) {
+      // The local filesystem is not an external one, and asking for an extfs.*
+      // entry that names it is asking for something no deployment configures.
+      //
+      // This path is reached with our OWN output: Format::explore() stamps the
+      // filesystem's type name as the scheme, so listing a local directory
+      // hands back "local:///local/<path>" for every file it found, and those
+      // strings go into the manifest. Feeding one back in -- which is exactly
+      // what reading that manifest does -- fell into the loop below, matched no
+      // extfs.* entry, and failed as StorageConfigInvalid. A path this library
+      // produces that this library cannot then open is a round-trip we broke,
+      // not a configuration the operator forgot.
+      //
+      if (uri.scheme == LOON_FS_TYPE_LOCAL) {
+        ArrowFileSystemConfig local_config;
+        ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(properties, local_config));
+        // Deliberately the deployment's own root_path: the key in these URIs is
+        // the path the local filesystem handed us, so it resolves against the
+        // same root it was listed from -- and lands on the same cache key,
+        // rather than building a second filesystem for the same directory.
+        local_config.storage_type = LOON_FS_TYPE_LOCAL;
+        return local_config;
+      }
+      if (uri.scheme == "file") {
+        return MakeExtendErrorMsg(
+            ExtendStatusCode::StorageConfigInvalid,
+            "file:// URIs are not supported by the rooted local filesystem; use the local:// URI emitted by "
+            "Format::explore instead: ",
+            path);
+      }
+
       ARROW_ASSIGN_OR_RAISE(auto external_fs_props_map, ExtractExternalFsProperties(properties));
 
       for (const auto& [fs_alias, fs_props] : external_fs_props_map) {
@@ -416,9 +456,10 @@ arrow::Result<ArrowFileSystemConfig> FilesystemCache::resolve_config(const api::
         }
       }
 
-      return arrow::Status::Invalid("No matching external filesystem config (extfs.*) found for URI '", path,
-                                    "' (address='", uri.address, "', bucket='", uri.bucket_name,
-                                    "'). Please check your extfs.* properties.");
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "No matching external filesystem config (extfs.*) found for URI '", path,
+                                "' (address='", uri.address, "', bucket='", uri.bucket_name,
+                                "'). Please check your extfs.* properties.");
     }
   }
 
@@ -430,6 +471,11 @@ arrow::Result<ArrowFileSystemConfig> FilesystemCache::resolve_config(const api::
 
 // ==================== StorageUri Implementation ====================
 
+bool IsParseableUri(const std::string& text) {
+  arrow::util::Uri parsed;
+  return parsed.Parse(text).ok();
+}
+
 arrow::Result<StorageUri> StorageUri::Parse(const std::string& uri, bool include_address) {
   // Try to parse as a URI
   arrow::util::Uri parsed;
@@ -437,7 +483,31 @@ arrow::Result<StorageUri> StorageUri::Parse(const std::string& uri, bool include
 
   StorageUri result;
 
-  // If parsing fails or scheme is empty, treat as relative path
+  // A string with no scheme is a relative path, and that is a legitimate,
+  // extremely common input -- so it stays a success.
+  //
+  // A string that HAS a scheme but will not parse is different: "s3://bucket/%ZZ"
+  // or "http://[::1" is a URI the caller meant, written wrong. Treating it as a
+  // relative path silently sent it to whatever fs.* the deployment defaults to,
+  // where it failed later as a missing key -- pointing the reader at the object
+  // store instead of at the malformed string. The scheme test is deliberately
+  // syntactic (RFC 3986 shape) rather than a list of known schemes, so a typo'd
+  // scheme is still reported as a bad URI rather than a filename.
+  if (!status.ok()) {
+    // RFC 3986 shape is "scheme:" -- the "//" authority is optional, so keying
+    // on the literal "://" let "s3:/bucket/%ZZ" through to be treated as a
+    // local relative path. Requiring at least two scheme characters keeps a
+    // Windows-style "C:\..." out.
+    const auto colon = uri.find(':');
+    const bool looks_like_uri =
+        colon != std::string::npos && colon > 1 && std::isalpha(static_cast<unsigned char>(uri.front())) != 0 &&
+        std::all_of(uri.begin(), uri.begin() + static_cast<std::ptrdiff_t>(colon),
+                    [](unsigned char c) { return std::isalnum(c) != 0 || c == '+' || c == '-' || c == '.'; });
+    if (looks_like_uri) {
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Storage URI is malformed and cannot be parsed: ", uri, " (", status.message(), ")");
+    }
+  }
   if (!status.ok() || parsed.scheme().empty()) {
     result.scheme = "";
     result.address = "";
@@ -456,20 +526,21 @@ arrow::Result<StorageUri> StorageUri::Parse(const std::string& uri, bool include
 
   std::string path = parsed.path();
   if (path.empty()) {
-    return arrow::Status::Invalid("Storage URI missing bucket and key: ", uri);
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "Storage URI missing bucket and key: ", uri);
   }
   if (path[0] == '/') {
     path = path.substr(1);
   }
   if (path.empty()) {
-    return arrow::Status::Invalid("Storage URI missing bucket/container name: ", uri);
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                              "Storage URI missing bucket/container name: ", uri);
   }
 
   if (include_address) {
     result.address = host;
     size_t slash_pos = path.find('/');
     if (slash_pos == std::string::npos) {
-      return arrow::Status::Invalid("Missing path in storage URI: ", uri);
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "Missing path in storage URI: ", uri);
     }
     result.bucket_name = path.substr(0, slash_pos);
     result.key = path.substr(slash_pos + 1);
@@ -482,7 +553,8 @@ arrow::Result<StorageUri> StorageUri::Parse(const std::string& uri, bool include
   }
 
   if (result.bucket_name.empty()) {
-    return arrow::Status::Invalid("Missing bucket/container name in storage URI: ", uri);
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                              "Missing bucket/container name in storage URI: ", uri);
   }
 
   return result;
@@ -490,13 +562,14 @@ arrow::Result<StorageUri> StorageUri::Parse(const std::string& uri, bool include
 
 arrow::Result<std::string> StorageUri::Make(const StorageUri& uri, bool include_address) {
   if (uri.scheme.empty()) {
-    return arrow::Status::Invalid("StorageUri::Make: scheme must not be empty");
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "StorageUri::Make: scheme must not be empty");
   }
   if (uri.bucket_name.empty()) {
-    return arrow::Status::Invalid("StorageUri::Make: bucket_name must not be empty");
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                              "StorageUri::Make: bucket_name must not be empty");
   }
   if (uri.key.empty()) {
-    return arrow::Status::Invalid("StorageUri::Make: key must not be empty");
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "StorageUri::Make: key must not be empty");
   }
 
   if (!include_address) {

--- a/cpp/src/filesystem/gcp/gcp_credential_provider.cpp
+++ b/cpp/src/filesystem/gcp/gcp_credential_provider.cpp
@@ -27,6 +27,10 @@
 #include <google/cloud/internal/unified_rest_credentials.h>
 #include <google/cloud/options.h>
 
+#include <arrow/util/string_builder.h>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/s3/s3_auth_signer.h"
@@ -55,27 +59,64 @@ std::shared_ptr<google::cloud::oauth2_internal::Credentials> MakeInternalCredent
 // Shared base for both OAuth2-backed providers (VM IAM and Impersonation).
 // Wraps a google-cloud-cpp oauth2_internal::Credentials and delegates to its
 // built-in token caching + refresh logic.
+// google-cloud-cpp reports why a token could not be minted. Return that cause
+// directly to the delegator before it puts a request on the wire. Without
+// this, "the metadata server did not answer" and "this identity lacks
+// roles/iam.serviceAccountTokenCreator" both arrive as a GCS 403 with no hint
+// which it was.
+//
+// Classified, not collapsed. The point is not to make google-cloud-cpp retry
+// again -- it has its own internal behaviour and by the time we see a Status
+// that is spent -- but to let the layer above re-run the whole operation later.
+// A single non-retryable code would make a metadata server that was restarting
+// fail a query exactly as permanently as a missing IAM binding.
+arrow::Status ClassifyTokenFailure(const google::cloud::Status& status) {
+  using google::cloud::StatusCode;
+  const auto what = arrow::util::StringBuilder("GCP OAuth2 token fetch failed: ", status.message());
+  switch (status.code()) {
+    case StatusCode::kUnavailable:
+    case StatusCode::kAborted:
+    case StatusCode::kInternal:
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientService, what);
+    case StatusCode::kDeadlineExceeded:
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientTimeout, what);
+    case StatusCode::kResourceExhausted:
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientThrottling, what);
+    case StatusCode::kUnauthenticated:
+    case StatusCode::kPermissionDenied:
+      // The identity exists and was refused. An operator changes a binding.
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageAccessDenied, what);
+    case StatusCode::kNotFound:
+    case StatusCode::kFailedPrecondition:
+      return MakeExtendError(ExtendStatusCode::StorageConfigInvalid, arrow::StatusCode::IOError, what);
+    case StatusCode::kInvalidArgument:
+      // NOT precise, and deliberately not called an access decision.
+      // google-cloud-cpp's generic fallback maps the whole 4xx range to
+      // kInvalidArgument (rest_response.h), so a 429 or a 408 lands here
+      // alongside a genuinely malformed request whenever the response body is
+      // not standard Google error JSON. When it IS standard, 429 arrives as
+      // kResourceExhausted and 401/403 as kUnauthenticated/kPermissionDenied
+      // and never reach this arm. Left unclassified rather than guessed.
+      return MakeCredentialResponseError(what);
+    default:
+      return MakeCredentialResponseError(what);
+  }
+}
+
 class OAuth2BearerProvider : public GcpCredentialProvider {
   public:
-  std::optional<std::pair<std::string, std::string>> AuthorizationHeader() override {
+  arrow::Result<std::optional<std::pair<std::string, std::string>>> AuthorizationHeader() override {
     auto header = google::cloud::oauth2_internal::AuthorizationHeader(*credentials_);
     if (!header.ok()) {
-      // On token fetch failure, return nullopt. The factory will issue the
-      // request without Authorization and the server will return 401/403,
-      // surfacing the auth failure at the call site via the usual AWS SDK path.
-      // Log the root cause here so operators can correlate the GCS 401/403
-      // with the underlying OAuth2/IAM error (e.g. missing
-      // roles/iam.serviceAccountTokenCreator, metadata server unreachable).
-      LOG_STORAGE_WARNING_ << "GCP OAuth2 token fetch failed: " << header.status().message()
-                           << "; request will proceed without Authorization, server will reply 401/403";
-      return std::nullopt;
+      LOG_STORAGE_WARNING_ << "GCP OAuth2 token fetch failed: " << header.status().message();
+      return ClassifyTokenFailure(header.status());
     }
     // AuthorizationHeader is called for every GCS request. Confirm that the
     // provider can obtain a token once without logging every object operation.
     std::call_once(success_log_once_, [this] {
       LOG_STORAGE_DEBUG_ << "GCP OAuth2 token obtained successfully: credential_type=" << credential_type_;
     });
-    return *header;
+    return std::optional<std::pair<std::string, std::string>>(std::move(*header));
   }
 
   arrow::Status MaybeSignConditionalWrite(const std::shared_ptr<Aws::Http::HttpRequest>&) override {
@@ -131,7 +172,9 @@ class HmacProvider : public GcpCredentialProvider {
   HmacProvider(std::string access_key, std::string secret_key)
       : access_key_(std::move(access_key)), secret_key_(std::move(secret_key)) {}
 
-  std::optional<std::pair<std::string, std::string>> AuthorizationHeader() override { return std::nullopt; }
+  arrow::Result<std::optional<std::pair<std::string, std::string>>> AuthorizationHeader() override {
+    return std::optional<std::pair<std::string, std::string>>{};
+  }
 
   arrow::Status MaybeSignConditionalWrite(const std::shared_ptr<Aws::Http::HttpRequest>& request) override {
     // Only re-sign conditional writes; GCS rejects SigV4 Authorization for
@@ -177,6 +220,15 @@ class HmacProvider : public GcpCredentialProvider {
 };
 
 }  // namespace
+
+arrow::Status ApplyGcpAuthorizationHeader(const std::shared_ptr<GcpCredentialProvider>& provider,
+                                          const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  ARROW_ASSIGN_OR_RAISE(auto header, provider->AuthorizationHeader());
+  if (header.has_value()) {
+    request->SetHeaderValue(header->first.c_str(), header->second.c_str());
+  }
+  return arrow::Status::OK();
+}
 
 arrow::Result<std::shared_ptr<GcpCredentialProvider>> BuildGcpProviderFromConfig(const ArrowFileSystemConfig& config) {
   if (config.use_iam && !config.gcp_target_service_account.empty()) {

--- a/cpp/src/filesystem/gcp/gcp_credential_registry.cpp
+++ b/cpp/src/filesystem/gcp/gcp_credential_registry.cpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <utility>
 
+#include "milvus-storage/common/extend_status.h"
+
 namespace milvus_storage {
 
 namespace {
@@ -55,10 +57,39 @@ GcpCredentialRegistry& GcpCredentialRegistry::Instance() {
   return instance;
 }
 
-void GcpCredentialRegistry::Register(GcpBucketKey key, std::shared_ptr<GcpCredentialProvider> provider) {
+arrow::Result<std::shared_ptr<GcpCredentialRegistration>> GcpCredentialRegistry::Register(
+    GcpBucketKey key, std::shared_ptr<GcpCredentialRegistration> registration) {
+  if (registration == nullptr || registration->provider_ == nullptr) {
+    return arrow::Status::Invalid("GCP credential registration and provider must not be null");
+  }
+
   key.endpoint.host = ToLower(std::move(key.endpoint.host));
   std::lock_guard<std::mutex> lock(mu_);
-  providers_[std::move(key)] = std::move(provider);
+
+  // Weak entries do not retain credentials. Opportunistically remove expired
+  // keys so repeated creation/destruction of filesystems cannot grow the map.
+  for (auto it = registrations_.begin(); it != registrations_.end();) {
+    if (it->second.expired()) {
+      it = registrations_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  if (auto it = registrations_.find(key); it != registrations_.end()) {
+    auto existing = it->second.lock();
+    if (existing != nullptr) {
+      if (existing->identity_ != registration->identity_) {
+        return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                  "GCP credential identity conflict for endpoint=", key.endpoint.host,
+                                  ", port=", std::to_string(key.endpoint.port), ", bucket=", key.bucket_name);
+      }
+      return existing;
+    }
+  }
+
+  registrations_[std::move(key)] = registration;
+  return registration;
 }
 
 std::shared_ptr<GcpCredentialProvider> GcpCredentialRegistry::Lookup(const Aws::Http::URI& uri) const {
@@ -67,8 +98,12 @@ std::shared_ptr<GcpCredentialProvider> GcpCredentialRegistry::Lookup(const Aws::
 
   auto find = [this](const GcpBucketKey& key) -> std::shared_ptr<GcpCredentialProvider> {
     std::lock_guard<std::mutex> lock(mu_);
-    auto it = providers_.find(key);
-    return it == providers_.end() ? nullptr : it->second;
+    auto it = registrations_.find(key);
+    if (it == registrations_.end()) {
+      return nullptr;
+    }
+    auto registration = it->second.lock();
+    return registration == nullptr ? nullptr : registration->provider_;
   };
 
   // Path-style: endpoint = request endpoint, bucket = first path segment.

--- a/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
+++ b/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
@@ -19,15 +19,19 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
 #include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/client/CoreErrors.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/curl/CurlHttpClient.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/http/standard/StandardHttpResponse.h>
+#include <aws/core/utils/xml/XmlSerializer.h>
 
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/status.h>
@@ -36,11 +40,14 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/gcp/gcp_credential_provider.h"
 #include "milvus-storage/filesystem/gcp/gcp_credential_registry.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/tls_http_client.h"
+
+#include "filesystem/gcp/gcp_filesystem_producer_internal.h"
 
 namespace milvus_storage {
 
@@ -51,6 +58,119 @@ constexpr const char* kGoogleClientFactoryAllocationTag = "GoogleHttpClientFacto
 const std::unordered_map<std::string, S3LogLevel> kLogLevelMap = {
     {"off", S3LogLevel::Off},   {"fatal", S3LogLevel::Fatal}, {"error", S3LogLevel::Error}, {"warn", S3LogLevel::Warn},
     {"info", S3LogLevel::Info}, {"debug", S3LogLevel::Debug}, {"trace", S3LogLevel::Trace}};
+
+void AppendIdentityPart(std::string* identity, std::string_view value) {
+  identity->append(std::to_string(value.size()));
+  identity->push_back(':');
+  identity->append(value.data(), value.size());
+}
+
+std::string GcpCredentialIdentity(const ArrowFileSystemConfig& config) {
+  std::string identity;
+  if (config.use_iam && config.gcp_target_service_account.empty()) {
+    return "vm-iam";
+  }
+  if (config.use_iam) {
+    identity = "impersonation|";
+    AppendIdentityPart(&identity, config.gcp_target_service_account);
+    AppendIdentityPart(&identity, std::to_string(config.load_frequency));
+    return identity;
+  }
+
+  identity = "hmac|";
+  AppendIdentityPart(&identity, config.access_key_id);
+  // The secret is kept only inside the live registration and is never logged.
+  // Comparing it exactly also handles credential rotation under one access ID.
+  AppendIdentityPart(&identity, config.access_key_value);
+  return identity;
+}
+
+// Preserve the SDK provider's exact dynamic type and behavior while tying the
+// registry registration to every copy of the provider held by the S3 client.
+// The alias points at sdk_provider, while its shared control block owns both
+// sdk_provider and registration.
+struct GcpCredentialsOwner {
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> sdk_provider;
+  std::shared_ptr<GcpCredentialRegistration> registration;
+};
+
+std::shared_ptr<Aws::Auth::AWSCredentialsProvider> RetainGcpRegistration(
+    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> sdk_provider,
+    std::shared_ptr<GcpCredentialRegistration> registration) {
+  auto owner =
+      std::make_shared<GcpCredentialsOwner>(GcpCredentialsOwner{std::move(sdk_provider), std::move(registration)});
+  return std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(owner, owner->sdk_provider.get());
+}
+
+void WriteS3XmlError(Aws::Http::HttpResponse& response, std::string_view code, std::string_view message) {
+  auto document = Aws::Utils::Xml::XmlDocument::CreateWithRootNode("Error");
+  auto root = document.GetRootElement();
+  root.CreateChildElement("Code").SetText(Aws::String(code.data(), code.size()));
+  root.CreateChildElement("Message").SetText(Aws::String(message.data(), message.size()));
+  response.GetResponseBody() << document.ConvertToString();
+}
+
+}  // namespace
+
+namespace gcp_internal {
+
+std::shared_ptr<Aws::Http::HttpResponse> MakeTokenErrorResponse(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                                                                const arrow::Status& token_status) {
+  auto detail = ExtendStatusDetail::UnwrapStatus(token_status);
+  auto response_code = Aws::Http::HttpResponseCode::BAD_REQUEST;
+  std::string error_code = "LoonGcpCredentialResponseInvalid";
+  bool network_client_error = false;
+  if (detail != nullptr) {
+    switch (detail->code()) {
+      case ExtendStatusCode::StorageTransientNetwork:
+        response_code = Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE;
+        error_code = "NetworkConnection";
+        network_client_error = true;
+        break;
+      case ExtendStatusCode::StorageTransientTimeout:
+        response_code = Aws::Http::HttpResponseCode::REQUEST_TIMEOUT;
+        error_code = "RequestTimeout";
+        break;
+      case ExtendStatusCode::StorageTransientThrottling:
+        response_code = Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS;
+        error_code = "Throttling";
+        break;
+      case ExtendStatusCode::StorageTransientService:
+        response_code = Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE;
+        error_code = "ServiceUnavailable";
+        break;
+      case ExtendStatusCode::StorageAccessDenied:
+        response_code = Aws::Http::HttpResponseCode::FORBIDDEN;
+        error_code = "AccessDenied";
+        break;
+      case ExtendStatusCode::StorageConfigInvalid:
+        error_code = "LoonGcpCredentialConfigInvalid";
+        break;
+      default:
+        if (detail->retryable()) {
+          response_code = Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE;
+          error_code = "ServiceUnavailable";
+        }
+        break;
+    }
+  }
+  auto error_response =
+      Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(kGoogleClientFactoryAllocationTag, request);
+  error_response->SetResponseCode(response_code);
+  if (network_client_error) {
+    // XML names are service-specific and the pinned S3 marshaller does not
+    // recognize IDPCommunicationError as a network failure. A client error is
+    // the SDK's typed transport channel and survives S3 marshalling unchanged.
+    error_response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    error_response->SetClientErrorMessage(token_status.message().c_str());
+  }
+  WriteS3XmlError(*error_response, error_code, token_status.message());
+  return error_response;
+}
+
+}  // namespace gcp_internal
+
+namespace {
 
 // Stateless HttpClient wrapper. Holds only a reference to the registry and an
 // optional TLS floor setting. Per-request credential work is dispatched by URI
@@ -80,6 +200,13 @@ class GoogleHttpClientDelegator : public Aws::Http::HttpClient {
       return MakeSignatureErrorResponse(request, fmt::format("No GcpCredentialProvider registered for URI: {}",
                                                              std::string(request->GetUri().GetURIString().c_str())));
     }
+    // Resolve the token in this send call and consume that exact Result before
+    // any other request can affect the decision. A failed lookup therefore
+    // cannot become an anonymous GCS request, nor can another request's success
+    // hide it.
+    if (auto token_status = ApplyGcpAuthorizationHeader(provider, request); !token_status.ok()) {
+      return gcp_internal::MakeTokenErrorResponse(request, token_status);
+    }
     auto status = provider->MaybeSignConditionalWrite(request);
     if (!status.ok()) {
       return MakeSignatureErrorResponse(request, status.message());
@@ -95,22 +222,16 @@ class GoogleHttpClientDelegator : public Aws::Http::HttpClient {
     auto error_response =
         Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>(kGoogleClientFactoryAllocationTag, request);
     error_response->SetResponseCode(Aws::Http::HttpResponseCode::FORBIDDEN);
-    error_response->GetResponseBody() << fmt::format(
-        R"(<?xml version="1.0" encoding="UTF-8"?>
-<Error>
-  <Code>SignatureFailed</Code>
-  <Message>{}</Message>
-</Error>)",
-        message);
+    WriteS3XmlError(*error_response, "SignatureFailed", message);
     return error_response;
   }
 
   std::shared_ptr<Aws::Http::HttpClient> underlying_client_;
 };
 
-// Stateless HttpClientFactory. Dispatches Authorization header injection by
-// URI lookup against GcpCredentialRegistry. Identity itself lives in the
-// registry, not in the factory — that's what allows N identities per process.
+// Stateless HttpClientFactory. Identity lives in GcpCredentialRegistry and is
+// resolved by GoogleHttpClientDelegator immediately before each send. Keeping
+// the factory free of credential state allows N identities per process.
 class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
   public:
   explicit GoogleHttpClientFactory(std::string tls_min_version) : tls_min_version_(std::move(tls_min_version)) {}
@@ -133,18 +254,6 @@ class GoogleHttpClientFactory : public Aws::Http::HttpClientFactory {
         Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(kGoogleClientFactoryAllocationTag, uri, method);
     request->SetResponseStreamFactory(streamFactory);
 
-    auto provider = GcpCredentialRegistry::Instance().Lookup(uri);
-    if (!provider) {
-      // Same invariant as Delegator::MakeRequest: every GCP URI should have a
-      // registered provider. This interface can only return a request (no error
-      // channel), so log here and let MakeRequest fail the request with a 403.
-      LOG_STORAGE_ERROR_ << "GoogleHttpClientFactory: no GcpCredentialProvider registered for URI: "
-                         << std::string(uri.GetURIString().c_str());
-      return request;
-    }
-    if (auto header = provider->AuthorizationHeader(); header.has_value()) {
-      request->SetHeaderValue(header->first.c_str(), header->second.c_str());
-    }
     return request;
   }
 
@@ -190,7 +299,10 @@ arrow::Status GcpFileSystemProducer::InitS3Compat(const ArrowFileSystemConfig& f
     }
 
     // Register cleanup on exit. atexit handlers must not throw, so log on failure.
+    // Construct the cache first so this callback runs before its destructor.
+    (void)FilesystemCache::getInstance();
     std::atexit([]() {
+      FilesystemCache::getInstance().clean();
       auto status = EnsureS3Finalized();
       if (!status.ok()) {
         LOG_STORAGE_ERROR_ << "GcpFileSystemProducer failed to finalize S3: " << status.ToString();
@@ -200,11 +312,12 @@ arrow::Status GcpFileSystemProducer::InitS3Compat(const ArrowFileSystemConfig& f
   return init_status;
 }
 
-arrow::Status GcpFileSystemProducer::RegisterIdentity(const ArrowFileSystemConfig& config) {
+arrow::Result<std::shared_ptr<GcpCredentialRegistration>> GcpFileSystemProducer::RegisterIdentity(
+    const ArrowFileSystemConfig& config) {
   ARROW_ASSIGN_OR_RAISE(auto provider, BuildGcpProviderFromConfig(config));
   GcpBucketKey key{NormalizeGcpEndpoint(config.address, config.use_ssl), config.bucket_name};
-  GcpCredentialRegistry::Instance().Register(std::move(key), std::move(provider));
-  return arrow::Status::OK();
+  auto registration = std::make_shared<GcpCredentialRegistration>(GcpCredentialIdentity(config), std::move(provider));
+  return GcpCredentialRegistry::Instance().Register(std::move(key), std::move(registration));
 }
 
 arrow::Result<S3Options> GcpFileSystemProducer::CreateS3Options() {
@@ -257,9 +370,11 @@ arrow::Result<S3Options> GcpFileSystemProducer::CreateS3Options() {
 
 arrow::Result<ArrowFileSystemPtr> GcpFileSystemProducer::Make() {
   ARROW_RETURN_NOT_OK(InitS3Compat(config_));
-  ARROW_RETURN_NOT_OK(RegisterIdentity(config_));
+  ARROW_ASSIGN_OR_RAISE(auto registration, RegisterIdentity(config_));
 
   ARROW_ASSIGN_OR_RAISE(auto s3_options, CreateS3Options());
+  s3_options.credentials_provider =
+      RetainGcpRegistration(std::move(s3_options.credentials_provider), std::move(registration));
   ARROW_ASSIGN_OR_RAISE(auto fs, S3FileSystem::Make(s3_options));
   return std::make_shared<FileSystemProxy>(config_.bucket_name, fs);
 }

--- a/cpp/src/filesystem/gcp/gcp_filesystem_producer_internal.h
+++ b/cpp/src/filesystem/gcp/gcp_filesystem_producer_internal.h
@@ -1,0 +1,31 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include <arrow/status.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+
+namespace milvus_storage::gcp_internal {
+
+// Convert a request-local token failure into the synthetic response consumed
+// by the S3 SDK. Kept source-private, but named so the marshalling boundary can
+// be exercised directly in tests.
+std::shared_ptr<Aws::Http::HttpResponse> MakeTokenErrorResponse(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                                                                const arrow::Status& token_status);
+
+}  // namespace milvus_storage::gcp_internal

--- a/cpp/src/filesystem/local_fs_producer.cpp
+++ b/cpp/src/filesystem/local_fs_producer.cpp
@@ -130,7 +130,8 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenAppendStream(
       const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
-    TRACK_METRICS(IncrementWriteCount, arrow::fs::LocalFileSystem::OpenAppendStream(path, metadata));
+    TRACK_METRICS_AND_WRAP(IncrementWriteCount, arrow::fs::LocalFileSystem::OpenAppendStream(path, metadata),
+                           MetricsOutputStream);
   }
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(
@@ -147,7 +148,7 @@ class LocalFileSystemWrapper : public arrow::fs::LocalFileSystem, public UploadC
     auto file_info = file_info_result.ValueOrDie();
     if (file_info.type() == arrow::fs::FileType::File) {
       metrics_->IncrementFailedCount();
-      return MakeExtendError(ExtendStatusCode::AwsErrorConflict, "File already exists: " + path, "");
+      return MakeExtendError(ExtendStatusCode::StorageConflict, "File already exists: " + path, "");
     }
     return OpenOutputStream(path, metadata);
   }

--- a/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunCredentialsProvider.cpp
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <chrono>
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
 
 #include "milvus-storage/common/log.h"
@@ -78,6 +79,7 @@ AliyunSTSAssumeRoleWebIdentityCredentialsProvider::AliyunSTSAssumeRoleWebIdentit
 
 void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
   if (m_tokenFile.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Aliyun OIDC token file is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] Token file must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -89,6 +91,7 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
   }
 
   if (m_roleArn.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Aliyun OIDC role ARN is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] RoleArn must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -97,6 +100,13 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
   } else {
     LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved role_arn from profile_config or environment variable to be {}",
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_roleArn);
+  }
+
+  if (Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN").empty()) {
+    m_lastResolution = MakeCredentialConfigError("Aliyun OIDC provider ARN is not configured");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] OIDC provider ARN must be specified",
+                                        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
+    return;
   }
 
   // not need in [aliyun]
@@ -126,8 +136,11 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
   retryableErrors.emplace_back("IDPCommunicationError");
   retryableErrors.emplace_back("InvalidIdentityToken");
 
+  // Shared credential retry budget; see credential_resolution.h.
+  config.connectTimeoutMs = kCredentialConnectTimeoutMs;
+  config.requestTimeoutMs = kCredentialRequestTimeoutMs;
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
-      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, kCredentialRetryAttempts);
 
   m_client = Aws::MakeUnique<AliyunSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
@@ -136,14 +149,28 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::InitializeClient() {
 }
 
 Aws::Auth::AWSCredentials AliyunSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
-  // A valid client means required information like role arn and token file were constructed correctly.
-  // We can use this provider to load creds, otherwise, we can just return empty creds.
-  if (!m_initialized) {
+  auto result = ResolveForRequest();
+  if (!result.ok()) {
     return {};
+  }
+  return std::move(result).ValueOrDie();
+}
+
+arrow::Result<Aws::Auth::AWSCredentials> AliyunSTSAssumeRoleWebIdentityCredentialsProvider::ResolveForRequest() {
+  if (!m_initialized) {
+    return m_lastResolution.ok() ? MakeCredentialConfigError("Aliyun OIDC credential provider is not initialized")
+                                 : m_lastResolution;
   }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-  return m_credentials;
+  if (ExpiresSoon() && !m_lastResolution.ok()) {
+    return m_lastResolution;
+  }
+  auto validation = ValidateTemporaryCredentials(m_credentials, "Aliyun STS");
+  if (validation.ok()) {
+    return m_credentials;
+  }
+  return m_lastResolution.ok() ? validation : m_lastResolution;
 }
 
 void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
@@ -153,8 +180,16 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   Aws::IFStream tokenFile(m_tokenFile.c_str());
   if (tokenFile) {
     Aws::String token((std::istreambuf_iterator<char>(tokenFile)), std::istreambuf_iterator<char>());
+    if (token.empty()) {
+      m_lastResolution = MakeCredentialConfigError(fmt::format("The OIDC token file {} is empty", m_tokenFile));
+      return;
+    }
     m_token = token;
   } else {
+    // A token file that will not open is the deployment's to fix -- the
+    // projected volume is missing or unreadable -- not something a retry
+    // outlasts.
+    m_lastResolution = MakeCredentialConfigError(fmt::format("Cannot open the OIDC token file {}", m_tokenFile));
     LOG_STORAGE_ERROR_ << fmt::format("[{}] Can't open token file: {}", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
                                       m_tokenFile);
     return;
@@ -162,6 +197,16 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_sessionName, m_roleArn, m_token};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
+  if (!result.status.ok()) {
+    m_lastResolution = result.status;
+    return;
+  }
+  auto validation = ValidateTemporaryCredentials(result.creds, "Aliyun STS");
+  if (!validation.ok()) {
+    m_lastResolution = validation;
+    return;
+  }
+  m_lastResolution = arrow::Status::OK();
   LOG_STORAGE_TRACE_ << fmt::format("[{}] Successfully retrieved credentials", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
   m_credentials = result.creds;
 }
@@ -172,6 +217,8 @@ bool AliyunSTSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() const {
 }
 
 void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
+  const auto started = std::chrono::steady_clock::now();
+
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
   if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
     return;
@@ -179,6 +226,9 @@ void AliyunSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
 
   guard.UpgradeToWriterLock();
   if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) {
+    return;
+  }
+  if (!CredentialAttemptStillWorthMaking(started)) {
     return;
   }
 

--- a/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.cpp
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
 
 #include "milvus-storage/common/log.h"
 
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/DateTime.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/core/utils/UUID.h>
 
 namespace milvus_storage {
@@ -33,6 +35,9 @@ AliyunOIDCAssumeRoleChainProvider::AliyunOIDCAssumeRoleChainProvider(const Aws::
     : m_targetRoleArn(target_role_arn),
       m_targetSessionName(target_session_name),
       m_targetExternalId(target_external_id) {
+  if (m_targetRoleArn.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Aliyun target role ARN is not configured");
+  }
   if (m_targetSessionName.empty()) {
     m_targetSessionName = Aws::Utils::UUID::RandomUUID();
   }
@@ -46,6 +51,10 @@ AliyunOIDCAssumeRoleChainProvider::AliyunOIDCAssumeRoleChainProvider(const Aws::
   m_innerOidc = Aws::MakeUnique<AliyunSTSAssumeRoleWebIdentityCredentialsProvider>(kLogTag);
 
   Aws::Client::ClientConfiguration cfg(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
+  // Shared credential retry budget; see credential_resolution.h.
+  cfg.connectTimeoutMs = kCredentialConnectTimeoutMs;
+  cfg.requestTimeoutMs = kCredentialRequestTimeoutMs;
+  cfg.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>(kLogTag, kCredentialRetryAttempts);
   cfg.scheme = Aws::Http::Scheme::HTTPS;
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 
@@ -55,9 +64,27 @@ AliyunOIDCAssumeRoleChainProvider::AliyunOIDCAssumeRoleChainProvider(const Aws::
 }
 
 Aws::Auth::AWSCredentials AliyunOIDCAssumeRoleChainProvider::GetAWSCredentials() {
+  auto result = ResolveForRequest();
+  if (!result.ok()) {
+    return {};
+  }
+  return std::move(result).ValueOrDie();
+}
+
+arrow::Result<Aws::Auth::AWSCredentials> AliyunOIDCAssumeRoleChainProvider::ResolveForRequest() {
+  if (m_targetRoleArn.empty()) {
+    return m_lastResolution;
+  }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-  return m_credentials;
+  if (ExpiresSoon() && !m_lastResolution.ok()) {
+    return m_lastResolution;
+  }
+  auto validation = ValidateTemporaryCredentials(m_credentials, "Aliyun chained AssumeRole");
+  if (validation.ok()) {
+    return m_credentials;
+  }
+  return m_lastResolution.ok() ? validation : m_lastResolution;
 }
 
 bool AliyunOIDCAssumeRoleChainProvider::ExpiresSoon() const {
@@ -65,6 +92,11 @@ bool AliyunOIDCAssumeRoleChainProvider::ExpiresSoon() const {
 }
 
 void AliyunOIDCAssumeRoleChainProvider::RefreshIfExpired() {
+  // The cooldown shares a fast failed refresh with queued callers. The caller
+  // budget separately prevents a waiter that already spent too long behind a
+  // slow refresh from starting another attempt after the cooldown expires.
+  const auto started = std::chrono::steady_clock::now();
+
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
   if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
     return;
@@ -72,6 +104,9 @@ void AliyunOIDCAssumeRoleChainProvider::RefreshIfExpired() {
 
   guard.UpgradeToWriterLock();
   if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) {
+    return;
+  }
+  if (!CredentialAttemptStillWorthMaking(started)) {
     return;
   }
 
@@ -82,14 +117,16 @@ void AliyunOIDCAssumeRoleChainProvider::Reload() {
   LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials missing or expiring; refreshing via OIDC -> AssumeRole.", kLogTag);
 
   // Step 1: inner provider self-refreshes on call.
-  Aws::Auth::AWSCredentials inner = m_innerOidc->GetAWSCredentials();
-  if (inner.IsEmpty()) {
+  auto inner_result = m_innerOidc->ResolveForRequest();
+  if (!inner_result.ok()) {
+    m_lastResolution = inner_result.status();
     LOG_STORAGE_ERROR_ << fmt::format(
         "[{}] Inner OIDC step returned empty credentials; cannot chain to "
         "target_role_arn={}",
         kLogTag, m_targetRoleArn);
     return;
   }
+  auto inner = std::move(inner_result).ValueOrDie();
 
   // Step 2: cross-account AssumeRole using inner creds as caller. SecurityToken
   // is mandatory because the caller is itself an STS-temporary identity.
@@ -107,13 +144,24 @@ void AliyunOIDCAssumeRoleChainProvider::Reload() {
                                    !req.externalId.empty());
 
   auto res = m_stsClient->GetAssumeRoleCredentials(req);
-  if (res.creds.IsEmpty()) {
+  if (!res.status.ok()) {
+    m_lastResolution = res.status;
     LOG_STORAGE_ERROR_ << fmt::format(
-        "[{}] Cross-account AssumeRole returned empty credentials; target_role_arn={} "
+        "[{}] Cross-account AssumeRole failed; target_role_arn={} — check the target role's trust policy lists the "
+        "OIDC step-1 role as Principal",
+        kLogTag, m_targetRoleArn);
+    return;
+  }
+  auto validation = ValidateTemporaryCredentials(res.creds, "Aliyun cross-account AssumeRole");
+  if (!validation.ok()) {
+    m_lastResolution = validation;
+    LOG_STORAGE_ERROR_ << fmt::format(
+        "[{}] Cross-account AssumeRole returned invalid credentials; target_role_arn={} "
         "— check the target role's trust policy lists the OIDC step-1 role as Principal",
         kLogTag, m_targetRoleArn);
     return;
   }
+  m_lastResolution = arrow::Status::OK();
   m_credentials = res.creds;
   LOG_STORAGE_INFO_ << fmt::format("[{}] OIDC chain succeeded; target_role_arn={} expires={}", kLogTag, m_targetRoleArn,
                                    m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));

--- a/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMCredentialsProvider.cpp
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <new>
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h"
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/log.h"
 
 #include <sstream>
+#include <optional>
 #include <string>
 
 #include <aws/core/client/ClientConfiguration.h>
@@ -25,6 +29,7 @@
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/http/HttpResponse.h>
+#include <aws/core/platform/Environment.h>
 #include <aws/core/utils/DateTime.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/UUID.h>
@@ -52,15 +57,29 @@ static const int kImdsV2TtlSecs = 21600;
 
 namespace {
 
+bool IsTrueEnvironmentVariable(const char* name) {
+  return Aws::Utils::StringUtils::CaselessCompare(Aws::Environment::GetEnv(name).c_str(), "true");
+}
+
+bool IsImdsV1Disabled() {
+  // Alibaba Cloud SDKs have shipped both spellings. Treat either as the same
+  // security boundary so a mixed-language deployment cannot accidentally
+  // downgrade to an unauthenticated metadata request.
+  return IsTrueEnvironmentVariable("ALIBABA_CLOUD_IMDSV1_DISABLED") ||
+         IsTrueEnvironmentVariable("ALIBABA_CLOUD_IMDSV1_DISABLE");
+}
+
 std::shared_ptr<Aws::Http::HttpClient> MakeImdsHttpClient() {
   Aws::Client::ClientConfiguration cfg(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   cfg.scheme = Aws::Http::Scheme::HTTP;
   // IMDS answers in milliseconds on a healthy VM; a multi-second stall means
   // the service is unreachable (e.g. not an ECS). Short caps keep a broken
   // refresh from blocking callers holding the credentials lock.
-  cfg.connectTimeoutMs = 2000;
-  cfg.requestTimeoutMs = 5000;
-  cfg.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>(kLogTag, 0 /*maxRetries*/);
+  cfg.connectTimeoutMs = kCredentialConnectTimeoutMs;
+  cfg.requestTimeoutMs = kImdsRequestTimeoutMs;
+  // Deliberately no retryStrategy here: this client is driven by raw
+  // MakeRequest calls, which do not consume one. The budget is applied by
+  // MakeRequestWithCredentialRetry at each call site instead.
   return Aws::Http::CreateHttpClient(cfg);
 }
 
@@ -72,8 +91,10 @@ std::string ReadBody(const std::shared_ptr<Aws::Http::HttpResponse>& resp) {
   return ss.str();
 }
 
-// Empty return means IMDSv2 is unavailable — caller must fall back to V1.
-std::string TryImdsV2Token(Aws::Http::HttpClient& http) {
+// A disengaged optional means the endpoint explicitly allows a V1 fallback.
+// Transport/timeout/throttling/service failures stay typed errors: sending a
+// bare GET after those would both hide the cause and weaken the request.
+arrow::Result<std::optional<std::string>> TryImdsV2Token(Aws::Http::HttpClient& http) {
   const std::string url = std::string(kImdsHost) + kImdsV2TokenPath;
   auto req = Aws::Http::CreateHttpRequest(url, Aws::Http::HttpMethod::HTTP_PUT,
                                           Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
@@ -81,12 +102,27 @@ std::string TryImdsV2Token(Aws::Http::HttpClient& http) {
   req->SetContentLength("0");
   req->SetUserAgent(Aws::Client::ComputeUserAgentString());
 
-  auto resp = http.MakeRequest(req);
-  if (!resp || resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
-    return {};
+  auto resp = MakeRequestWithCredentialRetry(http, req);
+  if (resp == nullptr) {
+    return ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::NO_RESPONSE,
+                                         "Aliyun ECS IMDSv2 token request received no response");
   }
-  auto token = ReadBody(resp);
-  return std::string(Aws::Utils::StringUtils::Trim(token.c_str()).c_str());
+  const auto code = resp->GetResponseCode();
+  if (code != Aws::Http::HttpResponseCode::OK) {
+    // Older/explicitly V1-only metadata endpoints use these responses for an
+    // unsupported token method. They are the only safe downgrade signal.
+    if (!IsImdsV1Disabled() &&
+        (code == Aws::Http::HttpResponseCode::FORBIDDEN || code == Aws::Http::HttpResponseCode::NOT_FOUND ||
+         code == Aws::Http::HttpResponseCode::METHOD_NOT_ALLOWED)) {
+      return std::nullopt;
+    }
+    return ClassifyCredentialHttpFailure(code, "Aliyun ECS IMDSv2 token request failed");
+  }
+  auto token = std::string(Aws::Utils::StringUtils::Trim(ReadBody(resp).c_str()).c_str());
+  if (token.empty()) {
+    return MakeCredentialResponseError("Aliyun ECS IMDSv2 returned an empty token");
+  }
+  return std::optional<std::string>(std::move(token));
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> MakeImdsGet(const std::string& url, const std::string& v2_token) {
@@ -103,52 +139,102 @@ struct ImdsCreds {
   std::string access_key_id;
   std::string access_key_secret;
   std::string security_token;
+  Aws::Utils::DateTime expiration;
 };
 
-bool FetchImdsCreds(ImdsCreds& out) {
-  auto http = MakeImdsHttpClient();
-  if (!http)
-    return false;
+// `status` receives why this failed, so the caller can tell an ECS without a
+// RAM role (fix the deployment) from an IMDS that did not answer (wait).
+bool FetchImdsCreds(ImdsCreds& out, arrow::Status& status) {
+  // This is the shared containment boundary for all three raw IMDS requests
+  // below. HttpClient and the SDK's stream/JSON helpers may throw instead of
+  // producing an HTTP response.
+  try {
+    if (IsTrueEnvironmentVariable("ALIBABA_CLOUD_ECS_METADATA_DISABLED")) {
+      status = MakeCredentialConfigError("Aliyun ECS metadata is disabled by ALIBABA_CLOUD_ECS_METADATA_DISABLED");
+      return false;
+    }
 
-  // V2 first; an empty return drops us back to V1-style bare GETs. Probing
-  // order is cheap — one PUT — and lets the same code path cover both
-  // "hardened mode" and V1-only instances.
-  const std::string v2_token = TryImdsV2Token(*http);
+    auto http = MakeImdsHttpClient();
+    if (!http) {
+      status = MakeCredentialResponseError("Cannot create an HTTP client for ECS IMDS");
+      return false;
+    }
 
-  auto list_req = MakeImdsGet(std::string(kImdsHost) + kImdsRoleListPath, v2_token);
-  auto list_resp = http->MakeRequest(list_req);
-  if (!list_resp || list_resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
-    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS role list request failed; no RAM role attached to this ECS?", kLogTag);
-    return false;
-  }
-  const auto role_name = std::string(Aws::Utils::StringUtils::Trim(ReadBody(list_resp).c_str()).c_str());
-  if (role_name.empty()) {
-    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS returned empty role name", kLogTag);
-    return false;
-  }
+    // V2 first. Only an explicit unsupported-method response drops back to
+    // V1-style bare GETs; a transient PUT failure aborts the refresh.
+    auto token_result = TryImdsV2Token(*http);
+    if (!token_result.ok()) {
+      status = token_result.status();
+      LOG_STORAGE_ERROR_ << fmt::format("[{}] {}", kLogTag, status.message());
+      return false;
+    }
+    const std::string v2_token = token_result.ValueOrDie().value_or("");
 
-  const std::string creds_url = std::string(kImdsHost) + kImdsRoleListPath + role_name;
-  auto creds_req = MakeImdsGet(creds_url, v2_token);
-  auto creds_resp = http->MakeRequest(creds_req);
-  if (!creds_resp || creds_resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
-    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials request failed for role {}", kLogTag, role_name);
-    return false;
-  }
+    auto list_req = MakeImdsGet(std::string(kImdsHost) + kImdsRoleListPath, v2_token);
+    auto list_resp = MakeRequestWithCredentialRetry(*http, list_req);
+    if (!list_resp || list_resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
+      status = ClassifyCredentialHttpFailure(
+          list_resp ? list_resp->GetResponseCode() : Aws::Http::HttpResponseCode::NO_RESPONSE,
+          "ECS IMDS role list request failed; is a RAM role attached to this instance?");
+      LOG_STORAGE_ERROR_ << fmt::format("[{}] {}", kLogTag, status.message());
+      return false;
+    }
+    const auto role_name = std::string(Aws::Utils::StringUtils::Trim(ReadBody(list_resp).c_str()).c_str());
+    if (role_name.empty()) {
+      // IMDS answered 200 with nothing in it: no role is attached, which is a
+      // deployment fact and not something a retry changes.
+      status = MakeExtendError(ExtendStatusCode::StorageConfigInvalid, arrow::StatusCode::IOError,
+                               "ECS IMDS reports no RAM role attached to this instance");
+      LOG_STORAGE_ERROR_ << fmt::format("[{}] {}", kLogTag, status.message());
+      return false;
+    }
 
-  Aws::Utils::Json::JsonValue json(ReadBody(creds_resp).c_str());
-  if (!json.WasParseSuccessful()) {
-    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials JSON parse failed: {}", kLogTag, json.GetErrorMessage());
-    return false;
+    const std::string creds_url = std::string(kImdsHost) + kImdsRoleListPath + role_name;
+    auto creds_req = MakeImdsGet(creds_url, v2_token);
+    auto creds_resp = MakeRequestWithCredentialRetry(*http, creds_req);
+    if (!creds_resp || creds_resp->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
+      status = ClassifyCredentialHttpFailure(
+          creds_resp ? creds_resp->GetResponseCode() : Aws::Http::HttpResponseCode::NO_RESPONSE,
+          fmt::format("ECS IMDS credentials request failed for role {}", role_name));
+      LOG_STORAGE_ERROR_ << fmt::format("[{}] {}", kLogTag, status.message());
+      return false;
+    }
+
+    Aws::Utils::Json::JsonValue json(ReadBody(creds_resp).c_str());
+    if (!json.WasParseSuccessful()) {
+      LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials JSON parse failed: {}", kLogTag, json.GetErrorMessage());
+      status = MakeCredentialResponseError("ECS IMDS credentials response is not valid JSON");
+      return false;
+    }
+    auto view = json.View();
+    if (!view.KeyExists("AccessKeyId") || !view.KeyExists("AccessKeySecret") || !view.KeyExists("SecurityToken") ||
+        !view.KeyExists("Expiration")) {
+      LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials response missing expected fields", kLogTag);
+      status = MakeCredentialResponseError("ECS IMDS credentials response is missing expected fields");
+      return false;
+    }
+    out.access_key_id = view.GetString("AccessKeyId");
+    out.access_key_secret = view.GetString("AccessKeySecret");
+    out.security_token = view.GetString("SecurityToken");
+    out.expiration = Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(view.GetString("Expiration").c_str()).c_str(),
+                                          Aws::Utils::DateFormat::ISO_8601);
+    Aws::Auth::AWSCredentials credentials(out.access_key_id.c_str(), out.access_key_secret.c_str(),
+                                          out.security_token.c_str(), out.expiration);
+    status = ValidateTemporaryCredentials(credentials, "Aliyun ECS IMDS");
+    if (!status.ok()) {
+      return false;
+    }
+    return true;
+  } catch (const std::bad_alloc&) {
+    status = MakeCredentialOutOfMemoryError("Aliyun ECS IMDS credential retrieval ran out of memory");
+  } catch (const std::exception& e) {
+    status = MakeCredentialExceptionError("Aliyun ECS IMDS credential retrieval raised", e);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Exception during IMDS credential retrieval: {}", kLogTag, e.what());
+  } catch (...) {
+    status = MakeCredentialUnknownExceptionError("Aliyun ECS IMDS credential retrieval raised");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Unknown exception during IMDS credential retrieval", kLogTag);
   }
-  auto view = json.View();
-  if (!view.KeyExists("AccessKeyId") || !view.KeyExists("AccessKeySecret") || !view.KeyExists("SecurityToken")) {
-    LOG_STORAGE_ERROR_ << fmt::format("[{}] IMDS credentials response missing expected fields", kLogTag);
-    return false;
-  }
-  out.access_key_id = view.GetString("AccessKeyId");
-  out.access_key_secret = view.GetString("AccessKeySecret");
-  out.security_token = view.GetString("SecurityToken");
-  return true;
+  return false;
 }
 
 }  // namespace
@@ -157,12 +243,22 @@ AliyunRAMCredentialsProvider::AliyunRAMCredentialsProvider(const Aws::String& ro
                                                            const Aws::String& role_session_name,
                                                            const Aws::String& external_id)
     : m_roleArn(role_arn), m_roleSessionName(role_session_name), m_externalId(external_id) {
+  if (m_roleArn.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Aliyun target role ARN is not configured");
+  }
   if (m_roleSessionName.empty()) {
     m_roleSessionName = Aws::Utils::UUID::RandomUUID();
   }
 
   Aws::Client::ClientConfiguration cfg(Aws::Client::ClientConfigurationInitValues{/*shouldDisableIMDS=*/true});
   cfg.scheme = Aws::Http::Scheme::HTTPS;
+  // Explicit, so the credential path takes a bounded and predictable amount of
+  // time. The default strategy reads AWS_MAX_ATTEMPTS, which a deployment may
+  // have set for object I/O without meaning to make credential resolution block
+  // for tens of seconds.
+  cfg.connectTimeoutMs = kCredentialConnectTimeoutMs;
+  cfg.requestTimeoutMs = kCredentialRequestTimeoutMs;
+  cfg.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>(kLogTag, kCredentialRetryAttempts);
   m_stsClient = Aws::MakeUnique<AliyunRAMSTSClient>(kLogTag, cfg);
 
   LOG_STORAGE_INFO_ << fmt::format("[{}] Created RAM provider for role_arn={} session={} external_id_set={}", kLogTag,
@@ -170,9 +266,27 @@ AliyunRAMCredentialsProvider::AliyunRAMCredentialsProvider(const Aws::String& ro
 }
 
 Aws::Auth::AWSCredentials AliyunRAMCredentialsProvider::GetAWSCredentials() {
+  auto result = ResolveForRequest();
+  if (!result.ok()) {
+    return {};
+  }
+  return std::move(result).ValueOrDie();
+}
+
+arrow::Result<Aws::Auth::AWSCredentials> AliyunRAMCredentialsProvider::ResolveForRequest() {
+  if (m_roleArn.empty()) {
+    return m_lastResolution;
+  }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-  return m_credentials;
+  if (ExpiresSoon() && !m_lastResolution.ok()) {
+    return m_lastResolution;
+  }
+  auto validation = ValidateTemporaryCredentials(m_credentials, "Aliyun AssumeRole");
+  if (validation.ok()) {
+    return m_credentials;
+  }
+  return m_lastResolution.ok() ? validation : m_lastResolution;
 }
 
 bool AliyunRAMCredentialsProvider::ExpiresSoon() const {
@@ -180,6 +294,11 @@ bool AliyunRAMCredentialsProvider::ExpiresSoon() const {
 }
 
 void AliyunRAMCredentialsProvider::RefreshIfExpired() {
+  // The cooldown shares a fast failed refresh with queued callers. The caller
+  // budget separately prevents a waiter that already spent too long behind a
+  // slow refresh from starting another attempt after the cooldown expires.
+  const auto started = std::chrono::steady_clock::now();
+
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
   if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
     return;
@@ -187,6 +306,9 @@ void AliyunRAMCredentialsProvider::RefreshIfExpired() {
 
   guard.UpgradeToWriterLock();
   if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) {
+    return;
+  }
+  if (!CredentialAttemptStillWorthMaking(started)) {
     return;
   }
 
@@ -197,8 +319,10 @@ void AliyunRAMCredentialsProvider::Reload() {
   LOG_STORAGE_INFO_ << fmt::format("[{}] Credentials missing or expiring; refreshing via IMDS → AssumeRole.", kLogTag);
 
   ImdsCreds imds;
-  if (!FetchImdsCreds(imds)) {
-    LOG_STORAGE_ERROR_ << fmt::format("[{}] Failed to fetch ECS IMDS credentials", kLogTag);
+  arrow::Status imds_status;
+  if (!FetchImdsCreds(imds, imds_status)) {
+    m_lastResolution =
+        imds_status.ok() ? MakeCredentialResponseError("Failed to fetch ECS IMDS credentials") : imds_status;
     return;
   }
 
@@ -213,10 +337,18 @@ void AliyunRAMCredentialsProvider::Reload() {
                                    !req.externalId.empty());
 
   auto res = m_stsClient->GetAssumeRoleCredentials(req);
-  if (res.creds.IsEmpty()) {
+  if (!res.status.ok()) {
+    m_lastResolution = res.status;
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] AssumeRole failed: {}", kLogTag, m_lastResolution.message());
+    return;
+  }
+  auto validation = ValidateTemporaryCredentials(res.creds, "Aliyun AssumeRole");
+  if (!validation.ok()) {
+    m_lastResolution = validation;
     LOG_STORAGE_ERROR_ << fmt::format("[{}] AssumeRole returned empty credentials", kLogTag);
     return;
   }
+  m_lastResolution = arrow::Status::OK();
   m_credentials = res.creds;
   LOG_STORAGE_INFO_ << fmt::format("[{}] AssumeRole succeeded; expires={}", kLogTag,
                                    m_credentials.GetExpiration().ToGmtString(Aws::Utils::DateFormat::ISO_8601));

--- a/cpp/src/filesystem/s3/provider/AliyunRAMSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunRAMSTSClient.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <map>
+#include <new>
 #include <random>
 #include <sstream>
 #include <string>
@@ -75,7 +76,7 @@ std::vector<uint8_t> HmacSha1(const std::string& key, const std::string& data) {
 
 AliyunRAMSTSClient::AliyunRAMSTSClient(const Aws::Client::ClientConfiguration& clientConfiguration)
     : AWSHttpResourceClient(clientConfiguration, kLogTag) {
-  SetErrorMarshaller(Aws::MakeUnique<Aws::Client::XmlErrorMarshaller>(kLogTag));
+  m_rawHttpClient = Aws::Http::CreateHttpClient(clientConfiguration);
   // Aliyun STS is region-agnostic; this endpoint is valid from every region.
   m_endpoint = "https://sts.aliyuncs.com/";
   LOG_STORAGE_INFO_ << fmt::format("[{}] Creating RAM STS client with endpoint: {}", kLogTag, m_endpoint);
@@ -83,126 +84,165 @@ AliyunRAMSTSClient::AliyunRAMSTSClient(const Aws::Client::ClientConfiguration& c
 
 AliyunRAMSTSClient::AssumeRoleResult AliyunRAMSTSClient::GetAssumeRoleCredentials(const AssumeRoleRequest& request) {
   AssumeRoleResult result;
+  try {
+    // std::map sorts keys ASCII-ascending, which is what POP v1 canonical-query
+    // construction needs. Values will be URL-encoded when we emit the string.
+    std::map<std::string, std::string> params;
+    params["AccessKeyId"] = request.callerAccessKeyId;
+    params["Action"] = "AssumeRole";
+    params["Format"] = "XML";
+    params["RoleArn"] = request.roleArn;
+    params["RoleSessionName"] = request.roleSessionName;
+    // SecurityToken is mandatory when the caller credentials are themselves
+    // temporary (e.g. STS creds from ECS IMDS). Omitting it for long-term
+    // AK/SK is also required by Aliyun (they disagree on which set signed).
+    if (!request.callerSecurityToken.empty()) {
+      params["SecurityToken"] = request.callerSecurityToken;
+    }
+    // ExternalId is optional and only included when the caller sets it.
+    // The target role's trust policy decides whether ExternalId is required;
+    // sending an empty value would still flip the request to the
+    // "ExternalId-supplied" branch on Aliyun's side, which fails the policy
+    // check, so the explicit non-empty guard matters.
+    LOG_STORAGE_INFO_ << fmt::format("[{}] Preparing AssumeRole request; external_id_set={}", kLogTag,
+                                     !request.externalId.empty());
+    if (!request.externalId.empty()) {
+      params["ExternalId"] = request.externalId;
+    }
+    params["SignatureMethod"] = "HMAC-SHA1";
+    // 64-bit random nonce. UUID alone is enough but cheap insurance against
+    // correlated clocks on the same host.
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<uint64_t> dist;
+    const Aws::String uuid = Aws::Utils::UUID::RandomUUID();
+    Aws::StringStream nonce;
+    nonce << dist(gen) << "-" << uuid;
+    params["SignatureNonce"] = nonce.str().c_str();
+    params["SignatureVersion"] = "1.0";
+    params["Timestamp"] = Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601).c_str();
+    params["Version"] = "2015-04-01";
 
-  // std::map sorts keys ASCII-ascending, which is what POP v1 canonical-query
-  // construction needs. Values will be URL-encoded when we emit the string.
-  std::map<std::string, std::string> params;
-  params["AccessKeyId"] = request.callerAccessKeyId;
-  params["Action"] = "AssumeRole";
-  params["Format"] = "XML";
-  params["RoleArn"] = request.roleArn;
-  params["RoleSessionName"] = request.roleSessionName;
-  // SecurityToken is mandatory when the caller credentials are themselves
-  // temporary (e.g. STS creds from ECS IMDS). Omitting it for long-term
-  // AK/SK is also required by Aliyun (they disagree on which set signed).
-  if (!request.callerSecurityToken.empty()) {
-    params["SecurityToken"] = request.callerSecurityToken;
-  }
-  // ExternalId is optional and only included when the caller sets it.
-  // The target role's trust policy decides whether ExternalId is required;
-  // sending an empty value would still flip the request to the
-  // "ExternalId-supplied" branch on Aliyun's side, which fails the policy
-  // check, so the explicit non-empty guard matters.
-  LOG_STORAGE_INFO_ << fmt::format("[{}] Preparing AssumeRole request; external_id_set={}", kLogTag,
-                                   !request.externalId.empty());
-  if (!request.externalId.empty()) {
-    params["ExternalId"] = request.externalId;
-  }
-  params["SignatureMethod"] = "HMAC-SHA1";
-  // 64-bit random nonce. UUID alone is enough but cheap insurance against
-  // correlated clocks on the same host.
-  std::random_device rd;
-  std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<uint64_t> dist;
-  const Aws::String uuid = Aws::Utils::UUID::RandomUUID();
-  Aws::StringStream nonce;
-  nonce << dist(gen) << "-" << uuid;
-  params["SignatureNonce"] = nonce.str().c_str();
-  params["SignatureVersion"] = "1.0";
-  params["Timestamp"] = Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601).c_str();
-  params["Version"] = "2015-04-01";
+    // Canonical query: sorted "URLEncode(k)=URLEncode(v)" joined by '&'.
+    std::ostringstream canonical;
+    bool first = true;
+    for (const auto& kv : params) {
+      if (!first)
+        canonical << '&';
+      first = false;
+      canonical << PopUrlEncode(kv.first) << '=' << PopUrlEncode(kv.second);
+    }
+    const std::string canonical_query = canonical.str();
 
-  // Canonical query: sorted "URLEncode(k)=URLEncode(v)" joined by '&'.
-  std::ostringstream canonical;
-  bool first = true;
-  for (const auto& kv : params) {
-    if (!first)
-      canonical << '&';
-    first = false;
-    canonical << PopUrlEncode(kv.first) << '=' << PopUrlEncode(kv.second);
-  }
-  const std::string canonical_query = canonical.str();
+    // We sign as POST and send as POST — the whole canonical query lives in the
+    // request body (form-urlencoded), with Signature appended. A GET with the
+    // same signature would be valid too, but AWS SDK's URI normaliser can re-
+    // encode query params and silently break the signature, so POST is safer.
+    const std::string string_to_sign = std::string("POST&") + PopUrlEncode("/") + "&" + PopUrlEncode(canonical_query);
 
-  // We sign as POST and send as POST — the whole canonical query lives in the
-  // request body (form-urlencoded), with Signature appended. A GET with the
-  // same signature would be valid too, but AWS SDK's URI normaliser can re-
-  // encode query params and silently break the signature, so POST is safer.
-  const std::string string_to_sign = std::string("POST&") + PopUrlEncode("/") + "&" + PopUrlEncode(canonical_query);
+    const std::string signing_key = std::string(request.callerAccessKeySecret.c_str()) + "&";
+    const std::vector<uint8_t> digest = HmacSha1(signing_key, string_to_sign);
 
-  const std::string signing_key = std::string(request.callerAccessKeySecret.c_str()) + "&";
-  const std::vector<uint8_t> digest = HmacSha1(signing_key, string_to_sign);
+    Aws::Utils::ByteBuffer digest_buf(digest.data(), digest.size());
+    const Aws::String signature = Aws::Utils::HashingUtils::Base64Encode(digest_buf);
 
-  Aws::Utils::ByteBuffer digest_buf(digest.data(), digest.size());
-  const Aws::String signature = Aws::Utils::HashingUtils::Base64Encode(digest_buf);
+    const std::string body_str = canonical_query + "&Signature=" + PopUrlEncode(std::string(signature.c_str()));
 
-  const std::string body_str = canonical_query + "&Signature=" + PopUrlEncode(std::string(signature.c_str()));
+    std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
+        m_endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+    httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
 
-  std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
-      m_endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
-  httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
+    auto body = Aws::MakeShared<Aws::StringStream>(kLogTag);
+    *body << body_str;
+    httpRequest->AddContentBody(body);
+    Aws::StringStream content_length;
+    content_length << body_str.size();
+    httpRequest->SetContentLength(content_length.str());
+    httpRequest->SetContentType("application/x-www-form-urlencoded");
 
-  auto body = Aws::MakeShared<Aws::StringStream>(kLogTag);
-  *body << body_str;
-  httpRequest->AddContentBody(body);
-  Aws::StringStream content_length;
-  content_length << body_str.size();
-  httpRequest->SetContentLength(content_length.str());
-  httpRequest->SetContentType("application/x-www-form-urlencoded");
+    if (m_rawHttpClient == nullptr) {
+      result.status = ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE,
+                                                    "Aliyun AssumeRole has no HTTP client");
+      return result;
+    }
+    const auto response = MakeRequestWithCredentialRetry(*m_rawHttpClient, httpRequest);
+    if (response == nullptr) {
+      result.status = ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::NO_RESPONSE,
+                                                    "Aliyun AssumeRole received no HTTP response");
+      return result;
+    }
+    const auto response_code = response->GetResponseCode();
+    Aws::IStreamBufIterator eos;
+    const Aws::String payload(Aws::IStreamBufIterator(response->GetResponseBody()), eos);
+    if (response_code != Aws::Http::HttpResponseCode::OK) {
+      result.status = ClassifyAliyunStsHttpFailure(response_code, payload,
+                                                   fmt::format("Aliyun AssumeRole failed against {} (http_status={})",
+                                                               m_endpoint, static_cast<int>(response_code)));
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", kLogTag, result.status.message());
+      return result;
+    }
+    if (payload.empty()) {
+      result.status = MakeCredentialResponseError("Aliyun AssumeRole returned an empty body");
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", kLogTag, result.status.message());
+      return result;
+    }
 
-  const Aws::String payload = GetResourceWithAWSWebServiceResult(httpRequest).GetPayload();
-  if (payload.empty()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Empty AssumeRole response from {}", kLogTag, m_endpoint);
+    // Response shape:
+    // <AssumeRoleResponse>
+    //   <Credentials>
+    //     <AccessKeyId>...</AccessKeyId>
+    //     <AccessKeySecret>...</AccessKeySecret>
+    //     <SecurityToken>...</SecurityToken>
+    //     <Expiration>2023-01-01T12:00:00Z</Expiration>
+    //   </Credentials>
+    // </AssumeRoleResponse>
+    const auto doc = Aws::Utils::Xml::XmlDocument::CreateFromXmlString(payload);
+    auto root = doc.GetRootElement();
+    auto resultNode = root;
+    if (!root.IsNull() && root.GetName() != "AssumeRoleResponse") {
+      resultNode = root.FirstChild("AssumeRoleResponse");
+    }
+    if (resultNode.IsNull()) {
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] Unexpected AssumeRole response root: {}", kLogTag, payload);
+      // A 200 whose body we cannot read does not establish either a transport
+      // failure or an access decision, so leave it conservatively unclassified.
+      result.status = MakeCredentialResponseError("Unexpected Aliyun AssumeRole response root");
+      return result;
+    }
+    auto credentials = resultNode.FirstChild("Credentials");
+    if (credentials.IsNull()) {
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] Missing <Credentials> in AssumeRole response: {}", kLogTag, payload);
+      result.status = MakeCredentialResponseError("Aliyun AssumeRole response carried no <Credentials>");
+      return result;
+    }
+
+    auto ak_node = credentials.FirstChild("AccessKeyId");
+    if (!ak_node.IsNull())
+      result.creds.SetAWSAccessKeyId(ak_node.GetText());
+    auto sk_node = credentials.FirstChild("AccessKeySecret");
+    if (!sk_node.IsNull())
+      result.creds.SetAWSSecretKey(sk_node.GetText());
+    auto tok_node = credentials.FirstChild("SecurityToken");
+    if (!tok_node.IsNull())
+      result.creds.SetSessionToken(tok_node.GetText());
+    auto exp_node = credentials.FirstChild("Expiration");
+    if (!exp_node.IsNull()) {
+      result.creds.SetExpiration(Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(exp_node.GetText().c_str()).c_str(),
+                                                      Aws::Utils::DateFormat::ISO_8601));
+    }
+    result.status = ValidateTemporaryCredentials(result.creds, "Aliyun AssumeRole");
+    if (!result.status.ok()) {
+      result.creds = {};
+    }
     return result;
-  }
-
-  // Response shape:
-  // <AssumeRoleResponse>
-  //   <Credentials>
-  //     <AccessKeyId>...</AccessKeyId>
-  //     <AccessKeySecret>...</AccessKeySecret>
-  //     <SecurityToken>...</SecurityToken>
-  //     <Expiration>2023-01-01T12:00:00Z</Expiration>
-  //   </Credentials>
-  // </AssumeRoleResponse>
-  const auto doc = Aws::Utils::Xml::XmlDocument::CreateFromXmlString(payload);
-  auto root = doc.GetRootElement();
-  auto resultNode = root;
-  if (!root.IsNull() && root.GetName() != "AssumeRoleResponse") {
-    resultNode = root.FirstChild("AssumeRoleResponse");
-  }
-  if (resultNode.IsNull()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Unexpected AssumeRole response root: {}", kLogTag, payload);
-    return result;
-  }
-  auto credentials = resultNode.FirstChild("Credentials");
-  if (credentials.IsNull()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Missing <Credentials> in AssumeRole response: {}", kLogTag, payload);
-    return result;
-  }
-
-  auto ak_node = credentials.FirstChild("AccessKeyId");
-  if (!ak_node.IsNull())
-    result.creds.SetAWSAccessKeyId(ak_node.GetText());
-  auto sk_node = credentials.FirstChild("AccessKeySecret");
-  if (!sk_node.IsNull())
-    result.creds.SetAWSSecretKey(sk_node.GetText());
-  auto tok_node = credentials.FirstChild("SecurityToken");
-  if (!tok_node.IsNull())
-    result.creds.SetSessionToken(tok_node.GetText());
-  auto exp_node = credentials.FirstChild("Expiration");
-  if (!exp_node.IsNull()) {
-    result.creds.SetExpiration(Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(exp_node.GetText().c_str()).c_str(),
-                                                    Aws::Utils::DateFormat::ISO_8601));
+  } catch (const std::bad_alloc&) {
+    result.status = MakeCredentialOutOfMemoryError("Aliyun AssumeRole ran out of memory");
+  } catch (const std::exception& e) {
+    result.status = MakeCredentialExceptionError("Aliyun AssumeRole raised", e);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Exception during credential retrieval: {}", kLogTag, e.what());
+  } catch (...) {
+    result.status = MakeCredentialUnknownExceptionError("Aliyun AssumeRole raised");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Unknown exception during credential retrieval", kLogTag);
   }
   return result;
 }

--- a/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/AliyunSTSClient.cpp
@@ -20,6 +20,7 @@
 
 #include <climits>
 #include <mutex>
+#include <new>
 #include <sstream>
 #include <random>
 
@@ -51,6 +52,7 @@ int IntRand(const int& min, const int& max) {
 
 AliyunSTSCredentialsClient::AliyunSTSCredentialsClient(const Aws::Client::ClientConfiguration& clientConfiguration)
     : AWSHttpResourceClient(clientConfiguration, STS_RESOURCE_CLIENT_LOG_TAG) {
+  m_rawHttpClient = Aws::Http::CreateHttpClient(clientConfiguration);
   m_aliyunOidcProviderArn = Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN");
   if (m_aliyunOidcProviderArn.empty()) {
     LOG_STORAGE_WARNING_ << fmt::format(
@@ -59,8 +61,6 @@ AliyunSTSCredentialsClient::AliyunSTSCredentialsClient(const Aws::Client::Client
         STS_RESOURCE_CLIENT_LOG_TAG);
     return;
   }
-  SetErrorMarshaller(Aws::MakeUnique<Aws::Client::XmlErrorMarshaller>(STS_RESOURCE_CLIENT_LOG_TAG));
-
   // [aliyun]
   m_endpoint = "https://sts.aliyuncs.com";
 
@@ -71,113 +71,150 @@ AliyunSTSCredentialsClient::AliyunSTSCredentialsClient(const Aws::Client::Client
 AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityResult
 AliyunSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     const STSAssumeRoleWithWebIdentityRequest& request) {
-  // Calculate query string
-  Aws::StringStream ss;
-  // [aliyun]
-  // linux curl example:
-  // Action=AssumeRoleWithOIDC
-  // Timestamp=`date -Iseconds`
-  // Version="2015-04-01"
-  // SignatureNonce=`$RANDOM`
-  // RoleSessionName="default_session"
-  // RoleArn=$ALIBABA_CLOUD_ROLE_ARN
-  // OIDCProviderArn=$ALIBABA_CLOUD_OIDC_PROVIDER_ARN
-  // OIDCToken=`cat $ALIBABA_CLOUD_OIDC_TOKEN_FILE`
-  // curl "https://sts.aliyuncs.com?Action=$Action&Timestamp=$time" \
-  //     -H "Host: sts.aliyuncs.com" \
-  //     -H "Accept-Encoding: identity" \
-  //     -H "SignatureNonce: $SignatureNonce" \
-  //     -d
-  //     "RoleArn=$RoleArn&OIDCProviderArn=$OIDCProviderArn&OIDCToken=$OIDCToken&RoleSessionName=$RoleSessionName&Version=$Version"
-  ss << "Action=AssumeRoleWithOIDC"
-     << "&Timestamp=" /*iso8601*/
-     << Aws::Utils::StringUtils::URLEncode(
-            Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601).c_str())
-     << "&Version=2015-04-01"
-     << "&SignatureNonce="
-     << Aws::Utils::HashingUtils::HashString(Aws::Utils::StringUtils::to_string(IntRand(0, INT_MAX)).c_str())
-     << "&RoleSessionName=" << Aws::Utils::StringUtils::URLEncode(request.roleSessionName.c_str())
-     << "&RoleArn=" << Aws::Utils::StringUtils::URLEncode(request.roleArn.c_str())
-     << "&OIDCProviderArn=" << Aws::Utils::StringUtils::URLEncode(m_aliyunOidcProviderArn.c_str())
-     << "&OIDCToken=" << Aws::Utils::StringUtils::URLEncode(request.webIdentityToken.c_str());
-
-  std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
-      m_endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
-
-  httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
-
-  std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("STS_RESOURCE_CLIENT_LOG_TAG");
-  *body << ss.str();
-
-  httpRequest->AddContentBody(body);
-  body->seekg(0, body->end);
-  auto streamSize = body->tellg();
-  body->seekg(0, body->beg);
-  Aws::StringStream contentLength;
-  contentLength << streamSize;
-  httpRequest->SetContentLength(contentLength.str());
-  httpRequest->SetContentType("application/x-www-form-urlencoded");
-
-  Aws::String credentialsStr = GetResourceWithAWSWebServiceResult(httpRequest).GetPayload();
-
-  // Parse credentials
   STSAssumeRoleWithWebIdentityResult result;
-  if (credentialsStr.empty()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get an empty credential from sts", STS_RESOURCE_CLIENT_LOG_TAG);
-    return result;
-  }
+  try {
+    // Calculate query string
+    Aws::StringStream ss;
+    // [aliyun]
+    // linux curl example:
+    // Action=AssumeRoleWithOIDC
+    // Timestamp=`date -Iseconds`
+    // Version="2015-04-01"
+    // SignatureNonce=`$RANDOM`
+    // RoleSessionName="default_session"
+    // RoleArn=$ALIBABA_CLOUD_ROLE_ARN
+    // OIDCProviderArn=$ALIBABA_CLOUD_OIDC_PROVIDER_ARN
+    // OIDCToken=`cat $ALIBABA_CLOUD_OIDC_TOKEN_FILE`
+    // curl "https://sts.aliyuncs.com?Action=$Action&Timestamp=$time" \
+    //     -H "Host: sts.aliyuncs.com" \
+    //     -H "Accept-Encoding: identity" \
+    //     -H "SignatureNonce: $SignatureNonce" \
+    //     -d
+    //     "RoleArn=$RoleArn&OIDCProviderArn=$OIDCProviderArn&OIDCToken=$OIDCToken&RoleSessionName=$RoleSessionName&Version=$Version"
+    ss << "Action=AssumeRoleWithOIDC"
+       << "&Timestamp=" /*iso8601*/
+       << Aws::Utils::StringUtils::URLEncode(
+              Aws::Utils::DateTime::Now().ToGmtString(Aws::Utils::DateFormat::ISO_8601).c_str())
+       << "&Version=2015-04-01"
+       << "&SignatureNonce="
+       << Aws::Utils::HashingUtils::HashString(Aws::Utils::StringUtils::to_string(IntRand(0, INT_MAX)).c_str())
+       << "&RoleSessionName=" << Aws::Utils::StringUtils::URLEncode(request.roleSessionName.c_str())
+       << "&RoleArn=" << Aws::Utils::StringUtils::URLEncode(request.roleArn.c_str())
+       << "&OIDCProviderArn=" << Aws::Utils::StringUtils::URLEncode(m_aliyunOidcProviderArn.c_str())
+       << "&OIDCToken=" << Aws::Utils::StringUtils::URLEncode(request.webIdentityToken.c_str());
 
-  // [aliyun] output example
-  // <?xml version='1.0' encoding='UTF-8'?>
-  // <AssumeRoleWithOIDCResponse>
-  //     <RequestId>D94AFCC3-54CA-508C-B6AF-21481E761BDB</RequestId>
-  //     <OIDCTokenInfo>
-  //         <Issuer>https://oidc-ack-cn-shanghai.oss-cn-shanghai.aliyuncs.com/c532c4ce5e84048a1972535df283f737d</Issuer>
-  //         <Subject>system:serviceaccount:default:my-release</Subject>
-  //         <ClientIds>sts.aliyuncs.com</ClientIds>
-  //     </OIDCTokenInfo>
-  //     <AssumedRoleUser>
-  //         <Arn>acs:ram::1413891078881348:role/vdc-poc-milvus/default</Arn>
-  //         <AssumedRoleId>383373758575348335:default</AssumedRoleId>
-  //     </AssumedRoleUser>
-  //     <Credentials>
-  //         <SecurityToken>xxx</SecurityToken>
-  //         <AccessKeyId>xxx</AccessKeyId>
-  //         <AccessKeySecret>xxx</AccessKeySecret>
-  //         <Expiration>2023-03-02T07:39:09Z</Expiration>
-  //     </Credentials>
-  // </AssumeRoleWithOIDCResponse>
-  const Aws::Utils::Xml::XmlDocument xmlDocument = Aws::Utils::Xml::XmlDocument::CreateFromXmlString(credentialsStr);
-  Aws::Utils::Xml::XmlNode rootNode = xmlDocument.GetRootElement();
-  Aws::Utils::Xml::XmlNode resultNode = rootNode;
-  if (!rootNode.IsNull() && (rootNode.GetName() != "AssumeRoleWithOIDCResponse")) {
-    resultNode = rootNode.FirstChild("AssumeRoleWithOIDCResponse");  // [aliyun]
-  }
+    std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
+        m_endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
 
-  if (!resultNode.IsNull()) {
-    Aws::Utils::Xml::XmlNode credentialsNode = resultNode.FirstChild("Credentials");
-    if (!credentialsNode.IsNull()) {
-      Aws::Utils::Xml::XmlNode accessKeyIdNode = credentialsNode.FirstChild("AccessKeyId");
-      if (!accessKeyIdNode.IsNull()) {
-        result.creds.SetAWSAccessKeyId(accessKeyIdNode.GetText());
-      }
+    httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
 
-      Aws::Utils::Xml::XmlNode secretAccessKeyNode = credentialsNode.FirstChild("AccessKeySecret");  // [aliyun]
-      if (!secretAccessKeyNode.IsNull()) {
-        result.creds.SetAWSSecretKey(secretAccessKeyNode.GetText());
-      }
+    std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("STS_RESOURCE_CLIENT_LOG_TAG");
+    *body << ss.str();
 
-      Aws::Utils::Xml::XmlNode sessionTokenNode = credentialsNode.FirstChild("SecurityToken");  // [aliyun]
-      if (!sessionTokenNode.IsNull()) {
-        result.creds.SetSessionToken(sessionTokenNode.GetText());
-      }
+    httpRequest->AddContentBody(body);
+    body->seekg(0, body->end);
+    auto streamSize = body->tellg();
+    body->seekg(0, body->beg);
+    Aws::StringStream contentLength;
+    contentLength << streamSize;
+    httpRequest->SetContentLength(contentLength.str());
+    httpRequest->SetContentType("application/x-www-form-urlencoded");
 
-      Aws::Utils::Xml::XmlNode expirationNode = credentialsNode.FirstChild("Expiration");
-      if (!expirationNode.IsNull()) {
-        result.creds.SetExpiration(Aws::Utils::DateTime(
-            Aws::Utils::StringUtils::Trim(expirationNode.GetText().c_str()).c_str(), Aws::Utils::DateFormat::ISO_8601));
+    if (m_rawHttpClient == nullptr) {
+      result.status = ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE,
+                                                    "Aliyun STS AssumeRoleWithWebIdentity has no HTTP client");
+      return result;
+    }
+    const auto response = MakeRequestWithCredentialRetry(*m_rawHttpClient, httpRequest);
+    if (response == nullptr) {
+      result.status = ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::NO_RESPONSE,
+                                                    "Aliyun STS AssumeRoleWithWebIdentity received no HTTP response");
+      return result;
+    }
+    const auto response_code = response->GetResponseCode();
+    Aws::IStreamBufIterator eos;
+    Aws::String credentialsStr(Aws::IStreamBufIterator(response->GetResponseBody()), eos);
+    if (response_code != Aws::Http::HttpResponseCode::OK) {
+      result.status = ClassifyAliyunStsHttpFailure(
+          response_code, credentialsStr,
+          fmt::format("Aliyun STS AssumeRoleWithWebIdentity failed (http_status={})", static_cast<int>(response_code)));
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", STS_RESOURCE_CLIENT_LOG_TAG, result.status.message());
+      return result;
+    }
+    if (credentialsStr.empty()) {
+      result.status = MakeCredentialResponseError("Aliyun STS AssumeRoleWithWebIdentity returned an empty body");
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", STS_RESOURCE_CLIENT_LOG_TAG, result.status.message());
+      return result;
+    }
+
+    // [aliyun] output example
+    // <?xml version='1.0' encoding='UTF-8'?>
+    // <AssumeRoleWithOIDCResponse>
+    //     <RequestId>D94AFCC3-54CA-508C-B6AF-21481E761BDB</RequestId>
+    //     <OIDCTokenInfo>
+    //         <Issuer>https://oidc-ack-cn-shanghai.oss-cn-shanghai.aliyuncs.com/c532c4ce5e84048a1972535df283f737d</Issuer>
+    //         <Subject>system:serviceaccount:default:my-release</Subject>
+    //         <ClientIds>sts.aliyuncs.com</ClientIds>
+    //     </OIDCTokenInfo>
+    //     <AssumedRoleUser>
+    //         <Arn>acs:ram::1413891078881348:role/vdc-poc-milvus/default</Arn>
+    //         <AssumedRoleId>383373758575348335:default</AssumedRoleId>
+    //     </AssumedRoleUser>
+    //     <Credentials>
+    //         <SecurityToken>xxx</SecurityToken>
+    //         <AccessKeyId>xxx</AccessKeyId>
+    //         <AccessKeySecret>xxx</AccessKeySecret>
+    //         <Expiration>2023-03-02T07:39:09Z</Expiration>
+    //     </Credentials>
+    // </AssumeRoleWithOIDCResponse>
+    const Aws::Utils::Xml::XmlDocument xmlDocument = Aws::Utils::Xml::XmlDocument::CreateFromXmlString(credentialsStr);
+    Aws::Utils::Xml::XmlNode rootNode = xmlDocument.GetRootElement();
+    Aws::Utils::Xml::XmlNode resultNode = rootNode;
+    if (!rootNode.IsNull() && (rootNode.GetName() != "AssumeRoleWithOIDCResponse")) {
+      resultNode = rootNode.FirstChild("AssumeRoleWithOIDCResponse");  // [aliyun]
+    }
+
+    if (!resultNode.IsNull()) {
+      Aws::Utils::Xml::XmlNode credentialsNode = resultNode.FirstChild("Credentials");
+      if (!credentialsNode.IsNull()) {
+        Aws::Utils::Xml::XmlNode accessKeyIdNode = credentialsNode.FirstChild("AccessKeyId");
+        if (!accessKeyIdNode.IsNull()) {
+          result.creds.SetAWSAccessKeyId(accessKeyIdNode.GetText());
+        }
+
+        Aws::Utils::Xml::XmlNode secretAccessKeyNode = credentialsNode.FirstChild("AccessKeySecret");  // [aliyun]
+        if (!secretAccessKeyNode.IsNull()) {
+          result.creds.SetAWSSecretKey(secretAccessKeyNode.GetText());
+        }
+
+        Aws::Utils::Xml::XmlNode sessionTokenNode = credentialsNode.FirstChild("SecurityToken");  // [aliyun]
+        if (!sessionTokenNode.IsNull()) {
+          result.creds.SetSessionToken(sessionTokenNode.GetText());
+        }
+
+        Aws::Utils::Xml::XmlNode expirationNode = credentialsNode.FirstChild("Expiration");
+        if (!expirationNode.IsNull()) {
+          result.creds.SetExpiration(
+              Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(expirationNode.GetText().c_str()).c_str(),
+                                   Aws::Utils::DateFormat::ISO_8601));
+        }
       }
     }
+    result.status = ValidateTemporaryCredentials(result.creds, "Aliyun STS AssumeRoleWithWebIdentity");
+    if (!result.status.ok()) {
+      result.creds = {};
+    }
+    return result;
+  } catch (const std::bad_alloc&) {
+    result.status = MakeCredentialOutOfMemoryError("Aliyun STS AssumeRoleWithWebIdentity ran out of memory");
+  } catch (const std::exception& e) {
+    result.status = MakeCredentialExceptionError("Aliyun STS AssumeRoleWithWebIdentity raised", e);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Exception during credential retrieval: {}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                      e.what());
+  } catch (...) {
+    result.status = MakeCredentialUnknownExceptionError("Aliyun STS AssumeRoleWithWebIdentity raised");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Unknown exception during credential retrieval",
+                                      STS_RESOURCE_CLIENT_LOG_TAG);
   }
   return result;
 }

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudCredentialsProvider.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
 
 #include "milvus-storage/common/log.h"
@@ -33,6 +34,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   }
 
   if (m_tokenFile.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Huawei Cloud web identity token file is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] Token file must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -44,6 +46,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   }
 
   if (m_roleArn.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Huawei Cloud project ID is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] RoleArn must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -55,6 +58,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   }
 
   if (m_region.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Huawei Cloud region is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] Region must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -63,6 +67,12 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   } else {
     LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved region from profile_config or environment variable to be {}",
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_region);
+  }
+
+  if (m_providerId.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Huawei Cloud identity provider ID is not configured");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] ProviderId must be specified", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
+    return;
   }
 
   if (m_sessionName.empty()) {
@@ -80,17 +90,19 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::HuaweiCloudSTSAssumeRole
   retryableErrors.emplace_back("IDPCommunicationError");
   retryableErrors.emplace_back("InvalidIdentityToken");
 
+  // Shared credential retry budget; see credential_resolution.h.
+  config.connectTimeoutMs = kCredentialConnectTimeoutMs;
+  config.requestTimeoutMs = kCredentialRequestTimeoutMs;
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
-      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, kCredentialRetryAttempts);
 
   m_client = Aws::MakeUnique<HuaweiCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
   LOG_STORAGE_INFO_ << fmt::format(
       "[{}] Initialized STS AssumeRole with web identity creds provider. region={}, "
-      "tokenFile={}, providerId={}, gracePeriodMs={}, cooldownNormalSec={}, "
-      "cooldownUrgentSec={}",
+      "tokenFile={}, providerId={}, gracePeriodMs={}",
       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_region, m_tokenFile, m_providerId,
-      STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD, RELOAD_COOLDOWN_SECONDS, RELOAD_COOLDOWN_SECONDS_URGENT);
+      STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
 }
 
 Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
@@ -99,17 +111,27 @@ Aws::Auth::AWSCredentials HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider
   }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-  // Do not return fully expired credentials — the caller would get silent
-  // auth failures. Return empty credentials instead so the error surfaces
-  // immediately rather than after an HTTP round-trip.
-  if (!m_credentials.IsEmpty() && m_credentials.IsExpired()) {
-    LOG_STORAGE_WARNING_ << fmt::format(
-        "[{}] Cached credentials have fully expired; returning empty credentials to "
-        "avoid silent auth failures.",
-        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
-    return {};
+  if (ValidateTemporaryCredentials(m_credentials, "Huawei Cloud STS").ok()) {
+    return m_credentials;
   }
-  return m_credentials;
+  return {};
+}
+
+arrow::Result<Aws::Auth::AWSCredentials> HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::ResolveForRequest() {
+  if (!m_initialized) {
+    return m_lastResolution.ok() ? MakeCredentialConfigError("Huawei Cloud credential provider is not initialized")
+                                 : m_lastResolution;
+  }
+  RefreshIfExpired();
+  Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+  if (ExpiresSoon() && !m_lastResolution.ok()) {
+    return m_lastResolution;
+  }
+  auto validation = ValidateTemporaryCredentials(m_credentials, "Huawei Cloud STS");
+  if (validation.ok()) {
+    return m_credentials;
+  }
+  return m_lastResolution.ok() ? validation : m_lastResolution;
 }
 
 void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
@@ -127,14 +149,21 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     if (!token.empty() && token.back() == '\n') {
       token.pop_back();
     }
+    if (token.empty()) {
+      ++m_stsFailureCount;
+      m_lastResolution = MakeCredentialConfigError(fmt::format("The OIDC token file {} is empty", m_tokenFile));
+      return;
+    }
     m_token = token;
   } else {
     ++m_stsFailureCount;
     LOG_STORAGE_ERROR_ << fmt::format("[{}] Can't open token file: {}, sts_success={}, sts_failure={}",
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_tokenFile, m_stsSuccessCount.load(),
                                       m_stsFailureCount.load());
-    m_lastReloadFailed = true;
-    m_lastFailedReloadTime = std::chrono::steady_clock::now();
+    // A token file that will not open is the deployment's to fix -- the
+    // projected volume is missing or unreadable -- not something a retry
+    // outlasts.
+    m_lastResolution = MakeCredentialConfigError(fmt::format("Cannot open the OIDC token file {}", m_tokenFile));
     return;
   }
   HuaweiCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{m_region, m_providerId, m_token,
@@ -147,18 +176,19 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
   const auto& creds = result.creds;
 
   if (!result.success) {
+    m_lastResolution = result.status.ok() ? MakeCredentialResponseError("Huawei Cloud STS call failed") : result.status;
     ++m_stsFailureCount;
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] STS call failed. has_valid_cached={}, retaining existing credentials. "
         "sts_success={}, sts_failure={}",
         STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, hasExisting, m_stsSuccessCount.load(), m_stsFailureCount.load());
-    m_lastReloadFailed = true;
-    m_lastFailedReloadTime = std::chrono::steady_clock::now();
     return;
   }
 
-  if (creds.GetAWSAccessKeyId().empty() || creds.GetAWSSecretKey().empty() || creds.GetSessionToken().empty()) {
+  auto validation = ValidateTemporaryCredentials(creds, "Huawei Cloud STS");
+  if (!validation.ok()) {
+    m_lastResolution = validation;
     ++m_stsFailureCount;
     bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
     LOG_STORAGE_WARNING_ << fmt::format(
@@ -166,14 +196,12 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
         "has_valid_cached={}, retaining existing credentials. sts_success={}, "
         "sts_failure={}",
         STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, hasExisting, m_stsSuccessCount.load(), m_stsFailureCount.load());
-    m_lastReloadFailed = true;
-    m_lastFailedReloadTime = std::chrono::steady_clock::now();
     return;
   }
 
+  m_lastResolution = arrow::Status::OK();
   ++m_stsSuccessCount;
   m_credentials = creds;
-  m_lastReloadFailed = false;
   auto expiresInMs = (creds.GetExpiration() - Aws::Utils::DateTime::Now()).count();
   LOG_STORAGE_INFO_ << fmt::format(
       "[{}] Successfully retrieved credentials, expires_in_ms={}, region={}, sts_success={}, sts_failure={}",
@@ -185,19 +213,13 @@ bool HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() const
           STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
 }
 
-bool HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::IsInCooldown() const {
-  if (!m_lastReloadFailed) {
-    return false;
-  }
-  // Use shorter cooldown when credentials are empty or expired (urgent),
-  // longer cooldown when credentials are still valid (not urgent).
-  int cooldownSeconds =
-      (m_credentials.IsEmpty() || m_credentials.IsExpired()) ? RELOAD_COOLDOWN_SECONDS_URGENT : RELOAD_COOLDOWN_SECONDS;
-  auto elapsed = std::chrono::steady_clock::now() - m_lastFailedReloadTime;
-  return std::chrono::duration_cast<std::chrono::seconds>(elapsed).count() < cooldownSeconds;
-}
-
 void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
+  // The caller's own budget, started before any waiting. See
+  // CredentialAttemptStillWorthMaking: the double-check below handles a leader
+  // that succeeded; this handles one that failed, whose empty credentials would
+  // otherwise make every queued caller replay the same outage in series.
+  const auto started = std::chrono::steady_clock::now();
+
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
   if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
     return;
@@ -208,12 +230,7 @@ void HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() 
     return;
   }
 
-  if (IsInCooldown()) {
-    bool hasExisting = !m_credentials.IsEmpty() && !m_credentials.IsExpired();
-    LOG_STORAGE_WARNING_ << fmt::format(
-        "[{}] Skipping credential reload — in cooldown after previous failure. "
-        "has_valid_cached={}",
-        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, hasExisting);
+  if (!CredentialAttemptStillWorthMaking(started)) {
     return;
   }
 

--- a/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/HuaweiCloudSTSClient.cpp
@@ -9,6 +9,8 @@
 #include <aws/core/http/HttpRequest.h>
 #include <aws/core/utils/DateTime.h>
 
+#include <new>
+
 namespace milvus_storage {
 using Aws::Http::HttpClient;
 using Aws::Http::HttpRequest;
@@ -29,45 +31,44 @@ HuaweiCloudSTSCredentialsClient::HuaweiCloudSTSCredentialsClient(
 HuaweiCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityResult
 HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     const STSAssumeRoleWithWebIdentityRequest& request) {
-  Aws::StringStream ss;
-  ss << R"({
+  STSAssumeRoleWithWebIdentityResult result;
+  try {
+    Aws::StringStream ss;
+    ss << R"({
         "auth": {
           "id_token": {
             "id": ")"
-     << request.webIdentityToken << R"("
+       << request.webIdentityToken << R"("
           },
           "scope": {
             "project": {
               "id": ")"
-     << request.roleArn << R"("
+       << request.roleArn << R"("
             }
           }
         }
       })";
 
-  Aws::String endpoint = m_token_endpoint;
-  size_t pos = endpoint.find("{region}");
-  if (pos != Aws::String::npos) {
-    endpoint.replace(pos, 8, request.region);
-  }
-  std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
-      endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
-  httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
-  httpRequest->SetHeaderValue("X-Idp-Id", request.providerId);
-  httpRequest->SetHeaderValue("Content-Type", "application/json");
+    Aws::String endpoint = m_token_endpoint;
+    size_t pos = endpoint.find("{region}");
+    if (pos != Aws::String::npos) {
+      endpoint.replace(pos, 8, request.region);
+    }
+    std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
+        endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+    httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
+    httpRequest->SetHeaderValue("X-Idp-Id", request.providerId);
+    httpRequest->SetHeaderValue("Content-Type", "application/json");
 
-  std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("STS_RESOURCE_CLIENT_LOG_TAG");
-  *body << ss.str();
-  body->seekg(0, body->end);
-  auto streamSize = body->tellg();
-  body->seekg(0, body->beg);
-  httpRequest->SetContentLength(std::to_string(streamSize));
-  httpRequest->AddContentBody(body);
-  httpRequest->SetContentType("application/json; charset=utf-8");
+    std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("STS_RESOURCE_CLIENT_LOG_TAG");
+    *body << ss.str();
+    body->seekg(0, body->end);
+    auto streamSize = body->tellg();
+    body->seekg(0, body->beg);
+    httpRequest->SetContentLength(std::to_string(streamSize));
+    httpRequest->AddContentBody(body);
+    httpRequest->SetContentType("application/json; charset=utf-8");
 
-  STSAssumeRoleWithWebIdentityResult result;
-
-  try {
     // Stage 1: Get IAM token via OIDC id-token endpoint
     // Note: GetResourceWithAWSWebServiceResult() only treats HTTP 200 as success,
     // so HuaweiCloud's 201 CREATED will produce spurious WARN/ERROR logs from the
@@ -79,10 +80,12 @@ HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     auto awsResult = GetResourceWithAWSWebServiceResult(httpRequest);
     auto responseCode = awsResult.GetResponseCode();
     if (responseCode != Aws::Http::HttpResponseCode::OK && responseCode != Aws::Http::HttpResponseCode::CREATED) {
-      LOG_STORAGE_WARNING_ << fmt::format(
-          "[{}] Failed to get credentials token from Huawei Cloud STS, response "
-          "code: {}",
-          STS_RESOURCE_CLIENT_LOG_TAG, static_cast<int>(responseCode));
+      // The response code is what separates an unreachable IAM endpoint from
+      // one that refused this token; both used to arrive as "no credentials".
+      result.status = ClassifyCredentialHttpFailure(
+          responseCode,
+          fmt::format("Huawei Cloud IAM token request failed (http_status={})", static_cast<int>(responseCode)));
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", STS_RESOURCE_CLIENT_LOG_TAG, result.status.message());
       return result;
     }
 
@@ -91,6 +94,7 @@ HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     if (subjectTokenIter == responseHeaders.end()) {
       LOG_STORAGE_WARNING_ << fmt::format("[{}] No x-subject-token in huawei cloud sts response headers",
                                           STS_RESOURCE_CLIENT_LOG_TAG);
+      result.status = MakeCredentialResponseError("Huawei Cloud IAM response carried no x-subject-token header");
       return result;
     }
 
@@ -102,6 +106,9 @@ HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     const Aws::String subjectToken = subjectTokenIter->second;
     auto stsResult = callHuaweiCloudSTS(subjectToken, request);
     if (!stsResult.success) {
+      result.status = stsResult.status.ok()
+                          ? MakeCredentialResponseError("Huawei Cloud STS returned no temporary credentials")
+                          : stsResult.status;
       LOG_STORAGE_WARNING_ << fmt::format("[{}] Failed to get credentials from Huawei Cloud STS: {}",
                                           STS_RESOURCE_CLIENT_LOG_TAG, stsResult.errorMessage);
       return result;
@@ -111,12 +118,18 @@ HuaweiCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     result.success = true;
     LOG_STORAGE_INFO_ << fmt::format("[{}] Stage 2 succeeded. expires_in_ms={}", STS_RESOURCE_CLIENT_LOG_TAG,
                                      (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
+  } catch (const std::bad_alloc&) {
+    result.success = false;
+    result.status = MakeCredentialOutOfMemoryError("Huawei Cloud STS credential retrieval ran out of memory");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Credential retrieval ran out of memory", STS_RESOURCE_CLIENT_LOG_TAG);
   } catch (const std::exception& e) {
     result.success = false;
+    result.status = MakeCredentialExceptionError("Huawei Cloud STS credential retrieval raised", e);
     LOG_STORAGE_ERROR_ << fmt::format("[{}] Exception during Huawei Cloud STS credential retrieval: {}",
                                       STS_RESOURCE_CLIENT_LOG_TAG, e.what());
   } catch (...) {
     result.success = false;
+    result.status = MakeCredentialUnknownExceptionError("Huawei Cloud STS credential retrieval raised");
     LOG_STORAGE_ERROR_ << fmt::format("[{}] Unknown exception during Huawei Cloud STS credential retrieval",
                                       STS_RESOURCE_CLIENT_LOG_TAG);
   }
@@ -151,11 +164,13 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   req->SetContentLength(std::to_string(streamSize));
   req->AddContentBody(body);
 
-  auto resp = m_httpClient->MakeRequest(req);
+  auto resp = MakeRequestWithCredentialRetry(*m_httpClient, req);
   STSCallResult result;
   result.success = false;
   if (!resp) {
     result.errorMessage = "Null response from Huawei Cloud STS HTTP request";
+    result.status = ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::NO_RESPONSE,
+                                                  "Huawei Cloud STS security token request returned no response");
     LOG_STORAGE_WARNING_ << fmt::format("[{}] Security token request returned null response",
                                         STS_RESOURCE_CLIENT_LOG_TAG);
     return result;
@@ -164,6 +179,9 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   if (httpResponseCode != Aws::Http::HttpResponseCode::OK && httpResponseCode != Aws::Http::HttpResponseCode::CREATED) {
     result.errorMessage = "Huawei Cloud STS security token request failed with HTTP code: " +
                           std::to_string(static_cast<int>(httpResponseCode));
+    result.status = ClassifyCredentialHttpFailure(
+        httpResponseCode, fmt::format("Huawei Cloud STS security token request failed (http_status={})",
+                                      static_cast<int>(httpResponseCode)));
     LOG_STORAGE_WARNING_ << fmt::format("[{}] Security token request failed, HTTP code={}", STS_RESOURCE_CLIENT_LOG_TAG,
                                         static_cast<int>(httpResponseCode));
     return result;
@@ -173,6 +191,7 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   Aws::String credentialsStr = oss.str();
   if (credentialsStr.empty()) {
     result.errorMessage = "Get an empty credential from Huawei Cloud STS";
+    result.status = MakeCredentialResponseError("Huawei Cloud STS returned an empty credential body");
     return result;
   }
   Aws::Utils::Json::JsonValue jsonValue(credentialsStr);
@@ -180,6 +199,7 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   auto rootNode = json.GetObject("credential");
   if (rootNode.IsNull()) {
     result.errorMessage = "Get credential from STS result failed";
+    result.status = MakeCredentialResponseError("Huawei Cloud STS response carried no credential object");
     return result;
   }
   result.credentials.SetAWSAccessKeyId(rootNode.GetString("access"));
@@ -189,15 +209,23 @@ HuaweiCloudSTSCredentialsClient::STSCallResult HuaweiCloudSTSCredentialsClient::
   auto expiresAt = rootNode.GetString("expires_at");
   if (expiresAt.empty()) {
     result.errorMessage = "STS response missing 'expires_at' field, rejecting credentials";
+    result.status = MakeCredentialResponseError("Huawei Cloud STS response is missing expires_at");
     return result;
   }
   auto parsedExpiration =
       Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(expiresAt.c_str()).c_str(), Aws::Utils::DateFormat::ISO_8601);
   if (!parsedExpiration.WasParseSuccessful()) {
     result.errorMessage = "STS response 'expires_at' field has invalid format: " + std::string(expiresAt.c_str());
+    result.status = MakeCredentialResponseError("Huawei Cloud STS response has an invalid expires_at");
     return result;
   }
   result.credentials.SetExpiration(parsedExpiration);
+  result.status = ValidateTemporaryCredentials(result.credentials, "Huawei Cloud STS");
+  if (!result.status.ok()) {
+    result.credentials = {};
+    result.errorMessage = result.status.message();
+    return result;
+  }
   result.success = true;
   return result;
 }

--- a/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudCredentialsProvider.cpp
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <chrono>
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
 
 #include "milvus-storage/common/log.h"
@@ -48,6 +49,7 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   }
 
   if (m_tokenFile.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Tencent Cloud web identity token file is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] Token file must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -59,6 +61,7 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   }
 
   if (m_roleArn.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Tencent Cloud role ARN is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] RoleArn must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -70,6 +73,7 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   }
 
   if (m_region.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Tencent Cloud region is not configured");
     LOG_STORAGE_WARNING_ << fmt::format(
         "[{}] Region must be specified to use STS AssumeRole web identity creds "
         "provider.",
@@ -78,6 +82,12 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   } else {
     LOG_STORAGE_DEBUG_ << fmt::format("[{}] Resolved region from profile_config or environment variable to be {}",
                                       STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, m_region);
+  }
+
+  if (m_providerId.empty()) {
+    m_lastResolution = MakeCredentialConfigError("Tencent Cloud identity provider ID is not configured");
+    LOG_STORAGE_WARNING_ << fmt::format("[{}] ProviderId must be specified", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG);
+    return;
   }
 
   if (m_sessionName.empty()) {
@@ -95,8 +105,11 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
   retryableErrors.emplace_back("IDPCommunicationError");
   retryableErrors.emplace_back("InvalidIdentityToken");
 
+  // Shared credential retry budget; see credential_resolution.h.
+  config.connectTimeoutMs = kCredentialConnectTimeoutMs;
+  config.requestTimeoutMs = kCredentialRequestTimeoutMs;
   config.retryStrategy = Aws::MakeShared<Aws::Client::SpecifiedRetryableErrorsRetryStrategy>(
-      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3 /*maxRetries*/);
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, kCredentialRetryAttempts);
 
   m_client = Aws::MakeUnique<TencentCloudSTSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
   m_initialized = true;
@@ -105,14 +118,28 @@ TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::TencentCloudSTSAssumeRo
 }
 
 Aws::Auth::AWSCredentials TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
-  // A valid client means required information like role arn and token file were constructed correctly.
-  // We can use this provider to load creds, otherwise, we can just return empty creds.
-  if (!m_initialized) {
+  auto result = ResolveForRequest();
+  if (!result.ok()) {
     return {};
+  }
+  return std::move(result).ValueOrDie();
+}
+
+arrow::Result<Aws::Auth::AWSCredentials> TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::ResolveForRequest() {
+  if (!m_initialized) {
+    return m_lastResolution.ok() ? MakeCredentialConfigError("Tencent Cloud credential provider is not initialized")
+                                 : m_lastResolution;
   }
   RefreshIfExpired();
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-  return m_credentials;
+  if (ExpiresSoon() && !m_lastResolution.ok()) {
+    return m_lastResolution;
+  }
+  auto validation = ValidateTemporaryCredentials(m_credentials, "Tencent Cloud STS");
+  if (validation.ok()) {
+    return m_credentials;
+  }
+  return m_lastResolution.ok() ? validation : m_lastResolution;
 }
 
 void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
@@ -125,8 +152,16 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     if (!token.empty() && token.back() == '\n') {
       token.pop_back();
     }
+    if (token.empty()) {
+      m_lastResolution = MakeCredentialConfigError(fmt::format("The OIDC token file {} is empty", m_tokenFile));
+      return;
+    }
     m_token = token;
   } else {
+    // A token file that will not open is the deployment's to fix -- the
+    // projected volume is missing or unreadable -- not something a retry
+    // outlasts.
+    m_lastResolution = MakeCredentialConfigError(fmt::format("Cannot open the OIDC token file {}", m_tokenFile));
     LOG_STORAGE_ERROR_ << fmt::format("[{}] Can't open token file: {}", STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
                                       m_tokenFile);
     return;
@@ -135,6 +170,16 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
                                                                                 m_roleArn, m_sessionName};
 
   auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
+  if (!result.status.ok()) {
+    m_lastResolution = result.status;
+    return;
+  }
+  auto validation = ValidateTemporaryCredentials(result.creds, "Tencent Cloud STS");
+  if (!validation.ok()) {
+    m_lastResolution = validation;
+    return;
+  }
+  m_lastResolution = arrow::Status::OK();
   LOG_STORAGE_DEBUG_ << fmt::format("[{}] Successfully retrieved credentials, expiration_count_diff_ms: {}",
                                     STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
                                     (result.creds.GetExpiration() - Aws::Utils::DateTime::Now()).count());
@@ -147,6 +192,11 @@ bool TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() cons
 }
 
 void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
+  // The cooldown shares a fast failed refresh with queued callers. The caller
+  // budget separately prevents a waiter that already spent too long behind a
+  // slow refresh from starting another attempt after the cooldown expires.
+  const auto started = std::chrono::steady_clock::now();
+
   Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
   if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
     return;
@@ -154,6 +204,9 @@ void TencentCloudSTSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired()
 
   guard.UpgradeToWriterLock();
   if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) {
+    return;
+  }
+  if (!CredentialAttemptStillWorthMaking(started)) {
     return;
   }
 

--- a/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
+++ b/cpp/src/filesystem/s3/provider/TencentCloudSTSClient.cpp
@@ -16,10 +16,13 @@
 
 #include "milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h"
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/log.h"
 
 #include <mutex>
+#include <new>
 #include <sstream>
+#include <string_view>
 
 #include <aws/core/internal/AWSHttpResourceClient.h>
 #include <aws/core/client/DefaultRetryStrategy.h>
@@ -35,12 +38,43 @@ using Aws::Http::HttpClient;
 using Aws::Http::HttpRequest;
 using Aws::Http::HttpResponseCode;
 
+namespace {
+
+bool StartsWith(std::string_view value, std::string_view prefix) {
+  return value.size() >= prefix.size() && value.substr(0, prefix.size()) == prefix;
+}
+
+arrow::Status ClassifyTencentStsError(std::string_view code, std::string_view message) {
+  const auto context = fmt::format("Tencent Cloud STS failed: code={} message={}", code, message);
+  if (code == "RequestLimitExceeded" || StartsWith(code, "RequestLimitExceeded.") ||
+      code == "InvalidParameter.OverLimit" || code == "Throttling" || StartsWith(code, "Throttling.")) {
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientThrottling, context);
+  }
+  if (code == "InternalError" || StartsWith(code, "InternalError.") || code == "ServiceUnavailable" ||
+      StartsWith(code, "ServiceUnavailable.") || code == "ResourceUnavailable") {
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientService, context);
+  }
+  if (code == "UnauthorizedOperation" || StartsWith(code, "UnauthorizedOperation.") || code == "AccessDenied" ||
+      StartsWith(code, "AccessDenied.") || code == "AuthFailure" || StartsWith(code, "AuthFailure.")) {
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageAccessDenied, context);
+  }
+  if (code.empty()) {
+    return MakeCredentialResponseError("Tencent Cloud STS returned Error without a Code");
+  }
+  // InvalidParameter, InvalidRole, InvalidIdentityToken and all other
+  // well-formed refusals describe deployment/input configuration. They are
+  // not repaired by replaying the object request.
+  return MakeExtendError(ExtendStatusCode::StorageConfigInvalid, arrow::StatusCode::IOError, context);
+}
+
+}  // namespace
+
 static const char STS_RESOURCE_CLIENT_LOG_TAG[] = "TencentCloudSTSResourceClient";  // [tencent cloud]
 
 TencentCloudSTSCredentialsClient::TencentCloudSTSCredentialsClient(
     const Aws::Client::ClientConfiguration& clientConfiguration)
     : AWSHttpResourceClient(clientConfiguration, STS_RESOURCE_CLIENT_LOG_TAG) {
-  SetErrorMarshaller(Aws::MakeUnique<Aws::Client::XmlErrorMarshaller>(STS_RESOURCE_CLIENT_LOG_TAG));
+  m_rawHttpClient = Aws::Http::CreateHttpClient(clientConfiguration);
 
   // [tencent cloud]
   m_endpoint = "https://sts.tencentcloudapi.com";
@@ -52,73 +86,122 @@ TencentCloudSTSCredentialsClient::TencentCloudSTSCredentialsClient(
 TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityResult
 TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
     const STSAssumeRoleWithWebIdentityRequest& request) {
-  // Calculate query string
-  Aws::StringStream ss;
-  // curl -X POST "https://sts.tencentcloudapi.com"
-  // -d "{\"ProviderId\": $ProviderId, \"WebIdentityToken\":
-  // $WebIdentityToken,\"RoleArn\":$RoleArn,\"RoleSessionName\":$RoleSessionName,\"DurationSeconds\":7200}" -H
-  // "Authorization: SKIP" -H "Content-Type: application/json; charset=utf-8" -H "Host: sts.tencentcloudapi.com" -H
-  // "X-TC-Action: AssumeRoleWithWebIdentity" -H "X-TC-Timestamp: $timestamp" -H "X-TC-Version: 2018-08-13" -H
-  // "X-TC-Region: $region" -H "X-TC-Token: $token"
-
-  ss << R"({"ProviderId": ")" << request.providerId << R"(", "WebIdentityToken": ")" << request.webIdentityToken
-     << R"(", "RoleArn": ")" << request.roleArn << R"(", "RoleSessionName": ")" << request.roleSessionName << R"("})";
-
-  std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
-      m_endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
-
-  httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
-  httpRequest->SetHeaderValue("Authorization", "SKIP");
-  httpRequest->SetHeaderValue("Host", "sts.tencentcloudapi.com");
-  httpRequest->SetHeaderValue("X-TC-Action", "AssumeRoleWithWebIdentity");
-  httpRequest->SetHeaderValue("X-TC-Timestamp", std::to_string(Aws::Utils::DateTime::Now().Seconds()));
-  httpRequest->SetHeaderValue("X-TC-Version", "2018-08-13");
-  httpRequest->SetHeaderValue("X-TC-Region", request.region);
-  httpRequest->SetHeaderValue("X-TC-Token", "");
-
-  std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("STS_RESOURCE_CLIENT_LOG_TAG");
-  *body << ss.str();
-
-  httpRequest->AddContentBody(body);
-  body->seekg(0, body->end);
-  auto streamSize = body->tellg();
-  body->seekg(0, body->beg);
-  Aws::StringStream contentLength;
-  contentLength << streamSize;
-  httpRequest->SetContentLength(contentLength.str());
-  //    httpRequest->SetContentType("application/x-www-form-urlencoded");
-  httpRequest->SetContentType("application/json; charset=utf-8");
-
-  auto headers = httpRequest->GetHeaders();
-  Aws::String credentialsStr = GetResourceWithAWSWebServiceResult(httpRequest).GetPayload();
-
-  // Parse credentials
   STSAssumeRoleWithWebIdentityResult result;
-  if (credentialsStr.empty()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get an empty credential from sts", STS_RESOURCE_CLIENT_LOG_TAG);
-    return result;
-  }
+  try {
+    // Calculate query string
+    Aws::StringStream ss;
+    // curl -X POST "https://sts.tencentcloudapi.com"
+    // -d "{\"ProviderId\": $ProviderId, \"WebIdentityToken\":
+    // $WebIdentityToken,\"RoleArn\":$RoleArn,\"RoleSessionName\":$RoleSessionName,\"DurationSeconds\":7200}" -H
+    // "Authorization: SKIP" -H "Content-Type: application/json; charset=utf-8" -H "Host: sts.tencentcloudapi.com" -H
+    // "X-TC-Action: AssumeRoleWithWebIdentity" -H "X-TC-Timestamp: $timestamp" -H "X-TC-Version: 2018-08-13" -H
+    // "X-TC-Region: $region" -H "X-TC-Token: $token"
 
-  Aws::Utils::Json::JsonValue jsonValue(credentialsStr);
-  auto json = jsonValue.View();
-  auto rootNode = json.GetObject("Response");
-  if (rootNode.IsNull()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get Response from credential result failed", STS_RESOURCE_CLIENT_LOG_TAG);
-    return result;
-  }
+    ss << R"({"ProviderId": ")" << request.providerId << R"(", "WebIdentityToken": ")" << request.webIdentityToken
+       << R"(", "RoleArn": ")" << request.roleArn << R"(", "RoleSessionName": ")" << request.roleSessionName << R"("})";
 
-  auto credentialsNode = rootNode.GetObject("Credentials");
-  if (credentialsNode.IsNull()) {
-    LOG_STORAGE_WARNING_ << fmt::format("[{}] Get Credentials from Response failed", STS_RESOURCE_CLIENT_LOG_TAG);
-    return result;
-  }
-  result.creds.SetAWSAccessKeyId(credentialsNode.GetString("TmpSecretId"));
-  result.creds.SetAWSSecretKey(credentialsNode.GetString("TmpSecretKey"));
-  result.creds.SetSessionToken(credentialsNode.GetString("Token"));
-  result.creds.SetExpiration(
-      Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(rootNode.GetString("Expiration").c_str()).c_str(),
-                           Aws::Utils::DateFormat::ISO_8601));
+    std::shared_ptr<Aws::Http::HttpRequest> httpRequest(Aws::Http::CreateHttpRequest(
+        m_endpoint, Aws::Http::HttpMethod::HTTP_POST, Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
 
+    httpRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
+    httpRequest->SetHeaderValue("Authorization", "SKIP");
+    httpRequest->SetHeaderValue("Host", "sts.tencentcloudapi.com");
+    httpRequest->SetHeaderValue("X-TC-Action", "AssumeRoleWithWebIdentity");
+    httpRequest->SetHeaderValue("X-TC-Timestamp", std::to_string(Aws::Utils::DateTime::Now().Seconds()));
+    httpRequest->SetHeaderValue("X-TC-Version", "2018-08-13");
+    httpRequest->SetHeaderValue("X-TC-Region", request.region);
+    httpRequest->SetHeaderValue("X-TC-Token", "");
+
+    std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("STS_RESOURCE_CLIENT_LOG_TAG");
+    *body << ss.str();
+
+    httpRequest->AddContentBody(body);
+    body->seekg(0, body->end);
+    auto streamSize = body->tellg();
+    body->seekg(0, body->beg);
+    Aws::StringStream contentLength;
+    contentLength << streamSize;
+    httpRequest->SetContentLength(contentLength.str());
+    //    httpRequest->SetContentType("application/x-www-form-urlencoded");
+    httpRequest->SetContentType("application/json; charset=utf-8");
+
+    if (m_rawHttpClient == nullptr) {
+      result.status = ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::REQUEST_NOT_MADE,
+                                                    "Tencent Cloud STS AssumeRoleWithWebIdentity has no HTTP client");
+      return result;
+    }
+    const auto response = MakeRequestWithCredentialRetry(*m_rawHttpClient, httpRequest);
+    if (response == nullptr) {
+      result.status =
+          ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode::NO_RESPONSE,
+                                        "Tencent Cloud STS AssumeRoleWithWebIdentity received no HTTP response");
+      return result;
+    }
+    const auto response_code = response->GetResponseCode();
+    if (response_code != Aws::Http::HttpResponseCode::OK) {
+      result.status = ClassifyCredentialHttpFailure(
+          response_code, fmt::format("Tencent Cloud STS AssumeRoleWithWebIdentity failed (http_status={})",
+                                     static_cast<int>(response_code)));
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", STS_RESOURCE_CLIENT_LOG_TAG, result.status.message());
+      return result;
+    }
+    Aws::IStreamBufIterator eos;
+    Aws::String credentialsStr(Aws::IStreamBufIterator(response->GetResponseBody()), eos);
+    if (credentialsStr.empty()) {
+      result.status = MakeCredentialResponseError("Tencent Cloud STS returned an empty body");
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", STS_RESOURCE_CLIENT_LOG_TAG, result.status.message());
+      return result;
+    }
+
+    Aws::Utils::Json::JsonValue jsonValue(credentialsStr);
+    auto json = jsonValue.View();
+    auto rootNode = json.GetObject("Response");
+    if (rootNode.IsNull()) {
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] Get Response from credential result failed",
+                                          STS_RESOURCE_CLIENT_LOG_TAG);
+      // A 200 whose body we cannot read does not establish either a transport
+      // failure or an access decision, so leave it conservatively unclassified.
+      result.status = MakeCredentialResponseError("Tencent Cloud STS response carried no Response object");
+      return result;
+    }
+
+    if (rootNode.KeyExists("Error")) {
+      const auto error_node = rootNode.GetObject("Error");
+      result.status = ClassifyTencentStsError(error_node.GetString("Code"), error_node.GetString("Message"));
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] {}", STS_RESOURCE_CLIENT_LOG_TAG, result.status.message());
+      return result;
+    }
+
+    auto credentialsNode = rootNode.GetObject("Credentials");
+    if (credentialsNode.IsNull()) {
+      LOG_STORAGE_WARNING_ << fmt::format("[{}] Get Credentials from Response failed", STS_RESOURCE_CLIENT_LOG_TAG);
+      result.status = MakeCredentialResponseError("Tencent Cloud STS response carried no Credentials");
+      return result;
+    }
+    result.creds.SetAWSAccessKeyId(credentialsNode.GetString("TmpSecretId"));
+    result.creds.SetAWSSecretKey(credentialsNode.GetString("TmpSecretKey"));
+    result.creds.SetSessionToken(credentialsNode.GetString("Token"));
+    result.creds.SetExpiration(
+        Aws::Utils::DateTime(Aws::Utils::StringUtils::Trim(rootNode.GetString("Expiration").c_str()).c_str(),
+                             Aws::Utils::DateFormat::ISO_8601));
+
+    result.status = ValidateTemporaryCredentials(result.creds, "Tencent Cloud STS AssumeRoleWithWebIdentity");
+    if (!result.status.ok()) {
+      result.creds = {};
+    }
+
+    return result;
+  } catch (const std::bad_alloc&) {
+    result.status = MakeCredentialOutOfMemoryError("Tencent Cloud STS AssumeRoleWithWebIdentity ran out of memory");
+  } catch (const std::exception& e) {
+    result.status = MakeCredentialExceptionError("Tencent Cloud STS AssumeRoleWithWebIdentity raised", e);
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Exception during credential retrieval: {}", STS_RESOURCE_CLIENT_LOG_TAG,
+                                      e.what());
+  } catch (...) {
+    result.status = MakeCredentialUnknownExceptionError("Tencent Cloud STS AssumeRoleWithWebIdentity raised");
+    LOG_STORAGE_ERROR_ << fmt::format("[{}] Unknown exception during credential retrieval",
+                                      STS_RESOURCE_CLIENT_LOG_TAG);
+  }
   return result;
 }
 

--- a/cpp/src/filesystem/s3/provider/credential_resolution.cpp
+++ b/cpp/src/filesystem/s3/provider/credential_resolution.cpp
@@ -1,0 +1,225 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
+
+#include <string>
+#include <thread>
+
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/utils/xml/XmlSerializer.h>
+#include <arrow/util/string_builder.h>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/common/log.h"
+
+namespace milvus_storage {
+
+namespace {
+
+// Only what a retry can fix. A 4xx is the service refusing the request on its
+// merits; repeating it changes nothing and delays the real answer.
+bool WorthRetrying(const std::shared_ptr<Aws::Http::HttpResponse>& response) {
+  if (response == nullptr) {
+    return true;
+  }
+  const auto code = static_cast<int>(response->GetResponseCode());
+  if (code <= 0 || code == 408 || code == 429 || code == 444) {
+    return true;
+  }
+  return code >= 500;
+}
+
+}  // namespace
+
+arrow::Status ValidateStaticCredentials(std::string_view access_key,
+                                        std::string_view secret_key,
+                                        std::string_view session_token,
+                                        std::string_view source) {
+  if (access_key.empty() && secret_key.empty() && session_token.empty()) {
+    return arrow::Status::OK();
+  }
+  if (access_key.empty() || secret_key.empty()) {
+    return MakeCredentialConfigError(std::string(source) +
+                                     " static credentials require both access key and secret key");
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status ValidateAwsEnvironmentCredentials() {
+  return ValidateStaticCredentials(Aws::Environment::GetEnv("AWS_ACCESS_KEY_ID"),
+                                   Aws::Environment::GetEnv("AWS_SECRET_ACCESS_KEY"),
+                                   Aws::Environment::GetEnv("AWS_SESSION_TOKEN"), "AWS environment");
+}
+
+arrow::Status ValidateTemporaryCredentials(const Aws::Auth::AWSCredentials& credentials, std::string_view source) {
+  const std::string prefix(source);
+  if (credentials.GetAWSAccessKeyId().empty()) {
+    return MakeCredentialResponseError(prefix + " returned temporary credentials without an access key");
+  }
+  if (credentials.GetAWSSecretKey().empty()) {
+    return MakeCredentialResponseError(prefix + " returned temporary credentials without a secret key");
+  }
+  if (credentials.GetSessionToken().empty()) {
+    return MakeCredentialResponseError(prefix + " returned temporary credentials without a session token");
+  }
+
+  const auto expiration = credentials.GetExpiration();
+  const auto never_expires = (std::chrono::system_clock::time_point::max)();
+  if (!expiration.WasParseSuccessful() || expiration.UnderlyingTimestamp() == never_expires) {
+    return MakeCredentialResponseError(prefix + " returned temporary credentials without a valid expiration");
+  }
+  if (expiration <= Aws::Utils::DateTime::Now()) {
+    return MakeCredentialResponseError(prefix + " returned expired temporary credentials");
+  }
+  return arrow::Status::OK();
+}
+
+bool CredentialAttemptStillWorthMaking(std::chrono::steady_clock::time_point started) {
+  return std::chrono::steady_clock::now() - started < kCredentialResolutionBudget;
+}
+
+// Put a request body back at the start so the next attempt sends it again.
+//
+// Resending the same HttpRequest resends a stream that the previous attempt
+// already read to the end, so a retried POST would go out with an empty body
+// and be rejected on its contents rather than retried on its merits. Curl's
+// own CURLOPT_SEEKFUNCTION does not help: that is for curl replaying a request
+// it is already in the middle of, and it is never called when MakeRequest is
+// entered again.
+//
+// Returns false when the body cannot be rewound, which is the signal to stop
+// retrying rather than send something malformed. Every credential POST in this
+// repository carries an in-memory StringStream, so this succeeds in practice.
+bool RewindBodyForRetry(const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  const auto& body = request->GetContentBody();
+  if (body == nullptr) {
+    return true;
+  }
+  body->clear();
+  body->seekg(0, std::ios_base::beg);
+  return !body->fail();
+}
+
+std::shared_ptr<Aws::Http::HttpResponse> MakeRequestWithCredentialRetry(
+    Aws::Http::HttpClient& client, const std::shared_ptr<Aws::Http::HttpRequest>& request) {
+  std::shared_ptr<Aws::Http::HttpResponse> response;
+  for (long attempt = 0; attempt <= kCredentialRetryAttempts; ++attempt) {
+    response = client.MakeRequest(request);
+    if (!WorthRetrying(response)) {
+      return response;
+    }
+    if (attempt == kCredentialRetryAttempts) {
+      break;
+    }
+    if (!RewindBodyForRetry(request)) {
+      LOG_STORAGE_WARNING_ << "Not retrying a credential request whose body cannot be rewound";
+      break;
+    }
+    // Exponential backoff from 25ms. The added sleep stays well under a second;
+    // each I/O attempt remains bounded separately by the client's connect and
+    // request timeouts. This runs while a caller holds the credentials lock.
+    std::this_thread::sleep_for(std::chrono::milliseconds(25L << attempt));
+  }
+  return response;
+}
+
+arrow::Status ClassifyCredentialHttpFailure(Aws::Http::HttpResponseCode code, std::string_view what) {
+  using Aws::Http::HttpResponseCode;
+  switch (code) {
+    case HttpResponseCode::REQUEST_NOT_MADE:
+    case HttpResponseCode::NO_RESPONSE:
+      // Nothing reached the service, so nothing about the deployment has been
+      // proven wrong. A retry is the only way to find out.
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientNetwork, what);
+    case HttpResponseCode::REQUEST_TIMEOUT:
+    case HttpResponseCode::NETWORK_READ_TIMEOUT:
+    case HttpResponseCode::NETWORK_CONNECT_TIMEOUT:
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientTimeout, what);
+    case HttpResponseCode::TOO_MANY_REQUESTS:
+    case HttpResponseCode::BANDWIDTH_LIMIT_EXCEEDED:
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientThrottling, what);
+    case HttpResponseCode::UNAUTHORIZED:
+    case HttpResponseCode::FORBIDDEN:
+      // The service identified us and said no: a trust policy that does not
+      // name us, an identity token it will not accept. This is the one
+      // credential failure that really is an access decision.
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageAccessDenied, what);
+    default:
+      break;
+  }
+
+  const auto value = static_cast<int>(code);
+  if (value <= 0) {
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientNetwork, what);
+  }
+  if (value >= 500) {
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientService, what);
+  }
+  if (value >= 400) {
+    // Refused on the merits, but not as an access decision -- a malformed
+    // request, an unknown role. Something in the deployment produced it.
+    return MakeExtendError(ExtendStatusCode::StorageConfigInvalid, arrow::StatusCode::IOError, std::string(what));
+  }
+  // A 2xx/3xx that still yielded no credentials.
+  return MakeCredentialResponseError(what);
+}
+
+arrow::Status ClassifyAliyunStsHttpFailure(Aws::Http::HttpResponseCode code,
+                                           std::string_view payload,
+                                           std::string_view what) {
+  if (!payload.empty()) {
+    const Aws::String xml(payload.data(), payload.size());
+    const auto document = Aws::Utils::Xml::XmlDocument::CreateFromXmlString(xml);
+    auto root = document.GetRootElement();
+    auto code_node = root.IsNull() ? root : root.FirstChild("Code");
+    if (!root.IsNull() && code_node.IsNull()) {
+      auto error_node = root.FirstChild("Error");
+      if (!error_node.IsNull()) {
+        code_node = error_node.FirstChild("Code");
+      }
+    }
+    if (!code_node.IsNull()) {
+      const std::string error_code = code_node.GetText().c_str();
+      if (error_code == "Throttling" || error_code.starts_with("Throttling.")) {
+        return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientThrottling, what, " (aliyun_code=", error_code,
+                                  ")");
+      }
+    }
+  }
+  return ClassifyCredentialHttpFailure(code, what);
+}
+
+arrow::Status MakeCredentialConfigError(std::string_view what) {
+  return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, what);
+}
+
+arrow::Status MakeCredentialResponseError(std::string_view what) {
+  // No ExtendStatusDetail on purpose: unclassified lands in the conservative
+  // non-retryable bucket without asserting a cause we have not established.
+  return arrow::Status::IOError(what);
+}
+
+arrow::Status MakeCredentialOutOfMemoryError(std::string_view what) { return arrow::Status::OutOfMemory(what); }
+
+arrow::Status MakeCredentialExceptionError(std::string_view what, const std::exception& exception) {
+  return MakeCredentialResponseError(arrow::util::StringBuilder(what, ": ", exception.what()));
+}
+
+arrow::Status MakeCredentialUnknownExceptionError(std::string_view what) {
+  return MakeCredentialResponseError(arrow::util::StringBuilder(what, ": unknown exception"));
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_client.cpp
+++ b/cpp/src/filesystem/s3/s3_client.cpp
@@ -52,6 +52,7 @@
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/filesystem/util_internal.h"
 
 using ::arrow::Result;
@@ -153,8 +154,8 @@ arrow::Result<std::string> S3Client::GetBucketRegionFromError(const std::string&
   if (!region.empty()) {
     return region;
   } else if (error.GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
-    // Permanent: the bucket does not exist; a retry/reroute fails identically.
-    return MakeExtendError(ExtendStatusCode::AwsErrorNotFound, "Bucket '" + bucket + "' not found",
+    // The bucket does not exist; replaying or rerouting the same request fails identically.
+    return MakeExtendError(ExtendStatusCode::StorageBucketNotFound, "Bucket '" + bucket + "' not found",
                            "" /* extra_info */);
   } else {
     return arrow::Status::IOError("When resolving region for bucket: ", bucket);
@@ -175,8 +176,8 @@ arrow::Result<std::string> S3Client::GetBucketRegion(const std::string& bucket,
   if (!region.empty()) {
     return region;
   } else if (outcome.GetResult().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
-    // Permanent: the bucket does not exist; a retry/reroute fails identically.
-    return MakeExtendError(ExtendStatusCode::AwsErrorNotFound,
+    // The bucket does not exist; replaying or rerouting the same request fails identically.
+    return MakeExtendError(ExtendStatusCode::StorageBucketNotFound,
                            "Bucket '" + std::string(request.GetBucket().c_str()) + "' not found", "" /* extra_info */);
   } else {
     return arrow::Status::IOError("When resolving region for bucket '", request.GetBucket(),
@@ -347,16 +348,20 @@ S3ClientLock S3ClientLock::Move() { return std::move(*this); }
 // ------------ Implementation of S3ClientHolder End ------------
 
 // ------------ Implementation of S3ClientHolder ------------
-S3ClientHolder::S3ClientHolder(std::weak_ptr<S3ClientFinalizer> finalizer, std::shared_ptr<S3Client> client)
-    : finalizer_(std::move(finalizer)), client_(std::move(client)) {}
+S3ClientHolder::S3ClientHolder(std::weak_ptr<S3ClientFinalizer> finalizer,
+                               std::shared_ptr<S3Client> client,
+                               std::shared_ptr<RequestCredentialsResolver> credentials_resolver,
+                               std::function<void()> release_resources)
+    : finalizer_(std::move(finalizer)),
+      client_(std::move(client)),
+      credentials_resolver_(std::move(credentials_resolver)),
+      release_resources_(std::move(release_resources)) {}
 
 arrow::Result<S3ClientLock> S3ClientHolder::Lock() {
   std::shared_ptr<S3ClientFinalizer> finalizer;
-  std::shared_ptr<S3Client> client;
   {
     std::unique_lock lock(mutex_);
     finalizer = finalizer_.lock();
-    client = client_;
   }
   // Do not hold mutex while taking finalizer lock below.
   //
@@ -379,6 +384,25 @@ arrow::Result<S3ClientLock> S3ClientHolder::Lock() {
   if (finalizer->finalized_) {
     return ErrorS3Finalized();
   }
+
+  // The declaration order is intentional: the resource snapshots must be
+  // released before client_lock drops the shared finalizer lease on every
+  // return path. More importantly, take that lease before copying either
+  // resource. If finalization won the race, no AWS object may be retained past
+  // the barrier and destruct after Aws::ShutdownAPI().
+  std::shared_ptr<S3Client> client;
+  std::shared_ptr<RequestCredentialsResolver> credentials_resolver;
+  {
+    std::unique_lock lock(mutex_);
+    client = client_;
+    credentials_resolver = credentials_resolver_;
+  }
+  if (credentials_resolver != nullptr) {
+    auto credentials = credentials_resolver->ResolveForRequest();
+    if (!credentials.ok()) {
+      return credentials.status();
+    }
+  }
   // (the client can be cleared only if finalizer->finalized_ is true)
   DCHECK(client) << "inconsistent S3ClientHolder";
   client_lock.client_ = std::move(client);
@@ -387,24 +411,79 @@ arrow::Result<S3ClientLock> S3ClientHolder::Lock() {
 
 void S3ClientHolder::Finalize() {
   std::shared_ptr<S3Client> client;
+  std::shared_ptr<RequestCredentialsResolver> credentials_resolver;
+  std::function<void()> release_resources;
   {
     std::unique_lock lock(mutex_);
     client = std::move(client_);
+    credentials_resolver = std::move(credentials_resolver_);
+    release_resources.swap(release_resources_);
   }
-  // Do not hold mutex while ~S3Client potentially runs
+  // Do not hold mutex while AWS-backed resources potentially destruct.
+  credentials_resolver.reset();
+  client.reset();
+  if (release_resources) {
+    release_resources();
+  }
 }
 // ------------ Implementation of S3ClientHolder End ------------
 
 using ClientHolderList = std::vector<std::weak_ptr<S3ClientHolder>>;
 
-arrow::Result<std::shared_ptr<S3ClientHolder>> S3ClientFinalizer::AddClient(std::shared_ptr<S3Client> client) {
+arrow::Result<std::shared_ptr<S3ClientHolder>> S3ClientFinalizer::AddClient(
+    ClientFactory make_client,
+    std::shared_ptr<RequestCredentialsResolver> credentials_resolver,
+    std::function<void()> release_resources) {
+  // Finalize() takes this same process-wide lock before closing admission.
+  // Holding it across the factory and publication removes the construction
+  // gap without taking the operation barrier exclusively for the whole build.
+  std::unique_lock construction_lock(construction_mutex_);
+  {
+    std::unique_lock lock(mutex_);
+    if (finalized_) {
+      lock.unlock();
+      make_client = nullptr;
+      credentials_resolver.reset();
+      if (release_resources) {
+        release_resources();
+      }
+      return ErrorS3Finalized();
+    }
+  }
+
+  auto client_result = make_client();
+  // Destroy factory captures while the construction barrier is still held. They
+  // may themselves retain AWS-backed configuration or credential resources.
+  make_client = nullptr;
+  if (!client_result.ok()) {
+    credentials_resolver.reset();
+    if (release_resources) {
+      release_resources();
+    }
+    return client_result.status();
+  }
+  auto client = std::move(client_result).ValueOrDie();
+  if (!client) {
+    credentials_resolver.reset();
+    if (release_resources) {
+      release_resources();
+    }
+    return arrow::Status::Invalid("S3 client factory returned a null client");
+  }
+
   std::unique_lock lock(mutex_);
   if (finalized_) {
+    lock.unlock();
+    credentials_resolver.reset();
+    client.reset();
+    if (release_resources) {
+      release_resources();
+    }
     return ErrorS3Finalized();
   }
 
-  auto holder = std::make_shared<S3ClientHolder>(shared_from_this(), std::move(client));
-
+  auto holder = std::make_shared<S3ClientHolder>(shared_from_this(), std::move(client), std::move(credentials_resolver),
+                                                 std::move(release_resources));
   // Remove expired entries before adding new one
   auto end = std::remove_if(holders_.begin(), holders_.end(),
                             [](const std::weak_ptr<S3ClientHolder>& holder) { return holder.expired(); });
@@ -414,14 +493,32 @@ arrow::Result<std::shared_ptr<S3ClientHolder>> S3ClientFinalizer::AddClient(std:
 }
 
 void S3ClientFinalizer::Finalize() {
-  std::unique_lock lock(mutex_);
-  finalized_ = true;
+  // Close admission without holding construction_mutex_. An S3 operation may
+  // be holding mutex_ in shared mode while indirectly finishing construction;
+  // taking the locks in the opposite order would let those two paths wait on
+  // each other.
+  {
+    std::unique_lock lock(mutex_);
+    finalized_ = true;
+  }
 
-  ClientHolderList finalizing = std::move(holders_);
-  lock.unlock();  // avoid lock ordering issue with S3ClientHolder::Finalize
+  // A factory admitted before finalized_ changed either published its holder
+  // already or will now discard its client at AddClient's second check. New
+  // factories are rejected at the first check. Taking this lock therefore
+  // waits for all client-construction cleanup to finish.
+  std::unique_lock construction_lock(construction_mutex_);
+  ClientHolderList finalizing;
+  {
+    std::unique_lock lock(mutex_);
+    finalizing = std::move(holders_);
+  }
+  construction_lock.unlock();
 
   // Finalize all client holders, such that no S3Client remains alive
   // after this.
+  // TODO: Track holder destruction completion as well as lockable weak holders.
+  // A weak_ptr may already be expired while the last holder is still destroying
+  // its AWS client, allowing Aws::ShutdownAPI() to race that destructor.
   for (auto&& weak_holder : finalizing) {
     auto holder = weak_holder.lock();
     if (holder) {

--- a/cpp/src/filesystem/s3/s3_client_builder.cpp
+++ b/cpp/src/filesystem/s3/s3_client_builder.cpp
@@ -34,10 +34,12 @@
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/common/path_util.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/filesystem/s3/s3_client.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/util_internal.h"
+#include "milvus-storage/common/extend_status.h"
 
 using ::arrow::Result;
 using ::arrow::Status;
@@ -97,6 +99,14 @@ const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& ClientBuilderBase::cre
   return credentials_provider_;
 }
 
+const std::string& ClientBuilderBase::region() const { return region_; }
+
+void ClientBuilderBase::ReleaseAwsResources() {
+  credentials_provider_.reset();
+  options_.credentials_provider.reset();
+  options_.retry_strategy.reset();
+}
+
 arrow::Status ClientBuilderBase::PrepareClientConfig(Aws::Client::ClientConfiguration* client_config,
                                                      std::optional<arrow::io::IOContext> io_context) {
   credentials_provider_ = options_.credentials_provider;
@@ -109,7 +119,18 @@ arrow::Status ClientBuilderBase::PrepareClientConfig(Aws::Client::ClientConfigur
                        << "This indicates a race condition or missing initialization. "
                        << "Using AnonymousCredentialsProvider as fallback. "
                        << "Please report this error with stack trace.";
-    return arrow::Status::Invalid("credentials_provider is nullptr");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "credentials_provider is nullptr");
+  }
+
+  if (options_.credentials_kind == S3CredentialsKind::Explicit) {
+    const auto credentials = credentials_provider_->GetAWSCredentials();
+    ARROW_RETURN_NOT_OK(ValidateStaticCredentials(FromAwsString(credentials.GetAWSAccessKeyId()),
+                                                  FromAwsString(credentials.GetAWSSecretKey()),
+                                                  FromAwsString(credentials.GetSessionToken()), "explicit S3 options"));
+  } else if ((options_.credentials_kind == S3CredentialsKind::Default ||
+              options_.credentials_kind == S3CredentialsKind::Role) &&
+             (options_.cloud_provider.empty() || options_.cloud_provider == kCloudProviderAWS)) {
+    ARROW_RETURN_NOT_OK(ValidateAwsEnvironmentCredentials());
   }
 
   if (!options_.region.empty()) {
@@ -181,33 +202,42 @@ arrow::Status ClientBuilderBase::PrepareClientConfig(Aws::Client::ClientConfigur
     client_config->checksumConfig.responseChecksumValidation = Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
   }
 
+  region_.assign(client_config->region.c_str(), client_config->region.size());
+
   return Status::OK();
 }
 
 template <>
 arrow::Result<std::shared_ptr<S3ClientHolder>> ClientBuilder<S3Client>::BuildClient(
-    std::optional<arrow::io::IOContext> io_context, std::shared_ptr<FilesystemMetrics> metrics) {
+    std::optional<arrow::io::IOContext> io_context,
+    std::shared_ptr<FilesystemMetrics> metrics,
+    std::function<void()> release_resources) {
   (void)metrics;
-  ARROW_RETURN_NOT_OK(PrepareClientConfig(io_context));
+  auto credentials_resolver = std::dynamic_pointer_cast<RequestCredentialsResolver>(options_.credentials_provider);
+  return GetClientFinalizer()->AddClient(
+      [this, io_context = std::move(io_context)]() mutable -> arrow::Result<std::shared_ptr<S3Client>> {
+        ARROW_RETURN_NOT_OK(PrepareClientConfig(std::move(io_context)));
 
-  if (options_.retry_strategy) {
-    client_config_.retryStrategy = fs::internal::MakeWrappedRetryStrategy(options_.retry_strategy);
-  } else {
-    client_config_.retryStrategy = std::make_shared<ConnectRetryStrategy>();
-  }
+        if (options_.retry_strategy) {
+          client_config_->retryStrategy = fs::internal::MakeWrappedRetryStrategy(options_.retry_strategy);
+        } else {
+          client_config_->retryStrategy = std::make_shared<ConnectRetryStrategy>();
+        }
 
-  const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
+        const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
 
 #ifdef ARROW_S3_HAS_S3CLIENT_CONFIGURATION
-  client_config_.useVirtualAddressing = use_virtual_addressing;
-  auto endpoint_provider = EndpointProviderCache::Instance()->Lookup(client_config_);
-  auto client = std::make_shared<S3Client>(credentials_provider_, endpoint_provider, client_config_);
+        client_config_->useVirtualAddressing = use_virtual_addressing;
+        auto endpoint_provider = EndpointProviderCache::Instance()->Lookup(*client_config_);
+        auto client = std::make_shared<S3Client>(credentials_provider_, endpoint_provider, *client_config_);
 #else
-  auto client =
-      std::make_shared<S3Client>(credentials_provider_, client_config_,
-                                 Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, use_virtual_addressing);
+        auto client = std::make_shared<S3Client>(credentials_provider_, *client_config_,
+                                                 Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+                                                 use_virtual_addressing);
 #endif
-  client->s3_retry_strategy_ = options_.retry_strategy;
-  return GetClientFinalizer()->AddClient(std::move(client));
+        client->s3_retry_strategy_ = options_.retry_strategy;
+        return client;
+      },
+      std::move(credentials_resolver), std::move(release_resources));
 }
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_crt_client.cpp
+++ b/cpp/src/filesystem/s3/s3_crt_client.cpp
@@ -34,6 +34,7 @@
 #include <aws/s3-crt/S3CrtClient.h>
 #include <aws/s3-crt/S3CrtClientConfiguration.h>
 
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 
 namespace milvus_storage {
@@ -176,10 +177,14 @@ void S3CrtClientLease::Release() {
 }
 
 S3CrtClientHolder::S3CrtClientHolder(std::shared_ptr<S3CrtClientFinalizer> finalizer,
-                                     std::shared_ptr<FilesystemMetrics> metrics)
+                                     std::shared_ptr<FilesystemMetrics> metrics,
+                                     std::shared_ptr<RequestCredentialsResolver> credentials_resolver,
+                                     std::function<void()> release_resources)
     : finalizer_(std::move(finalizer)),
       operation_state_(std::make_shared<S3CrtClientOperationState>()),
-      metrics_(std::move(metrics)) {}
+      metrics_(std::move(metrics)),
+      credentials_resolver_(std::move(credentials_resolver)),
+      release_resources_(std::move(release_resources)) {}
 
 S3CrtClientHolder::~S3CrtClientHolder() { Finalize(); }
 
@@ -203,6 +208,18 @@ arrow::Result<S3CrtClientLease> S3CrtClientHolder::Acquire() {
     lease.client_ = client_.get();
     lease.operation_state_ = operation_state_;
   }
+
+  // Credential refresh may enter STS, a container endpoint, or IMDS through
+  // AWS HTTP code. It therefore belongs to the same shutdown barrier as the
+  // object request. The operation mutex is released before network I/O, while
+  // the lease keeps active_operations non-zero. A failed refresh returns
+  // through the local lease destructor and decrements the count exactly once.
+  if (credentials_resolver_ != nullptr) {
+    auto credentials = credentials_resolver_->ResolveForRequest();
+    if (!credentials.ok()) {
+      return credentials.status();
+    }
+  }
   return lease;
 }
 
@@ -213,32 +230,47 @@ arrow::Result<S3CrtClientLease> S3CrtClientHolder::Acquire() {
 //   ----------------------------             ------------------------------
 //   closing = true
 //   wait(active_operations == 0)   <-------  lease Release(): active--, notify
-//   move client_ out
+//   move client_ + credentials_resolver_ out
 //   unlock operation mutex
+//   credentials_resolver.reset()
 //   client.reset()
 //   ClientDestroyed()
 //
 // No new lease can start after closing is set. Existing leases keep only the
-// operation state alive and eventually wake this waiter. client.reset() is
-// outside the operation mutex because the SDK destructor may block while CRT
-// completes its own shutdown callbacks.
+// operation state alive and eventually wake this waiter. Both AWS-owning
+// objects are destroyed outside the operation mutex because their SDK
+// destructors may block while HTTP/CRT shutdown callbacks complete.
 void S3CrtClientHolder::Finalize() {
   std::shared_ptr<Aws::S3Crt::S3CrtClient> client;
+  std::shared_ptr<RequestCredentialsResolver> credentials_resolver;
+  std::function<void()> release_resources;
   {
     std::unique_lock lock(operation_state_->mutex);
     operation_state_->closing = true;
     operation_state_->cv.wait(lock, [this] { return operation_state_->active_operations == 0; });
     client = std::move(client_);
+    credentials_resolver = std::move(credentials_resolver_);
+    release_resources.swap(release_resources_);
   }
-  if (!client) {
+  if (!client && !release_resources) {
     return;
   }
+  const bool had_client = client != nullptr;
 
+  // A resolver may own STS/IMDS AWS clients. Release it inside the same global
+  // shutdown barrier as the CRT client, after all credential refreshes have
+  // left their operation leases and before Aws::ShutdownAPI() can run.
+  credentials_resolver.reset();
   // S3CrtClient::~S3CrtClient waits for the native CRT client shutdown
   // callback. This runs only after every operation lease has left its callback
   // and always on the thread finalizing/destroying the holder.
   client.reset();
-  finalizer_->ClientDestroyed();
+  if (release_resources) {
+    release_resources();
+  }
+  if (had_client) {
+    finalizer_->ClientDestroyed();
+  }
 }
 
 std::shared_ptr<FilesystemMetrics> S3CrtClientHolder::GetMetrics() const { return metrics_; }
@@ -255,31 +287,66 @@ std::shared_ptr<FilesystemMetrics> S3CrtClientHolder::GetMetrics() const { retur
 // failure the construction guard performs only the final decrement, so a null
 // or multiply-owned client is never counted as live.
 arrow::Result<std::shared_ptr<S3CrtClientHolder>> S3CrtClientFinalizer::AddClient(
-    ClientFactory make_client, std::shared_ptr<FilesystemMetrics> metrics) {
+    ClientFactory make_client,
+    std::shared_ptr<FilesystemMetrics> metrics,
+    std::shared_ptr<RequestCredentialsResolver> credentials_resolver,
+    std::function<void()> release_resources) {
   auto finalizer = shared_from_this();
+  bool finalized = false;
   {
     std::lock_guard lock(mutex_);
     if (finalized_.load(std::memory_order_acquire)) {
-      return ErrorS3Finalized();
+      finalized = true;
+    } else {
+      ++constructing_clients_;
     }
-    ++constructing_clients_;
+  }
+  if (finalized) {
+    make_client = nullptr;
+    credentials_resolver.reset();
+    if (release_resources) {
+      release_resources();
+    }
+    return ErrorS3Finalized();
   }
   S3CrtClientConstructionLease construction(finalizer);
+  // Function parameters are destroyed after local variables. Move the resolver
+  // into a local declared after the lease so every failure-path destructor runs
+  // before the construction reservation is released.
+  auto resolver = std::move(credentials_resolver);
 
   // Destroy the std::function and all of its captures outside mutex_. Captures
   // may perform arbitrary cleanup; that cleanup remains inside the construction
   // reservation but never blocks other finalizer state transitions.
   ClientFactory factory = std::move(make_client);
   make_client = nullptr;
-  ARROW_ASSIGN_OR_RAISE(auto client, factory());
+  auto client_result = factory();
   factory = nullptr;
+  if (!client_result.ok()) {
+    resolver.reset();
+    if (release_resources) {
+      release_resources();
+    }
+    return client_result.status();
+  }
+  auto client = std::move(client_result).ValueOrDie();
   if (!client) {
+    resolver.reset();
+    if (release_resources) {
+      release_resources();
+    }
     return arrow::Status::Invalid("S3 CRT client factory returned a null client");
   }
   if (client.use_count() != 1) {
+    client.reset();
+    resolver.reset();
+    if (release_resources) {
+      release_resources();
+    }
     return arrow::Status::Invalid("S3CrtClientHolder must be the sole shared owner");
   }
-  auto holder = std::shared_ptr<S3CrtClientHolder>(new S3CrtClientHolder(finalizer, std::move(metrics)));
+  auto holder = std::shared_ptr<S3CrtClientHolder>(
+      new S3CrtClientHolder(finalizer, std::move(metrics), std::move(resolver), std::move(release_resources)));
 
   bool notify = false;
   {
@@ -368,7 +435,9 @@ std::shared_ptr<S3CrtClientFinalizer> GetCrtClientFinalizer() {
 
 template <>
 arrow::Result<std::shared_ptr<S3CrtClientHolder>> ClientBuilder<Aws::S3Crt::S3CrtClient>::BuildClient(
-    std::optional<arrow::io::IOContext> io_context, std::shared_ptr<FilesystemMetrics> metrics) {
+    std::optional<arrow::io::IOContext> io_context,
+    std::shared_ptr<FilesystemMetrics> metrics,
+    std::function<void()> release_resources) {
   if (!metrics) {
     metrics = std::make_shared<FilesystemMetrics>();
   }
@@ -380,23 +449,24 @@ arrow::Result<std::shared_ptr<S3CrtClientHolder>> ClientBuilder<Aws::S3Crt::S3Cr
         ARROW_RETURN_NOT_OK(PrepareClientConfig(std::move(io_context)));
 
         if (options_.retry_strategy) {
-          client_config_.retryStrategy = fs::internal::MakeWrappedRetryStrategy(options_.retry_strategy);
+          client_config_->retryStrategy = fs::internal::MakeWrappedRetryStrategy(options_.retry_strategy);
         } else {
-          client_config_.retryStrategy = std::make_shared<fs::internal::ConnectRetryStrategy>();
+          client_config_->retryStrategy = std::make_shared<fs::internal::ConnectRetryStrategy>();
         }
 
         const bool use_virtual_addressing = options_.endpoint_override.empty() || options_.force_virtual_addressing;
-        client_config_.useVirtualAddressing = use_virtual_addressing;
+        client_config_->useVirtualAddressing = use_virtual_addressing;
         // Raise the CRT target from its SDK default so small concurrent range reads
         // get enough connection budget for the Vortex reader workload.
         // TODO: make this configurable instead of using a fixed workload-specific default.
-        client_config_.throughputTargetGbps = 50.0;
+        client_config_->throughputTargetGbps = 50.0;
 
-        return std::make_shared<Aws::S3Crt::S3CrtClient>(credentials_provider_, client_config_,
-                                                         client_config_.payloadSigningPolicy,
-                                                         client_config_.useVirtualAddressing);
+        return std::make_shared<Aws::S3Crt::S3CrtClient>(credentials_provider_, *client_config_,
+                                                         client_config_->payloadSigningPolicy,
+                                                         client_config_->useVirtualAddressing);
       },
-      std::move(metrics));
+      std::move(metrics), std::dynamic_pointer_cast<RequestCredentialsResolver>(options_.credentials_provider),
+      std::move(release_resources));
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -20,12 +20,18 @@
 #include <cinttypes>
 #include <cstdio>
 #include <chrono>
+#include <exception>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
+#include <new>
+#include <sstream>
 #include <optional>
 #include <shared_mutex>
+#include <string_view>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <arrow/util/async_generator.h>
 #include "milvus-storage/common/extend_status.h"
@@ -76,11 +82,13 @@
 #include <aws/s3/model/UploadPartRequest.h>
 #ifdef WITH_CRT
 #include <aws/s3-crt/model/GetObjectRequest.h>
+#include <aws/s3-crt/model/HeadBucketRequest.h>
 #include <aws/s3-crt/model/HeadObjectRequest.h>
 #endif
 
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/path_util.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/filesystem/async_random_access_file.h"
 #include "milvus-storage/filesystem/s3/s3_internal.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
@@ -105,13 +113,25 @@ using ::arrow::fs::S3FileSystem;
 using ::arrow::fs::internal::RemoveTrailingSlash;
 using ::Aws::Client::AWSError;
 using ::milvus_storage::S3Options;
+using ::milvus_storage::fs::internal::BoundedDetail;
 using ::milvus_storage::fs::internal::ConnectRetryStrategy;
 using ::milvus_storage::fs::internal::DetectS3Backend;
 using ::milvus_storage::fs::internal::ErrorToStatus;
+using ::milvus_storage::fs::internal::S3ErrorProvenance;
+using ::milvus_storage::fs::internal::S3ResourceKind;
+
+namespace {
+template <typename Holder>
+S3ErrorProvenance ProvenanceOf(const Holder&, S3ResourceKind resource_kind = S3ResourceKind::Unknown) {
+  return S3ErrorProvenance{resource_kind};
+}
+}  // namespace
 using ::milvus_storage::fs::internal::FromAwsDatetime;
 using ::milvus_storage::fs::internal::FromAwsString;
 using ::milvus_storage::fs::internal::IsAlreadyExists;
-using ::milvus_storage::fs::internal::IsNotFound;
+using ::milvus_storage::fs::internal::IsBucketNotFound;
+using ::milvus_storage::fs::internal::IsExplicitBucketNotFound;
+using ::milvus_storage::fs::internal::IsObjectNotFound;
 using ::milvus_storage::fs::internal::OutcomeToResult;
 using ::milvus_storage::fs::internal::OutcomeToStatus;
 using ::milvus_storage::fs::internal::S3Backend;
@@ -125,6 +145,7 @@ namespace S3CrtModel = Aws::S3Crt::Model;
 namespace milvus_storage {
 
 using arrow::io::internal::SubmitIO;
+using arrow::io::internal::SubmitIOWithCompletion;
 
 // -----------------------------------------------------------------------
 // S3FileSystem implementation
@@ -406,6 +427,19 @@ std::string FormatRange(int64_t start, int64_t length) {
   return ss.str();
 }
 
+template <typename ErrorType>
+arrow::Status ObjectReadErrorToStatus(const S3Path& path,
+                                      int64_t start,
+                                      int64_t length,
+                                      const Aws::Client::AWSError<ErrorType>& error,
+                                      S3ErrorProvenance provenance,
+                                      S3ResourceKind resource_kind = S3ResourceKind::Object) {
+  provenance.resource_kind = resource_kind;
+  return ErrorToStatus(fmt::format("When reading {} bytes at offset {} for key '{}' in bucket '{}': ", length, start,
+                                   BoundedDetail(path.key, 256), BoundedDetail(path.bucket, 128)),
+                       "GetObject", error, provenance);
+}
+
 std::optional<int64_t> ParseContentRangeSize(const Aws::String& content_range) {
   int64_t first = 0;
   int64_t last = 0;
@@ -442,14 +476,22 @@ Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
   return [=]() { return Aws::New<StringViewStream>("", data, nbytes); };
 }
 
-arrow::Result<S3Model::GetObjectResult> GetObjectRange(
-    Aws::S3::S3Client* client, const S3Path& path, int64_t start, int64_t length, void* out) {
+arrow::Result<S3Model::GetObjectResult> GetObjectRange(Aws::S3::S3Client* client,
+                                                       const S3Path& path,
+                                                       int64_t start,
+                                                       int64_t length,
+                                                       void* out,
+                                                       S3ErrorProvenance provenance) {
   S3Model::GetObjectRequest req;
   req.SetBucket(ToAwsString(path.bucket));
   req.SetKey(ToAwsString(path.key));
   req.SetRange(ToAwsString(FormatRange(start, length)));
   req.SetResponseStreamFactory(AwsWriteableStreamFactory(out, length));
-  return OutcomeToResult("GetObject", client->GetObject(req));
+  auto outcome = client->GetObject(req);
+  if (outcome.IsSuccess()) {
+    return std::move(outcome).GetResultWithOwnership();
+  }
+  return ObjectReadErrorToStatus(path, start, length, outcome.GetError(), provenance);
 }
 
 template <typename ObjectResult>
@@ -578,7 +620,7 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     // Read the desired range of bytes
     ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
     ARROW_ASSIGN_OR_RAISE(S3Model::GetObjectResult result,
-                          GetObjectRange(client_lock.get(), path_, position, nbytes, out));
+                          GetObjectRange(client_lock.get(), path_, position, nbytes, out, ProvenanceOf(holder_)));
 
     // The response body has already been written into the caller-provided
     // PreallocatedStreamBuf. If the requested range extends past EOF, the
@@ -663,12 +705,16 @@ class ObjectInputFile final : public arrow::io::RandomAccessFile {
     ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
     auto outcome = client_lock.Move()->HeadObject(req);
     if (!outcome.IsSuccess()) {
-      if (IsNotFound(outcome.GetError())) {
+      // HEAD responses carry no body, so a missing bucket and a missing key
+      // both arrive as a generic 404 here. Report key-level ENOENT without
+      // probing further: disambiguation probes cost an extra RPC on every
+      // miss and are deliberately not done.
+      if (IsObjectNotFound(outcome.GetError())) {
         return PathNotFound(path_);
       }
       return ErrorToStatus(
           std::forward_as_tuple("When reading information for key '", path_.key, "' in bucket '", path_.bucket, "': "),
-          "HeadObject", outcome.GetError());
+          "HeadObject", outcome.GetError(), ProvenanceOf(holder_));
     }
 
     auto content_length = outcome.GetResult().GetContentLength();
@@ -835,6 +881,8 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     ctx->client_lease = std::move(maybe_client_lease).ValueOrDie();
     ctx->read_state = read_state_;
     ctx->metrics = holder_->GetMetrics();
+    ctx->path = path_;
+    ctx->provenance = ProvenanceOf(holder_);
     ctx->position = position;
     ctx->nbytes = nbytes;
     ctx->request.SetBucket(ToAwsString(path_.bucket));
@@ -847,9 +895,15 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
         ctx->request,
         [ctx](const Aws::S3Crt::S3CrtClient*, const S3CrtModel::GetObjectRequest&, S3CrtModel::GetObjectOutcome outcome,
               const std::shared_ptr<const Aws::Client::AsyncCallerContext>&) mutable {
+          auto finish = [&ctx](arrow::Result<int64_t> result) {
+            // Result construction is complete, so the callback no longer needs
+            // the client. Leave the shutdown barrier before publishing to user code.
+            ctx->client_lease = S3CrtClientLease{};
+            ctx->future.MarkFinished(std::move(result));
+          };
           if (!outcome.IsSuccess()) {
             ctx->metrics->IncrementFailedCount();
-            ctx->future.MarkFinished(arrow::Result<int64_t>(ErrorToStatus("GetObject", outcome.GetError())));
+            finish(ObjectReadErrorToStatus(ctx->path, ctx->position, ctx->nbytes, outcome.GetError(), ctx->provenance));
             return;
           }
 
@@ -857,9 +911,8 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
           const auto response_content_length = result.GetContentLength();
           if (response_content_length < 0 || response_content_length > ctx->nbytes) {
             ctx->metrics->IncrementFailedCount();
-            ctx->future.MarkFinished(arrow::Result<int64_t>(
-                arrow::Status::IOError("Unexpected GetObject Content-Length ", response_content_length,
-                                       " for range read of ", ctx->nbytes, " bytes")));
+            finish(arrow::Status::IOError("Unexpected GetObject Content-Length ", response_content_length,
+                                          " for range read of ", ctx->nbytes, " bytes"));
             return;
           }
 
@@ -874,10 +927,12 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
           if (bytes_read > 0) {
             ctx->metrics->IncrementReadBytes(bytes_read);
           }
-          ctx->future.MarkFinished(bytes_read);
+          finish(bytes_read);
         });
-    // Keep executor selection at the caller-owned continuation boundary.
-    return ctx->future;
+    // Arrow callbacks run inline by default. Transfer the user-visible future
+    // so releasing its last filesystem owner cannot finalize the CRT client
+    // from inside this native callback while the operation lease is active.
+    return arrow::io::default_io_context().executor()->Transfer(ctx->future);
   }
 
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
@@ -998,12 +1053,16 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     ARROW_ASSIGN_OR_RAISE(auto client_lease, holder_->Acquire());
     auto outcome = client_lease->HeadObject(req);
     if (!outcome.IsSuccess()) {
-      if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
+      // Same bucket/key split as the non-CRT read path: a 404 that is not a
+      // typed NO_SUCH_BUCKET is reported as key-level ENOENT, with no extra
+      // disambiguation RPC.
+      if (outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND &&
+          static_cast<Aws::S3::S3Errors>(outcome.GetError().GetErrorType()) != Aws::S3::S3Errors::NO_SUCH_BUCKET) {
         return PathNotFound(path_);
       }
       return ErrorToStatus(
           std::forward_as_tuple("When reading information for key '", path_.key, "' in bucket '", path_.bucket, "': "),
-          "HeadObject", outcome.GetError());
+          "HeadObject", outcome.GetError(), ProvenanceOf(holder_));
     }
 
     auto content_length = outcome.GetResult().GetContentLength();
@@ -1045,7 +1104,11 @@ class ObjectCrtInputFile final : public arrow::io::RandomAccessFile, public NonB
     S3CrtClientLease client_lease;
     S3CrtModel::GetObjectRequest request;
     std::shared_ptr<ReadState> read_state;
+#ifdef WITH_CRT
     std::shared_ptr<FilesystemMetrics> metrics;
+#endif
+    S3Path path;
+    S3ErrorProvenance provenance;
     int64_t position = 0;
     int64_t nbytes = 0;
   };
@@ -1096,7 +1159,14 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         default_metadata_(options.default_metadata),
         background_writes_(options.background_writes),
         use_crc32c_checksum_(options.use_crc32c_checksum),
-        part_upload_size_(part_size) {}
+        part_upload_size_(part_size),
+        writer_status_(std::make_shared<WriterStatus>()) {}
+
+  ~CustomOutputStream() override {
+    if (!closed_) {
+      DiscardLocal();
+    }
+  }
 
   template <typename ObjectRequest>
   arrow::Status SetMetadataInRequest(ObjectRequest* request) {
@@ -1149,11 +1219,27 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     if (!outcome.IsSuccess()) {
       return ErrorToStatus(std::forward_as_tuple("When initiating multiple part upload for key '", path_.key,
                                                  "' in bucket '", path_.bucket, "': "),
-                           "CreateMultipartUpload", outcome.GetError());
+                           "CreateMultipartUpload", outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Bucket));
     }
     multipart_upload_id_ = outcome.GetResult().GetUploadId();
+    PublishUploadForAbort();
 
     return arrow::Status::OK();
+  }
+
+  /// Hand the upload's identity to UploadState so a completion that outlives
+  /// this stream can still cancel it. Called wherever the id or the state is
+  /// created, because either can come first: a delayed-open stream creates the
+  /// upload long after Init(), while a non-delayed one creates it before.
+  void PublishUploadForAbort() {
+    if (upload_state_ == nullptr || multipart_upload_id_.empty()) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(upload_state_->mutex);
+    upload_state_->holder = holder_;
+    upload_state_->bucket = path_.bucket;
+    upload_state_->key = path_.key;
+    upload_state_->multipart_upload_id = multipart_upload_id_;
   }
 
   arrow::Status Init() {
@@ -1165,37 +1251,203 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     }
 
     upload_state_ = std::make_shared<UploadState>();
+    PublishUploadForAbort();
     closed_ = false;
     return arrow::Status::OK();
   }
 
   arrow::Status Abort() override {
-    if (closed_) {
+    // Abort after a successful Close is an idempotent no-op. Check the healthy
+    // closed state before recording the discard, otherwise a completed stream becomes
+    // Cancelled and a later idempotent Close returns the wrong result.
+    if (closed_ && writer_status_->Check().ok()) {
+      return arrow::Status::OK();
+    }
+    (void)writer_status_->RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+    // Release the server-side upload before dropping the local handle.
+    //
+    // This is the one piece of I/O a giving-up path still owes the store, and
+    // it is not diagnosis: the parts we already uploaded are a resource THIS
+    // stream created and nobody else can name. They do not appear in
+    // ListObjectsV2, so neither a bucket listing, a usage report, nor any GC
+    // that walks object keys will ever find them again -- only
+    // ListMultipartUploads or an AbortIncompleteMultipartUpload lifecycle rule
+    // will, and the second one is not something this library can assume a
+    // deployment configured.
+    //
+    // Close failure deliberately ignores this cleanup result so its original
+    // error remains primary. A caller invoking Abort() directly receives the
+    // remote cleanup failure and can retry while the upload identity is kept.
+    // Mark first, so a part completing while this runs knows a cancel is owed.
+    // Whether one is still in flight decides who finishes the job, not whether
+    // it gets finished.
+    bool uploads_still_in_flight = false;
+    if (upload_state_ != nullptr) {
+      std::lock_guard<std::mutex> lock(upload_state_->mutex);
+      upload_state_->abort_requested = true;
+      uploads_still_in_flight = upload_state_->uploads_in_progress > 0;
+    }
+
+    arrow::Status abort_status = arrow::Status::OK();
+    if (!uploads_still_in_flight) {
+      // Nothing can land behind us, so this attempt is the whole job. Consume
+      // the shared identity through the same exactly-once path used by the last
+      // completion. A repeated Abort() may race that completion after it drops
+      // the state lock, and must not clear the identity before either caller
+      // has issued the remote abort.
+      if (upload_state_ != nullptr) {
+        abort_status = AbortRecordedUpload(upload_state_);
+      } else {
+        abort_status = AbortMultipartUploadIfCreated();
+      }
+    }
+    // Otherwise the cancel is deliberately deferred to the completion that
+    // takes uploads_in_progress to zero (AbortRecordedUpload). Aborting now as
+    // well would be wasted: the parts still on the wire would land afterwards
+    // and orphan themselves anyway, which is exactly the leak this exists to
+    // close. Waiting for them here is not an option either -- R2.6 forbids a
+    // failure path from waiting on children.
+    DiscardLocal();
+    return abort_status;
+  }
+
+  /// Cancel an upload using only what UploadState holds, so it works from a
+  /// completion callback running after the stream is gone.
+  ///
+  /// Takes the identity out of the state under the lock and clears it, which
+  /// makes the cancel happen at most once, then issues the request with the
+  /// lock released. Internal failure cleanup drops the returned status to keep
+  /// its primary error; public Abort() returns it to the caller.
+  static arrow::Status AbortRecordedUpload(const std::shared_ptr<UploadState>& state) noexcept {
+    std::shared_ptr<S3ClientHolder> holder;
+    std::string bucket;
+    std::string key;
+    Aws::String upload_id;
+    {
+      std::lock_guard<std::mutex> lock(state->mutex);
+      if (!state->abort_requested || state->holder == nullptr || state->multipart_upload_id.empty()) {
+        return arrow::Status::OK();
+      }
+      holder = std::move(state->holder);
+      bucket = std::move(state->bucket);
+      key = std::move(state->key);
+      upload_id = std::move(state->multipart_upload_id);
+      state->holder = nullptr;
+      state->multipart_upload_id.clear();
+    }
+
+    bool released = false;
+    arrow::Status abort_status = arrow::Status::OK();
+    try {
+      auto client_lock = holder->Lock();
+      if (!client_lock.ok()) {
+        abort_status = client_lock.status();
+        LOG_STORAGE_WARNING_ << "Cannot abort multipart upload for key '" << key << "' in bucket '" << bucket
+                             << "' right now: " << abort_status.ToString();
+      } else {
+        S3Model::AbortMultipartUploadRequest req;
+        req.SetBucket(ToAwsString(bucket));
+        req.SetKey(ToAwsString(key));
+        req.SetUploadId(upload_id);
+
+        auto outcome = std::move(client_lock).ValueOrDie().Move()->AbortMultipartUpload(req);
+        released = outcome.IsSuccess() || outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD;
+        if (!released) {
+          abort_status = ErrorToStatus(
+              fmt::format("When aborting multiple part upload for key '{}' in bucket '{}': ", BoundedDetail(key, 256),
+                          BoundedDetail(bucket, 128)),
+              "AbortMultipartUpload", outcome.GetError(), ProvenanceOf(holder, S3ResourceKind::MultipartUpload));
+          LOG_STORAGE_WARNING_ << "Failed to abort multipart upload for key '" << key << "' in bucket '" << bucket
+                               << "', parts may remain until a lifecycle rule removes them: "
+                               << abort_status.ToString();
+        }
+      }
+    } catch (const std::exception& e) {
+      abort_status = arrow::Status::IOError("Exception while aborting multipart upload: ", e.what());
+    } catch (...) {
+      abort_status = arrow::Status::IOError("Unknown exception while aborting multipart upload");
+    }
+
+    if (released) {
       return arrow::Status::OK();
     }
 
-    if (IsMultipartCreated()) {
-      ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
-
-      S3Model::AbortMultipartUploadRequest req;
-      req.SetBucket(ToAwsString(path_.bucket));
-      req.SetKey(ToAwsString(path_.key));
-      req.SetUploadId(multipart_upload_id_);
-
-      auto outcome = client_lock.Move()->AbortMultipartUpload(req);
-      if (!outcome.IsSuccess()) {
-        return ErrorToStatus(std::forward_as_tuple("When aborting multiple part upload for key '", path_.key,
-                                                   "' in bucket '", path_.bucket, "': "),
-                             "AbortMultipartUpload", outcome.GetError());
-      }
+    // This call did not establish that the upload was released. Taking the
+    // identity is what makes concurrent cancels happen at most once, but
+    // keeping it after a transient service failure turns that failure into a
+    // permanent leak: every later Abort() early-returns on an empty identity,
+    // so nothing can name the upload again. Hand it back. If the first request
+    // actually succeeded but its response was lost, a retry is harmless -- S3
+    // answers NoSuchUpload, which is treated as released above.
+    std::lock_guard<std::mutex> lock(state->mutex);
+    if (state->holder == nullptr && state->multipart_upload_id.empty()) {
+      state->holder = std::move(holder);
+      state->bucket = std::move(bucket);
+      state->key = std::move(key);
+      state->multipart_upload_id = std::move(upload_id);
     }
+    return abort_status;
+  }
 
+  /// Cancel the multipart upload this stream created, if it created one.
+  ///
+  /// Returns the remote cleanup failure to public Abort(). Failure cleanup from
+  /// Close deliberately discards it to preserve the original error. Like
+  /// arrow's own ObjectOutputStream::Abort, this does not wait for
+  /// background part uploads that are still in flight -- one that lands after
+  /// the abort is orphaned again, and only a second abort or a lifecycle rule
+  /// clears it. Close failure invokes this best-effort release automatically,
+  /// but still does not wait for unrelated in-flight parts.
+  arrow::Status AbortMultipartUploadIfCreated() {
+    // Deliberately NOT gated on closed_. A failed Write/Flush/Close marks the
+    // stream closed and drops its buffers, and that is precisely the case an
+    // abort has to still work for. What proves there is nothing to release is
+    // holder_ == nullptr, which only a SUCCESSFUL close produces
+    // (CleanupAfterClose) -- a completed upload has no parts left to cancel.
+    if (!IsMultipartCreated() || holder_ == nullptr) {
+      return arrow::Status::OK();
+    }
+    ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
+
+    S3Model::AbortMultipartUploadRequest req;
+    req.SetBucket(ToAwsString(path_.bucket));
+    req.SetKey(ToAwsString(path_.key));
+    req.SetUploadId(multipart_upload_id_);
+
+    auto outcome = client_lock.Move()->AbortMultipartUpload(req);
+    if (!outcome.IsSuccess()) {
+      auto status = ErrorToStatus(std::forward_as_tuple("When aborting multiple part upload for key '", path_.key,
+                                                        "' in bucket '", path_.bucket, "': "),
+                                  "AbortMultipartUpload", outcome.GetError(),
+                                  ProvenanceOf(holder_, S3ResourceKind::MultipartUpload));
+      LOG_STORAGE_WARNING_ << "Failed to abort multipart upload, parts may remain until a lifecycle rule "
+                              "removes them: "
+                           << status.ToString();
+      return status;
+    }
+    return arrow::Status::OK();
+  }
+
+  /// Drop the buffered part and refuse further work, but KEEP the upload id and
+  /// the client.
+  ///
+  /// Used as the local portion of Abort(). Forgetting the upload id before the
+  /// remote abort is scheduled is what made a failed Close leak: the writer was
+  /// terminal, the caller destroyed it, and nothing could name the upload.
+  void DiscardBuffersAfterFailure() {
     current_part_.reset();
     current_part_buffer_.reset();
-    holder_ = nullptr;
+    current_part_size_ = 0;
     closed_ = true;
+  }
 
-    return arrow::Status::OK();
+  /// Full local release: also forgets the upload. Only correct once the upload
+  /// has been cancelled (Abort) or completed, or when nothing can act on it any
+  /// more (destruction).
+  void DiscardLocal() {
+    DiscardBuffersAfterFailure();
+    multipart_upload_id_.clear();
+    holder_ = nullptr;
   }
 
   // OutputStream interface
@@ -1223,6 +1475,14 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   arrow::Status CleanupAfterClose() {
+    // A successful close has completed the multipart upload. Forget the
+    // shared abort identity as well as the stream-local one, so a later
+    // idempotent Abort() cannot try to cancel an already committed upload.
+    if (upload_state_ != nullptr) {
+      std::lock_guard<std::mutex> lock(upload_state_->mutex);
+      upload_state_->holder = nullptr;
+      upload_state_->multipart_upload_id.clear();
+    }
     holder_ = nullptr;
     closed_ = true;
     return arrow::Status::OK();
@@ -1247,11 +1507,12 @@ class CustomOutputStream final : public arrow::io::OutputStream {
 
     ARROW_RETURN_NOT_OK(SetMetadataInRequest(&req));
 
-    auto outcome = client_lock.Move()->CompleteMultipartUploadWithErrorFixup(std::move(req));
+    auto outcome = client_lock.get()->CompleteMultipartUploadWithErrorFixup(std::move(req));
     if (!outcome.IsSuccess()) {
-      return ErrorToStatus(std::forward_as_tuple("When completing multiple part upload for key '", path_.key,
-                                                 "' in bucket '", path_.bucket, "': "),
-                           "CompleteMultipartUpload", outcome.GetError());
+      return ErrorToStatus(fmt::format("When completing multiple part upload for key '{}' in bucket '{}': ",
+                                       BoundedDetail(path_.key, 256), BoundedDetail(path_.bucket, 128)),
+                           "CompleteMultipartUpload", outcome.GetError(),
+                           ProvenanceOf(holder_, S3ResourceKind::MultipartUpload));
     }
 
     return arrow::Status::OK();
@@ -1259,25 +1520,46 @@ class CustomOutputStream final : public arrow::io::OutputStream {
 
   arrow::Status CleanupIfFailed(Status status) {
     if (!status.ok()) {
-      ARROW_RETURN_NOT_OK(CleanupAfterClose());
-      return status;
+      return CloseAfterFailure(std::move(status));
     }
     return arrow::Status::OK();
   }
 
   arrow::Status Close() override {
+    auto check_status = writer_status_->Check();
+    if (!check_status.ok()) {
+      return CloseAfterFailure(std::move(check_status));
+    }
+    return writer_status_->RecordFirstFailure(CloseImpl());
+  }
+
+  arrow::Status CloseAfterFailure(arrow::Status primary_status = arrow::Status::OK()) {
+    (void)writer_status_->RecordFirstFailure(primary_status);
+    auto first_status = writer_status_->Check();
+    // Close is the terminal ownership boundary exposed by Arrow. Once it has
+    // failed, automatically abandon the multipart upload this stream still
+    // owns; callers must not need a second Abort() call to avoid leaking
+    // server-side parts. Abort is best effort and the first-failure state preserves the
+    // first failure already recorded above.
+    (void)Abort();
+    return first_status;
+  }
+
+  arrow::Status CloseImpl() {
+    if (!writer_status_->Check().ok()) {
+      return CloseAfterFailure();
+    }
     if (closed_) {
       return arrow::Status::OK();
     }
 
     FIU_RETURN_ON(FIUKEY_S3FS_WRITER_CLOSE_FAIL,
-                  MakeExtendError(ExtendStatusCode::StorageTransientNetwork,
-                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL),
-                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL)));
+                  CleanupIfFailed(MakeExtendError(ExtendStatusCode::StorageTransientNetwork,
+                                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL),
+                                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL))));
 
     ARROW_RETURN_NOT_OK(CleanupIfFailed(EnsureReadyToFlushFromClose()));
-
-    ARROW_RETURN_NOT_OK(CleanupIfFailed(Flush()));
+    ARROW_RETURN_NOT_OK(CleanupIfFailed(FlushImpl()));
 
     if (IsMultipartCreated()) {
       ARROW_RETURN_NOT_OK(CleanupIfFailed(FinishPartUploadAfterFlush()));
@@ -1287,31 +1569,52 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   Future<> CloseAsync() override {
+    auto check_status = writer_status_->Check();
+    if (!check_status.ok()) {
+      return CloseAfterFailureAsync(std::move(check_status));
+    }
+    auto future = CloseAsyncImpl();
+    return future.Then([]() { return arrow::Status::OK(); },
+                       [writer_status = writer_status_](const arrow::Status& status) {
+                         return writer_status->RecordFirstFailure(status);
+                       });
+  }
+
+  Future<> CloseAsyncImpl() {
+    if (!writer_status_->Check().ok()) {
+      return CloseAfterFailureAsync();
+    }
     if (closed_) {
       return arrow::Status::OK();
     }
 
-    FIU_RETURN_ON(FIUKEY_S3FS_WRITER_CLOSE_FAIL,
-                  MakeExtendError(ExtendStatusCode::StorageTransientNetwork,
-                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL),
-                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL)));
+    FIU_RETURN_ON(
+        FIUKEY_S3FS_WRITER_CLOSE_FAIL,
+        CloseAfterFailureAsync(MakeExtendError(ExtendStatusCode::StorageTransientNetwork,
+                                               fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL),
+                                               fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_CLOSE_FAIL))));
 
-    ARROW_RETURN_NOT_OK(CleanupIfFailed(EnsureReadyToFlushFromClose()));
+    auto ready_status = EnsureReadyToFlushFromClose();
+    if (!ready_status.ok()) {
+      return CloseAfterFailureAsync(std::move(ready_status));
+    }
 
-    // Wait for in-progress uploads to finish (if async writes are enabled)
-    return FlushAsync().Then([self = Self()]() {
-      if (self->IsMultipartCreated()) {
-        ARROW_RETURN_NOT_OK(self->CleanupIfFailed(self->FinishPartUploadAfterFlush()));
-      }
-      return self->CleanupAfterClose();
-    });
+    return FlushAsyncImpl().Then(
+        [self = Self()]() {
+          if (self->IsMultipartCreated()) {
+            ARROW_RETURN_NOT_OK(self->CleanupIfFailed(self->FinishPartUploadAfterFlush()));
+          }
+          return self->CleanupAfterClose();
+        },
+        [self = Self()](const arrow::Status& status) { return self->CloseAfterFailureAsync(status); });
   }
 
   bool closed() const override { return closed_; }
 
   arrow::Result<int64_t> Tell() const override {
+    ARROW_RETURN_NOT_OK(writer_status_->Check());
     if (closed_) {
-      return arrow::Status::Invalid("Operation on closed stream");
+      return writer_status_->RecordFirstFailure(arrow::Status::Invalid("Operation on closed stream"));
     }
     return pos_;
   }
@@ -1323,6 +1626,18 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   arrow::Status Write(const void* data, int64_t nbytes) override { return DoWrite(data, nbytes); }
 
   arrow::Status DoWrite(const void* data, int64_t nbytes, const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
+    ARROW_RETURN_NOT_OK(writer_status_->Check());
+    auto status = DoWriteImpl(data, nbytes, owned_buffer);
+    if (!status.ok()) {
+      return writer_status_->RecordFirstFailure(std::move(status));
+    }
+    // A background part may have failed while DoWriteImpl was preparing or
+    // submitting this write. Never report success after that failure has
+    // already made the writer terminal.
+    return writer_status_->Check();
+  }
+
+  arrow::Status DoWriteImpl(const void* data, int64_t nbytes, const std::shared_ptr<Buffer>& owned_buffer = nullptr) {
     if (closed_) {
       return arrow::Status::Invalid("Operation on closed stream");
     }
@@ -1376,25 +1691,54 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   arrow::Status Flush() override {
-    FIU_RETURN_ON(FIUKEY_S3FS_WRITER_FLUSH_FAIL,
-                  MakeExtendError(ExtendStatusCode::StorageTransientNetwork,
-                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_FLUSH_FAIL),
-                                  fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_FLUSH_FAIL)));
-    auto fut = FlushAsync();
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
+    ARROW_RETURN_NOT_OK(writer_status_->Check());
+    return writer_status_->RecordFirstFailure(FlushImpl());
+  }
+
+  arrow::Status FlushImpl() {
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
+    auto fut = FlushAsyncImpl();
     return fut.status();
   }
 
   Future<> FlushAsync() {
-    if (closed_) {
-      return arrow::Status::Invalid("Operation on closed stream");
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
+    }
+    auto check_status = writer_status_->Check();
+    if (!check_status.ok()) {
+      return check_status;
+    }
+    auto future = FlushAsyncImpl();
+    future.AddCallback([writer_status = writer_status_](const arrow::Status& status) {
+      (void)writer_status->RecordFirstFailure(status);
+    });
+    return future;
+  }
+
+  Future<> FlushAsyncImpl() {
+    if (!writer_status_->Check().ok()) {
+      return writer_status_->Check();
     }
     FIU_RETURN_ON(FIUKEY_S3FS_WRITER_FLUSH_FAIL,
                   MakeExtendError(ExtendStatusCode::StorageTransientNetwork,
                                   fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_FLUSH_FAIL),
                                   fmt::format("Injected fault: {}", FIUKEY_S3FS_WRITER_FLUSH_FAIL)));
+    if (closed_) {
+      return arrow::Status::Invalid("Operation on closed stream");
+    }
     // Wait for background writes to finish
     std::unique_lock<std::mutex> lock(upload_state_->mutex);
     return upload_state_->pending_uploads_completed;
+  }
+
+  Future<> CloseAfterFailureAsync(arrow::Status primary_status = arrow::Status::OK()) {
+    return CloseAfterFailure(std::move(primary_status));
   }
 
   // Upload-related helpers
@@ -1492,21 +1836,54 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         req.SetBody(std::make_shared<StringViewStream>(owned_buffer->data(), owned_buffer->size()));
       }
 
+      // A previous part can complete while one large Write() is still walking
+      // its input. Stop before accepting another request once that failure has
+      // made the writer terminal.
+      ARROW_RETURN_NOT_OK(writer_status_->Check());
+
+      auto make_task = [&]() {
+        return [owned_buffer, holder = holder_, req = std::move(req), state = upload_state_, async_result_callback,
+                part_number = part_number_]() mutable -> arrow::Status {
+          auto outcome_result = TriggerUploadRequest(req, holder);
+          if (!outcome_result.ok()) {
+            return outcome_result.status();
+          }
+          return async_result_callback(req, state, part_number, std::move(outcome_result).ValueOrDie());
+        };
+      };
+      auto make_completion = [&]() {
+        return [state = upload_state_, writer_status = writer_status_](const arrow::Status& status) {
+          HandleUploadOutcome(state, writer_status, status);
+        };
+      };
+
+      using Task = decltype(make_task());
+      using Completion = decltype(make_completion());
+      std::optional<Task> task;
+      std::optional<Completion> completion;
+      // Construct every caller-owned object that may allocate before this
+      // upload owns a counter slot. Once registered, every remaining exit is
+      // settled by SubmitIOWithCompletion; before it, an exception unwinds
+      // without leaving a phantom upload behind, so it is left to propagate.
+      task.emplace(make_task());
+      completion.emplace(make_completion());
+
       {
         std::unique_lock<std::mutex> lock(upload_state_->mutex);
-        if (upload_state_->uploads_in_progress++ == 0) {
+        // Serialize admission with completion failure observation. If the
+        // completion got this lock first, no later part may register.
+        ARROW_RETURN_NOT_OK(writer_status_->Check());
+        if (upload_state_->uploads_in_progress == 0) {
           upload_state_->pending_uploads_completed = Future<>::Make();
+          upload_state_->pending_completion_published = false;
         }
+        ++upload_state_->uploads_in_progress;
       }
 
-      // The closure keeps the buffer and the upload state alive
-      auto deferred = [owned_buffer, holder = holder_, req = std::move(req), state = upload_state_,
-                       async_result_callback, part_number = part_number_]() mutable -> arrow::Status {
-        ARROW_ASSIGN_OR_RAISE(auto outcome, TriggerUploadRequest(req, holder));
-
-        return async_result_callback(req, state, part_number, outcome);
-      };
-      ARROW_RETURN_NOT_OK(SubmitIO(io_context_, std::move(deferred)));
+      // SubmitIOWithCompletion keeps the buffer and upload state alive and
+      // settles the registered counter/future for task rejection,
+      // pre-request failures, exceptions, and normal SDK outcomes.
+      ARROW_RETURN_NOT_OK(SubmitIOWithCompletion(io_context_, std::move(*task), std::move(*completion)));
     }
 
     ++part_number_;
@@ -1515,10 +1892,11 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   static arrow::Status UploadUsingSingleRequestError(const Aws::S3::Model::PutObjectRequest& request,
-                                                     const Aws::S3::Model::PutObjectOutcome& outcome) {
+                                                     const Aws::S3::Model::PutObjectOutcome& outcome,
+                                                     S3ErrorProvenance provenance) {
     return ErrorToStatus(std::forward_as_tuple("When uploading object with key '", request.GetKey(), "' in bucket '",
                                                request.GetBucket(), "': "),
-                         "PutObject", outcome.GetError());
+                         "PutObject", outcome.GetError(), provenance);
   }
 
   arrow::Status UploadUsingSingleRequest(const std::shared_ptr<Buffer>& buffer) {
@@ -1528,19 +1906,24 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   arrow::Status UploadUsingSingleRequest(const void* data,
                                          int64_t nbytes,
                                          std::shared_ptr<Buffer> owned_buffer = nullptr) {
-    auto sync_result_callback = [](const Aws::S3::Model::PutObjectRequest& request,
-                                   const std::shared_ptr<UploadState>& state, int32_t part_number,
-                                   const Aws::S3::Model::PutObjectOutcome& outcome) {
+    // PutObject creates or replaces a key. A request-level 404 therefore cannot
+    // mean "that key is absent"; it names the destination bucket.
+    const auto provenance = ProvenanceOf(holder_, S3ResourceKind::Bucket);
+    auto sync_result_callback = [provenance](const Aws::S3::Model::PutObjectRequest& request,
+                                             const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                             const Aws::S3::Model::PutObjectOutcome& outcome) {
       if (!outcome.IsSuccess()) {
-        return UploadUsingSingleRequestError(request, outcome);
+        return UploadUsingSingleRequestError(request, outcome, provenance);
       }
       return arrow::Status::OK();
     };
 
-    auto async_result_callback = [](const Aws::S3::Model::PutObjectRequest& request,
-                                    const std::shared_ptr<UploadState>& state, int32_t part_number,
-                                    const Aws::S3::Model::PutObjectOutcome& outcome) {
-      HandleUploadUsingSingleRequestOutcome(state, request, outcome);
+    auto async_result_callback = [provenance](const Aws::S3::Model::PutObjectRequest& request,
+                                              const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                              const Aws::S3::Model::PutObjectOutcome& outcome) {
+      if (!outcome.IsSuccess()) {
+        return UploadUsingSingleRequestError(request, outcome, provenance);
+      }
       return arrow::Status::OK();
     };
 
@@ -1557,10 +1940,13 @@ class CustomOutputStream final : public arrow::io::OutputStream {
   }
 
   static arrow::Status UploadPartError(const Aws::S3::Model::UploadPartRequest& request,
-                                       const Aws::S3::Model::UploadPartOutcome& outcome) {
-    return ErrorToStatus(std::forward_as_tuple("When uploading part for key '", request.GetKey(), "' in bucket '",
-                                               request.GetBucket(), "': "),
-                         "UploadPart", outcome.GetError());
+                                       const Aws::S3::Model::UploadPartOutcome& outcome,
+                                       const std::shared_ptr<S3ClientHolder>& holder) {
+    const std::string bucket(FromAwsString(request.GetBucket()));
+    return ErrorToStatus(
+        fmt::format("When uploading part for key '{}' in bucket '{}': ",
+                    BoundedDetail(std::string(FromAwsString(request.GetKey())), 256), BoundedDetail(bucket, 128)),
+        "UploadPart", outcome.GetError(), ProvenanceOf(holder, S3ResourceKind::MultipartUpload));
   }
 
   arrow::Status UploadPart(const void* data, int64_t nbytes, std::shared_ptr<Buffer> owned_buffer = nullptr) {
@@ -1572,11 +1958,11 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     req.SetPartNumber(part_number_);
     req.SetUploadId(multipart_upload_id_);
 
-    auto sync_result_callback = [](const Aws::S3::Model::UploadPartRequest& request,
-                                   const std::shared_ptr<UploadState>& state, int32_t part_number,
-                                   Aws::S3::Model::UploadPartOutcome outcome) {
+    auto sync_result_callback = [holder = holder_](const Aws::S3::Model::UploadPartRequest& request,
+                                                   const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                                   Aws::S3::Model::UploadPartOutcome outcome) {
       if (!outcome.IsSuccess()) {
-        return UploadPartError(request, outcome);
+        return UploadPartError(request, outcome, holder);
       } else {
         AddCompletedPart(state, part_number, outcome.GetResult());
       }
@@ -1584,10 +1970,14 @@ class CustomOutputStream final : public arrow::io::OutputStream {
       return arrow::Status::OK();
     };
 
-    auto async_result_callback = [](const Aws::S3::Model::UploadPartRequest& request,
-                                    const std::shared_ptr<UploadState>& state, int32_t part_number,
-                                    const Aws::S3::Model::UploadPartOutcome& outcome) {
-      HandleUploadPartOutcome(state, part_number, request, outcome);
+    auto async_result_callback = [holder = holder_](const Aws::S3::Model::UploadPartRequest& request,
+                                                    const std::shared_ptr<UploadState>& state, int32_t part_number,
+                                                    const Aws::S3::Model::UploadPartOutcome& outcome) {
+      if (!outcome.IsSuccess()) {
+        return UploadPartError(request, outcome, holder);
+      }
+      std::unique_lock<std::mutex> lock(state->mutex);
+      AddCompletedPart(state, part_number, outcome.GetResult());
       return arrow::Status::OK();
     };
 
@@ -1599,43 +1989,46 @@ class CustomOutputStream final : public arrow::io::OutputStream {
         std::move(owned_buffer));
   }
 
-  static void HandleUploadUsingSingleRequestOutcome(const std::shared_ptr<UploadState>& state,
-                                                    const S3Model::PutObjectRequest& req,
-                                                    const S3Model::PutObjectOutcome& outcome) {
+  static void HandleUploadOutcome(const std::shared_ptr<UploadState>& state,
+                                  const std::shared_ptr<WriterStatus>& writer_status,
+                                  const arrow::Status& status) {
+    Future<> future;
+    bool publish = false;
     std::unique_lock<std::mutex> lock(state->mutex);
-    if (!outcome.IsSuccess()) {
-      state->status &= UploadUsingSingleRequestError(req, outcome);
+    DCHECK_GT(state->uploads_in_progress, 0);
+    --state->uploads_in_progress;
+    if (!status.ok()) {
+      // Counter settlement comes first. Observe while holding the admission
+      // lock so a foreground Write cannot register a new part after this
+      // failure has won the ordering race.
+      (void)writer_status->RecordFirstFailure(status);
     }
-
-    // GH-41862: avoid potential deadlock if the Future's callback is called
-    // with the mutex taken.
-    auto fut = state->pending_uploads_completed;
+    if (!state->pending_completion_published && (!status.ok() || state->uploads_in_progress == 0)) {
+      state->pending_completion_published = true;
+      future = state->pending_uploads_completed;
+      publish = true;
+    }
+    const bool owes_abort = state->abort_requested && state->uploads_in_progress == 0;
     lock.unlock();
-    fut.MarkFinished(state->status);
-  }
 
-  static void HandleUploadPartOutcome(const std::shared_ptr<UploadState>& state,
-                                      int part_number,
-                                      const S3Model::UploadPartRequest& req,
-                                      const S3Model::UploadPartOutcome& outcome) {
-    std::unique_lock<std::mutex> lock(state->mutex);
-    if (!outcome.IsSuccess()) {
-      state->status &= UploadPartError(req, outcome);
-    } else {
-      AddCompletedPart(state, part_number, outcome.GetResult());
+    // Publishing may allocate. If it fails the exception propagates and the
+    // process dies. That is deliberate: the publish slot above has already been
+    // consumed, so anything that swallows the failure here leaves
+    // pending_uploads_completed unfinished with no later completion able to
+    // claim it, and every FlushAsync/CloseAsync waiter blocks forever. A crash
+    // is restartable; that hang is not.
+    auto completion_status = arrow::io::internal::ObserveBackgroundIOStatus(writer_status.get(), status);
+    if (publish) {
+      future.MarkFinished(std::move(completion_status));
     }
-
-    // Notify completion
-    if (--state->uploads_in_progress == 0) {
-      // GH-41862: avoid potential deadlock if the Future's callback is called
-      // with the mutex taken.
-      auto fut = state->pending_uploads_completed;
-      lock.unlock();
-      // State could be mutated concurrently if another thread writes to the
-      // stream, but in this case the Flush() call is only advisory anyway.
-      // Besides, it's not generally sound to write to an OutputStream from
-      // several threads at once.
-      fut.MarkFinished(state->status);
+    if (owes_abort) {
+      // Last one out cancels the upload. By now nothing else can add a part, so
+      // this attempt cannot be raced by another in-flight one.
+      try {
+        (void)AbortRecordedUpload(state);
+      } catch (...) {
+        // Remote cleanup is best effort and must not escape the completion.
+      }
     }
   }
 
@@ -1685,20 +2078,36 @@ class CustomOutputStream final : public arrow::io::OutputStream {
     // Only populated for multi-part uploads.
     Aws::Vector<S3Model::CompletedPart> completed_parts;
     int64_t uploads_in_progress = 0;
-    arrow::Status status;
+    bool pending_completion_published = true;
     arrow::Future<> pending_uploads_completed = arrow::Future<>::MakeFinished(arrow::Status::OK());
+
+    // Everything the LAST completing part needs to cancel the upload, kept here
+    // rather than on the stream because this struct outlives it.
+    //
+    // Abort() cannot finish the job on its own: background part uploads capture
+    // their client by value at submit time, so a part already in flight will
+    // land successfully after the abort and orphan itself. AWS documents the
+    // same thing -- an abort raced by in-flight parts has to be repeated. The
+    // repeat happens here, driven by the completion that takes the counter to
+    // zero, so no failure path ever waits on a child (R2.6).
+    bool abort_requested = false;
+    std::shared_ptr<S3ClientHolder> holder;
+    std::string bucket;
+    std::string key;
+    Aws::String multipart_upload_id;
   };
   std::shared_ptr<UploadState> upload_state_;
+  std::shared_ptr<WriterStatus> writer_status_;
 };
 
 class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Impl> {
   public:
-  ClientBuilder<S3Client> builder_;
+  std::shared_ptr<ClientBuilder<S3Client>> builder_;
   const arrow::io::IOContext io_context_;
   std::shared_ptr<S3ClientHolder> holder_;
 #ifdef WITH_CRT
   bool use_crt_async_reads_ = false;
-  ClientBuilder<Aws::S3Crt::S3CrtClient> crt_builder_;
+  std::shared_ptr<ClientBuilder<Aws::S3Crt::S3CrtClient>> crt_builder_;
   std::shared_ptr<S3CrtClientHolder> crt_holder_;
 #endif
   std::optional<S3Backend> backend_;
@@ -1708,32 +2117,49 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
   static constexpr int32_t kMultipleDeleteMaxKeys = 1000;
 
   explicit Impl(S3Options options, arrow::io::IOContext io_context)
-      : builder_(options),
+      : builder_(std::make_shared<ClientBuilder<S3Client>>(options)),
         io_context_(std::move(io_context))
 #ifdef WITH_CRT
         ,
         use_crt_async_reads_(options.use_crt_async_reads),
-        crt_builder_(std::move(options))
+        crt_builder_(std::make_shared<ClientBuilder<Aws::S3Crt::S3CrtClient>>(std::move(options)))
 #endif
   {
   }
 
   arrow::Status Init() {
-    auto result = builder_.BuildClient(io_context_);
+    // The standard holder owns the final cleanup for both builders. Global S3
+    // finalization drains CRT holders first, so this callback cannot release a
+    // CRT config while CRT construction or a native client is still active.
+    auto release_builders = [builder = builder_
+#ifdef WITH_CRT
+                             ,
+                             crt_builder = crt_builder_
+#endif
+    ] {
+#ifdef WITH_CRT
+      crt_builder->ReleaseAwsResources();
+#endif
+      builder->ReleaseAwsResources();
+    };
+    auto result = builder_->BuildClient(io_context_, nullptr, std::move(release_builders));
     if (!result.ok()) {
-      return arrow::Status::IOError("Failed to build S3 client: ", result.status().ToString());
+      return result.status().WithMessage("Failed to build S3 client: ", result.status().message());
     }
     ARROW_RETURN_NOT_OK(std::move(result).Value(&holder_));
+
 #ifdef WITH_CRT
     if (UseCrtReadPath()) {
+      // Borrow metrics through the existing standard-client operation guard.
       std::shared_ptr<FilesystemMetrics> metrics;
       {
         ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
         metrics = client_lock.Move()->GetMetrics();
       }
-      auto crt_result = crt_builder_.BuildClient(io_context_, std::move(metrics));
+      auto crt_result = crt_builder_->BuildClient(io_context_, std::move(metrics),
+                                                  [builder = crt_builder_] { builder->ReleaseAwsResources(); });
       if (!crt_result.ok()) {
-        return arrow::Status::IOError("Failed to build S3 CRT client: ", crt_result.status().ToString());
+        return crt_result.status().WithMessage("Failed to build S3 CRT client: ", crt_result.status().message());
       }
       ARROW_RETURN_NOT_OK(std::move(crt_result).Value(&crt_holder_));
     }
@@ -1748,13 +2174,13 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     }
   }
 
-  const S3Options& options() const { return builder_.options(); }
+  const S3Options& options() const { return builder_->options(); }
 
 #ifdef WITH_CRT
   bool UseCrtReadPath() const { return use_crt_async_reads_ && options().cloud_provider != kCloudProviderGCP; }
 #endif
 
-  std::string region() const { return std::string(FromAwsString(builder_.config().region)); }
+  std::string region() const { return builder_->region(); }
 
   // Tests to see if a bucket exists
   arrow::Result<bool> BucketExists(const std::string& bucket) {
@@ -1765,9 +2191,9 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
 
     auto outcome = client_lock.Move()->HeadBucket(req);
     if (!outcome.IsSuccess()) {
-      if (!IsNotFound(outcome.GetError())) {
+      if (!IsBucketNotFound(outcome.GetError())) {
         return ErrorToStatus(std::forward_as_tuple("When testing for existence of bucket '", bucket, "': "),
-                             "HeadBucket", outcome.GetError());
+                             "HeadBucket", outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Bucket));
       }
       return false;
     }
@@ -1785,9 +2211,9 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
 
       if (outcome.IsSuccess()) {
         return arrow::Status::OK();
-      } else if (!IsNotFound(outcome.GetError())) {
+      } else if (!IsBucketNotFound(outcome.GetError())) {
         return ErrorToStatus(std::forward_as_tuple("When creating bucket '", bucket, "': "), "HeadBucket",
-                             outcome.GetError());
+                             outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Bucket));
       }
 
       if (!options().allow_bucket_creation) {
@@ -1812,7 +2238,7 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     auto outcome = client_lock.Move()->CreateBucket(req);
     if (!outcome.IsSuccess() && !IsAlreadyExists(outcome.GetError())) {
       return ErrorToStatus(std::forward_as_tuple("When creating bucket '", bucket, "': "), "CreateBucket",
-                           outcome.GetError());
+                           outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Bucket));
     }
     return arrow::Status::OK();
   }
@@ -1830,7 +2256,8 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
     }
     return OutcomeToStatus(std::forward_as_tuple("When creating key '", key, "' in bucket '", bucket, "': "),
-                           "PutObject", client_lock.Move()->PutObject(req));
+                           "PutObject", client_lock.Move()->PutObject(req),
+                           ProvenanceOf(holder_, S3ResourceKind::Bucket));
   }
 
   arrow::Status DeleteObject(const std::string& bucket, const std::string& key) {
@@ -1840,7 +2267,8 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     req.SetBucket(ToAwsString(bucket));
     req.SetKey(ToAwsString(key));
     return OutcomeToStatus(std::forward_as_tuple("When delete key '", key, "' in bucket '", bucket, "': "),
-                           "DeleteObject", client_lock.Move()->DeleteObject(req));
+                           "DeleteObject", client_lock.Move()->DeleteObject(req),
+                           ProvenanceOf(holder_, S3ResourceKind::Bucket));
   }
 
   arrow::Status CopyObject(const S3Path& src_path, const S3Path& dest_path) {
@@ -1855,9 +2283,14 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     if (options().use_crc32c_checksum) {
       req.SetChecksumAlgorithm(S3Model::ChecksumAlgorithm::CRC32C);
     }
-    return OutcomeToStatus(std::forward_as_tuple("When copying key '", src_path.key, "' in bucket '", src_path.bucket,
-                                                 "' to key '", dest_path.key, "' in bucket '", dest_path.bucket, "': "),
-                           "CopyObject", client_lock.Move()->CopyObject(req));
+    auto outcome = client_lock.get()->CopyObject(req);
+    if (outcome.IsSuccess()) {
+      return arrow::Status::OK();
+    }
+    return ErrorToStatus(fmt::format("When copying key '{}' in bucket '{}' to key '{}' in bucket '{}': ",
+                                     BoundedDetail(src_path.key, 256), BoundedDetail(src_path.bucket, 128),
+                                     BoundedDetail(dest_path.key, 256), BoundedDetail(dest_path.bucket, 128)),
+                         "CopyObject", outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Object));
   }
 
   // On Minio, an empty "directory" doesn't satisfy the same API requests as
@@ -1908,12 +2341,17 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
         return IsEmptyDirectory(bucket, key);
       }
     }
-    if (IsNotFound(outcome.GetError())) {
+    if (IsExplicitBucketNotFound(outcome.GetError())) {
+      return ErrorToStatus(
+          std::forward_as_tuple("When reading information for key '", key, "' in bucket '", bucket, "': "),
+          "HeadObject", outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Bucket));
+    }
+    if (IsObjectNotFound(outcome.GetError())) {
       return false;
     }
     return ErrorToStatus(
         std::forward_as_tuple("When reading information for key '", key, "' in bucket '", bucket, "': "), "HeadObject",
-        outcome.GetError());
+        outcome.GetError(), ProvenanceOf(holder_));
   }
 
   arrow::Result<bool> IsEmptyDirectory(const S3Path& path,
@@ -1935,12 +2373,14 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       // In some cases, there may be 0 keys but some prefixes
       return r.GetKeyCount() > 0 || !r.GetCommonPrefixes().empty();
     }
-    if (IsNotFound(outcome.GetError())) {
-      return false;
+    if (IsBucketNotFound(outcome.GetError())) {
+      return ErrorToStatus(
+          std::forward_as_tuple("When listing objects under key '", path.key, "' in bucket '", path.bucket, "': "),
+          "ListObjectsV2", outcome.GetError(), ProvenanceOf(holder_, S3ResourceKind::Bucket));
     }
     return ErrorToStatus(
         std::forward_as_tuple("When listing objects under key '", path.key, "' in bucket '", path.bucket, "': "),
-        "ListObjectsV2", outcome.GetError());
+        "ListObjectsV2", outcome.GetError(), ProvenanceOf(holder_));
   }
 
   static FileInfo MakeDirectoryInfo(std::string dirname) {
@@ -2149,13 +2589,10 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       S3Model::ListObjectsV2Outcome outcome = client_lock->Move()->ListObjectsV2(state->req);
       if (!outcome.IsSuccess()) {
         const auto& err = outcome.GetError();
-        if (state->allow_not_found && IsNotFound(err)) {
-          return;
-        }
         state->files_queue.Push(
             ErrorToStatus(std::forward_as_tuple("When listing objects under key '", state->req.GetPrefix(),
                                                 "' in bucket '", state->req.GetBucket(), "': "),
-                          "ListObjectsV2", err));
+                          "ListObjectsV2", err, ProvenanceOf(state->holder, S3ResourceKind::Bucket)));
         return;
       }
       const S3Model::ListObjectsV2Result& result = outcome.GetResult();
@@ -2244,34 +2681,53 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
         std::string_view("FullListBucketScan"));
   }
 
-  // Delete multiple objects at once
+  static arrow::Status DeleteKeyErrorToStatus(const std::string& code, const std::string& message) {
+    const auto lower_message = code + ": " + message;
+    if (fs::internal::IsAccessDeniedErrorName(code)) {
+      return MakeExtendError(ExtendStatusCode::StorageAccessDenied, lower_message);
+    }
+    if (code == "SlowDown" || code == "RequestLimitExceeded" || code == "Throttling") {
+      return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, lower_message);
+    }
+    if (code == "InternalError" || code == "ServiceUnavailable") {
+      return MakeExtendError(ExtendStatusCode::StorageTransientService, lower_message);
+    }
+    if (code == "RequestTimeout") {
+      return MakeExtendError(ExtendStatusCode::StorageTransientTimeout, lower_message);
+    }
+    if (code == "OperationAborted") {
+      return MakeExtendError(ExtendStatusCode::StorageConflict, lower_message);
+    }
+    return arrow::Status::IOError(lower_message);
+  }
+
+  // Delete multiple objects concurrently. Return the first observed
+  // lower-layer failure without waiting for sibling requests to finish.
   Future<> DeleteObjectsAsync(const std::string& bucket, const std::vector<std::string>& keys) {
     struct DeleteCallback {
       std::string bucket;
+      S3ErrorProvenance provenance;
 
       arrow::Status operator()(const S3Model::DeleteObjectsOutcome& outcome) const {
         if (!outcome.IsSuccess()) {
-          return ErrorToStatus("DeleteObjects", outcome.GetError());
+          return ErrorToStatus(std::forward_as_tuple("When deleting objects in bucket '", bucket, "': "),
+                               "DeleteObjects", outcome.GetError(), provenance);
         }
         // Also need to check per-key errors, even on successful outcome
         // See
         // https://docs.aws.amazon.com/fr_fr/AmazonS3/latest/API/multiobjectdeleteapi.html
-        const auto& errors = outcome.GetResult().GetErrors();
-        if (!errors.empty()) {
-          std::stringstream ss;
-          ss << "Got the following " << errors.size() << " errors when deleting objects in S3 bucket '" << bucket
-             << "':\n";
-          for (const auto& error : errors) {
-            ss << "- key '" << error.GetKey() << "': " << error.GetMessage() << "\n";
-          }
-          return arrow::Status::IOError(ss.str());
+        for (const auto& error : outcome.GetResult().GetErrors()) {
+          return DeleteKeyErrorToStatus(error.GetCode(), error.GetMessage());
         }
         return arrow::Status::OK();
       }
     };
 
     const auto chunk_size = static_cast<size_t>(kMultipleDeleteMaxKeys);
-    const DeleteCallback delete_cb{bucket};
+    // A request-level failure says nothing about any individual key: S3 did
+    // not process the batch. In particular, a generic 404 here can only name
+    // the bucket, so do not turn it into object-missing.
+    const DeleteCallback delete_cb{bucket, ProvenanceOf(holder_, S3ResourceKind::Bucket)};
 
     std::vector<Future<>> futures;
     futures.reserve(arrow::bit_util::CeilDiv(keys.size(), chunk_size));
@@ -2303,15 +2759,16 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
             "Content-MD5",
             Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(req.SerializePayload())));
       }
-      ARROW_ASSIGN_OR_RAISE(
-          auto fut, SubmitIO(io_context_, [holder = holder_, req = std::move(req), delete_cb]() -> arrow::Status {
-            ARROW_ASSIGN_OR_RAISE(auto client_lock, holder->Lock());
-            return delete_cb(client_lock.Move()->DeleteObjects(req));
-          }));
-      futures.push_back(std::move(fut));
+      auto maybe_fut = SubmitIO(io_context_, [holder = holder_, req = std::move(req), delete_cb]() -> arrow::Status {
+        ARROW_ASSIGN_OR_RAISE(auto client_lock, holder->Lock());
+        return delete_cb(client_lock.Move()->DeleteObjects(req));
+      });
+      if (!maybe_fut.ok()) {
+        return Future<>::MakeFinished(maybe_fut.status());
+      }
+      futures.push_back(std::move(maybe_fut).ValueOrDie());
     }
-
-    return AllFinished(futures);
+    return AllComplete(futures);
   }
 
   arrow::Status DeleteObjects(const std::string& bucket, const std::vector<std::string>& keys) {
@@ -2337,13 +2794,20 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
       if (outcome.IsSuccess()) {
         return IsDirectory(key, outcome.GetResult());
       }
-      if (IsNotFound(outcome.GetError())) {
-        // If we can't find it then it isn't a file.
+      if (IsExplicitBucketNotFound(outcome.GetError())) {
+        return ErrorToStatus(
+            std::forward_as_tuple("When getting information for key '", key, "' in bucket '", bucket, "': "),
+            "HeadObject", outcome.GetError(), ProvenanceOf(self->holder_, S3ResourceKind::Bucket));
+      }
+      if (IsObjectNotFound(outcome.GetError())) {
+        // If we can't find the key then it isn't a file. A generic 404 may still
+        // be a missing bucket; the ListObjects step that follows this guard is
+        // bucket-level and will return 118 rather than swallowing it.
         return true;
       } else {
         return ErrorToStatus(
             std::forward_as_tuple("When getting information for key '", key, "' in bucket '", bucket, "': "),
-            "HeadObject", outcome.GetError());
+            "HeadObject", outcome.GetError(), ProvenanceOf(self->holder_));
       }
     }));
   }
@@ -2465,9 +2929,11 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
     return arrow::Status::OK();
   }
 
-  static arrow::Result<std::vector<std::string>> ProcessListBuckets(const S3Model::ListBucketsOutcome& outcome) {
+  static arrow::Result<std::vector<std::string>> ProcessListBuckets(const S3Model::ListBucketsOutcome& outcome,
+                                                                    S3ErrorProvenance provenance) {
     if (!outcome.IsSuccess()) {
-      return ErrorToStatus(std::forward_as_tuple("When listing buckets: "), "ListBuckets", outcome.GetError());
+      return ErrorToStatus(std::forward_as_tuple("When listing buckets: "), "ListBuckets", outcome.GetError(),
+                           provenance);
     }
     std::vector<std::string> buckets;
     buckets.reserve(outcome.GetResult().GetBuckets().size());
@@ -2479,13 +2945,13 @@ class S3FileSystem::Impl : public std::enable_shared_from_this<S3FileSystem::Imp
 
   arrow::Result<std::vector<std::string>> ListBuckets() {
     ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
-    return ProcessListBuckets(client_lock.Move()->ListBuckets());
+    return ProcessListBuckets(client_lock.Move()->ListBuckets(), ProvenanceOf(holder_));
   }
 
   Future<std::vector<std::string>> ListBucketsAsync() {
     auto deferred = [self = shared_from_this()]() mutable -> arrow::Result<std::vector<std::string>> {
       ARROW_ASSIGN_OR_RAISE(auto client_lock, self->holder_->Lock());
-      return self->ProcessListBuckets(client_lock.Move()->ListBuckets());
+      return self->ProcessListBuckets(client_lock.Move()->ListBuckets(), ProvenanceOf(self->holder_));
     };
     return DeferNotOk(SubmitIO(io_context_, std::move(deferred)));
   }
@@ -2593,12 +3059,9 @@ arrow::Result<FileInfo> S3FileSystem::GetFileInfo(const std::string& s) {
 
     auto outcome = client_lock.Move()->HeadBucket(req);
     if (!outcome.IsSuccess()) {
-      if (!IsNotFound(outcome.GetError())) {
-        const auto msg = "When getting information for bucket '" + path.bucket + "': ";
-        return ErrorToStatus(msg, "HeadBucket", outcome.GetError(), impl_->options().region);
-      }
-      info.set_type(FileType::NotFound);
-      return info;
+      const auto msg = "When getting information for bucket '" + path.bucket + "': ";
+      return ErrorToStatus(msg, "HeadBucket", outcome.GetError(), S3ErrorProvenance{S3ResourceKind::Bucket},
+                           impl_->options().region);
     }
     // NOTE: S3 doesn't have a bucket modification time.  Only a creation
     // time is available, and you have to list all buckets to get it.
@@ -2616,9 +3079,15 @@ arrow::Result<FileInfo> S3FileSystem::GetFileInfo(const std::string& s) {
       FileObjectToInfo(path.key, outcome.GetResult(), &info);
       return info;
     }
-    if (!IsNotFound(outcome.GetError())) {
+    if (IsExplicitBucketNotFound(outcome.GetError())) {
       const auto msg = "When getting information for key '" + path.key + "' in bucket '" + path.bucket + "': ";
-      return ErrorToStatus(msg, "HeadObject", outcome.GetError(), impl_->options().region);
+      return ErrorToStatus(msg, "HeadObject", outcome.GetError(), S3ErrorProvenance{S3ResourceKind::Bucket},
+                           impl_->options().region);
+    }
+    if (!IsObjectNotFound(outcome.GetError())) {
+      const auto msg = "When getting information for key '" + path.key + "' in bucket '" + path.bucket + "': ";
+      return ErrorToStatus(msg, "HeadObject", outcome.GetError(), S3ErrorProvenance{S3ResourceKind::Object},
+                           impl_->options().region);
     }
     // Not found => perhaps it's an empty "directory"
     ARROW_ASSIGN_OR_RAISE(bool is_dir, impl_->IsEmptyDirectory(path, &outcome));
@@ -2736,7 +3205,7 @@ arrow::Status S3FileSystem::DeleteDir(const std::string& s) {
     S3Model::DeleteBucketRequest req;
     req.SetBucket(ToAwsString(path.bucket));
     return OutcomeToStatus(std::forward_as_tuple("When deleting bucket '", path.bucket, "': "), "DeleteBucket",
-                           client_lock.Move()->DeleteBucket(req));
+                           client_lock.Move()->DeleteBucket(req), S3ErrorProvenance{S3ResourceKind::Bucket});
   } else if (path.key.empty()) {
     return arrow::Status::IOError("Would delete bucket '", path.bucket, "'. ",
                                   "To delete buckets, enable the allow_bucket_deletion option.");
@@ -2790,12 +3259,20 @@ arrow::Status S3FileSystem::DeleteFile(const std::string& s) {
 
   auto outcome = client_lock.Move()->HeadObject(req);
   if (!outcome.IsSuccess()) {
-    if (IsNotFound(outcome.GetError())) {
+    if (IsExplicitBucketNotFound(outcome.GetError())) {
+      return ErrorToStatus(
+          std::forward_as_tuple("When getting information for key '", path.key, "' in bucket '", path.bucket, "': "),
+          "HeadObject", outcome.GetError(), S3ErrorProvenance{S3ResourceKind::Bucket});
+    }
+    if (IsObjectNotFound(outcome.GetError())) {
+      // A bodyless object HEAD cannot distinguish a missing key from a missing
+      // bucket. Keep the operation-level missing-object result; diagnosing it
+      // with HeadBucket would add I/O only after the original operation failed.
       return PathNotFound(path);
     } else {
       return ErrorToStatus(
           std::forward_as_tuple("When getting information for key '", path.key, "' in bucket '", path.bucket, "': "),
-          "HeadObject", outcome.GetError());
+          "HeadObject", outcome.GetError(), S3ErrorProvenance{});
     }
   }
   // Object found, delete it

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/filesystem/fs.h"
 
+#include <chrono>
 #include <cstdlib>
 #include <mutex>
 #include <sstream>
@@ -23,7 +25,6 @@
 
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
-#include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
 #include <aws/core/platform/Environment.h>
@@ -48,8 +49,10 @@
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
+#include "milvus-storage/filesystem/s3/s3_client.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
@@ -98,6 +101,25 @@ class TlsHttpClientFactory : public Aws::Http::HttpClientFactory {
   std::string tls_min_version_;
 };
 
+arrow::Status ResolveCredentialsForConstruction(const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& provider,
+                                                std::string_view source) {
+  if (provider == nullptr) {
+    return MakeCredentialConfigError(std::string(source) + " credential provider is null");
+  }
+  auto resolver = std::dynamic_pointer_cast<RequestCredentialsResolver>(provider);
+  if (resolver == nullptr) {
+    // AWS SDK providers expose only GetAWSCredentials(), which cannot preserve
+    // a typed failure cause. Let the SDK resolve them at request time.
+    return arrow::Status::OK();
+  }
+
+  // Repository-owned providers can preserve typed causes. Their preflight may
+  // enter STS or IMDS, so keep it inside the SDK shutdown barrier.
+  auto operation_lease = GetClientFinalizer()->LockShared();
+  ARROW_RETURN_NOT_OK(CheckS3Initialized());
+  return resolver->ResolveForRequest().status();
+}
+
 }  // namespace
 
 static std::unordered_map<std::string, S3LogLevel> LogLevel_Map = {
@@ -130,7 +152,10 @@ arrow::Status S3FileSystemProducer::InitS3() {
     }
 
     // Register cleanup on exit. atexit handlers must not throw, so log on failure.
+    // Construct the cache first so this callback runs before its destructor.
+    (void)FilesystemCache::getInstance();
     std::atexit([]() {
+      FilesystemCache::getInstance().clean();
       auto status = EnsureS3Finalized();
       if (!status.ok()) {
         LOG_STORAGE_ERROR_ << "S3FileSystemProducer failed to finalize S3: " << status.ToString();
@@ -177,6 +202,10 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
   options.use_crc32c_checksum = config_.use_crc32c_checksum;
   options.use_crt_async_reads = config_.s3_crt_async_read;
 
+  if (config_.cloud_provider == kCloudProviderAWS && (config_.use_iam || !config_.role_arn.empty())) {
+    ARROW_RETURN_NOT_OK(ValidateAwsEnvironmentCredentials());
+  }
+
   // Credential configuration priority:
   // 1. AssumeRole (role_arn) — AWS (AssumeRole) or Aliyun (AssumeRoleWithOIDC)
   // 2. IAM — use provider-specific STS credential providers
@@ -215,11 +244,11 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
         if (Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_TOKEN_FILE").empty() ||
             Aws::Environment::GetEnv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN").empty() ||
             Aws::Environment::GetEnv("ALIBABA_CLOUD_ROLE_ARN").empty()) {
-          return arrow::Status::Invalid(
-              "Aliyun role_arn requires ALIBABA_CLOUD_OIDC_TOKEN_FILE, "
-              "ALIBABA_CLOUD_OIDC_PROVIDER_ARN and ALIBABA_CLOUD_ROLE_ARN "
-              "in process environment (or set ALIYUN_ROLE_ARN_AUTH_MODE=ram "
-              "for ECS IMDS-based AssumeRole)");
+          return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                    "Aliyun role_arn requires ALIBABA_CLOUD_OIDC_TOKEN_FILE, "
+                                    "ALIBABA_CLOUD_OIDC_PROVIDER_ARN and ALIBABA_CLOUD_ROLE_ARN "
+                                    "in process environment (or set ALIYUN_ROLE_ARN_AUTH_MODE=ram "
+                                    "for ECS IMDS-based AssumeRole)");
         }
         if (config_.load_frequency > 0) {
           LOG_STORAGE_WARNING_ << "Aliyun OIDC chain AssumeRole refresh grace is fixed; load_frequency ignored";
@@ -237,20 +266,32 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
         options.credentials_kind = S3CredentialsKind::WebIdentity;
       }
     } else {
-      return arrow::Status::Invalid("role_arn not supported for cloud provider: ", config_.cloud_provider);
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "role_arn not supported for cloud provider: ", config_.cloud_provider);
     }
+    ARROW_RETURN_NOT_OK(
+        ResolveCredentialsForConstruction(options.credentials_provider, config_.cloud_provider + " role_arn"));
   } else if (config_.use_iam) {
     auto provider = CreateCredentialsProvider();
     if (!provider) {
-      return arrow::Status::Invalid("Unknown credentials provider, cloud provider: ", config_.cloud_provider);
+      return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid,
+                                "Unknown credentials provider, cloud provider: ", config_.cloud_provider);
     }
-    auto credentials = provider->GetAWSCredentials();
-    assert(!credentials.GetAWSAccessKeyId().empty() && "AWS Access Key ID is empty");
-    assert(!credentials.GetAWSSecretKey().empty() && "AWS Secret Key is empty");
-    assert(!credentials.GetSessionToken().empty() && "AWS Session Token is empty");
+    ARROW_RETURN_NOT_OK(ResolveCredentialsForConstruction(provider, config_.cloud_provider + " IAM provider"));
     options.credentials_provider = provider;
+    if (config_.cloud_provider == kCloudProviderAWS) {
+      options.credentials_kind = S3CredentialsKind::Default;
+    } else {
+      options.credentials_kind = S3CredentialsKind::WebIdentity;
+    }
   } else {
-    options.ConfigureAccessKey(config_.access_key_id, config_.access_key_value);
+    ARROW_RETURN_NOT_OK(
+        ValidateStaticCredentials(config_.access_key_id, config_.access_key_value, "", "filesystem configuration"));
+    if (config_.access_key_id.empty()) {
+      options.ConfigureAnonymousCredentials();
+    } else {
+      options.ConfigureAccessKey(config_.access_key_id, config_.access_key_value);
+    }
   }
 
   return options;
@@ -274,7 +315,8 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3FileSystemProducer::CreateC
 
 // Factories below deliberately do not cache a `static` instance:
 // - FilesystemCache dedupes one level up (fs.cpp:223).
-// - Provider construction is cheap; STS I/O happens lazily in GetAWSCredentials().
+// - Provider construction is cheap; CreateS3Options performs one explicit
+//   request-local preflight before publishing the filesystem.
 // - Per-tenant role_arn requires multiple instances per process; `static` defeats that.
 // - `static` + AWS SDK has a shutdown-order hazard (Aws::ShutdownAPI runs before static dtors).
 

--- a/cpp/src/filesystem/s3/s3_options.cpp
+++ b/cpp/src/filesystem/s3/s3_options.cpp
@@ -14,10 +14,12 @@
 
 #include "milvus-storage/filesystem/s3/s3_options.h"
 
+#include <typeinfo>
+
 #include <aws/core/auth/AWSCredentials.h>
-#include <aws/core/auth/STSCredentialsProvider.h>
-#include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 
@@ -256,6 +258,50 @@ arrow::Result<S3Options> S3Options::FromUri(const std::string& uri_string, std::
   return FromUri(uri, out_path);
 }
 
+namespace {
+
+bool CredentialsEqualWithoutRefresh(const S3Options& left, const S3Options& right) {
+  if (left.credentials_provider == right.credentials_provider) {
+    return true;
+  }
+  if (left.credentials_provider == nullptr || right.credentials_provider == nullptr) {
+    return false;
+  }
+  auto* left_provider = left.credentials_provider.get();
+  auto* right_provider = right.credentials_provider.get();
+
+  if (left.credentials_kind == S3CredentialsKind::Anonymous) {
+    return typeid(*left_provider) == typeid(Aws::Auth::AnonymousAWSCredentialsProvider) &&
+           typeid(*right_provider) == typeid(Aws::Auth::AnonymousAWSCredentialsProvider);
+  }
+  if (left.credentials_kind != S3CredentialsKind::Explicit) {
+    // Resolving a dynamic provider here can enter STS, a container endpoint, or
+    // IMDS without a filesystem operation lease. Provider identity is a safe,
+    // conservative equality rule when no stable credential identity is stored
+    // in S3Options: a false negative is preferable to treating two tenants as
+    // the same filesystem.
+    return false;
+  }
+
+  // SimpleAWSCredentialsProvider::GetAWSCredentials is virtual. Only call it
+  // for the exact SDK value-holder type; a caller-supplied subclass may refresh
+  // credentials and has no stable identity that Equals can safely infer.
+  if (typeid(*left_provider) != typeid(Aws::Auth::SimpleAWSCredentialsProvider) ||
+      typeid(*right_provider) != typeid(Aws::Auth::SimpleAWSCredentialsProvider)) {
+    return false;
+  }
+
+  const auto left_credentials =
+      static_cast<Aws::Auth::SimpleAWSCredentialsProvider*>(left_provider)->GetAWSCredentials();
+  const auto right_credentials =
+      static_cast<Aws::Auth::SimpleAWSCredentialsProvider*>(right_provider)->GetAWSCredentials();
+  return left_credentials.GetAWSAccessKeyId() == right_credentials.GetAWSAccessKeyId() &&
+         left_credentials.GetAWSSecretKey() == right_credentials.GetAWSSecretKey() &&
+         left_credentials.GetSessionToken() == right_credentials.GetSessionToken();
+}
+
+}  // namespace
+
 bool S3Options::Equals(const S3Options& other) const {
   const int64_t default_metadata_size = default_metadata ? default_metadata->size() : 0;
   const bool default_metadata_equals =
@@ -266,11 +312,14 @@ bool S3Options::Equals(const S3Options& other) const {
           scheme == other.scheme && role_arn == other.role_arn && session_name == other.session_name &&
           external_id == other.external_id && load_frequency == other.load_frequency &&
           proxy_options.Equals(other.proxy_options) && credentials_kind == other.credentials_kind &&
-          background_writes == other.background_writes && use_crc32c_checksum == other.use_crc32c_checksum &&
-          use_crt_async_reads == other.use_crt_async_reads && allow_bucket_creation == other.allow_bucket_creation &&
-          allow_bucket_deletion == other.allow_bucket_deletion && default_metadata_equals &&
-          GetAccessKey() == other.GetAccessKey() && GetSecretKey() == other.GetSecretKey() &&
-          GetSessionToken() == other.GetSessionToken());
+          force_virtual_addressing == other.force_virtual_addressing && background_writes == other.background_writes &&
+          use_crc32c_checksum == other.use_crc32c_checksum && use_crt_async_reads == other.use_crt_async_reads &&
+          allow_bucket_creation == other.allow_bucket_creation &&
+          allow_bucket_deletion == other.allow_bucket_deletion &&
+          check_directory_existence_before_creation == other.check_directory_existence_before_creation &&
+          default_metadata_equals && retry_strategy == other.retry_strategy &&
+          max_connections == other.max_connections && multi_part_upload_size == other.multi_part_upload_size &&
+          cloud_provider == other.cloud_provider && CredentialsEqualWithoutRefresh(*this, other));
 }
 
 bool S3ProxyOptions::Equals(const S3ProxyOptions& other) const {

--- a/cpp/test/common/extend_status_test.cpp
+++ b/cpp/test/common/extend_status_test.cpp
@@ -161,7 +161,6 @@ TEST_F(ExtendStatusTest, WrapExtendErrorPreservesOutOfMemory) {
 TEST_F(ExtendStatusTest, ExtendCodesMapToSegcoreErrorCode) {
   EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::PackedUnexpected), milvus::UnexpectedError);
   EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::StorageAccessDenied), milvus::ConfigInvalid);
-  EXPECT_EQ(ToSegcoreErrorCode(ExtendStatusCode::AwsErrorNonRetryable), milvus::StorageError);
 }
 
 TEST_F(ExtendStatusTest, PlainArrowStatusFallsBackToCoarseClassification) {

--- a/cpp/test/ffi/error_taxonomy_test.cpp
+++ b/cpp/test/ffi/error_taxonomy_test.cpp
@@ -235,7 +235,6 @@ TEST(ErrorTaxonomyTest, ExportedConstantsMatchMacros) {
   EXPECT_EQ(loon_errcode_storage_precondition_failed, LOON_STORAGE_PRECONDITION_FAILED);
   EXPECT_EQ(loon_errcode_storage_not_found, LOON_STORAGE_NOT_FOUND);
   EXPECT_EQ(loon_errcode_storage_access_denied, LOON_STORAGE_ACCESS_DENIED);
-  EXPECT_EQ(loon_errcode_aws_non_retryable, LOON_AWS_ERROR_NON_RETRYABLE);
   EXPECT_EQ(loon_errcode_transient_network, LOON_TRANSIENT_NETWORK);
   EXPECT_EQ(loon_errcode_transient_timeout, LOON_TRANSIENT_TIMEOUT);
   EXPECT_EQ(loon_errcode_transient_throttling, LOON_TRANSIENT_THROTTLING);

--- a/cpp/test/ffi/ffi_filesystem_test.c
+++ b/cpp/test/ffi/ffi_filesystem_test.c
@@ -976,7 +976,6 @@ static void test_retryable_errcode_helper(void) {
   ck_assert(!loon_ffi_is_retryable_errcode(loon_errcode_aws_precondition_failed));
   ck_assert(!loon_ffi_is_retryable_errcode(loon_errcode_aws_not_found));
   ck_assert(!loon_ffi_is_retryable_errcode(loon_errcode_aws_access_denied));
-  ck_assert(!loon_ffi_is_retryable_errcode(loon_errcode_aws_non_retryable));
   ck_assert(!loon_ffi_is_retryable_errcode(loon_errcode_txn_exhausted_retry));
   ck_assert(!loon_ffi_is_retryable_errcode(loon_errcode_txn_resolution_failed));
   ck_assert(!loon_ffi_is_retryable_errcode(99999));

--- a/cpp/test/filesystem/azure_error_classification_test.cpp
+++ b/cpp/test/filesystem/azure_error_classification_test.cpp
@@ -20,7 +20,10 @@
 
 #include <gtest/gtest.h>
 
+#include <azure/core/exception.hpp>
+
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include "common/EasyAssert.h"
@@ -30,8 +33,10 @@
 namespace milvus_storage::fs::internal {
 namespace {
 
-milvus::ErrorCode SegcoreCodeFor(int http_status, std::string_view error_code = "") {
-  auto code = ClassifyAzureError(http_status, error_code, /*transport_failure=*/false);
+milvus::ErrorCode SegcoreCodeFor(int http_status,
+                                 std::string_view error_code = "",
+                                 std::string_view reason_phrase = "") {
+  auto code = ClassifyAzureError(http_status, error_code, /*transport_failure=*/false, reason_phrase);
   if (!code.has_value()) {
     // Untagged: this is what the caller actually produces -- a plain IOError.
     return ToSegcoreError(arrow::Status::IOError("azure failure")).get_error_code();
@@ -64,7 +69,7 @@ TEST(AzureErrorClassification, TransientStatusesAreRetriable) {
     auto code = ClassifyAzureError(c.http_status, c.error_code, /*transport_failure=*/false);
     ASSERT_TRUE(code.has_value()) << c.http_status << " " << c.error_code;
     EXPECT_EQ(*code, c.expected) << c.http_status << " " << c.error_code;
-    EXPECT_TRUE(DefaultRetryableForExtendStatusCode(*code)) << c.http_status;
+    EXPECT_TRUE(RetryableForExtendStatusCode(*code)) << c.http_status;
     EXPECT_EQ(ToSegcoreErrorCode(*code), milvus::StorageTransientError) << c.http_status;
   }
 
@@ -73,7 +78,7 @@ TEST(AzureErrorClassification, TransientStatusesAreRetriable) {
   auto transport = ClassifyAzureError(0, "", /*transport_failure=*/true);
   ASSERT_TRUE(transport.has_value());
   EXPECT_EQ(*transport, ExtendStatusCode::StorageTransientNetwork);
-  EXPECT_TRUE(DefaultRetryableForExtendStatusCode(*transport));
+  EXPECT_TRUE(RetryableForExtendStatusCode(*transport));
 }
 
 // The counter-example that makes `transport_failure` load-bearing.
@@ -96,7 +101,7 @@ TEST(AzureErrorClassification, StatusZeroWithoutTransportIsNotRetriable) {
   EXPECT_EQ(ToSegcoreErrorCode(*transport), milvus::StorageTransientError);
 }
 
-TEST(AzureErrorClassification, PermanentStatusesAreNotRetriable) {
+TEST(AzureErrorClassification, NonRetriableStatusesNeverLookTransient) {
   struct Case {
     int http_status;
     std::string_view error_code;
@@ -106,22 +111,49 @@ TEST(AzureErrorClassification, PermanentStatusesAreNotRetriable) {
   const Case cases[] = {
       // Not-found is fine-grained: a consumer can tell "data missing" from a
       // generic storage failure, matching what the S3 path already reports.
-      {404, "BlobNotFound", ExtendStatusCode::AwsErrorNotFound, milvus::ObjectNotExist},
-      {401, "", ExtendStatusCode::AwsErrorAccessDenied, milvus::ConfigInvalid},
-      {403, "AuthenticationFailed", ExtendStatusCode::AwsErrorAccessDenied, milvus::ConfigInvalid},
-      {412, "ConditionNotMet", ExtendStatusCode::AwsErrorPreConditionFailed, milvus::StorageError},
-      {409, "BlobAlreadyExists", ExtendStatusCode::AwsErrorPreConditionFailed, milvus::StorageError},
+      {404, "BlobNotFound", ExtendStatusCode::StorageNotFound, milvus::ObjectNotExist},
+      // System: the credentials are operator configuration, so this has to
+      // reach whoever owns the deployment (segcore 2006) rather than be filed
+      // as a generic storage failure (2044).
+      {401, "", ExtendStatusCode::StorageAccessDenied, milvus::ConfigInvalid},
+      {403, "AuthenticationFailed", ExtendStatusCode::StorageAccessDenied, milvus::ConfigInvalid},
   };
 
   for (const auto& c : cases) {
     auto code = ClassifyAzureError(c.http_status, c.error_code, /*transport_failure=*/false);
     ASSERT_TRUE(code.has_value()) << c.http_status << " " << c.error_code;
     EXPECT_EQ(*code, c.expected) << c.http_status;
-    EXPECT_FALSE(DefaultRetryableForExtendStatusCode(*code)) << c.http_status;
+    EXPECT_FALSE(RetryableForExtendStatusCode(*code)) << c.http_status;
     EXPECT_EQ(ToSegcoreErrorCode(*code), c.segcore) << c.http_status;
-    // A permanent failure must never look transient, or a consumer retry-storms
-    // a request that can never succeed.
+    // A non-retriable failure must never look transient, or a consumer
+    // retry-storms a request that can never succeed.
     EXPECT_NE(ToSegcoreErrorCode(*code), milvus::StorageTransientError) << c.http_status;
+  }
+}
+
+// 412 and 409-already-exists used to sit in the System test above. They are
+// Conflict: someone else won a race, and a new re-read/rebase attempt may
+// succeed, while replaying the same conditional request fails identically.
+//
+// That is why Conflict is its own category rather than part of Transient, and
+// why these cases need their own test.
+TEST(AzureErrorClassification, PreconditionFailuresAreConflictNotSystem) {
+  struct Case {
+    int http_status;
+    std::string_view error_code;
+  };
+  const Case cases[] = {
+      {412, "ConditionNotMet"},
+      {409, "BlobAlreadyExists"},
+  };
+
+  for (const auto& c : cases) {
+    auto code = ClassifyAzureError(c.http_status, c.error_code, /*transport_failure=*/false);
+    ASSERT_TRUE(code.has_value()) << c.http_status << " " << c.error_code;
+    EXPECT_EQ(*code, ExtendStatusCode::StoragePreConditionFailed) << c.http_status;
+    EXPECT_EQ(CategoryForExtendStatusCode(*code), ErrorCategory::Conflict) << c.http_status;
+    EXPECT_FALSE(RetryableForExtendStatusCode(*code)) << c.http_status;
+    EXPECT_EQ(ToSegcoreErrorCode(*code), milvus::StorageError) << c.http_status;
   }
 }
 
@@ -136,6 +168,15 @@ TEST(AzureErrorClassification, UnidentifiedStatusesStayUntagged) {
 
   // 409 that is not "already exists" is a different condition; not guessed at.
   EXPECT_FALSE(ClassifyAzureError(409, "LeaseIdMissing", /*transport_failure=*/false).has_value());
+
+  // 412 gets the same treatment, which it did not used to. Azure answers 412
+  // both for a genuine etag mismatch and for lease problems; classifying every
+  // 412 as a precondition conflict was a guess, and it sat directly above the
+  // 409 case that already refused to guess.
+  EXPECT_FALSE(ClassifyAzureError(412, "LeaseIdMismatchWithBlobOperation", /*transport_failure=*/false).has_value());
+  EXPECT_FALSE(ClassifyAzureError(412, "LeaseNotPresentWithBlobOperation", /*transport_failure=*/false).has_value());
+  EXPECT_FALSE(ClassifyAzureError(412, "", /*transport_failure=*/false).has_value());
+  EXPECT_EQ(SegcoreCodeFor(412, "LeaseIdMismatchWithBlobOperation"), milvus::StorageError);
   EXPECT_EQ(SegcoreCodeFor(409, "LeaseIdMissing"), milvus::StorageError);
 }
 
@@ -150,6 +191,106 @@ TEST(AzureErrorClassification, ClosesTheTwoGapsFrom595) {
   // (b) A missing blob is distinguishable from a generic storage failure.
   EXPECT_EQ(SegcoreCodeFor(404, "BlobNotFound"), milvus::ObjectNotExist);
   EXPECT_NE(SegcoreCodeFor(404, "BlobNotFound"), SegcoreCodeFor(400, ""));
+}
+
+// A missing container is a deployment mistake, a missing blob may be a GC race.
+// Azure answers 404 to both; before this split the consumer was told to re-read
+// its metadata in a case where no metadata could ever produce a container.
+TEST(AzureErrorClassification, MissingContainerAndBlobAreDistinctSystemCodes) {
+  // Azure reports it either way -- ErrorCode when it has one, ReasonPhrase when
+  // it does not. Both must reach the same verdict, or the classification would
+  // depend on which form the service happened to send.
+  const std::vector<std::pair<std::string_view, std::string_view>> container_gone = {
+      {"ContainerNotFound", ""},
+      {"", "The specified container does not exist."},
+      {"", "The specified filesystem does not exist."},
+  };
+  for (const auto& [error_code, reason] : container_gone) {
+    auto code = ClassifyAzureError(404, error_code, /*transport_failure=*/false, reason);
+    ASSERT_TRUE(code.has_value()) << error_code << "/" << reason;
+    EXPECT_EQ(*code, ExtendStatusCode::StorageBucketNotFound) << error_code << "/" << reason;
+    EXPECT_EQ(CategoryForExtendStatusCode(*code), ErrorCategory::System) << error_code << "/" << reason;
+    EXPECT_EQ(SegcoreCodeFor(404, error_code, reason), milvus::BucketInvalid) << error_code << "/" << reason;
+  }
+
+  // Container-level operations retain their provenance even when a proxy
+  // strips both Azure diagnostic strings from a bodyless 404.
+  auto bodyless_container = ClassifyAzureError(404, "", /*transport_failure=*/false, "", AzureResourceKind::Container);
+  ASSERT_TRUE(bodyless_container.has_value());
+  EXPECT_EQ(*bodyless_container, ExtendStatusCode::StorageBucketNotFound);
+  EXPECT_EQ(CategoryForExtendStatusCode(*bodyless_container), ErrorCategory::System);
+
+  // A missing blob keeps the object-not-found code. This is the half that must
+  // NOT move to BucketInvalid, which would page an operator for what may be a GC
+  // race the consumer can resolve itself.
+  auto blob = ClassifyAzureError(404, "BlobNotFound", /*transport_failure=*/false, "");
+  ASSERT_TRUE(blob.has_value());
+  EXPECT_EQ(*blob, ExtendStatusCode::StorageNotFound);
+  EXPECT_EQ(CategoryForExtendStatusCode(*blob), ErrorCategory::System);
+  EXPECT_EQ(SegcoreCodeFor(404, "BlobNotFound"), milvus::ObjectNotExist);
+}
+
+TEST(AzureErrorClassification, SyntheticBrokerUnexpectedStaysUnexpected) {
+  Azure::Core::RequestFailedException error("broker failure");
+  error.StatusCode = Azure::Core::Http::HttpStatusCode::InternalServerError;
+  error.ErrorCode = kSyntheticBrokerUnexpectedErrorCode;
+
+  auto status = AzureExceptionToStatus(error, "FetchSasToken:");
+
+  EXPECT_TRUE(status.IsUnknownError()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+}
+
+TEST(AzureErrorClassification, SyntheticBrokerOutOfMemoryStaysOutOfMemory) {
+  Azure::Core::RequestFailedException error("broker allocation failure");
+  error.StatusCode = Azure::Core::Http::HttpStatusCode::InternalServerError;
+  error.ErrorCode = kSyntheticBrokerOutOfMemoryErrorCode;
+
+  auto status = AzureExceptionToStatus(error, "FetchSasToken:");
+
+  EXPECT_TRUE(status.IsOutOfMemory()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::MemAllocateFailed);
+}
+
+// The producer/consumer round-trip: every LoonBroker* code the SAS policy
+// stamps must map back to the exact ExtendStatusCode it started from. The
+// prefix is what lets ClassifyAzureError short-circuit before the HTTP-status
+// switch, so the synthetic status is deliberately varied -- and, for network,
+// 503 rather than a "connection dropped" status HTTP does not have.
+TEST(AzureErrorClassification, BrokerErrorCodeRoundTripsToExtendStatus) {
+  struct Case {
+    std::string_view error_code;
+    ExtendStatusCode expected;
+  };
+  const Case cases[] = {
+      {kSyntheticBrokerAccessDeniedErrorCode, ExtendStatusCode::StorageAccessDenied},
+      {kSyntheticBrokerTimeoutErrorCode, ExtendStatusCode::StorageTransientTimeout},
+      {kSyntheticBrokerThrottlingErrorCode, ExtendStatusCode::StorageTransientThrottling},
+      {kSyntheticBrokerServiceUnavailableErrorCode, ExtendStatusCode::StorageTransientService},
+      {kSyntheticBrokerNetworkErrorCode, ExtendStatusCode::StorageTransientNetwork},
+  };
+  for (const auto& c : cases) {
+    auto code = BrokerErrorCodeToExtendStatus(c.error_code);
+    ASSERT_TRUE(code.has_value()) << c.error_code;
+    EXPECT_EQ(*code, c.expected) << c.error_code;
+  }
+
+  // The OOM and unexpected codes are not ExtendStatusCode conditions and stay
+  // unmapped here -- AzureExceptionToStatus handles them before the classifier.
+  EXPECT_FALSE(BrokerErrorCodeToExtendStatus(kSyntheticBrokerOutOfMemoryErrorCode).has_value());
+  EXPECT_FALSE(BrokerErrorCodeToExtendStatus(kSyntheticBrokerUnexpectedErrorCode).has_value());
+
+  // The prefix short-circuits the status switch, so the synthetic HTTP status
+  // never leaks into the classification -- including the OOM/unexpected codes,
+  // which must not fall through to 500 -> StorageTransientService.
+  auto via_classifier = ClassifyAzureError(503, kSyntheticBrokerNetworkErrorCode, false);
+  ASSERT_TRUE(via_classifier.has_value());
+  EXPECT_EQ(*via_classifier, ExtendStatusCode::StorageTransientNetwork);
+
+  EXPECT_FALSE(ClassifyAzureError(500, kSyntheticBrokerOutOfMemoryErrorCode, false).has_value());
+  EXPECT_FALSE(ClassifyAzureError(500, kSyntheticBrokerUnexpectedErrorCode, false).has_value());
 }
 
 }  // namespace milvus_storage::fs::internal

--- a/cpp/test/filesystem/azure_file_system_test.cpp
+++ b/cpp/test/filesystem/azure_file_system_test.cpp
@@ -21,9 +21,20 @@
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/files/datalake.hpp>
 
+#include <cstdint>
+#include <vector>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/filesystem/azure/azure_fs_producer.h"
 #include "milvus-storage/filesystem/azure/azurefs.h"
 
 namespace milvus_storage::fs {
+
+namespace internal {
+std::vector<arrow::Status> RunHealthyCloseAbortCloseForTest();
+std::vector<arrow::Status> RunBackgroundUploadOutcomeFailureForTest(int64_t* blocks_in_progress, bool* future_finished);
+}  // namespace internal
 
 // ============================================================================
 // AzureFileSystem initialization tests (no network required)
@@ -101,6 +112,34 @@ TEST(AzureFileSystem, InitializeWithEnvironmentCredential) {
 TEST(AzureFileSystem, OptionsCompare) {
   AzureOptions options;
   EXPECT_TRUE(options.Equals(options));
+}
+
+TEST(AzureFileSystem, BackgroundUploadChildFailureSettlesBlockAndPublishesFuture) {
+  int64_t blocks_in_progress = -1;
+  bool future_finished = false;
+  std::vector<arrow::Status> statuses;
+  ASSERT_NO_THROW(statuses = internal::RunBackgroundUploadOutcomeFailureForTest(&blocks_in_progress, &future_finished));
+
+  EXPECT_EQ(blocks_in_progress, 0);
+  // The aggregate future must always be completed by the completion that claims
+  // the publish slot. Leaving it pending strands every FlushAsync/CloseAsync
+  // waiter, which no later completion can rescue once the slot is consumed.
+  EXPECT_TRUE(future_finished);
+  ASSERT_EQ(statuses.size(), 4);
+  EXPECT_TRUE(statuses[0].IsIOError()) << statuses[0].ToString();
+  EXPECT_NE(statuses[0].message().find("injected Azure child upload failure"), std::string::npos)
+      << statuses[0].ToString();
+  EXPECT_TRUE(statuses[1].Equals(statuses[0])) << statuses[1].ToString();
+  EXPECT_TRUE(statuses[2].Equals(statuses[0])) << statuses[2].ToString();
+  EXPECT_TRUE(statuses[3].ok()) << statuses[3].ToString();
+}
+
+TEST(AzureFileSystem, AbortAfterSuccessfulClosePreservesIdempotentClose) {
+  auto statuses = internal::RunHealthyCloseAbortCloseForTest();
+  ASSERT_EQ(statuses.size(), 3);
+  EXPECT_TRUE(statuses[0].ok()) << statuses[0].ToString();
+  EXPECT_TRUE(statuses[1].ok()) << statuses[1].ToString();
+  EXPECT_TRUE(statuses[2].ok()) << statuses[2].ToString();
 }
 
 // ============================================================================
@@ -284,3 +323,26 @@ TEST_F(TestAzureOptions, MakeDataLakeServiceClientInvalidDfsStorageScheme) {
 }
 
 }  // namespace milvus_storage::fs
+
+namespace milvus_storage {
+
+TEST(AzureFileSystemProducer, RejectsIamAuthenticationOverHttp) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "remote";
+  config.cloud_provider = kCloudProviderAzure;
+  config.access_key_id = "dummy-account-name";
+  config.bucket_name = "dummy-container";
+  config.use_iam = true;
+  config.use_ssl = false;
+
+  auto result = AzureFileSystemProducer(config).Make();
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid);
+  EXPECT_NE(result.status().message().find("fs.use_ssl=true"), std::string::npos);
+}
+
+}  // namespace milvus_storage

--- a/cpp/test/filesystem/azure_sas_token_policy_test.cpp
+++ b/cpp/test/filesystem/azure_sas_token_policy_test.cpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <string>
 #include <thread>
 #include <utility>
@@ -30,6 +31,7 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include "milvus-storage/filesystem/azure/azurefs_internal.h"
 #include "milvus-storage/filesystem/azure/azure_sas_token_policy.h"
 
 namespace milvus_storage::fs {
@@ -104,6 +106,14 @@ class MockTransport final : public Azure::Core::Http::HttpTransport {
   std::deque<std::pair<Azure::Core::Http::HttpStatusCode, std::string>> responses_;
   std::deque<std::vector<uint8_t>> streamed_response_bodies_;
   std::vector<RequestRecord> requests_;
+};
+
+class OutOfMemoryTransport final : public Azure::Core::Http::HttpTransport {
+  public:
+  std::unique_ptr<Azure::Core::Http::RawResponse> Send(Azure::Core::Http::Request&,
+                                                       const Azure::Core::Context&) override {
+    throw std::bad_alloc();
+  }
 };
 
 static AzureSasBrokerConfig MakeConfig() {
@@ -185,6 +195,27 @@ TEST(AzureSasTokenPolicyTest, SendsBrokerContractAndNormalizesToken) {
   EXPECT_EQ(body["azureAccountName"].get<std::string>(), "account");
 }
 
+// Azure / .NET brokers commonly emit expiredAt with 7 fractional digits
+// (100ns "ticks"). The parser must accept sub-millisecond precision; a
+// MILLI-precision parse rejects these outright and turns every token fetch
+// into a permanent failure.
+TEST(AzureSasTokenPolicyTest, AcceptsDotNetTicksExpirationTimestamp) {
+  const auto now = std::chrono::system_clock::from_time_t(1785146400);
+  auto transport = std::make_shared<MockTransport>();
+  const std::string response = R"({"success":true,"credentials":{"tempAk":"account",)"
+                               R"("sessionToken":"sv=2026-01-01&sig=x","expiredAt":"2026-07-27T11:00:00.1234567Z"}})";
+  transport->Enqueue(Azure::Core::Http::HttpStatusCode::Ok, response);
+  AzureSasTokenPolicy policy(MakeConfig(), transport, [now] { return now; });
+
+  bool called = false;
+  std::map<std::string, std::string> query;
+  auto policy_response = SendRequest(policy, &called, &query);
+  EXPECT_EQ(policy_response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok)
+      << policy_response->GetReasonPhrase();
+  EXPECT_TRUE(called);
+  EXPECT_EQ(query.at("sig"), "x");
+}
+
 TEST(AzureSasTokenPolicyTest, PerOperationPolicyKeepsSasAcrossSdkRetries) {
   const auto now = std::chrono::system_clock::from_time_t(1785146400);
   auto broker_transport = std::make_shared<MockTransport>();
@@ -221,7 +252,7 @@ TEST(AzureSasTokenPolicyTest, PerOperationPolicyKeepsSasAcrossSdkRetries) {
   }
 }
 
-TEST(AzureSasTokenPolicyTest, RefreshFailureReturnsOldTokenAndRetriesEveryRequest) {
+TEST(AzureSasTokenPolicyTest, RefreshFailureDoesNotUseCachedToken) {
   auto now = std::make_shared<TimePoint>(std::chrono::system_clock::from_time_t(1785146400));
   auto transport = std::make_shared<MockTransport>();
   transport->Enqueue(Azure::Core::Http::HttpStatusCode::Ok,
@@ -237,26 +268,25 @@ TEST(AzureSasTokenPolicyTest, RefreshFailureReturnsOldTokenAndRetriesEveryReques
   transport->Enqueue(Azure::Core::Http::HttpStatusCode::InternalServerError, "do not log this body");
   transport->Enqueue(Azure::Core::Http::HttpStatusCode::InternalServerError, "do not log this body");
 
-  auto first_fallback = SendRequest(policy, &called, &query);
-  ASSERT_EQ(first_fallback->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
-  EXPECT_EQ(query.at("sig"), "old");
-  auto second_fallback = SendRequest(policy, &called, &query);
-  ASSERT_EQ(second_fallback->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
-  EXPECT_EQ(query.at("sig"), "old");
-  EXPECT_EQ(transport->Requests().size(), 3u);
+  called = false;
+  auto first_failure = SendRequest(policy, &called, &query);
+  ASSERT_EQ(first_failure->GetStatusCode(), Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
+  EXPECT_FALSE(called) << "a failed refresh must not continue with the cached token";
 
-  *now += std::chrono::seconds(60);
-  transport->Enqueue(Azure::Core::Http::HttpStatusCode::InternalServerError, "expired fallback");
-  auto expired_fallback = SendRequest(policy, &called, &query);
-  ASSERT_EQ(expired_fallback->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
-  EXPECT_EQ(query.at("sig"), "old");
+  called = false;
+  auto second_failure = SendRequest(policy, &called, &query);
+  ASSERT_EQ(second_failure->GetStatusCode(), Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
+  EXPECT_FALSE(called) << "each caller may retry the broker, but not the storage request";
+  EXPECT_EQ(transport->Requests().size(), 3u);
 
   transport->Enqueue(Azure::Core::Http::HttpStatusCode::Ok,
                      SuccessResponse("account", "sv=2&sig=new", *now + std::chrono::hours(1)));
+  called = false;
   auto refreshed = SendRequest(policy, &called, &query);
   ASSERT_EQ(refreshed->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Ok);
+  EXPECT_TRUE(called);
   EXPECT_EQ(query.at("sig"), "new");
-  EXPECT_EQ(transport->Requests().size(), 5u);
+  EXPECT_EQ(transport->Requests().size(), 4u);
 }
 
 TEST(AzureSasTokenPolicyTest, DoesNotRefreshWithMoreThanSixtySecondsRemaining) {
@@ -301,9 +331,22 @@ TEST(AzureSasTokenPolicyTest, ClonesShareTokenCache) {
   EXPECT_EQ(transport->Requests().size(), 1u);
 }
 
+// None of these is a credential rejection, and none of them may be reported as
+// one. A broker that answers 200 with a body we cannot use -- success=false, a
+// token for the wrong account, an unparsable expiry, plain garbage -- is
+// misbehaving or misconfigured. Reporting them as 401/AuthenticationFailed made
+// ClassifyAzureError read them as StorageAccessDenied and segcore as
+// ConfigInvalid, which sent an operator to rotate a credential that was never
+// the problem. They stay UNCLASSIFIED (R1.2): not transient, not the caller's,
+// not a credential verdict.
 TEST(AzureSasTokenPolicyTest, RejectsInvalidBrokerResponsesWithoutCachedToken) {
   const auto now = std::chrono::system_clock::from_time_t(1785146400);
-  const std::vector<std::pair<std::string, std::string>> invalid_responses = {
+  struct Case {
+    std::string response;
+    std::string expected_error;
+    Azure::Core::Http::HttpStatusCode expected_status = Azure::Core::Http::HttpStatusCode::InternalServerError;
+  };
+  const std::vector<Case> invalid_responses = {
       {R"({"success":false})", "returned success=false"},
       {R"({"success":true})", "response schema is invalid"},
       {SuccessResponse("other-account", "sv=1&sig=x", now + std::chrono::hours(1)),
@@ -320,16 +363,79 @@ TEST(AzureSasTokenPolicyTest, RejectsInvalidBrokerResponsesWithoutCachedToken) {
       {R"({not-json})", "returned invalid JSON"},
   };
 
-  for (const auto& [response, expected_error] : invalid_responses) {
+  for (const auto& test_case : invalid_responses) {
     auto transport = std::make_shared<MockTransport>();
-    transport->Enqueue(Azure::Core::Http::HttpStatusCode::Ok, response);
+    transport->Enqueue(Azure::Core::Http::HttpStatusCode::Ok, test_case.response);
     AzureSasTokenPolicy policy(MakeConfig(), transport, [now] { return now; });
     bool called = false;
     std::map<std::string, std::string> query;
     auto policy_response = SendRequest(policy, &called, &query);
-    ASSERT_EQ(policy_response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Unauthorized);
-    EXPECT_NE(policy_response->GetReasonPhrase().find(expected_error), std::string::npos)
+    ASSERT_EQ(policy_response->GetStatusCode(), test_case.expected_status);
+    EXPECT_NE(policy_response->GetReasonPhrase().find(test_case.expected_error), std::string::npos)
         << policy_response->GetReasonPhrase();
+    auto classified = internal::ClassifyAzureError(static_cast<int>(policy_response->GetStatusCode()),
+                                                   policy_response->GetHeaders().at("x-ms-error-code"),
+                                                   /*transport_failure=*/false);
+    if (test_case.expected_status == Azure::Core::Http::HttpStatusCode::ServiceUnavailable) {
+      ASSERT_TRUE(classified.has_value());
+      EXPECT_TRUE(RetryableForExtendStatusCode(*classified));
+    } else {
+      // The synthetic 500 must NOT be read as a service blip either: the
+      // marker short-circuits the status switch, so an unusable broker answer
+      // stays unclassified instead of trading one wrong verdict for another.
+      EXPECT_EQ(policy_response->GetHeaders().at("x-ms-error-code"), internal::kSyntheticBrokerUnexpectedErrorCode);
+      EXPECT_FALSE(classified.has_value());
+    }
+    EXPECT_EQ(transport->Requests().size(), 1u);
+    EXPECT_FALSE(called);
+  }
+}
+
+// The other side of the same rule: a broker that actually rejects us IS a
+// credential verdict, and it has to survive as one. This is the only path that
+// may produce 401/LoonBrokerAccessDenied, and it does so because GetSasToken()
+// classified it, not because nothing else matched.
+TEST(AzureSasTokenPolicyTest, BrokerRejectionIsReportedAsAuthenticationFailure) {
+  const auto now = std::chrono::system_clock::from_time_t(1785146400);
+  for (auto broker_status :
+       {Azure::Core::Http::HttpStatusCode::Unauthorized, Azure::Core::Http::HttpStatusCode::Forbidden}) {
+    auto transport = std::make_shared<MockTransport>();
+    transport->Enqueue(broker_status, "");
+    AzureSasTokenPolicy policy(MakeConfig(), transport, [now] { return now; });
+    bool called = false;
+    std::map<std::string, std::string> query;
+    auto policy_response = SendRequest(policy, &called, &query);
+
+    ASSERT_EQ(policy_response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Unauthorized);
+    EXPECT_EQ(policy_response->GetHeaders().at("x-ms-error-code"), internal::kSyntheticBrokerAccessDeniedErrorCode);
+    auto classified = internal::ClassifyAzureError(static_cast<int>(policy_response->GetStatusCode()),
+                                                   policy_response->GetHeaders().at("x-ms-error-code"),
+                                                   /*transport_failure=*/false);
+    ASSERT_TRUE(classified.has_value());
+    EXPECT_EQ(*classified, ExtendStatusCode::StorageAccessDenied);
+    EXPECT_FALSE(RetryableForExtendStatusCode(*classified));
+    EXPECT_FALSE(called);
+  }
+}
+
+// A broker error that is neither a rejection nor transient -- a 400 or a 404 --
+// must not borrow either verdict.
+TEST(AzureSasTokenPolicyTest, NonAuthBrokerHttpErrorStaysUnclassified) {
+  const auto now = std::chrono::system_clock::from_time_t(1785146400);
+  for (auto broker_status :
+       {Azure::Core::Http::HttpStatusCode::BadRequest, Azure::Core::Http::HttpStatusCode::NotFound}) {
+    auto transport = std::make_shared<MockTransport>();
+    transport->Enqueue(broker_status, "");
+    AzureSasTokenPolicy policy(MakeConfig(), transport, [now] { return now; });
+    bool called = false;
+    std::map<std::string, std::string> query;
+    auto policy_response = SendRequest(policy, &called, &query);
+
+    EXPECT_EQ(policy_response->GetHeaders().at("x-ms-error-code"), internal::kSyntheticBrokerUnexpectedErrorCode);
+    auto classified = internal::ClassifyAzureError(static_cast<int>(policy_response->GetStatusCode()),
+                                                   policy_response->GetHeaders().at("x-ms-error-code"),
+                                                   /*transport_failure=*/false);
+    EXPECT_FALSE(classified.has_value());
     EXPECT_FALSE(called);
   }
 }
@@ -392,10 +498,66 @@ TEST(AzureSasTokenPolicyTest, InitialFetchFailureDoesNotSendAnonymousRequest) {
   bool called = false;
   std::map<std::string, std::string> query;
   auto response = SendRequest(policy, &called, &query);
-  EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::Unauthorized);
+  // 503, not 401. A broker that answered 500 is unwell; it did not reject our
+  // credentials. Synthesising 401 here made ClassifyAzureError read it as
+  // AccessDenied -- System with no transient hint -- so a broker blip looked
+  // exactly like a bad key and a generic adapter could not distinguish the
+  // recoverable broker outage. This assertion is the whole point of the split.
+  EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::ServiceUnavailable);
+  auto classified = internal::ClassifyAzureError(static_cast<int>(response->GetStatusCode()),
+                                                 response->GetHeaders().at("x-ms-error-code"),
+                                                 /*transport_failure=*/false);
+  ASSERT_TRUE(classified.has_value());
+  EXPECT_TRUE(RetryableForExtendStatusCode(*classified));
   EXPECT_NE(response->GetReasonPhrase().find("status_code=500"), std::string::npos);
   EXPECT_EQ(response->GetReasonPhrase().find("secret response body"), std::string::npos);
   EXPECT_FALSE(called);
+}
+
+TEST(AzureSasTokenPolicyTest, AllocationFailureRoundTripsAsOutOfMemory) {
+  const auto now = std::chrono::system_clock::from_time_t(1785146400);
+  auto transport = std::make_shared<OutOfMemoryTransport>();
+  AzureSasTokenPolicy policy(MakeConfig(), transport, [now] { return now; });
+
+  bool called = false;
+  std::map<std::string, std::string> query;
+  auto response = SendRequest(policy, &called, &query);
+
+  EXPECT_EQ(response->GetStatusCode(), Azure::Core::Http::HttpStatusCode::InternalServerError);
+  const auto& error_code = response->GetHeaders().at("x-ms-error-code");
+  EXPECT_EQ(error_code, internal::kSyntheticBrokerOutOfMemoryErrorCode);
+  EXPECT_FALSE(called);
+
+  Azure::Core::RequestFailedException downstream(response->GetReasonPhrase());
+  downstream.StatusCode = response->GetStatusCode();
+  downstream.ErrorCode = error_code;
+  auto status = internal::AzureExceptionToStatus(downstream, "FetchSasToken:");
+  EXPECT_TRUE(status.IsOutOfMemory()) << status.ToString();
+}
+
+TEST(AzureSasTokenPolicyTest, ExpiredCachedTokenIsNotUsedWhenTheBrokerFails) {
+  const auto now = std::chrono::system_clock::from_time_t(1785146400);
+  auto transport = std::make_shared<MockTransport>();
+  // First fetch succeeds with a token that expires almost immediately.
+  transport->Enqueue(Azure::Core::Http::HttpStatusCode::Ok,
+                     SuccessResponse("account", "sv=1&sig=cached", now + std::chrono::seconds(1)));
+  // Second fetch, after it has expired, finds the broker down.
+  transport->Enqueue(Azure::Core::Http::HttpStatusCode::InternalServerError, "broker down");
+
+  auto clock_now = now;
+  AzureSasTokenPolicy policy(MakeConfig(), transport, [&clock_now] { return clock_now; });
+
+  bool called = false;
+  std::map<std::string, std::string> query;
+  auto first = SendRequest(policy, &called, &query);
+  ASSERT_TRUE(called) << "the first request should have been signed with the fresh token";
+
+  clock_now = now + std::chrono::hours(1);
+  called = false;
+  auto second = SendRequest(policy, &called, &query);
+  EXPECT_FALSE(called) << "an expired token must not be used to sign a request";
+  EXPECT_EQ(second->GetStatusCode(), Azure::Core::Http::HttpStatusCode::ServiceUnavailable)
+      << second->GetReasonPhrase();
 }
 
 }  // namespace milvus_storage::fs

--- a/cpp/test/filesystem/cloud_file_system_test.cpp
+++ b/cpp/test/filesystem/cloud_file_system_test.cpp
@@ -148,7 +148,7 @@ TEST_F(CloudFsTest, ConditionalWriteAzure) {
     ASSERT_FALSE(result.ok());
     auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
     ASSERT_NE(detail, nullptr);
-    ASSERT_EQ(detail->code(), ExtendStatusCode::AwsErrorPreConditionFailed);
+    ASSERT_EQ(detail->code(), ExtendStatusCode::StoragePreConditionFailed);
   }
 
   // Original content should be preserved

--- a/cpp/test/filesystem/external_fs_test.cpp
+++ b/cpp/test/filesystem/external_fs_test.cpp
@@ -15,6 +15,9 @@
 #include <gtest/gtest.h>
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/properties.h"
+#include <optional>
+
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::test {
 
@@ -341,23 +344,34 @@ TEST_F(ExternalFilesystemTest, AzureCredentialBrokerConfigValidation) {
   non_azure_config.cloud_provider = kCloudProviderAWS;
   EXPECT_FALSE(non_azure_config.IsAzureCredentialBrokerEnabled());
 
+  // The three rejection paths below were already executed by this test, but it
+  // only ever asserted IsInvalid() -- so replacing the classified status with a
+  // plain arrow::Status::Invalid at either producer would have left it green.
+  // The path was covered; the classification was not. AssertBrokerConfigError
+  // pins the part that actually reaches an operator.
+  auto AssertBrokerConfigError = [](const arrow::Status& status, const char* what) {
+    ASSERT_FALSE(status.ok()) << what;
+    EXPECT_TRUE(status.IsInvalid()) << what;  // detected before any IO
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << what << ": arrived unclassified, so a broken deployment reaches segcore"
+                               << " as a generic storage failure: " << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid) << what;
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::System) << what;
+    EXPECT_FALSE(RetryableForExtendStatusCode(detail->code())) << what;
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ConfigInvalid) << what;
+  };
+
   auto partial = props;
   partial.erase(PROPERTY_FS_AZURE_TENANT_ID);
-  auto partial_result = FilesystemCache::resolve_config(partial);
-  ASSERT_FALSE(partial_result.ok());
-  EXPECT_TRUE(partial_result.status().IsInvalid());
+  AssertBrokerConfigError(FilesystemCache::resolve_config(partial).status(), "missing azure_tenant_id");
 
   auto invalid_endpoint = props;
   invalid_endpoint[PROPERTY_FS_AZURE_CREDENTIAL_ENDPOINT] = std::string("file:///tmp/credentials");
-  auto invalid_endpoint_result = FilesystemCache::resolve_config(invalid_endpoint);
-  ASSERT_FALSE(invalid_endpoint_result.ok());
-  EXPECT_TRUE(invalid_endpoint_result.status().IsInvalid());
+  AssertBrokerConfigError(FilesystemCache::resolve_config(invalid_endpoint).status(), "non-HTTP endpoint scheme");
 
   auto missing_host = props;
   missing_host[PROPERTY_FS_AZURE_CREDENTIAL_ENDPOINT] = std::string("http:///credentials");
-  auto missing_host_result = FilesystemCache::resolve_config(missing_host);
-  ASSERT_FALSE(missing_host_result.ok());
-  EXPECT_TRUE(missing_host_result.status().IsInvalid());
+  AssertBrokerConfigError(FilesystemCache::resolve_config(missing_host).status(), "endpoint with no host");
 }
 
 TEST_F(ExternalFilesystemTest, ExtractExternalFsRejectsUndefinedProperty) {
@@ -534,6 +548,139 @@ TEST_F(ExternalFilesystemTest, ResolveConfigWithQueryComponent) {
   ASSERT_TRUE(rel.ok()) << rel.status().ToString();
   EXPECT_EQ(rel.ValueOrDie().bucket_name, "default-bucket");
   EXPECT_EQ(rel.ValueOrDie().access_key_id, "default_key");
+}
+
+// ==================== Classification of config / URI failures ====================
+//
+// These are the tests the rest of the taxonomy suite cannot substitute for.
+// Every other test compares the tables to each other -- category table against
+// segcore switch against FFI constants -- and those all pass whether or not any
+// layer ever emits the code. StorageConfigInvalid shipped
+// for a while with no producer at all and every self-consistency test stayed
+// green. So: call the real entry points with real bad input and read the code
+// back off the Status.
+
+namespace {
+
+std::optional<ExtendStatusCode> CodeOf(const arrow::Status& status) {
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  return detail ? std::optional{detail->code()} : std::nullopt;
+}
+
+}  // namespace
+
+// This test used to assert User, and was renamed rather than relaxed when 116
+// merged into 115. The reason is the point of the merge: StorageUri::Parse is
+// called for BOTH a location the user typed into an external-source definition
+// and a path milvus generated itself, and it cannot tell them apart. Guessing
+// User here would tell an operator's broken deployment "your query is wrong";
+// guessing at this layer at all is the mistake. System is the honest category,
+// and the external-table entry points may present the unified System code
+// LOON_SOURCE_INVALID.
+TEST_F(ExternalFilesystemTest, UnparseableUriIsSystemNotGuessedAsUser) {
+  struct Case {
+    const char* uri;
+    const char* what;
+  };
+  const Case cases[] = {
+      {"s3://", "no bucket and no key"},
+      {"s3:///", "empty after scheme"},
+      {"s3://my-bucket", "host only, no path to take the bucket from"},
+      // These parse-FAIL rather than parsing into something incomplete, which
+      // is a different path through StorageUri::Parse and used to be silently
+      // swallowed: the whole string became a relative key against whatever
+      // fs.* the deployment defaults to, and the eventual complaint pointed at
+      // a missing object instead of at the malformed location.
+      {"s3://bucket/%ZZ", "invalid percent-escape"},
+      {"s3://bucket/a b", "unescaped space"},
+      {"http://[::1", "unterminated IPv6 literal"},
+      // Single slash: RFC 3986's authority component is optional, so this is
+      // still a scheme'd URI. Keying the check on the literal "://" let it
+      // through as a local relative path.
+      {"s3:/bucket/%ZZ", "scheme with no authority, still malformed"},
+  };
+
+  for (const auto& c : cases) {
+    auto result = StorageUri::Parse(c.uri);
+    ASSERT_FALSE(result.ok()) << c.what;
+    auto code = CodeOf(result.status());
+    ASSERT_TRUE(code.has_value()) << c.what << ": arrived unclassified, so segcore sees a generic"
+                                  << " failure instead of 'your location is wrong': " << result.status().ToString();
+    EXPECT_EQ(*code, ExtendStatusCode::StorageConfigInvalid) << c.what;
+    EXPECT_EQ(CategoryForExtendStatusCode(*code), ErrorCategory::System) << c.what;
+    EXPECT_FALSE(RetryableForExtendStatusCode(*code)) << c.what;
+    EXPECT_EQ(ToSegcoreError(result.status()).get_error_code(), milvus::ConfigInvalid) << c.what;
+    // Never 2042: this producer does not know whose string it is, and blaming
+    // the caller is the more expensive of the two possible mistakes.
+    EXPECT_NE(ToSegcoreError(result.status()).get_error_code(), milvus::InvalidParameter) << c.what;
+    // Detected before any IO was attempted, so it must not masquerade as one.
+    EXPECT_TRUE(result.status().IsInvalid()) << c.what;
+  }
+}
+
+// ...but a string with no scheme is a relative path, which is legitimate and
+// extremely common. The malformed-URI check above keys on RFC 3986 shape, not
+// on a list of known schemes, so this pins that it did not become a trap for
+// ordinary filenames.
+//
+// Only strings arrow FAILS to parse reach that check at all, which is why
+// "C:/data/x.parquet" is absent here: arrow parses it successfully with
+// scheme "c", so it never had a chance to be mistaken for a bad URI. That is
+// pre-existing behaviour of the parser, not of this classification.
+TEST_F(ExternalFilesystemTest, RelativePathsAreStillAcceptedAfterTheMalformedUriCheck) {
+  const char* relative[] = {
+      "some/dir/file.parquet", "file.parquet", "a b/c d.parquet", "100%-done/x.parquet", "./x", "../y/z",
+  };
+  for (const auto* path : relative) {
+    auto result = StorageUri::Parse(path);
+    ASSERT_TRUE(result.ok()) << path << " -> " << result.status().ToString();
+    EXPECT_TRUE(result->scheme.empty()) << path;
+    EXPECT_EQ(result->key, path);
+  }
+}
+
+TEST_F(ExternalFilesystemTest, UnusableExtfsConfigIsClassifiedAsConfigError) {
+  struct Case {
+    const char* key;
+    const char* what;
+  };
+  const Case cases[] = {
+      {"extfs.prod", "missing property name after fs name"},
+      {"extfs..address", "empty filesystem name"},
+      {"extfs.prod.", "empty property name"},
+  };
+
+  for (const auto& c : cases) {
+    api::Properties props;
+    props[c.key] = std::string("value");
+
+    auto fs_result = FilesystemCache::getInstance().get(props, "s3://test.com/bucket/key");
+    ASSERT_FALSE(fs_result.ok()) << c.what;
+    auto code = CodeOf(fs_result.status());
+    ASSERT_TRUE(code.has_value()) << c.what << ": arrived unclassified: " << fs_result.status().ToString();
+    EXPECT_EQ(*code, ExtendStatusCode::StorageConfigInvalid) << c.what;
+    EXPECT_EQ(CategoryForExtendStatusCode(*code), ErrorCategory::System) << c.what;
+    EXPECT_FALSE(RetryableForExtendStatusCode(*code)) << c.what;
+    // 2006 ConfigInvalid, not 2044 StorageError: nobody retries out of a
+    // malformed extfs.* key, and it has to page whoever wrote it.
+    EXPECT_EQ(ToSegcoreError(fs_result.status()).get_error_code(), milvus::ConfigInvalid) << c.what;
+    EXPECT_TRUE(fs_result.status().IsInvalid()) << c.what;
+  }
+}
+
+TEST_F(ExternalFilesystemTest, UnknownCloudProviderIsClassifiedAsConfigError) {
+  api::Properties props;
+  props["extfs.myfs.address"] = std::string("s3.amazonaws.com");
+  props["extfs.myfs.bucket_name"] = std::string("my-bucket");
+  props["extfs.myfs.storage_type"] = std::string("remote");
+  props["extfs.myfs.cloud_provider"] = std::string("not-a-real-cloud");
+
+  auto fs_result = FilesystemCache::getInstance().get(props, "s3://s3.amazonaws.com/my-bucket/data/f.parquet");
+  ASSERT_FALSE(fs_result.ok());
+  auto code = CodeOf(fs_result.status());
+  ASSERT_TRUE(code.has_value()) << "arrived unclassified: " << fs_result.status().ToString();
+  EXPECT_EQ(*code, ExtendStatusCode::StorageConfigInvalid);
+  EXPECT_EQ(ToSegcoreError(fs_result.status()).get_error_code(), milvus::ConfigInvalid);
 }
 
 }  // namespace milvus_storage::test

--- a/cpp/test/filesystem/gcp_credential_registry_test.cpp
+++ b/cpp/test/filesystem/gcp_credential_registry_test.cpp
@@ -14,15 +14,28 @@
 
 #include <gtest/gtest.h>
 
+#include <condition_variable>
+#include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 
+#include <arrow/result.h>
 #include <arrow/status.h>
 #include <aws/core/http/URI.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/s3/S3ErrorMarshaller.h>
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/gcp/gcp_credential_registry.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/s3/s3_internal.h"
+#include "milvus-storage/filesystem/s3/s3_global.h"
+
+#include "filesystem/gcp/gcp_filesystem_producer_internal.h"
 
 namespace milvus_storage {
 
@@ -30,14 +43,157 @@ namespace {
 
 class TestGcpCredentialProvider final : public GcpCredentialProvider {
   public:
-  std::optional<std::pair<std::string, std::string>> AuthorizationHeader() override { return std::nullopt; }
+  arrow::Result<std::optional<std::pair<std::string, std::string>>> AuthorizationHeader() override {
+    return std::optional<std::pair<std::string, std::string>>{};
+  }
 
   arrow::Status MaybeSignConditionalWrite(const std::shared_ptr<Aws::Http::HttpRequest>&) override {
     return arrow::Status::OK();
   }
 };
 
+// Forces request A's token lookup to finish after request B's. This is the
+// interleaving that made provider-global last_token_status_ associate A's
+// failure with B's request (or B's success with A's request).
+class InterleavedGcpCredentialProvider final : public GcpCredentialProvider {
+  public:
+  arrow::Result<std::optional<std::pair<std::string, std::string>>> AuthorizationHeader() override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (calls_++ == 0) {
+      first_call_started_ = true;
+      cv_.notify_all();
+      cv_.wait(lock, [this] { return release_first_call_; });
+      return arrow::Status::IOError("request A token lookup failed");
+    }
+    return std::optional<std::pair<std::string, std::string>>(std::in_place, "Authorization", "Bearer request-b-token");
+  }
+
+  arrow::Status MaybeSignConditionalWrite(const std::shared_ptr<Aws::Http::HttpRequest>&) override {
+    return arrow::Status::OK();
+  }
+
+  void WaitForFirstCall() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return first_call_started_; });
+  }
+
+  void ReleaseFirstCall() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      release_first_call_ = true;
+    }
+    cv_.notify_all();
+  }
+
+  private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int calls_ = 0;
+  bool first_call_started_ = false;
+  bool release_first_call_ = false;
+};
+
 }  // namespace
+
+class GcpCredentialProviderTest : public ::testing::Test {
+  protected:
+  static void SetUpTestSuite() {
+    ASSERT_TRUE(EnsureS3Initialized().ok());
+    static std::once_flag finalize_once;
+    std::call_once(finalize_once, [] { std::atexit([] { EnsureS3Finalized().ok(); }); });
+  }
+};
+
+TEST_F(GcpCredentialProviderTest, AuthorizationResultBelongsToTheRequestThatResolvedIt) {
+  auto provider = std::make_shared<InterleavedGcpCredentialProvider>();
+  auto request_a = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(
+      "gcp-request-local-test", Aws::Http::URI("https://storage.googleapis.com/bucket/a"),
+      Aws::Http::HttpMethod::HTTP_GET);
+  auto request_b = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(
+      "gcp-request-local-test", Aws::Http::URI("https://storage.googleapis.com/bucket/b"),
+      Aws::Http::HttpMethod::HTTP_GET);
+
+  arrow::Status status_a;
+  arrow::Status status_b;
+  std::thread thread_a([&] { status_a = ApplyGcpAuthorizationHeader(provider, request_a); });
+  provider->WaitForFirstCall();
+  std::thread thread_b([&] { status_b = ApplyGcpAuthorizationHeader(provider, request_b); });
+  thread_b.join();
+  provider->ReleaseFirstCall();
+  thread_a.join();
+
+  EXPECT_FALSE(status_a.ok());
+  EXPECT_NE(status_a.message().find("request A token lookup failed"), std::string::npos);
+  EXPECT_FALSE(request_a->HasHeader("Authorization"));
+
+  EXPECT_TRUE(status_b.ok()) << status_b.ToString();
+  ASSERT_TRUE(request_b->HasHeader("Authorization"));
+  EXPECT_EQ(request_b->GetHeaderValue("Authorization"), "Bearer request-b-token");
+}
+
+TEST_F(GcpCredentialProviderTest, HmacConditionalWriteStillUsesGoogV4Signing) {
+  ArrowFileSystemConfig config;
+  config.access_key_id = "GOOGACCESSKEY";
+  config.access_key_value = "secret";
+  auto provider_result = BuildGcpProviderFromConfig(config);
+  ASSERT_TRUE(provider_result.ok()) << provider_result.status().ToString();
+  auto provider = std::move(provider_result).ValueOrDie();
+
+  auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(
+      "gcp-hmac-test", Aws::Http::URI("https://storage.googleapis.com/bucket/object"), Aws::Http::HttpMethod::HTTP_PUT);
+  request->SetHeaderValue("Authorization", "AWS4-HMAC-SHA256 old-signature");
+  request->SetHeaderValue("x-amz-date", "20260819T000000Z");
+  request->SetHeaderValue("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
+  request->SetHeaderValue("x-goog-if-generation-match", "0");
+
+  auto authorization_status = ApplyGcpAuthorizationHeader(provider, request);
+  ASSERT_TRUE(authorization_status.ok()) << authorization_status.ToString();
+  EXPECT_EQ(request->GetHeaderValue("Authorization"), "AWS4-HMAC-SHA256 old-signature");
+
+  auto signing_status = provider->MaybeSignConditionalWrite(request);
+  ASSERT_TRUE(signing_status.ok()) << signing_status.ToString();
+  EXPECT_NE(std::string(request->GetHeaderValue("Authorization")).find("GOOG4-HMAC-SHA256"), std::string::npos);
+  EXPECT_FALSE(request->HasHeader("x-amz-date"));
+  EXPECT_TRUE(request->HasHeader("x-goog-date"));
+}
+
+TEST_F(GcpCredentialProviderTest, TokenFailureSubtypeSurvivesS3Marshalling) {
+  struct TestCase {
+    ExtendStatusCode input;
+    ExtendStatusCode expected;
+  };
+  const TestCase test_cases[] = {
+      {ExtendStatusCode::StorageTransientNetwork, ExtendStatusCode::StorageTransientNetwork},
+      {ExtendStatusCode::StorageTransientTimeout, ExtendStatusCode::StorageTransientTimeout},
+      {ExtendStatusCode::StorageTransientThrottling, ExtendStatusCode::StorageTransientThrottling},
+      {ExtendStatusCode::StorageTransientService, ExtendStatusCode::StorageTransientService},
+      {ExtendStatusCode::StorageAccessDenied, ExtendStatusCode::StorageAccessDenied},
+      {ExtendStatusCode::StorageConfigInvalid, ExtendStatusCode::StorageConfigInvalid},
+  };
+
+  auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(
+      "gcp-token-marshalling-test", Aws::Http::URI("https://storage.googleapis.com/bucket/object"),
+      Aws::Http::HttpMethod::HTTP_GET);
+  request->SetResponseStreamFactory(Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  Aws::Client::S3ErrorMarshaller marshaller;
+  for (const auto& test_case : test_cases) {
+    auto token_status = MakeExtendErrorMsg(test_case.input, "bad <token> & endpoint");
+    auto response = gcp_internal::MakeTokenErrorResponse(request, token_status);
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(marshaller.BuildAWSError(response));
+    EXPECT_EQ(error.ShouldRetry(), RetryableForExtendStatusCode(test_case.expected));
+    auto status = fs::internal::ErrorToStatus("gcp token: ", "GetObject", error, fs::internal::S3ErrorProvenance{});
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), test_case.expected) << status.ToString();
+  }
+
+  auto response = gcp_internal::MakeTokenErrorResponse(request, arrow::Status::IOError("malformed token response"));
+  Aws::Client::AWSError<Aws::S3::S3Errors> error(marshaller.BuildAWSError(response));
+  EXPECT_FALSE(error.ShouldRetry());
+  auto status = fs::internal::ErrorToStatus("gcp token: ", "GetObject", error, fs::internal::S3ErrorProvenance{});
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+}
 
 TEST(GcpCredentialRegistryTest, CanonicalizesConfigEndpoints) {
   auto implicit_https = NormalizeGcpEndpoint("Storage.GoogleApis.com", true);
@@ -68,7 +224,12 @@ TEST(GcpCredentialRegistryTest, LooksUpDefaultHttpsPort) {
   const std::string bucket = "gcp-registry-default-port-bucket";
   auto provider = std::make_shared<TestGcpCredentialProvider>();
   auto& registry = GcpCredentialRegistry::Instance();
-  registry.Register({NormalizeGcpEndpoint("storage.googleapis.com:443", true), bucket}, provider);
+  auto registration_result =
+      registry.Register({NormalizeGcpEndpoint("storage.googleapis.com:443", true), bucket},
+                        std::make_shared<GcpCredentialRegistration>("default-port-identity", provider));
+  ASSERT_TRUE(registration_result.ok()) << registration_result.status().ToString();
+  auto registration = std::move(registration_result).ValueOrDie();
+  ASSERT_NE(registration, nullptr);
 
   auto implicit_port_uri = Aws::Http::URI(("https://storage.googleapis.com/" + bucket + "/key").c_str());
   EXPECT_EQ(registry.Lookup(implicit_port_uri), provider);
@@ -82,7 +243,12 @@ TEST(GcpCredentialRegistryTest, PreservesNonDefaultPortAndScheme) {
   const std::string bucket = "gcp-registry-port-bucket";
   auto provider = std::make_shared<TestGcpCredentialProvider>();
   auto& registry = GcpCredentialRegistry::Instance();
-  registry.Register({NormalizeGcpEndpoint(host + ":8443", true), bucket}, provider);
+  auto registration_result =
+      registry.Register({NormalizeGcpEndpoint(host + ":8443", true), bucket},
+                        std::make_shared<GcpCredentialRegistration>("non-default-port-identity", provider));
+  ASSERT_TRUE(registration_result.ok()) << registration_result.status().ToString();
+  auto registration = std::move(registration_result).ValueOrDie();
+  ASSERT_NE(registration, nullptr);
 
   auto matching_uri = Aws::Http::URI(("https://" + host + ":8443/" + bucket + "/key").c_str());
   EXPECT_EQ(registry.Lookup(matching_uri), provider);
@@ -100,15 +266,91 @@ TEST(GcpCredentialRegistryTest, LooksUpVirtualHostAndIpv6Endpoints) {
   const std::string virtual_host = "gcp-registry-vhost.example";
   const std::string virtual_bucket = "gcp-registry-vhost-bucket";
   auto virtual_provider = std::make_shared<TestGcpCredentialProvider>();
-  registry.Register({NormalizeGcpEndpoint(virtual_host + ":8443", true), virtual_bucket}, virtual_provider);
+  auto virtual_registration_result =
+      registry.Register({NormalizeGcpEndpoint(virtual_host + ":8443", true), virtual_bucket},
+                        std::make_shared<GcpCredentialRegistration>("virtual-host-identity", virtual_provider));
+  ASSERT_TRUE(virtual_registration_result.ok()) << virtual_registration_result.status().ToString();
+  auto virtual_registration = std::move(virtual_registration_result).ValueOrDie();
+  ASSERT_NE(virtual_registration, nullptr);
   auto virtual_uri = Aws::Http::URI(("https://" + virtual_bucket + "." + virtual_host + ":8443/key").c_str());
   EXPECT_EQ(registry.Lookup(virtual_uri), virtual_provider);
 
   const std::string ipv6_bucket = "gcp-registry-ipv6-bucket";
   auto ipv6_provider = std::make_shared<TestGcpCredentialProvider>();
-  registry.Register({NormalizeGcpEndpoint("[2001:db8::7]:80", false), ipv6_bucket}, ipv6_provider);
+  auto ipv6_registration_result =
+      registry.Register({NormalizeGcpEndpoint("[2001:db8::7]:80", false), ipv6_bucket},
+                        std::make_shared<GcpCredentialRegistration>("ipv6-identity", ipv6_provider));
+  ASSERT_TRUE(ipv6_registration_result.ok()) << ipv6_registration_result.status().ToString();
+  auto ipv6_registration = std::move(ipv6_registration_result).ValueOrDie();
+  ASSERT_NE(ipv6_registration, nullptr);
   auto ipv6_uri = Aws::Http::URI(("http://[2001:db8::7]/" + ipv6_bucket + "/key").c_str());
   EXPECT_EQ(registry.Lookup(ipv6_uri), ipv6_provider);
+}
+
+TEST(GcpCredentialRegistryTest, RejectsDifferentLiveIdentityWithoutReplacingIt) {
+  const std::string bucket = "gcp-registry-identity-conflict-bucket";
+  const auto key = GcpBucketKey{NormalizeGcpEndpoint("identity-conflict.example", true), bucket};
+  auto provider_a = std::make_shared<TestGcpCredentialProvider>();
+  auto provider_b = std::make_shared<TestGcpCredentialProvider>();
+  auto& registry = GcpCredentialRegistry::Instance();
+
+  auto first_result = registry.Register(key, std::make_shared<GcpCredentialRegistration>("identity-a", provider_a));
+  ASSERT_TRUE(first_result.ok()) << first_result.status().ToString();
+  auto first = std::move(first_result).ValueOrDie();
+
+  auto conflicting = registry.Register(key, std::make_shared<GcpCredentialRegistration>("identity-b", provider_b));
+  ASSERT_FALSE(conflicting.ok());
+  EXPECT_TRUE(conflicting.status().IsInvalid()) << conflicting.status().ToString();
+  auto detail = ExtendStatusDetail::UnwrapStatus(conflicting.status());
+  ASSERT_NE(detail, nullptr) << conflicting.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid);
+
+  auto uri = Aws::Http::URI(("https://identity-conflict.example/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(uri), provider_a);
+}
+
+TEST(GcpCredentialRegistryTest, ReusesEquivalentLiveIdentity) {
+  const std::string bucket = "gcp-registry-equivalent-identity-bucket";
+  const auto key = GcpBucketKey{NormalizeGcpEndpoint("equivalent-identity.example", true), bucket};
+  auto provider_a = std::make_shared<TestGcpCredentialProvider>();
+  auto provider_b = std::make_shared<TestGcpCredentialProvider>();
+  auto& registry = GcpCredentialRegistry::Instance();
+
+  auto first_result = registry.Register(key, std::make_shared<GcpCredentialRegistration>("same-identity", provider_a));
+  ASSERT_TRUE(first_result.ok()) << first_result.status().ToString();
+  auto first = std::move(first_result).ValueOrDie();
+
+  auto second_result = registry.Register(key, std::make_shared<GcpCredentialRegistration>("same-identity", provider_b));
+  ASSERT_TRUE(second_result.ok()) << second_result.status().ToString();
+  auto second = std::move(second_result).ValueOrDie();
+  EXPECT_EQ(second, first);
+
+  auto uri = Aws::Http::URI(("https://equivalent-identity.example/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(uri), provider_a);
+}
+
+TEST(GcpCredentialRegistryTest, DoesNotRetainProviderAfterLastRegistrationOwner) {
+  const std::string bucket = "gcp-registry-release-bucket";
+  const auto key = GcpBucketKey{NormalizeGcpEndpoint("release.example", true), bucket};
+  auto provider = std::make_shared<TestGcpCredentialProvider>();
+  std::weak_ptr<GcpCredentialProvider> weak_provider = provider;
+  auto& registry = GcpCredentialRegistry::Instance();
+
+  auto registration_result =
+      registry.Register(key, std::make_shared<GcpCredentialRegistration>("released-identity", provider));
+  ASSERT_TRUE(registration_result.ok()) << registration_result.status().ToString();
+  auto registration = std::move(registration_result).ValueOrDie();
+  provider.reset();
+  EXPECT_FALSE(weak_provider.expired());
+
+  registration.reset();
+  EXPECT_TRUE(weak_provider.expired());
+  auto uri = Aws::Http::URI(("https://release.example/" + bucket + "/key").c_str());
+  EXPECT_EQ(registry.Lookup(uri), nullptr);
+
+  auto replacement = registry.Register(key, std::make_shared<GcpCredentialRegistration>(
+                                                "replacement-identity", std::make_shared<TestGcpCredentialProvider>()));
+  EXPECT_TRUE(replacement.ok()) << replacement.status().ToString();
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/filesystem/local_file_system_test.cpp
+++ b/cpp/test/filesystem/local_file_system_test.cpp
@@ -13,23 +13,387 @@
 // limitations under the License.
 
 #include <arrow/testing/gtest_util.h>
+#include <arrow/testing/executor_util.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <cstdlib>
+#include <future>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
+
+#include <unistd.h>
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/filesystem/upload_conditional.h"
 #include "milvus-storage/filesystem/upload_sizable.h"
+#include "milvus-storage/filesystem/util_internal.h"
 
 #include "test_env.h"
 
 namespace milvus_storage {
+namespace {
+
+void PrepareDeathTest() {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  const auto prefix = "/tmp/milvus-storage-submit-io-death-test-gcov-" + std::to_string(getpid());
+  (void)setenv("GCOV_PREFIX", prefix.c_str(), 1);
+}
+
+class RejectingExecutor final : public arrow::internal::Executor {
+  public:
+  int GetCapacity() override { return 1; }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints,
+                          arrow::internal::FnOnce<void()>,
+                          arrow::StopToken,
+                          StopCallback&&) override {
+    return arrow::Status::IOError("executor rejected background task");
+  }
+};
+
+class ThrowingExecutor final : public arrow::internal::Executor {
+  public:
+  int GetCapacity() override { return 1; }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints,
+                          arrow::internal::FnOnce<void()>,
+                          arrow::StopToken,
+                          StopCallback&&) override {
+    throw std::runtime_error("executor submission exploded");
+  }
+};
+
+class BadAllocThrowingExecutor final : public arrow::internal::Executor {
+  public:
+  int GetCapacity() override { return 1; }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints,
+                          arrow::internal::FnOnce<void()>,
+                          arrow::StopToken,
+                          StopCallback&&) override {
+    throw std::bad_alloc();
+  }
+};
+
+class CancellingExecutor final : public arrow::internal::Executor {
+  public:
+  int GetCapacity() override { return 1; }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints,
+                          arrow::internal::FnOnce<void()>,
+                          arrow::StopToken,
+                          StopCallback&& stop_callback) override {
+    std::move(stop_callback)(arrow::Status::Cancelled("background I/O cancelled before execution"));
+    return arrow::Status::OK();
+  }
+};
+
+class BadAllocCopyCompletion {
+  public:
+  BadAllocCopyCompletion(int* completion_count, arrow::Status* completed_status)
+      : completion_count_(completion_count), completed_status_(completed_status) {}
+
+  BadAllocCopyCompletion(const BadAllocCopyCompletion&) { throw std::bad_alloc(); }
+  BadAllocCopyCompletion(BadAllocCopyCompletion&&) noexcept = default;
+
+  void operator()(const arrow::Status& status) {
+    ++*completion_count_;
+    *completed_status_ = status;
+  }
+
+  private:
+  int* completion_count_;
+  arrow::Status* completed_status_;
+};
+
+class BadAllocMoveTask {
+  public:
+  BadAllocMoveTask() = default;
+  BadAllocMoveTask(const BadAllocMoveTask&) = delete;
+  BadAllocMoveTask(BadAllocMoveTask&&) { throw std::bad_alloc(); }
+
+  arrow::Status operator()() { return arrow::Status::OK(); }
+};
+
+class FailOnceOutputStream final : public arrow::io::OutputStream {
+  public:
+  arrow::Status Close() override {
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Abort() override {
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<int64_t> Tell() const override { return position_; }
+
+  bool closed() const override { return closed_; }
+
+  arrow::Status Write(const void*, int64_t nbytes) override {
+    if (fail_next_) {
+      fail_next_ = false;
+      return arrow::Status::IOError("injected output failure");
+    }
+    position_ += nbytes;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override { return arrow::Status::OK(); }
+
+  private:
+  bool fail_next_ = true;
+  bool closed_ = false;
+  int64_t position_ = 0;
+};
+
+}  // namespace
+
+TEST(SubmitIOWithCompletionTest, ExecutorRejectionStillCompletesExactlyOnce) {
+  RejectingExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  int completion_count = 0;
+  arrow::Status completed_status;
+
+  auto status = arrow::io::internal::SubmitIOWithCompletion(
+      io_context, [] { return arrow::Status::OK(); },
+      [&](const arrow::Status& task_status) {
+        ++completion_count;
+        completed_status = task_status;
+      });
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(completion_count, 1);
+  EXPECT_TRUE(completed_status.Equals(status));
+}
+
+TEST(SubmitIOWithCompletionTest, ExecutorExceptionCompletesExactlyOnceWithInvariantDetail) {
+  ThrowingExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  int completion_count = 0;
+  arrow::Status completed_status;
+
+  auto status = arrow::io::internal::SubmitIOWithCompletion(
+      io_context, [] { return arrow::Status::OK(); },
+      [&](const arrow::Status& task_status) {
+        ++completion_count;
+        completed_status = task_status;
+      });
+
+  ASSERT_FALSE(status.ok());
+  EXPECT_EQ(completion_count, 1);
+  EXPECT_TRUE(completed_status.Equals(status));
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::InternalInvariantViolated);
+  EXPECT_NE(status.message().find("executor submission exploded"), std::string::npos);
+}
+
+TEST(SubmitIOWithCompletionTest, ExecutorAllocationFailureIsFailStop) {
+  PrepareDeathTest();
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        BadAllocThrowingExecutor executor;
+        arrow::io::IOContext io_context(&executor);
+        (void)arrow::io::internal::SubmitIOWithCompletion(
+            io_context, [] { return arrow::Status::OK(); }, [](const arrow::Status&) {});
+      },
+      "");
+}
+
+TEST(SubmitIOWithCompletionTest, CompletionConstructionAllocationFailureIsFailStop) {
+  PrepareDeathTest();
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        RejectingExecutor executor;
+        arrow::io::IOContext io_context(&executor);
+        int completion_count = 0;
+        arrow::Status completed_status;
+        BadAllocCopyCompletion completion(&completion_count, &completed_status);
+        (void)arrow::io::internal::SubmitIOWithCompletion(io_context, [] { return arrow::Status::OK(); }, completion);
+      },
+      "");
+}
+
+TEST(SubmitIOWithCompletionTest, TaskConstructionAllocationFailureIsFailStop) {
+  PrepareDeathTest();
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        RejectingExecutor executor;
+        arrow::io::IOContext io_context(&executor);
+        BadAllocMoveTask task;
+        (void)arrow::io::internal::SubmitIOWithCompletion(io_context, std::move(task), [](const arrow::Status&) {});
+      },
+      "");
+}
+
+TEST(SubmitIOWithCompletionTest, CancellationBeforeExecutionCompletesWithoutRunningTask) {
+  CancellingExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  bool task_ran = false;
+  int completion_count = 0;
+  arrow::Status completed_status;
+
+  ASSERT_STATUS_OK(arrow::io::internal::SubmitIOWithCompletion(
+      io_context,
+      [&] {
+        task_ran = true;
+        return arrow::Status::OK();
+      },
+      [&](const arrow::Status& task_status) {
+        ++completion_count;
+        completed_status = task_status;
+      }));
+
+  EXPECT_FALSE(task_ran);
+  EXPECT_EQ(completion_count, 1);
+  EXPECT_TRUE(completed_status.IsCancelled()) << completed_status.ToString();
+}
+
+TEST(SubmitIOWithCompletionTest, TaskFailureStillCompletesExactlyOnce) {
+  std::promise<arrow::Status> completion;
+  auto completed = completion.get_future();
+  auto expected = arrow::Status::IOError("client acquisition failed");
+
+  ASSERT_STATUS_OK(arrow::io::internal::SubmitIOWithCompletion(
+      arrow::io::default_io_context(), [expected] { return expected; },
+      [&completion](const arrow::Status& status) { completion.set_value(status); }));
+
+  ASSERT_EQ(completed.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  EXPECT_TRUE(completed.get().Equals(expected));
+}
+
+TEST(SubmitIOWithCompletionTest, StandardTaskExceptionCompletesExactlyOnceWithInvariantDetail) {
+  arrow::MockExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  int completion_count = 0;
+  arrow::Status completed_status;
+
+  ASSERT_STATUS_OK(arrow::io::internal::SubmitIOWithCompletion(
+      io_context, []() -> arrow::Status { throw std::runtime_error("background task exploded"); },
+      [&](const arrow::Status& task_status) {
+        ++completion_count;
+        completed_status = task_status;
+      }));
+
+  EXPECT_EQ(completion_count, 1);
+  auto detail = ExtendStatusDetail::UnwrapStatus(completed_status);
+  ASSERT_NE(detail, nullptr) << completed_status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::InternalInvariantViolated);
+  EXPECT_NE(completed_status.message().find("background task exploded"), std::string::npos);
+}
+
+TEST(SubmitIOWithCompletionTest, TaskAllocationFailureIsFailStop) {
+  PrepareDeathTest();
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        arrow::MockExecutor executor;
+        arrow::io::IOContext io_context(&executor);
+        (void)arrow::io::internal::SubmitIOWithCompletion(
+            io_context, []() -> arrow::Status { throw std::bad_alloc(); }, [](const arrow::Status&) {});
+      },
+      "");
+}
+
+TEST(SubmitIOWithCompletionTest, CompletionExceptionIsFailStop) {
+  PrepareDeathTest();
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        RejectingExecutor executor;
+        arrow::io::IOContext io_context(&executor);
+        (void)arrow::io::internal::SubmitIOWithCompletion(
+            io_context, [] { return arrow::Status::OK(); },
+            [](const arrow::Status&) { throw std::runtime_error("completion exploded"); });
+      },
+      "");
+}
+
+TEST(SubmitIOWithCompletionTest, NonStandardTaskExceptionCompletesExactlyOnceWithInvariantDetail) {
+  arrow::MockExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  int completion_count = 0;
+  arrow::Status completed_status;
+
+  ASSERT_STATUS_OK(arrow::io::internal::SubmitIOWithCompletion(
+      io_context, []() -> arrow::Status { throw 42; },
+      [&](const arrow::Status& task_status) {
+        ++completion_count;
+        completed_status = task_status;
+      }));
+
+  EXPECT_EQ(completion_count, 1);
+  auto detail = ExtendStatusDetail::UnwrapStatus(completed_status);
+  ASSERT_NE(detail, nullptr) << completed_status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::InternalInvariantViolated);
+  EXPECT_NE(completed_status.message().find("non-standard exception"), std::string::npos);
+}
+
+TEST(WriterStatusTest, ObservedAsyncFailureRemainsTheTerminalVerdict) {
+  WriterStatus writer_status;
+  auto first_child = MakeExtendError(ExtendStatusCode::StorageAccessDenied, "part 1 denied");
+  auto later = MakeExtendError(ExtendStatusCode::StorageTransientService, "later failure");
+
+  (void)writer_status.RecordFirstFailure(first_child);
+
+  EXPECT_TRUE(writer_status.Check().Equals(first_child));
+  EXPECT_TRUE(writer_status.RecordFirstFailure(later).Equals(first_child));
+  EXPECT_TRUE(writer_status.Check().Equals(first_child));
+}
+
+TEST(WriterStatusTest, LocallySuccessfulOperationStillReturnsConcurrentFailure) {
+  WriterStatus writer_status;
+  auto child_failure = MakeExtendError(ExtendStatusCode::StorageTransientService, "background upload failed");
+
+  // Models a foreground operation that passed Check(), then lost the race to
+  // an asynchronous completion before publishing its local OK.
+  (void)writer_status.RecordFirstFailure(child_failure);
+  EXPECT_TRUE(writer_status.RecordFirstFailure(arrow::Status::OK()).Equals(child_failure));
+  EXPECT_TRUE(writer_status.RecordFirstFailure(arrow::Status::OK()).Equals(child_failure));
+}
+
+TEST(WriterStatusTest, BackgroundCompletionPublishesTheObservedFirstFailure) {
+  WriterStatus writer_status;
+  auto first_child = MakeExtendError(ExtendStatusCode::StorageAccessDenied, "part 1 denied");
+  auto later = MakeExtendError(ExtendStatusCode::StorageTransientService, "later failure");
+
+  auto first_observed = arrow::io::internal::ObserveBackgroundIOStatus(&writer_status, first_child);
+  auto later_observed = arrow::io::internal::ObserveBackgroundIOStatus(&writer_status, later);
+  EXPECT_TRUE(first_observed.Equals(first_child));
+  EXPECT_TRUE(later_observed.Equals(first_child));
+
+  auto future = arrow::Future<>::Make();
+  future.MarkFinished(std::move(later_observed));
+  ASSERT_TRUE(future.Wait(1.0));
+  EXPECT_TRUE(future.status().Equals(first_child));
+}
+
+TEST(MetricsOutputStreamTest, FailureIsTerminal) {
+  auto underlying = std::make_shared<FailOnceOutputStream>();
+  auto metrics = std::make_shared<FilesystemMetrics>();
+  auto writer = std::make_shared<MetricsOutputStream>(underlying, metrics);
+  const uint8_t byte = 1;
+
+  auto first_failure = writer->Write(&byte, 1);
+  ASSERT_STATUS_NOT_OK(first_failure);
+
+  EXPECT_TRUE(writer->Flush().Equals(first_failure));
+
+  ASSERT_STATUS_OK(writer->Abort());
+}
 
 class LocalFsTest : public ::testing::Test {
   protected:

--- a/cpp/test/filesystem/s3_crt_build_test.cpp
+++ b/cpp/test/filesystem/s3_crt_build_test.cpp
@@ -44,6 +44,7 @@
 #include "milvus-storage/filesystem/s3/s3_crt_client.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/format/parquet/folly_arrow_executor.h"
 #include "test_env.h"
 
@@ -99,6 +100,218 @@ bool WaitUntilConstructionRejected(const std::shared_ptr<S3CrtClientFinalizer>& 
 
 constexpr std::size_t kConcurrentOperations = 100;
 
+class BlockingRangeGetServer final {
+  using Tcp = boost::asio::ip::tcp;
+
+  public:
+  BlockingRangeGetServer(std::string expected_range = "bytes=2-5",
+                         boost::beast::http::status response_status = boost::beast::http::status::partial_content,
+                         std::string response_body = "cdef",
+                         std::string content_range = "bytes 2-5/9")
+      : expected_range_(std::move(expected_range)),
+        response_status_(response_status),
+        response_body_(std::move(response_body)),
+        content_range_(std::move(content_range)) {}
+
+  ~BlockingRangeGetServer() { Stop(); }
+
+  bool Start() {
+    boost::system::error_code error;
+    acceptor_.open(Tcp::v4(), error);
+    if (RecordError(error)) {
+      return false;
+    }
+    acceptor_.set_option(Tcp::acceptor::reuse_address(true), error);
+    if (RecordError(error)) {
+      return false;
+    }
+    acceptor_.bind(Tcp::endpoint(boost::asio::ip::address_v4::loopback(), 0), error);
+    if (RecordError(error)) {
+      return false;
+    }
+    acceptor_.listen(1, error);
+    if (RecordError(error)) {
+      return false;
+    }
+    port_ = acceptor_.local_endpoint(error).port();
+    if (RecordError(error)) {
+      return false;
+    }
+    worker_ = std::thread([this] { Serve(); });
+    return true;
+  }
+
+  uint16_t port() const { return port_; }
+
+  bool WaitForRequest(std::chrono::milliseconds timeout) {
+    std::unique_lock lock(mutex_);
+    cv_.wait_for(lock, timeout, [this] { return request_received_ || stopped_ || !error_.empty(); });
+    return request_received_;
+  }
+
+  void ReleaseResponse() {
+    {
+      std::lock_guard lock(mutex_);
+      response_released_ = true;
+    }
+    cv_.notify_all();
+  }
+
+  std::string error() const {
+    std::lock_guard lock(mutex_);
+    return error_;
+  }
+
+  void Stop() {
+    std::shared_ptr<Tcp::socket> socket;
+    {
+      std::lock_guard lock(mutex_);
+      stopped_ = true;
+      response_released_ = true;
+      socket = socket_;
+    }
+    cv_.notify_all();
+
+    boost::system::error_code error;
+    acceptor_.close(error);
+    if (socket) {
+      socket->cancel(error);
+      socket->shutdown(Tcp::socket::shutdown_both, error);
+      socket->close(error);
+    }
+    if (worker_.joinable()) {
+      worker_.join();
+    }
+  }
+
+  private:
+  bool RecordError(const boost::system::error_code& error) {
+    if (!error) {
+      return false;
+    }
+    SetError(error.message());
+    return true;
+  }
+
+  void SetError(std::string error) {
+    {
+      std::lock_guard lock(mutex_);
+      if (error_.empty()) {
+        error_ = std::move(error);
+      }
+    }
+    cv_.notify_all();
+  }
+
+  void Serve() {
+    auto socket = std::make_shared<Tcp::socket>(io_context_);
+    {
+      std::lock_guard lock(mutex_);
+      socket_ = socket;
+    }
+    boost::system::error_code error;
+    acceptor_.accept(*socket, error);
+    if (error) {
+      std::lock_guard lock(mutex_);
+      if (!stopped_) {
+        error_ = error.message();
+        cv_.notify_all();
+      }
+      return;
+    }
+
+    boost::beast::flat_buffer buffer;
+    boost::beast::http::request<boost::beast::http::empty_body> request;
+    boost::beast::http::read(*socket, buffer, request, error);
+    if (RecordError(error)) {
+      return;
+    }
+    if (request.method() != boost::beast::http::verb::get ||
+        request[boost::beast::http::field::range] != expected_range_) {
+      SetError("Unexpected CRT range GET");
+      return;
+    }
+
+    {
+      std::lock_guard lock(mutex_);
+      request_received_ = true;
+    }
+    cv_.notify_all();
+
+    {
+      std::unique_lock lock(mutex_);
+      cv_.wait(lock, [this] { return response_released_ || stopped_; });
+      if (stopped_) {
+        return;
+      }
+    }
+
+    boost::beast::http::response<boost::beast::http::string_body> response{response_status_, request.version()};
+    if (!content_range_.empty()) {
+      response.set(boost::beast::http::field::content_range, content_range_);
+      response.set(boost::beast::http::field::accept_ranges, "bytes");
+      response.set(boost::beast::http::field::etag, "\"0123456789abcdef0123456789abcdef\"");
+    }
+    response.keep_alive(false);
+    response.body() = response_body_;
+    response.prepare_payload();
+    boost::beast::http::write(*socket, response, error);
+    if (RecordError(error)) {
+      return;
+    }
+    socket->shutdown(Tcp::socket::shutdown_both, error);
+    if (error && error != boost::asio::error::not_connected) {
+      RecordError(error);
+    }
+    socket->close(error);
+    RecordError(error);
+  }
+
+  const std::string expected_range_;
+  const boost::beast::http::status response_status_;
+  const std::string response_body_;
+  const std::string content_range_;
+  boost::asio::io_context io_context_;
+  Tcp::acceptor acceptor_{io_context_};
+  std::shared_ptr<Tcp::socket> socket_;
+  uint16_t port_ = 0;
+  std::thread worker_;
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  std::string error_;
+  bool request_received_ = false;
+  bool response_released_ = false;
+  bool stopped_ = false;
+};
+
+class BlockingCredentialsResolver final : public RequestCredentialsResolver {
+  public:
+  arrow::Result<Aws::Auth::AWSCredentials> ResolveForRequest() override {
+    std::unique_lock lock(mutex_);
+    entered_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return released_; });
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageTransientNetwork, "credential refresh failed");
+  }
+
+  bool WaitUntilEntered() {
+    std::unique_lock lock(mutex_);
+    return cv_.wait_for(lock, std::chrono::seconds(5), [this] { return entered_; });
+  }
+
+  void Release() {
+    std::lock_guard lock(mutex_);
+    released_ = true;
+    cv_.notify_all();
+  }
+
+  private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool entered_ = false;
+  bool released_ = false;
+};
+
 }  // namespace
 
 TEST(S3CrtBuildSupportTest, HeadersAndStaticClientSymbolsAreAvailable) {
@@ -131,6 +344,20 @@ TEST(S3CrtClientFinalizerTest, RejectsClientWithAnotherSharedOwner) {
 
   ASSERT_FALSE(result.ok());
   EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
+}
+
+TEST(S3CrtClientFinalizerTest, FinalizeReleasesRegisteredBuilderResources) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  int cleanup_count = 0;
+  ASSERT_AND_ASSIGN(auto holder, finalizer->AddClient([] { return MakeTestS3CrtClient(); }, nullptr, nullptr,
+                                                      [&cleanup_count] { ++cleanup_count; }));
+
+  ASSERT_EQ(cleanup_count, 0);
+  finalizer->Finalize();
+  EXPECT_EQ(cleanup_count, 1);
+
+  holder.reset();
+  EXPECT_EQ(cleanup_count, 1);
 }
 
 TEST(S3CrtClientFinalizerTest, FinalizationWaitsForClientConstructionToRegister) {
@@ -418,6 +645,38 @@ TEST(S3CrtClientFinalizerTest, FinalizationWaitsForEveryActiveOperation) {
   EXPECT_FALSE(factory_called);
 }
 
+TEST(S3CrtClientFinalizerTest, CredentialRefreshIsInsideShutdownBarrier) {
+  auto finalizer = std::make_shared<S3CrtClientFinalizer>();
+  auto resolver = std::make_shared<BlockingCredentialsResolver>();
+  std::weak_ptr<RequestCredentialsResolver> weak_resolver = resolver;
+  auto client = MakeTestS3CrtClient();
+  std::weak_ptr<Aws::S3Crt::S3CrtClient> weak_client = client;
+  ASSERT_AND_ASSIGN(
+      auto holder,
+      finalizer->AddClient([client = std::move(client)]() mutable { return std::move(client); }, nullptr, resolver));
+
+  auto acquired = std::async(std::launch::async, [holder] { return holder->Acquire(); });
+  ASSERT_TRUE(resolver->WaitUntilEntered());
+
+  auto finalized = std::async(std::launch::async, [finalizer] { finalizer->Finalize(); });
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(250)), std::future_status::timeout);
+  EXPECT_FALSE(weak_client.expired());
+
+  resolver->Release();
+  resolver.reset();
+  ASSERT_EQ(acquired.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto acquire_result = acquired.get();
+  ASSERT_FALSE(acquire_result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(acquire_result.status());
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientNetwork);
+
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+  EXPECT_TRUE(weak_client.expired());
+  EXPECT_TRUE(weak_resolver.expired());
+}
+
 TEST(S3CrtClientFinalizerTest, InlineContinuationDoesNotDeadlockWithConcurrentFinalization) {
   auto finalizer = std::make_shared<S3CrtClientFinalizer>();
   ASSERT_AND_ASSIGN(auto holder, finalizer->AddClient([] { return MakeTestS3CrtClient(); }, nullptr));
@@ -574,168 +833,6 @@ TEST(S3CrtBuildSupportTest, InFlightNativeReadCompletesDuringFinalizeS3) {
   const auto original_death_test_style = GTEST_FLAG_GET(death_test_style);
   GTEST_FLAG_SET(death_test_style, "threadsafe");
   const auto run_child = []() -> int {
-    class BlockingRangeGetServer final {
-      using Tcp = boost::asio::ip::tcp;
-
-   public:
-      ~BlockingRangeGetServer() { Stop(); }
-
-      bool Start() {
-        boost::system::error_code error;
-        acceptor_.open(Tcp::v4(), error);
-        if (RecordError(error)) {
-          return false;
-        }
-        acceptor_.set_option(Tcp::acceptor::reuse_address(true), error);
-        if (RecordError(error)) {
-          return false;
-        }
-        acceptor_.bind(Tcp::endpoint(boost::asio::ip::address_v4::loopback(), 0), error);
-        if (RecordError(error)) {
-          return false;
-        }
-        acceptor_.listen(1, error);
-        if (RecordError(error)) {
-          return false;
-        }
-        port_ = acceptor_.local_endpoint(error).port();
-        if (RecordError(error)) {
-          return false;
-        }
-        worker_ = std::thread([this] { Serve(); });
-        return true;
-      }
-
-      uint16_t port() const { return port_; }
-
-      bool WaitForRequest(std::chrono::milliseconds timeout) {
-        std::unique_lock lock(mutex_);
-        cv_.wait_for(lock, timeout, [this] { return request_received_ || stopped_ || !error_.empty(); });
-        return request_received_;
-      }
-
-      void ReleaseResponse() {
-        {
-          std::lock_guard lock(mutex_);
-          response_released_ = true;
-        }
-        cv_.notify_all();
-      }
-
-      std::string error() const {
-        std::lock_guard lock(mutex_);
-        return error_;
-      }
-
-      void Stop() {
-        std::shared_ptr<Tcp::socket> socket;
-        {
-          std::lock_guard lock(mutex_);
-          stopped_ = true;
-          response_released_ = true;
-          socket = socket_;
-        }
-        cv_.notify_all();
-
-        boost::system::error_code error;
-        acceptor_.close(error);
-        if (socket) {
-          socket->cancel(error);
-          socket->shutdown(Tcp::socket::shutdown_both, error);
-          socket->close(error);
-        }
-        if (worker_.joinable()) {
-          worker_.join();
-        }
-      }
-
-   private:
-      bool RecordError(const boost::system::error_code& error) {
-        if (!error) {
-          return false;
-        }
-        SetError(error.message());
-        return true;
-      }
-
-      void SetError(std::string error) {
-        {
-          std::lock_guard lock(mutex_);
-          if (error_.empty()) {
-            error_ = std::move(error);
-          }
-        }
-        cv_.notify_all();
-      }
-
-      void Serve() {
-        auto socket = std::make_shared<Tcp::socket>(io_context_);
-        {
-          std::lock_guard lock(mutex_);
-          socket_ = socket;
-        }
-        boost::system::error_code error;
-        acceptor_.accept(*socket, error);
-        if (error) {
-          std::lock_guard lock(mutex_);
-          if (!stopped_) {
-            error_ = error.message();
-            cv_.notify_all();
-          }
-          return;
-        }
-
-        boost::beast::flat_buffer buffer;
-        boost::beast::http::request<boost::beast::http::empty_body> request;
-        boost::beast::http::read(*socket, buffer, request, error);
-        if (RecordError(error)) {
-          return;
-        }
-        if (request.method() != boost::beast::http::verb::get ||
-            request[boost::beast::http::field::range] != "bytes=2-5") {
-          SetError("Unexpected CRT range GET");
-          return;
-        }
-
-        {
-          std::lock_guard lock(mutex_);
-          request_received_ = true;
-        }
-        cv_.notify_all();
-
-        {
-          std::unique_lock lock(mutex_);
-          cv_.wait(lock, [this] { return response_released_ || stopped_; });
-          if (stopped_) {
-            return;
-          }
-        }
-
-        boost::beast::http::response<boost::beast::http::string_body> response{
-            boost::beast::http::status::partial_content, request.version()};
-        response.set(boost::beast::http::field::content_range, "bytes 2-5/9");
-        response.set(boost::beast::http::field::accept_ranges, "bytes");
-        response.set(boost::beast::http::field::etag, "\"s3-crt-finalize-test\"");
-        response.keep_alive(false);
-        response.body() = "cdef";
-        response.prepare_payload();
-        boost::beast::http::write(*socket, response, error);
-        RecordError(error);
-      }
-
-      boost::asio::io_context io_context_;
-      Tcp::acceptor acceptor_{io_context_};
-      std::shared_ptr<Tcp::socket> socket_;
-      uint16_t port_ = 0;
-      std::thread worker_;
-      mutable std::mutex mutex_;
-      std::condition_variable cv_;
-      std::string error_;
-      bool request_received_ = false;
-      bool response_released_ = false;
-      bool stopped_ = false;
-    };
-
     auto fail = [](const std::string& message) {
       std::cerr << message << std::endl;
       return 1;
@@ -808,6 +905,105 @@ TEST(S3CrtBuildSupportTest, InFlightNativeReadCompletesDuringFinalizeS3) {
       return fail(finalize_status.ToString());
     }
     server.Stop();
+    return 0;
+  };
+  EXPECT_EXIT((::alarm(20), ::_exit(run_child())), ::testing::ExitedWithCode(0), "");
+  GTEST_FLAG_SET(death_test_style, original_death_test_style);
+#endif
+}
+
+TEST(S3CrtBuildSupportTest, AsyncReadCallbackCanReleaseLastFilesystemOwner) {
+#if defined(_WIN32)
+  GTEST_SKIP() << "Test requires POSIX process and socket APIs.";
+#else
+  const auto original_death_test_style = GTEST_FLAG_GET(death_test_style);
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  const auto run_child = []() -> int {
+    auto fail = [](const std::string& message) {
+      std::cerr << message << std::endl;
+      return 1;
+    };
+
+    BlockingRangeGetServer server("bytes=0-0", boost::beast::http::status::forbidden,
+                                  "<Error><Code>AccessDenied</Code><Message>test failure</Message></Error>", "");
+    if (!server.Start()) {
+      return fail("Failed to start the blocking S3 server: " + server.error());
+    }
+
+    auto initialize_status = EnsureS3Initialized();
+    if (!initialize_status.ok()) {
+      return fail(initialize_status.ToString());
+    }
+
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.cloud_provider = kCloudProviderAWS;
+    options.region = "us-east-1";
+    options.scheme = "http";
+    options.endpoint_override = "127.0.0.1:" + std::to_string(server.port());
+    options.connect_timeout = 5;
+    options.request_timeout = 5;
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(0);
+    options.use_crt_async_reads = true;
+
+    auto fs_result = S3FileSystem::Make(options);
+    if (!fs_result.ok()) {
+      return fail(fs_result.status().ToString());
+    }
+    auto fs = std::move(fs_result).ValueOrDie();
+    arrow::fs::FileInfo file_info("test-bucket/path/object.txt", arrow::fs::FileType::File);
+    file_info.set_size(1);
+    auto input_result = fs->OpenInputFile(file_info);
+    if (!input_result.ok()) {
+      return fail(input_result.status().ToString());
+    }
+    auto input = std::move(input_result).ValueOrDie();
+    auto* async_file = dynamic_cast<NonBlockingReadAtFile*>(input.get());
+    if (async_file == nullptr) {
+      return fail("OpenInputFile did not select the CRT async read path");
+    }
+
+    uint8_t out = 0;
+    auto read = async_file->ReadAtAsyncInto(0, 1, &out);
+    if (!server.WaitForRequest(std::chrono::seconds(5))) {
+      return fail("Timed out waiting for a real CRT range GET: " + server.error());
+    }
+
+    struct ReadOwners {
+      std::shared_ptr<milvus_storage::S3FileSystem> filesystem;
+      std::shared_ptr<arrow::io::RandomAccessFile> input;
+    };
+    auto owners = std::make_shared<ReadOwners>(ReadOwners{fs, input});
+    fs.reset();
+    input.reset();
+
+    auto callback_entered_promise = std::make_shared<std::promise<void>>();
+    auto callback_entered = callback_entered_promise->get_future();
+    auto callback_done_promise = std::make_shared<std::promise<void>>();
+    auto callback_done = callback_done_promise->get_future();
+    read.AddCallback([owners, callback_entered_promise, callback_done_promise](const arrow::Result<int64_t>&) {
+      callback_entered_promise->set_value();
+      owners->input.reset();
+      owners->filesystem.reset();
+      callback_done_promise->set_value();
+    });
+
+    server.ReleaseResponse();
+    if (callback_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+      return fail("Async read callback did not run on the completion executor");
+    }
+    callback_entered.get();
+    if (callback_done.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+      return fail("Async read callback deadlocked while releasing the final filesystem owner");
+    }
+    callback_done.get();
+    server.Stop();
+    if (!read.result().status().IsIOError()) {
+      return fail("Closing the test connection did not fail the CRT range read");
+    }
+    auto finalize_status = FinalizeS3();
+    if (!finalize_status.ok()) {
+      return fail(finalize_status.ToString());
+    }
     return 0;
   };
   EXPECT_EXIT((::alarm(20), ::_exit(run_child())), ::testing::ExitedWithCode(0), "");

--- a/cpp/test/filesystem/s3_file_system_test.cpp
+++ b/cpp/test/filesystem/s3_file_system_test.cpp
@@ -17,10 +17,17 @@
 #include <arrow/io/memory.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <future>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <sstream>
 #include <thread>
+#include <tuple>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -39,12 +46,71 @@
 #include "milvus-storage/filesystem/s3/s3_auth_signer.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
 #include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/filesystem/util_internal.h"
 #include "milvus-storage/filesystem/fs.h"
 
 #include "test_env.h"
 
 namespace milvus_storage {
+
+namespace {
+
+class ScopedEnvironmentVariable {
+  public:
+  ScopedEnvironmentVariable(std::string name, std::string value) : name_(std::move(name)) {
+    if (const char* old = std::getenv(name_.c_str()); old != nullptr) {
+      old_value_ = old;
+    }
+    setenv(name_.c_str(), value.c_str(), 1);
+  }
+
+  ~ScopedEnvironmentVariable() {
+    if (old_value_.has_value()) {
+      setenv(name_.c_str(), old_value_->c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+  ScopedEnvironmentVariable& operator=(const ScopedEnvironmentVariable&) = delete;
+
+  private:
+  std::string name_;
+  std::optional<std::string> old_value_;
+};
+
+class FinalizerProbeResolver final : public RequestCredentialsResolver {
+  public:
+  arrow::Result<Aws::Auth::AWSCredentials> ResolveForRequest() override {
+    return Aws::Auth::AWSCredentials("ak", "sk");
+  }
+};
+
+class ControllableS3ClientFinalizer final : public S3ClientFinalizer {
+  public:
+  std::unique_lock<std::shared_mutex> MarkFinalizedAndHoldBarrier() {
+    std::unique_lock lock(mutex_);
+    finalized_ = true;
+    return lock;
+  }
+
+  bool IsFinalizedForTest() {
+    std::shared_lock lock(mutex_);
+    return finalized_;
+  }
+};
+
+std::shared_ptr<S3Client> MakeTestS3Client() {
+  // Lifecycle tests never dereference the client. An aliasing pointer gives
+  // them observable ownership without constructing another SDK client.
+  auto storage = std::make_shared<char>();
+  return {storage, reinterpret_cast<S3Client*>(storage.get())};
+}
+
+}  // namespace
+
 // ============================================================================
 // Non-cloud unit tests — S3 SDK initialized but no real cloud connection needed
 // ============================================================================
@@ -63,60 +129,214 @@ class S3UnitTest : public ::testing::Test {
       return;
     }
     ASSERT_TRUE(EnsureS3Initialized().ok());
+    // Keep filtered runs of this suite safe too. Finalize once at process exit,
+    // after every S3-using suite has finished and before AwsInstance's static
+    // destructor.
+    static std::once_flag flag;
+    std::call_once(flag, [] { std::atexit([] { EnsureS3Finalized().ok(); }); });
   }
 };
 
+constexpr fs::internal::S3ErrorProvenance kDefaultProvenance{};
+
 TEST_F(S3UnitTest, TestExtendErrorInFs) {
   Aws::Client::AWSError<Aws::S3::S3Errors> test_err(Aws::S3::S3Errors::NO_SUCH_UPLOAD,
-                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "AwsErrorNoSuchUpload",
+                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "StorageNoSuchUpload",
                                                     "Just for test");
 
-  auto status = fs::internal::ErrorToStatus("test", test_err);
+  auto status = fs::internal::ErrorToStatus("test", test_err, kDefaultProvenance);
   ASSERT_STATUS_NOT_OK(status);
   auto extend_status = ExtendStatusDetail::UnwrapStatus(status);
   ASSERT_NE(extend_status, nullptr);
-  ASSERT_EQ(extend_status->code(), ExtendStatusCode::AwsErrorNoSuchUpload);
+  ASSERT_EQ(extend_status->code(), ExtendStatusCode::StorageNoSuchUpload);
   ASSERT_TRUE(status.ToString().find(extend_status->ToString()) != std::string::npos);
 }
 
-TEST_F(S3UnitTest, TestErrorToStatusPermanentVsTransient) {
-  // NoSuchKey: permanent, tagged AwsErrorNotFound.
+TEST_F(S3UnitTest, ExpiredTokenIsAuthenticationFailure) {
+  auto expired_token = [](Aws::S3::S3Errors error_type) {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(error_type, Aws::Client::RetryableType::NOT_RETRYABLE,
+                                                   "ExpiredToken", "token has expired");
+    error.SetResponseCode(Aws::Http::HttpResponseCode::FORBIDDEN);
+    return error;
+  };
+
+  // Both shapes occur in practice: some SDK/parser combinations keep the
+  // service error UNKNOWN, while others normalize the same named condition to
+  // ACCESS_DENIED. Neither shape proves that the configured provider will
+  // return a different credential on an immediate replay.
+  for (auto error_type : {Aws::S3::S3Errors::UNKNOWN, Aws::S3::S3Errors::ACCESS_DENIED}) {
+    auto error = expired_token(error_type);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, fs::internal::S3ErrorProvenance{});
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied);
+    EXPECT_FALSE(detail->retryable());
+  }
+
+  // Some SDK versions expose the same named service condition through a core
+  // credential enum. The exception name still carries the authoritative
+  // ExpiredToken spelling and must still map to the authentication verdict.
+  const Aws::Client::CoreErrors core_shapes[] = {
+      Aws::Client::CoreErrors::INVALID_CLIENT_TOKEN_ID,
+      Aws::Client::CoreErrors::MISSING_AUTHENTICATION_TOKEN,
+  };
+  for (auto core : core_shapes) {
+    auto error = expired_token(static_cast<Aws::S3::S3Errors>(core));
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, fs::internal::S3ErrorProvenance{});
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied);
+    EXPECT_FALSE(detail->retryable());
+  }
+}
+
+TEST_F(S3UnitTest, WrongBucketRegionIsConfigurationFailure) {
+  Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE,
+                                                 "AuthorizationHeaderMalformed",
+                                                 "the authorization header is malformed");
+  error.SetResponseCode(Aws::Http::HttpResponseCode::BAD_REQUEST);
+  Aws::Http::HeaderValueCollection headers;
+  headers["x-amz-bucket-region"] = "us-west-2";
+  error.SetResponseHeaders(headers);
+
+  auto status = fs::internal::ErrorToStatus("When reading bucket 'b': ", "HeadBucket", error,
+                                            fs::internal::S3ErrorProvenance{fs::internal::S3ResourceKind::Bucket},
+                                            std::string("us-east-1"));
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid);
+  EXPECT_FALSE(detail->retryable());
+  EXPECT_NE(status.message().find("configured region is 'us-east-1'"), std::string::npos) << status.ToString();
+  EXPECT_NE(status.message().find("bucket is located in 'us-west-2'"), std::string::npos) << status.ToString();
+  EXPECT_NE(detail->extra_info().find("configured_region=us-east-1"), std::string::npos);
+  EXPECT_NE(detail->extra_info().find("actual_region=us-west-2"), std::string::npos);
+}
+
+// A store may echo x-amz-bucket-region on any response, including one that
+// identifies a different, sharper condition. The region mismatch is judged last
+// so it cannot erase that condition: a request that was throttled while pointed
+// at the wrong region was still throttled, and reporting it as a configuration
+// failure would strip the transient hint from a failure that has one.
+TEST_F(S3UnitTest, WrongBucketRegionDoesNotMaskAnIdentifiedCondition) {
+  Aws::Http::HeaderValueCollection headers;
+  headers["x-amz-bucket-region"] = "us-west-2";
+
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::SLOW_DOWN, Aws::Client::RetryableType::RETRYABLE,
+                                                   "SlowDown", "please reduce your request rate");
+    error.SetResponseCode(Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS);
+    error.SetResponseHeaders(headers);
+
+    auto status = fs::internal::ErrorToStatus("When reading key 'k' in bucket 'b': ", "GetObject", error,
+                                              fs::internal::S3ErrorProvenance{fs::internal::S3ResourceKind::Object},
+                                              std::string("us-east-1"));
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
+    EXPECT_TRUE(detail->retryable());
+    // The mismatch is not lost, it is just not the verdict.
+    EXPECT_NE(status.message().find("bucket is located in 'us-west-2'"), std::string::npos) << status.ToString();
+    EXPECT_NE(detail->extra_info().find("actual_region=us-west-2"), std::string::npos);
+  }
+
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "access denied");
+    error.SetResponseCode(Aws::Http::HttpResponseCode::FORBIDDEN);
+    error.SetResponseHeaders(headers);
+
+    auto status = fs::internal::ErrorToStatus("When reading key 'k' in bucket 'b': ", "GetObject", error,
+                                              fs::internal::S3ErrorProvenance{fs::internal::S3ResourceKind::Object},
+                                              std::string("us-east-1"));
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied);
+    EXPECT_FALSE(detail->retryable());
+  }
+}
+
+// A classified status names what it was operating on, and extra_info carries
+// something the message does not.
+//
+// Both used to be missing: the prefix -- which is where the bucket and key are
+// -- was glued onto the fallback IOError only, so every status that DID carry a
+// verdict said "AccessDenied during HeadObject" and nothing about which object,
+// while extra_info was the message a second time.
+TEST_F(S3UnitTest, ClassifiedErrorsKeepPrefixAndExceptionName) {
+  Aws::Client::AWSError<Aws::S3::S3Errors> error(
+      Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
+  auto status = fs::internal::ErrorToStatus("When reading information for key 'k' in bucket 'b': ", "HeadObject", error,
+                                            kDefaultProvenance);
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+
+  EXPECT_NE(status.message().find("key 'k'"), std::string::npos) << status.message();
+  EXPECT_NE(status.message().find("bucket 'b'"), std::string::npos) << status.message();
+
+  EXPECT_NE(detail->extra_info().find("AccessDenied"), std::string::npos) << detail->extra_info();
+  EXPECT_NE(detail->extra_info().find("HeadObject"), std::string::npos) << detail->extra_info();
+  EXPECT_NE(detail->extra_info(), status.message());
+
+  // An endpoint that answers with a whole page does not get to put it all in a
+  // Status that is then logged, wrapped and carried across the FFI boundary.
+  const std::string huge(4096, 'x');
+  Aws::Client::AWSError<Aws::S3::S3Errors> chatty(
+      Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE,
+      Aws::String(huge.begin(), huge.end()), Aws::String(huge.begin(), huge.end()));
+  auto bounded = fs::internal::ErrorToStatus("prefix: ", "HeadObject", chatty, kDefaultProvenance);
+  EXPECT_LT(bounded.message().size(), huge.size());
+  auto bounded_detail = ExtendStatusDetail::UnwrapStatus(bounded);
+  ASSERT_NE(bounded_detail, nullptr) << bounded.ToString();
+  EXPECT_LT(bounded_detail->extra_info().size(), huge.size());
+
+  // The caller-supplied prefix carries bucket/key context, but it is not
+  // trusted input either. Bounding only the AWS response still allowed a huge
+  // key or endpoint diagnostic to cross the FFI boundary and flood logs.
+  auto bounded_prefix = fs::internal::ErrorToStatus(huge, "HeadObject", error, kDefaultProvenance);
+  EXPECT_LT(bounded_prefix.message().size(), huge.size());
+  EXPECT_NE(bounded_prefix.message().find("HeadObject"), std::string::npos) << bounded_prefix.message();
+}
+
+TEST_F(S3UnitTest, TestErrorToStatusNonRetryableVsRetryable) {
+  // NoSuchKey: non-retryable, tagged StorageNotFound.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::NO_SUCH_KEY, Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchKey", "object gone");
-    auto status = fs::internal::ErrorToStatus("test", error);
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
     ASSERT_STATUS_NOT_OK(status);
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
     ASSERT_NE(detail, nullptr);
-    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorNotFound);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound);
   }
-  // AccessDenied: permanent, tagged AwsErrorAccessDenied.
+  // AccessDenied: System/non-retryable, tagged StorageAccessDenied. Operator
+  // credentials still land on segcore's 2006 ConfigInvalid rather than 2044.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
-    auto status = fs::internal::ErrorToStatus("test", error);
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
     ASSERT_STATUS_NOT_OK(status);
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
     ASSERT_NE(detail, nullptr);
-    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorAccessDenied);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied);
   }
-  // A recognized error type the SDK judged non-retryable: tagged permanent.
-  {
-    Aws::Client::AWSError<Aws::S3::S3Errors> error(
-        Aws::S3::S3Errors::VALIDATION, Aws::Client::RetryableType::NOT_RETRYABLE, "ValidationError", "bad request");
-    auto status = fs::internal::ErrorToStatus("test", error);
+  // An otherwise unclassified error remains a bare IOError regardless of the
+  // AWS SDK retry-policy flag. ShouldRetry is not an observed error cause.
+  for (auto retry_policy : {Aws::Client::RetryableType::NOT_RETRYABLE, Aws::Client::RetryableType::RETRYABLE}) {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::VALIDATION, retry_policy, "ValidationError",
+                                                   "bad request");
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
     ASSERT_STATUS_NOT_OK(status);
+    EXPECT_TRUE(status.IsIOError()) << status.ToString();
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
-    ASSERT_NE(detail, nullptr);
-    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorNonRetryable);
+    EXPECT_EQ(detail, nullptr) << status.ToString();
   }
   // MinIO-style SlowDown: arrives as UNKNOWN + non-retryable, but it is a
   // genuine transient (rate limiting), so it must carry retryable throttling
-  // detail instead of being tagged permanent.
+  // detail instead of being treated as a System failure.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDown", "rate limited");
-    auto status = fs::internal::ErrorToStatus("test", error);
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
     ASSERT_STATUS_NOT_OK(status);
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
     ASSERT_NE(detail, nullptr);
@@ -127,12 +347,107 @@ TEST_F(S3UnitTest, TestErrorToStatusPermanentVsTransient) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::SLOW_DOWN, Aws::Client::RetryableType::RETRYABLE_THROTTLING, "SlowDown", "rate limited");
-    auto status = fs::internal::ErrorToStatus("test", error);
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
     ASSERT_STATUS_NOT_OK(status);
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
     ASSERT_NE(detail, nullptr);
     EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
     EXPECT_TRUE(detail->retryable());
+  }
+}
+
+// The SDK's own core errors, which are not S3 errors at all.
+//
+// CoreErrors and S3Errors share a numeric space only because the S3 enum
+// continues where the core one stops, so casting a core code into it names
+// whichever S3 error happens to sit at that number. These three then missed
+// every arm and fell through to the unclassified IOError path -- a local
+// allocation failure reported as generic storage I/O, and rejected credentials
+// reported as a generic storage failure instead of something an operator can
+// fix.
+//
+// This test exists because the first attempt at the fix gated on
+// CoreErrors::VALIDATION (14) while the codes it handles are 17, 21 and 26 --
+// the branch could not execute, and nothing said so.
+TEST_F(S3UnitTest, CoreErrorsAreClassifiedBeforeTheS3Cast) {
+  {
+    Aws::Client::AWSError<Aws::Client::CoreErrors> error(
+        Aws::Client::CoreErrors::MEMORY_ALLOCATION, Aws::Client::RetryableType::NOT_RETRYABLE, "OOM", "alloc failed");
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
+    ASSERT_STATUS_NOT_OK(status);
+    EXPECT_TRUE(status.IsOutOfMemory()) << status.ToString();
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::MemAllocateFailed);
+  }
+
+  for (auto core : {Aws::Client::CoreErrors::UNRECOGNIZED_CLIENT, Aws::Client::CoreErrors::INVALID_SIGNATURE}) {
+    Aws::Client::AWSError<Aws::Client::CoreErrors> error(core, Aws::Client::RetryableType::NOT_RETRYABLE, "Auth",
+                                                         "bad credentials");
+    error.SetResponseCode(Aws::Http::HttpResponseCode::FORBIDDEN);
+    auto status =
+        fs::internal::ErrorToStatus("When reading key 'k' in bucket 'b': ", "HeadObject", error, kDefaultProvenance);
+    ASSERT_STATUS_NOT_OK(status);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied);
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::System);
+    EXPECT_FALSE(detail->retryable());
+    EXPECT_NE(status.message().find("key 'k'"), std::string::npos) << status.message();
+    EXPECT_NE(status.message().find("bucket 'b'"), std::string::npos) << status.message();
+    EXPECT_NE(detail->extra_info().find("operation=HeadObject"), std::string::npos) << detail->extra_info();
+    EXPECT_NE(detail->extra_info().find("exception=Auth"), std::string::npos) << detail->extra_info();
+    EXPECT_NE(detail->extra_info().find("http_status=403"), std::string::npos) << detail->extra_info();
+    EXPECT_NE(detail->extra_info(), status.message());
+  }
+
+  {
+    Aws::Client::AWSError<Aws::Client::CoreErrors> error(Aws::Client::CoreErrors::CLIENT_SIGNING_FAILURE,
+                                                         Aws::Client::RetryableType::NOT_RETRYABLE, "Signing",
+                                                         "credential provider returned empty credentials");
+    auto status = fs::internal::ErrorToStatus("test", "GetObject", error, kDefaultProvenance);
+    ASSERT_STATUS_NOT_OK(status);
+    EXPECT_TRUE(status.IsIOError()) << status.ToString();
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+  }
+}
+
+TEST_F(S3UnitTest, Conflict409IsNotForNonConflictBucketStates) {
+  // A 409 with no recognized non-conflict name is a race. It remains Conflict so
+  // a business-aware caller can coordinate, but generic retry stays disabled.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN,
+                                                   Aws::Client::RetryableType::NOT_RETRYABLE, "OperationAborted",
+                                                   "conditional request conflict");
+    error.SetResponseCode(Aws::Http::HttpResponseCode::CONFLICT);
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
+    ASSERT_STATUS_NOT_OK(status);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConflict);
+    EXPECT_FALSE(detail->retryable());
+  }
+
+  // But not every 409 is a race. BucketNotEmpty and InvalidBucketState are
+  // answers about the bucket -- replaying the same request cannot change
+  // either, so classifying them Conflict would send a non-conflict condition to
+  // business coordination.
+  for (const char* name : {"BucketNotEmpty", "InvalidBucketState"}) {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN,
+                                                   Aws::Client::RetryableType::NOT_RETRYABLE, name, "non-conflict 409");
+    error.SetResponseCode(Aws::Http::HttpResponseCode::CONFLICT);
+    auto status = fs::internal::ErrorToStatus("test", error, kDefaultProvenance);
+    SCOPED_TRACE(name);
+    ASSERT_STATUS_NOT_OK(status);
+    // Today these land unclassified (plain IOError): the blocklist returns
+    // nullopt and the SDK-verdict fallback is gated on a recognized error
+    // type. Pinned so a future reclassification is a conscious choice -- the
+    // one outcome that must never come back is retryable Conflict.
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    EXPECT_EQ(detail, nullptr);
+    if (detail != nullptr) {
+      EXPECT_NE(detail->code(), ExtendStatusCode::StorageConflict);
+      EXPECT_FALSE(detail->retryable());
+    }
   }
 }
 
@@ -352,6 +667,75 @@ TEST_F(S3UnitTest, TestS3Options) {
 
     auto opt3 = S3Options::FromAccessKey("ak", "sk2");
     EXPECT_FALSE(opt1.Equals(opt3));
+
+    auto different_behavior = opt1;
+    different_behavior.force_virtual_addressing = !opt1.force_virtual_addressing;
+    EXPECT_FALSE(opt1.Equals(different_behavior));
+
+    class CountingCredentialsProvider final : public Aws::Auth::AWSCredentialsProvider {
+   public:
+      Aws::Auth::AWSCredentials GetAWSCredentials() override {
+        ++calls;
+        return Aws::Auth::AWSCredentials("dynamic-ak", "dynamic-sk", "dynamic-token");
+      }
+
+      int calls = 0;
+    };
+
+    auto dynamic_provider = std::make_shared<CountingCredentialsProvider>();
+    auto dynamic1 = S3Options::Defaults();
+    dynamic1.credentials_provider = dynamic_provider;
+    auto dynamic2 = dynamic1;
+    EXPECT_TRUE(dynamic1.Equals(dynamic2));
+    EXPECT_EQ(dynamic_provider->calls, 0) << "Equals must not refresh dynamic credentials";
+
+    auto other_dynamic_provider = std::make_shared<CountingCredentialsProvider>();
+    dynamic2.credentials_provider = other_dynamic_provider;
+    EXPECT_FALSE(dynamic1.Equals(dynamic2));
+    EXPECT_EQ(dynamic_provider->calls, 0);
+    EXPECT_EQ(other_dynamic_provider->calls, 0);
+
+    class DerivedSimpleCredentialsProvider final : public Aws::Auth::SimpleAWSCredentialsProvider {
+   public:
+      DerivedSimpleCredentialsProvider() : Aws::Auth::SimpleAWSCredentialsProvider("ak", "sk") {}
+
+      Aws::Auth::AWSCredentials GetAWSCredentials() override {
+        ++calls;
+        return Aws::Auth::SimpleAWSCredentialsProvider::GetAWSCredentials();
+      }
+
+      int calls = 0;
+    };
+
+    auto derived_explicit1 = opt1;
+    auto derived_explicit2 = opt1;
+    auto explicit_provider1 = std::make_shared<DerivedSimpleCredentialsProvider>();
+    auto explicit_provider2 = std::make_shared<DerivedSimpleCredentialsProvider>();
+    derived_explicit1.credentials_provider = explicit_provider1;
+    derived_explicit2.credentials_provider = explicit_provider2;
+    EXPECT_FALSE(derived_explicit1.Equals(derived_explicit2));
+    EXPECT_EQ(explicit_provider1->calls, 0);
+    EXPECT_EQ(explicit_provider2->calls, 0);
+
+    class DerivedAnonymousCredentialsProvider final : public Aws::Auth::AnonymousAWSCredentialsProvider {
+   public:
+      Aws::Auth::AWSCredentials GetAWSCredentials() override {
+        ++calls;
+        return {};
+      }
+
+      int calls = 0;
+    };
+
+    auto derived_anonymous1 = S3Options::Anonymous();
+    auto derived_anonymous2 = S3Options::Anonymous();
+    auto anonymous_provider1 = std::make_shared<DerivedAnonymousCredentialsProvider>();
+    auto anonymous_provider2 = std::make_shared<DerivedAnonymousCredentialsProvider>();
+    derived_anonymous1.credentials_provider = anonymous_provider1;
+    derived_anonymous2.credentials_provider = anonymous_provider2;
+    EXPECT_FALSE(derived_anonymous1.Equals(derived_anonymous2));
+    EXPECT_EQ(anonymous_provider1->calls, 0);
+    EXPECT_EQ(anonymous_provider2->calls, 0);
   }
 
   // S3ProxyOptions::Equals
@@ -426,58 +810,39 @@ TEST_F(S3UnitTest, TestDetectS3Backend) {
   }
 }
 
-TEST_F(S3UnitTest, TestIsConnectError) {
-  // Retryable network error
-  {
-    Aws::Client::AWSError<Aws::Client::CoreErrors> error(Aws::Client::CoreErrors::NETWORK_CONNECTION, true);
-    EXPECT_TRUE(fs::internal::IsConnectError(error));
-  }
-  // SlowDown
-  {
-    Aws::Client::AWSError<Aws::Client::CoreErrors> error(
-        Aws::Client::CoreErrors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDown", "rate limited");
-    EXPECT_TRUE(fs::internal::IsConnectError(error));
-  }
-  // SlowDownWrite
-  {
-    Aws::Client::AWSError<Aws::Client::CoreErrors> error(
-        Aws::Client::CoreErrors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDownWrite", "rate limited");
-    EXPECT_TRUE(fs::internal::IsConnectError(error));
-  }
-  // XMinioServerNotInitialized
-  {
-    Aws::Client::AWSError<Aws::Client::CoreErrors> error(Aws::Client::CoreErrors::UNKNOWN,
-                                                         Aws::Client::RetryableType::NOT_RETRYABLE,
-                                                         "XMinioServerNotInitialized", "Server not initialized");
-    EXPECT_TRUE(fs::internal::IsConnectError(error));
-  }
-  // Non-retryable access denied
-  {
-    Aws::Client::AWSError<Aws::Client::CoreErrors> error(
-        Aws::Client::CoreErrors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
-    EXPECT_FALSE(fs::internal::IsConnectError(error));
-  }
-}
-
 TEST_F(S3UnitTest, TestS3ErrorClassification) {
-  // IsNotFound — bucket
+  // Bucket and object absence are separate control-flow predicates. A missing
+  // bucket must never be swallowed by an object-level allow_not_found gate.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::NO_SUCH_BUCKET, Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchBucket", "not found");
-    EXPECT_TRUE(fs::internal::IsNotFound(error));
+    EXPECT_TRUE(fs::internal::IsBucketNotFound(error));
+    EXPECT_TRUE(fs::internal::IsExplicitBucketNotFound(error));
+    EXPECT_FALSE(fs::internal::IsObjectNotFound(error));
   }
-  // IsNotFound — resource
+  // Generic RESOURCE_NOT_FOUND is ambiguous until the operation supplies the
+  // resource kind.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::RESOURCE_NOT_FOUND,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "ResourceNotFound",
                                                    "not found");
-    EXPECT_TRUE(fs::internal::IsNotFound(error));
+    EXPECT_TRUE(fs::internal::IsBucketNotFound(error));
+    EXPECT_TRUE(fs::internal::IsObjectNotFound(error));
+    EXPECT_FALSE(fs::internal::IsExplicitBucketNotFound(error));
   }
-  // IsNotFound — false
+  // NO_SUCH_KEY was previously omitted from the existence predicate.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::NO_SUCH_KEY,
+                                                   Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchKey", "not found");
+    EXPECT_TRUE(fs::internal::IsObjectNotFound(error));
+    EXPECT_FALSE(fs::internal::IsBucketNotFound(error));
+  }
+  // Neither kind of not-found.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
-    EXPECT_FALSE(fs::internal::IsNotFound(error));
+    EXPECT_FALSE(fs::internal::IsBucketNotFound(error));
+    EXPECT_FALSE(fs::internal::IsObjectNotFound(error));
   }
   // IsAlreadyExists — BUCKET_ALREADY_EXISTS
   {
@@ -526,21 +891,92 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     }
   };
 
-  // NO_SUCH_UPLOAD
+  // The same generic 404 means opposite actions depending on the operation:
+  // HeadObject -> object-not-found handling, HeadBucket/ListObjects -> fix the
+  // deployment bucket (BucketNotFound).
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::RESOURCE_NOT_FOUND,
+                                                   Aws::Client::RetryableType::NOT_RETRYABLE, "ResourceNotFound",
+                                                   "not found");
+    auto object_status = fs::internal::ErrorToStatus(
+        "object: ", "HeadObject", error, fs::internal::S3ErrorProvenance{fs::internal::S3ResourceKind::Object});
+    auto object_detail = ExtendStatusDetail::UnwrapStatus(object_status);
+    ASSERT_NE(object_detail, nullptr);
+    EXPECT_EQ(object_detail->code(), ExtendStatusCode::StorageNotFound);
+
+    auto bucket_status = fs::internal::ErrorToStatus(
+        "bucket: ", "HeadBucket", error, fs::internal::S3ErrorProvenance{fs::internal::S3ResourceKind::Bucket});
+    auto bucket_detail = ExtendStatusDetail::UnwrapStatus(bucket_status);
+    ASSERT_NE(bucket_detail, nullptr);
+    EXPECT_EQ(bucket_detail->code(), ExtendStatusCode::StorageBucketNotFound);
+
+    auto upload_status =
+        fs::internal::ErrorToStatus("upload: ", "UploadPart", error,
+                                    fs::internal::S3ErrorProvenance{fs::internal::S3ResourceKind::MultipartUpload});
+    auto upload_detail = ExtendStatusDetail::UnwrapStatus(upload_status);
+    ASSERT_NE(upload_detail, nullptr);
+    EXPECT_EQ(upload_detail->code(), ExtendStatusCode::StorageNoSuchUpload);
+  }
+
+  // NO_SUCH_UPLOAD is retryable only at the operation boundary: the failed
+  // writer is discarded and a new upload is started. The stale id is never
+  // reused.
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::NO_SUCH_UPLOAD,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchUpload",
                                                    "Upload not found");
-    auto status = fs::internal::ErrorToStatus("test_prefix", "CompleteMultipart", error);
-    AssertRetryableCode(status, ExtendStatusCode::AwsErrorNoSuchUpload);
+    auto status = fs::internal::ErrorToStatus("test_prefix", "CompleteMultipart", error, kDefaultProvenance);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNoSuchUpload);
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::Retryable);
+    EXPECT_TRUE(detail->retryable());
+  }
+
+  // NO_SUCH_BUCKET is deliberately NOT the same code as a missing key: nothing
+  // was lost, and re-reading metadata cannot conjure a bucket. It is a
+  // deployment pointing somewhere that does not exist.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(
+        Aws::S3::S3Errors::NO_SUCH_BUCKET, Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchBucket", "bucket gone");
+    auto status = fs::internal::ErrorToStatus("test_prefix", "GetObject", error, kDefaultProvenance);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageBucketNotFound);
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::System);
+    EXPECT_FALSE(detail->retryable());
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::BucketInvalid);  // 2016, not 2017
+  }
+
+  // A missing KEY keeps ObjectNotExist -- the two must not collapse back.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::NO_SUCH_KEY,
+                                                   Aws::Client::RetryableType::NOT_RETRYABLE, "NoSuchKey", "key gone");
+    auto status = fs::internal::ErrorToStatus("test_prefix", "GetObject", error, kDefaultProvenance);
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound);
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::System);
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist);  // 2017
   }
 
   // AWS SDK retryable error
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::INTERNAL_FAILURE, Aws::Client::RetryableType::RETRYABLE, "InternalFailure", "retryable");
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
-    AssertRetryableCode(status, ExtendStatusCode::StorageTransientNetwork);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
+    AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
+  }
+
+  // ShouldRetry alone is policy, not evidence that the underlying condition
+  // is a network or otherwise transient failure.
+  {
+    Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::RETRYABLE,
+                                                   "UnclassifiedRetryable", "SDK policy allows retry");
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
+    ASSERT_STATUS_NOT_OK(status);
+    EXPECT_TRUE(status.IsIOError());
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
   }
 
   // NETWORK_CONNECTION
@@ -548,7 +984,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::NETWORK_CONNECTION,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "NetworkConnection",
                                                    "network");
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientNetwork);
   }
 
@@ -556,7 +992,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::REQUEST_TIMEOUT, Aws::Client::RetryableType::NOT_RETRYABLE, "RequestTimeout", "timeout");
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientTimeout);
   }
 
@@ -565,7 +1001,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "RequestTimeout", "timeout");
     error.SetResponseCode(Aws::Http::HttpResponseCode::REQUEST_TIMEOUT);
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientTimeout);
   }
 
@@ -574,7 +1010,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "TooManyRequests", "rate limited");
     error.SetResponseCode(Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS);
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientThrottling);
   }
 
@@ -582,7 +1018,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::SLOW_DOWN,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDown", "slow");
-    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientThrottling);
   }
 
@@ -590,7 +1026,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::THROTTLING, Aws::Client::RetryableType::NOT_RETRYABLE, "Throttling", "throttled");
-    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientThrottling);
   }
 
@@ -598,7 +1034,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDown", "slow");
-    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientThrottling);
   }
 
@@ -606,7 +1042,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "SlowDownWrite", "slow");
-    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientThrottling);
   }
 
@@ -615,7 +1051,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::SERVICE_UNAVAILABLE,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "ServiceUnavailable",
                                                    "unavailable");
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
   }
 
@@ -624,7 +1060,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "InternalError", "internal");
     error.SetResponseCode(Aws::Http::HttpResponseCode::INTERNAL_SERVER_ERROR);
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
   }
 
@@ -633,7 +1069,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "BadGateway", "bad gateway");
     error.SetResponseCode(Aws::Http::HttpResponseCode::BAD_GATEWAY);
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
   }
 
@@ -642,7 +1078,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "ServiceUnavailable", "unavailable");
     error.SetResponseCode(Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE);
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
   }
 
@@ -651,7 +1087,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "GatewayTimeout", "gateway timeout");
     error.SetResponseCode(Aws::Http::HttpResponseCode::GATEWAY_TIMEOUT);
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
   }
 
@@ -660,7 +1096,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE,
                                                    "XMinioServerNotInitialized", "server not initialized");
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertRetryableCode(status, ExtendStatusCode::StorageTransientService);
   }
 
@@ -670,11 +1106,11 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "PreconditionFailed",
                                                    "condition failed");
     error.SetResponseCode(Aws::Http::HttpResponseCode::PRECONDITION_FAILED);
-    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error, kDefaultProvenance);
     ASSERT_FALSE(status.ok());
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
     ASSERT_NE(detail, nullptr);
-    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorPreConditionFailed);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StoragePreConditionFailed);
     EXPECT_FALSE(detail->retryable());
   }
 
@@ -683,11 +1119,11 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(Aws::S3::S3Errors::UNKNOWN,
                                                    Aws::Client::RetryableType::NOT_RETRYABLE, "Conflict", "conflict");
     error.SetResponseCode(Aws::Http::HttpResponseCode::CONFLICT);
-    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "PutObject", error, kDefaultProvenance);
     ASSERT_FALSE(status.ok());
     auto detail = ExtendStatusDetail::UnwrapStatus(status);
     ASSERT_NE(detail, nullptr);
-    EXPECT_EQ(detail->code(), ExtendStatusCode::AwsErrorConflict);
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConflict);
     EXPECT_FALSE(detail->retryable());
   }
 
@@ -696,7 +1132,7 @@ TEST_F(S3UnitTest, TestErrorToStatus) {
   {
     Aws::Client::AWSError<Aws::S3::S3Errors> error(
         Aws::S3::S3Errors::UNKNOWN, Aws::Client::RetryableType::NOT_RETRYABLE, "SomeBackendSpecificError", "opaque");
-    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error);
+    auto status = fs::internal::ErrorToStatus("prefix", "GetObject", error, kDefaultProvenance);
     AssertNonRetryable(status);
     EXPECT_TRUE(status.IsIOError());
     EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
@@ -709,7 +1145,7 @@ TEST_F(S3UnitTest, TestOutcomeToStatus) {
     Aws::S3::Model::PutObjectResult put_result;
     Aws::Utils::Outcome<Aws::S3::Model::PutObjectResult, Aws::Client::AWSError<Aws::S3::S3Errors>> outcome(
         std::move(put_result));
-    EXPECT_TRUE(fs::internal::OutcomeToStatus("prefix", "PutObject", outcome).ok());
+    EXPECT_TRUE(fs::internal::OutcomeToStatus("prefix", "PutObject", outcome, kDefaultProvenance).ok());
   }
 
   // Failure
@@ -718,7 +1154,7 @@ TEST_F(S3UnitTest, TestOutcomeToStatus) {
         Aws::S3::S3Errors::ACCESS_DENIED, Aws::Client::RetryableType::NOT_RETRYABLE, "AccessDenied", "forbidden");
     Aws::Utils::Outcome<Aws::S3::Model::PutObjectResult, Aws::Client::AWSError<Aws::S3::S3Errors>> outcome(
         std::move(error));
-    EXPECT_FALSE(fs::internal::OutcomeToStatus("prefix", "PutObject", outcome).ok());
+    EXPECT_FALSE(fs::internal::OutcomeToStatus("prefix", "PutObject", outcome, kDefaultProvenance).ok());
   }
 }
 
@@ -883,6 +1319,15 @@ TEST_F(S3UnitTest, TestCopyStream) {
 }
 
 TEST_F(S3UnitTest, TestCreateS3Options) {
+  auto assert_config_error = [](const arrow::Status& status) {
+    ASSERT_FALSE(status.ok()) << status.ToString();
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid) << status.ToString();
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::System);
+    EXPECT_FALSE(detail->retryable());
+  };
+
   // No SSL → scheme=http
   {
     ArrowFileSystemConfig config;
@@ -976,6 +1421,149 @@ TEST_F(S3UnitTest, TestCreateS3Options) {
     EXPECT_EQ(result->GetAccessKey(), "mykey");
     EXPECT_EQ(result->GetSecretKey(), "mysecret");
   }
+
+  // An absent static identity is explicitly anonymous. A partially supplied
+  // identity is a configuration error instead of an unsigned request.
+  {
+    ArrowFileSystemConfig config;
+    config.cloud_provider = kCloudProviderAWS;
+    config.use_iam = false;
+
+    S3FileSystemProducer producer(config);
+    auto result = producer.CreateS3Options();
+    ASSERT_TRUE(result.ok()) << result.status().ToString();
+    EXPECT_EQ(result->credentials_kind, S3CredentialsKind::Anonymous);
+  }
+  for (const auto& [access_key, secret_key] :
+       std::vector<std::pair<std::string, std::string>>{{"ak-only", ""}, {"", "sk-only"}}) {
+    ArrowFileSystemConfig config;
+    config.cloud_provider = kCloudProviderAWS;
+    config.access_key_id = access_key;
+    config.access_key_value = secret_key;
+    config.use_iam = false;
+
+    S3FileSystemProducer producer(config);
+    assert_config_error(producer.CreateS3Options().status());
+  }
+
+  // Producer-side deployment mistakes must not fall through as an untyped
+  // Invalid/System error.
+  {
+    ScopedEnvironmentVariable auth_mode("ALIYUN_ROLE_ARN_AUTH_MODE", "");
+    ScopedEnvironmentVariable token_file("ALIBABA_CLOUD_OIDC_TOKEN_FILE", "");
+    ScopedEnvironmentVariable provider_arn("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "");
+    ScopedEnvironmentVariable machine_role("ALIBABA_CLOUD_ROLE_ARN", "");
+
+    ArrowFileSystemConfig config;
+    config.cloud_provider = kCloudProviderAliyun;
+    config.role_arn = "acs:ram::123456:role/target";
+    S3FileSystemProducer producer(config);
+    assert_config_error(producer.CreateS3Options().status());
+  }
+  {
+    ArrowFileSystemConfig config;
+    config.cloud_provider = "unsupported-cloud";
+    config.role_arn = "role";
+    S3FileSystemProducer producer(config);
+    assert_config_error(producer.CreateS3Options().status());
+  }
+  {
+    ArrowFileSystemConfig config;
+    config.cloud_provider = "unsupported-cloud";
+    config.use_iam = true;
+    S3FileSystemProducer producer(config);
+    assert_config_error(producer.CreateS3Options().status());
+  }
+
+  // AWS use_iam still selects the environment provider first when static
+  // credentials are present.
+  {
+    ScopedEnvironmentVariable access_key("AWS_ACCESS_KEY_ID", "environment-ak");
+    ScopedEnvironmentVariable secret_key("AWS_SECRET_ACCESS_KEY", "environment-sk");
+    ScopedEnvironmentVariable session_token("AWS_SESSION_TOKEN", "expired-static-token");
+
+    ArrowFileSystemConfig config;
+    config.use_ssl = false;
+    config.cloud_provider = kCloudProviderAWS;
+    config.use_iam = true;
+
+    S3FileSystemProducer producer(config);
+    auto result = producer.CreateS3Options();
+    ASSERT_TRUE(result.ok()) << result.status().ToString();
+    EXPECT_EQ(result->credentials_kind, S3CredentialsKind::Default);
+  }
+
+  // Once any environment static-credential field is present, the environment
+  // source is authoritative and must be complete. Do not fall through to a
+  // profile, container identity, or IMDS under a different principal.
+  for (const auto& [access_key, secret_key, session_token] :
+       std::vector<std::tuple<std::string, std::string, std::string>>{
+           {"environment-ak", "", ""}, {"", "environment-sk", ""}, {"", "", "environment-token"}}) {
+    ScopedEnvironmentVariable scoped_access_key("AWS_ACCESS_KEY_ID", access_key);
+    ScopedEnvironmentVariable scoped_secret_key("AWS_SECRET_ACCESS_KEY", secret_key);
+    ScopedEnvironmentVariable scoped_session_token("AWS_SESSION_TOKEN", session_token);
+
+    ArrowFileSystemConfig config;
+    config.cloud_provider = kCloudProviderAWS;
+    config.use_iam = true;
+
+    S3FileSystemProducer producer(config);
+    assert_config_error(producer.CreateS3Options().status());
+
+    config.use_iam = false;
+    config.role_arn = "arn:aws:iam::123456789012:role/target";
+    S3FileSystemProducer role_producer(config);
+    assert_config_error(role_producer.CreateS3Options().status());
+  }
+
+  // Long-lived static credentials are a complete AWS credential without a
+  // session token. The producer must accept this ordinary default-chain result.
+  {
+    ScopedEnvironmentVariable access_key("AWS_ACCESS_KEY_ID", "environment-long-lived-ak");
+    ScopedEnvironmentVariable secret_key("AWS_SECRET_ACCESS_KEY", "environment-long-lived-sk");
+    ScopedEnvironmentVariable session_token("AWS_SESSION_TOKEN", "");
+
+    ArrowFileSystemConfig config;
+    config.use_ssl = false;
+    config.cloud_provider = kCloudProviderAWS;
+    config.use_iam = true;
+
+    S3FileSystemProducer producer(config);
+    auto result = producer.CreateS3Options();
+    ASSERT_TRUE(result.ok()) << result.status().ToString();
+    EXPECT_EQ(result->GetAccessKey(), "environment-long-lived-ak");
+    EXPECT_EQ(result->GetSecretKey(), "environment-long-lived-sk");
+    EXPECT_TRUE(result->GetSessionToken().empty());
+  }
+}
+
+TEST_F(S3UnitTest, ExplicitS3OptionsRejectPartialStaticCredentialsBeforeClientConstruction) {
+  for (auto options : {S3Options::FromAccessKey("ak-only", ""), S3Options::FromAccessKey("", "sk-only"),
+                       S3Options::FromAccessKey("", "", "token-only")}) {
+    ClientBuilder<S3Client> builder(std::move(options));
+    auto status = builder.PrepareClientConfig(std::nullopt);
+    ASSERT_FALSE(status.ok()) << status.ToString();
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid) << status.ToString();
+  }
+}
+
+TEST_F(S3UnitTest, DefaultS3OptionsRejectPartialEnvironmentCredentialsBeforeClientConstruction) {
+  for (const auto& [access_key, secret_key, session_token] :
+       std::vector<std::tuple<std::string, std::string, std::string>>{
+           {"environment-ak", "", ""}, {"", "environment-sk", ""}, {"", "", "environment-token"}}) {
+    ScopedEnvironmentVariable scoped_access_key("AWS_ACCESS_KEY_ID", access_key);
+    ScopedEnvironmentVariable scoped_secret_key("AWS_SECRET_ACCESS_KEY", secret_key);
+    ScopedEnvironmentVariable scoped_session_token("AWS_SESSION_TOKEN", session_token);
+
+    ClientBuilder<S3Client> builder(S3Options::Defaults());
+    auto status = builder.PrepareClientConfig(std::nullopt);
+    ASSERT_FALSE(status.ok()) << status.ToString();
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid) << status.ToString();
+  }
 }
 
 TEST_F(S3UnitTest, TestS3GlobalOptions) {
@@ -1058,6 +1646,12 @@ TEST_F(S3UnitTest, TestClientBuilder) {
 
     ClientBuilder<S3Client> builder(options);
     EXPECT_FALSE(builder.BuildClient().ok());
+
+    auto fs_result = S3FileSystem::Make(options);
+    ASSERT_FALSE(fs_result.ok());
+    EXPECT_TRUE(fs_result.status().IsInvalid()) << fs_result.status().ToString();
+    EXPECT_NE(fs_result.status().message().find("Failed to build S3 client"), std::string::npos)
+        << fs_result.status().ToString();
   }
 
   // Build with proxy
@@ -1131,6 +1725,168 @@ TEST_F(S3UnitTest, TestS3ClientHolder) {
     auto moved = lock.Move();
     EXPECT_EQ(moved.get(), ptr_before);
   }
+}
+
+TEST_F(S3UnitTest, FinalizedLockDoesNotRetainAwsResourcesPastTheBarrier) {
+  auto finalizer = std::make_shared<ControllableS3ClientFinalizer>();
+
+  // An aliasing shared_ptr gives the holder an observable control block without
+  // constructing a real SDK client. Lock() must return on finalized_ before it
+  // ever dereferences this non-owning sentinel pointer.
+  auto client_owner = std::make_shared<int>(1);
+  std::weak_ptr<int> weak_client = client_owner;
+  auto* client_sentinel = reinterpret_cast<S3Client*>(client_owner.get());
+  auto resolver = std::make_shared<FinalizerProbeResolver>();
+  std::weak_ptr<FinalizerProbeResolver> weak_resolver = resolver;
+  std::shared_ptr<S3Client> client(client_owner, client_sentinel);
+  client_owner.reset();
+  ASSERT_AND_ASSIGN(auto holder, finalizer->AddClient(
+                                     [client = std::move(client)]() mutable { return std::move(client); }, resolver));
+  resolver.reset();
+
+  auto barrier = finalizer->MarkFinalizedAndHoldBarrier();
+  auto lock_future = std::async(std::launch::async, [holder] { return holder->Lock(); });
+
+  // Once the Lock thread owns a strong finalizer reference, it has completed
+  // the only holder-mutex section allowed before the barrier and is blocked on
+  // this test's exclusive lease.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (finalizer.use_count() == 1 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+  if (finalizer.use_count() == 1) {
+    barrier.unlock();
+    (void)lock_future.get();
+    FAIL() << "Lock did not reach the finalizer barrier";
+  }
+
+  // Lock() has not copied either AWS-backed resource before entering the
+  // finalizer barrier, so finalization can release both while it is blocked.
+  holder->Finalize();
+  EXPECT_TRUE(weak_client.expired());
+  EXPECT_TRUE(weak_resolver.expired());
+
+  barrier.unlock();
+
+  auto lock_result = lock_future.get();
+  EXPECT_FALSE(lock_result.ok());
+  EXPECT_TRUE(lock_result.status().IsInvalid()) << lock_result.status().ToString();
+}
+
+TEST_F(S3UnitTest, FinalizeReleasesClientBuilderAwsResources) {
+  auto finalizer = std::make_shared<S3ClientFinalizer>();
+  auto builder = [] {
+    auto options = S3Options::FromAccessKey("ak", "sk");
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(1);
+    return std::make_shared<ClientBuilder<S3Client>>(std::move(options));
+  }();
+  std::weak_ptr<Aws::Auth::AWSCredentialsProvider> weak_provider = builder->options().credentials_provider;
+  std::weak_ptr<S3RetryStrategy> weak_retry_strategy = builder->options().retry_strategy;
+  int cleanup_count = 0;
+  ASSERT_AND_ASSIGN(auto holder, finalizer->AddClient([] { return MakeTestS3Client(); }, nullptr,
+                                                      [&, builder] {
+                                                        ++cleanup_count;
+                                                        builder->ReleaseAwsResources();
+                                                      }));
+
+  ASSERT_EQ(cleanup_count, 0);
+  finalizer->Finalize();
+  EXPECT_EQ(cleanup_count, 1);
+  EXPECT_EQ(builder->options().credentials_provider, nullptr);
+  EXPECT_EQ(builder->options().retry_strategy, nullptr);
+  EXPECT_TRUE(weak_provider.expired());
+  EXPECT_TRUE(weak_retry_strategy.expired());
+
+  // Holder finalization is idempotent and must not retain or rerun cleanup.
+  holder->Finalize();
+  EXPECT_EQ(cleanup_count, 1);
+}
+
+TEST_F(S3UnitTest, FinalizeWaitsForClientConstructionCleanup) {
+  auto finalizer = std::make_shared<ControllableS3ClientFinalizer>();
+  ASSERT_AND_ASSIGN(auto existing_holder, finalizer->AddClient([] { return MakeTestS3Client(); }));
+  std::promise<void> construction_entered_promise;
+  auto construction_entered = construction_entered_promise.get_future();
+  std::promise<void> release_construction_promise;
+  auto release_construction = release_construction_promise.get_future().share();
+  std::promise<std::weak_ptr<S3Client>> client_created_promise;
+  auto client_created = client_created_promise.get_future();
+
+  auto constructing = std::async(
+      std::launch::async, [finalizer, &construction_entered_promise, release_construction, &client_created_promise] {
+        return finalizer->AddClient([&construction_entered_promise, release_construction, &client_created_promise] {
+          construction_entered_promise.set_value();
+          release_construction.wait();
+          auto client = MakeTestS3Client();
+          client_created_promise.set_value(std::weak_ptr<S3Client>(client));
+          return client;
+        });
+      });
+
+  if (construction_entered.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    release_construction_promise.set_value();
+    constructing.wait();
+    FAIL() << "S3 client construction did not start";
+  }
+
+  // Construction is serialized only with shutdown. It must not take the
+  // shared operation barrier and pause requests on existing filesystems.
+  auto existing_operation = std::async(std::launch::async, [existing_holder] { return existing_holder->Lock(); });
+  if (existing_operation.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    release_construction_promise.set_value();
+    constructing.wait();
+    FAIL() << "S3 client construction blocked an existing client operation";
+  }
+  ASSERT_TRUE(existing_operation.get().ok());
+
+  std::promise<void> finalize_started_promise;
+  auto finalize_started = finalize_started_promise.get_future();
+  auto finalized = std::async(std::launch::async, [finalizer, &finalize_started_promise] {
+    finalize_started_promise.set_value();
+    finalizer->Finalize();
+  });
+  if (finalize_started.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+    release_construction_promise.set_value();
+    constructing.wait();
+    finalized.wait();
+    FAIL() << "S3 finalization did not start";
+  }
+  const auto finalize_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!finalizer->IsFinalizedForTest() && std::chrono::steady_clock::now() < finalize_deadline) {
+    std::this_thread::yield();
+  }
+  if (!finalizer->IsFinalizedForTest()) {
+    release_construction_promise.set_value();
+    constructing.wait();
+    finalized.wait();
+    FAIL() << "S3 finalization did not close client-construction admission";
+  }
+  EXPECT_EQ(finalized.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+  release_construction_promise.set_value();
+  ASSERT_EQ(constructing.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  auto construction_result = constructing.get();
+  EXPECT_FALSE(construction_result.ok());
+  auto weak_client = client_created.get();
+  ASSERT_EQ(finalized.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  finalized.get();
+
+  EXPECT_TRUE(weak_client.expired());
+  EXPECT_FALSE(existing_holder->Lock().ok());
+}
+
+TEST_F(S3UnitTest, FinalizedClientFactoryIsNotInvoked) {
+  auto finalizer = std::make_shared<S3ClientFinalizer>();
+  finalizer->Finalize();
+
+  bool factory_called = false;
+  auto result = finalizer->AddClient([&factory_called] {
+    factory_called = true;
+    return MakeTestS3Client();
+  });
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_FALSE(factory_called);
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/filesystem/s3_provider_test.cpp
+++ b/cpp/test/filesystem/s3_provider_test.cpp
@@ -14,18 +14,29 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
+#include <exception>
+#include <functional>
+#include <future>
 #include <mutex>
 #include <fstream>
 #include <map>
 #include <memory>
+#include <new>
+#include <optional>
 #include <queue>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include <unistd.h>
+
+#include <aws/core/platform/Environment.h>
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/client/DefaultRetryStrategy.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
 #include <aws/core/http/HttpRequest.h>
@@ -34,15 +45,31 @@
 #include <aws/core/http/standard/StandardHttpResponse.h>
 #include <aws/core/http/HttpTypes.h>
 #include <aws/core/utils/stream/ResponseStream.h>
+#include <arrow/testing/executor_util.h>
+#include <arrow/util/thread_pool.h>
 
 #include "milvus-storage/filesystem/s3/provider/AliyunCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunOIDCAssumeRoleChainProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMCredentialsProvider.h"
 #include "milvus-storage/filesystem/s3/provider/AliyunRAMSTSClient.h"
+#include "milvus-storage/filesystem/s3/provider/AliyunSTSClient.h"
+#include "milvus-storage/filesystem/s3/provider/credential_resolution.h"
 #include "milvus-storage/filesystem/s3/provider/TencentCloudCredentialsProvider.h"
+#include "milvus-storage/filesystem/s3/provider/TencentCloudSTSClient.h"
 #include "milvus-storage/filesystem/s3/provider/HuaweiCloudCredentialsProvider.h"
+#include "milvus-storage/filesystem/s3/s3_client_builder.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem.h"
+#include "milvus-storage/filesystem/s3/s3_filesystem_producer.h"
 #include "milvus-storage/filesystem/s3/s3_global.h"
+#ifdef WITH_CRT
+#include "milvus-storage/filesystem/s3/s3_crt_client.h"
+#endif
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/ffi_c.h"
+#include "milvus-storage/ffi_filesystem_c.h"
+#include "milvus-storage/filesystem/ffi/filesystem_internal.h"
 #include "test_env.h"
 
 namespace milvus_storage {
@@ -133,14 +160,26 @@ class TempFile {
   std::string path_;
 };
 
+void PrepareS3DeathTest() {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  // Set this before GoogleTest re-execs the child: gcov reads the prefix at
+  // process startup, and parent/child must not write the same coverage file.
+  const auto prefix = "/tmp/milvus-storage-s3-death-test-gcov-" + std::to_string(getpid());
+  (void)setenv("GCOV_PREFIX", prefix.c_str(), 1);
+}
+
 // ============================================================================
 // Mock HTTP infrastructure
 // ============================================================================
+
+enum class MockExceptionKind { None, RuntimeError, BadAlloc };
 
 struct MockResponseSpec {
   Aws::Http::HttpResponseCode code;
   std::string body;
   Aws::Http::HeaderValueCollection headers;
+  std::function<void()> on_request;
+  MockExceptionKind exception_kind = MockExceptionKind::None;
 };
 
 class MockHttpClient : public Aws::Http::HttpClient {
@@ -151,18 +190,35 @@ class MockHttpClient : public Aws::Http::HttpClient {
       const std::shared_ptr<Aws::Http::HttpRequest>& request,
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
       Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override {
-    std::lock_guard<std::mutex> lock(mutex_);
-    recorded_requests_.push_back(request);
+    std::optional<MockResponseSpec> matched;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      recorded_requests_.push_back(request);
 
-    auto uri = request->GetURIString();
-
-    // Find a matching response queue by URL substring
-    for (auto& [url_key, q] : response_map_) {
-      if (!q.empty() && uri.find(url_key) != Aws::String::npos) {
-        auto spec = q.front();
-        q.pop();
-        return BuildResponse(request, spec);
+      auto uri = request->GetURIString();
+      // Find a matching response queue by URL substring.
+      for (auto& [url_key, q] : response_map_) {
+        if (!q.empty() && uri.find(url_key) != Aws::String::npos) {
+          matched = std::move(q.front());
+          q.pop();
+          break;
+        }
       }
+    }
+
+    if (matched.has_value()) {
+      switch (matched->exception_kind) {
+        case MockExceptionKind::None:
+          break;
+        case MockExceptionKind::RuntimeError:
+          throw std::runtime_error("synthetic credential dependency failure");
+        case MockExceptionKind::BadAlloc:
+          throw std::bad_alloc();
+      }
+      if (matched->on_request) {
+        matched->on_request();
+      }
+      return BuildResponse(request, *matched);
     }
 
     // Default: return 404 for unmatched requests (e.g., background SDK requests)
@@ -174,8 +230,15 @@ class MockHttpClient : public Aws::Http::HttpClient {
   void EnqueueResponse(const std::string& url_match,
                        Aws::Http::HttpResponseCode code,
                        const std::string& body,
-                       const Aws::Http::HeaderValueCollection& headers = {}) {
-    response_map_[url_match].push({code, body, headers});
+                       const Aws::Http::HeaderValueCollection& headers = {},
+                       std::function<void()> on_request = {}) {
+    response_map_[url_match].push({code, body, headers, std::move(on_request)});
+  }
+
+  void EnqueueException(const std::string& url_match, MockExceptionKind exception_kind) {
+    MockResponseSpec spec;
+    spec.exception_kind = exception_kind;
+    response_map_[url_match].push(std::move(spec));
   }
 
   std::vector<std::shared_ptr<Aws::Http::HttpRequest>> GetRecordedRequests() const {
@@ -231,6 +294,92 @@ class MockHttpClientFactory : public Aws::Http::HttpClientFactory {
   std::shared_ptr<MockHttpClient> mock_client_;
 };
 
+class RejectingS3Executor final : public arrow::internal::Executor {
+  public:
+  int GetCapacity() override { return 1; }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints,
+                          arrow::internal::FnOnce<void()>,
+                          arrow::StopToken,
+                          StopCallback&&) override {
+    return arrow::Status::IOError("executor rejected S3 upload task");
+  }
+};
+
+class RejectAfterOneS3Executor final : public arrow::internal::Executor {
+  public:
+  explicit RejectAfterOneS3Executor(std::shared_ptr<arrow::internal::ThreadPool> pool)
+      : pool_(std::move(pool)), rejection_observed_(rejection_promise_.get_future().share()) {}
+
+  int GetCapacity() override { return pool_->GetCapacity(); }
+
+  void Arm() { accepted_before_rejection_.store(1, std::memory_order_release); }
+
+  const std::shared_future<void>& rejection_observed() const { return rejection_observed_; }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints hints,
+                          arrow::internal::FnOnce<void()> task,
+                          arrow::StopToken stop_token,
+                          StopCallback&& stop_callback) override {
+    int remaining = accepted_before_rejection_.load(std::memory_order_acquire);
+    while (remaining >= 0) {
+      if (remaining == 0) {
+        if (!rejection_signaled_.exchange(true, std::memory_order_acq_rel)) {
+          rejection_promise_.set_value();
+        }
+        return arrow::Status::IOError("executor rejected S3 delete task");
+      }
+      if (accepted_before_rejection_.compare_exchange_weak(remaining, remaining - 1, std::memory_order_acq_rel)) {
+        break;
+      }
+    }
+    return pool_->Spawn(hints, std::move(task), std::move(stop_token), std::move(stop_callback));
+  }
+
+  private:
+  std::shared_ptr<arrow::internal::ThreadPool> pool_;
+  std::atomic<int> accepted_before_rejection_{-1};
+  std::atomic<bool> rejection_signaled_{false};
+  std::promise<void> rejection_promise_;
+  std::shared_future<void> rejection_observed_;
+};
+
+enum class S3SubmissionExceptionKind { kUnexpected, kBadAlloc };
+
+class UnexpectedS3SubmissionException final : public std::exception {
+  public:
+  const char* what() const noexcept override { return "executor submission exploded unexpectedly"; }
+};
+
+class ThrowAfterOneS3Executor final : public arrow::internal::Executor {
+  public:
+  ThrowAfterOneS3Executor(std::shared_ptr<arrow::internal::ThreadPool> pool, S3SubmissionExceptionKind exception_kind)
+      : pool_(std::move(pool)), exception_kind_(exception_kind) {}
+
+  int GetCapacity() override { return pool_->GetCapacity(); }
+
+  protected:
+  arrow::Status SpawnReal(arrow::internal::TaskHints hints,
+                          arrow::internal::FnOnce<void()> task,
+                          arrow::StopToken stop_token,
+                          StopCallback&& stop_callback) override {
+    if (submissions_.fetch_add(1, std::memory_order_acq_rel) == 0) {
+      return pool_->Spawn(hints, std::move(task), std::move(stop_token), std::move(stop_callback));
+    }
+    if (exception_kind_ == S3SubmissionExceptionKind::kBadAlloc) {
+      throw std::bad_alloc();
+    }
+    throw UnexpectedS3SubmissionException();
+  }
+
+  private:
+  std::shared_ptr<arrow::internal::ThreadPool> pool_;
+  S3SubmissionExceptionKind exception_kind_;
+  std::atomic<int> submissions_{0};
+};
+
 // ============================================================================
 // Test Fixture
 // ============================================================================
@@ -268,8 +417,158 @@ class S3ProviderTest : public ::testing::Test {
     Aws::Http::InitHttp();
   }
 
+  void AssertBackgroundUploadSubmissionExceptionDrains(S3SubmissionExceptionKind exception_kind) {
+    const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+    Aws::Http::HeaderValueCollection create_headers;
+    create_headers["content-type"] = "application/xml";
+    create_headers["content-length"] = std::to_string(create_result.size());
+
+    std::promise<void> upload_started_promise;
+    auto upload_started = upload_started_promise.get_future();
+    std::promise<void> release_upload_promise;
+    auto release_upload = release_upload_promise.get_future().share();
+    std::atomic<bool> upload_release_timed_out{false};
+
+    Aws::Http::HeaderValueCollection upload_headers;
+    upload_headers["etag"] = "\"etag-1\"";
+    upload_headers["content-length"] = "0";
+    mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, create_headers);
+    mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::OK, "", upload_headers,
+                                  [&upload_started_promise, release_upload, &upload_release_timed_out] {
+                                    upload_started_promise.set_value();
+                                    if (release_upload.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+                                      upload_release_timed_out.store(true, std::memory_order_release);
+                                    }
+                                  });
+    mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+    S3Options options;
+    options.ConfigureAnonymousCredentials();
+    options.region = "us-east-1";
+    options.scheme = "http";
+    options.endpoint_override = "mock-s3.local";
+    options.cloud_provider = kCloudProviderAWS;
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+    options.use_crt_async_reads = false;
+    options.background_writes = true;
+
+    ASSERT_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(1));
+    ThrowAfterOneS3Executor executor(pool, exception_kind);
+    arrow::io::IOContext io_context(&executor);
+    ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+    ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+
+    const uint8_t bytes[] = {7, 8};
+    arrow::Status write_status;
+    try {
+      write_status = stream->Write(bytes, 2);
+    } catch (const std::exception& e) {
+      // Keep the regression failure deterministic: do not leave the accepted
+      // sibling blocked while GoogleTest reports the escaped exception.
+      release_upload_promise.set_value();
+      pool->WaitForIdle();
+      FAIL() << "executor submission exception escaped the Status API: " << e.what();
+      return;
+    } catch (...) {
+      release_upload_promise.set_value();
+      pool->WaitForIdle();
+      FAIL() << "non-standard executor submission exception escaped the Status API";
+      return;
+    }
+    const auto upload_started_state = upload_started.wait_for(std::chrono::seconds(5));
+    if (upload_started_state != std::future_status::ready) {
+      release_upload_promise.set_value();
+      pool->WaitForIdle();
+      FAIL() << "the accepted first upload did not start";
+      return;
+    }
+
+    ASSERT_STATUS_NOT_OK(write_status);
+    // Both exception kinds report the same verdict now: an allocation failure
+    // in submission is not distinguished from any other submission exception.
+    auto detail = ExtendStatusDetail::UnwrapStatus(write_status);
+    ASSERT_NE(detail, nullptr) << write_status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::InternalInvariantViolated) << write_status.ToString();
+
+    // The synchronous failure is already the writer's terminal status. Close
+    // must return it without waiting for the accepted sibling upload.
+    auto close_status = stream->Close();
+    EXPECT_TRUE(close_status.Equals(write_status)) << close_status.ToString();
+
+    // Abort is deferred while that sibling remains in flight. The failed
+    // submission must already have decremented its own counter slot, otherwise
+    // the sibling's eventual completion can never take the counter to zero.
+    ASSERT_STATUS_OK(stream->Abort());
+    stream.reset();
+    auto count_remote_aborts = [this] {
+      size_t count = 0;
+      for (const auto& request : mock_client_->GetRecordedRequests()) {
+        if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+            request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+          ++count;
+        }
+      }
+      return count;
+    };
+    EXPECT_EQ(count_remote_aborts(), 0);
+
+    release_upload_promise.set_value();
+    pool->WaitForIdle();
+
+    EXPECT_FALSE(upload_release_timed_out.load(std::memory_order_acquire));
+    EXPECT_EQ(count_remote_aborts(), 1);
+  }
+
   std::shared_ptr<MockHttpClient> mock_client_;
 };
+
+namespace {
+
+void ExpectExtendStatusCode(const arrow::Status& status, ExtendStatusCode expected) {
+  ASSERT_FALSE(status.ok()) << status.ToString();
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), expected) << status.ToString();
+}
+
+void ExpectCredentialDependencyException(const arrow::Status& status) {
+  ASSERT_FALSE(status.ok()) << status.ToString();
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  EXPECT_FALSE(status.IsOutOfMemory()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  EXPECT_NE(status.message().find("synthetic credential dependency failure"), std::string::npos) << status.ToString();
+}
+
+void ExpectCredentialOutOfMemory(const arrow::Status& status) {
+  ASSERT_FALSE(status.ok()) << status.ToString();
+  EXPECT_TRUE(status.IsOutOfMemory()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::MemAllocateFailed) << status.ToString();
+}
+
+class FailingRequestCredentialsProvider final : public Aws::Auth::AWSCredentialsProvider,
+                                                public RequestCredentialsResolver {
+  public:
+  explicit FailingRequestCredentialsProvider(arrow::Status failure) : failure_(std::move(failure)) {}
+
+  Aws::Auth::AWSCredentials GetAWSCredentials() override { return {}; }
+
+  arrow::Result<Aws::Auth::AWSCredentials> ResolveForRequest() override {
+    ++resolve_calls_;
+    return failure_;
+  }
+
+  int resolve_calls() const { return resolve_calls_.load(); }
+
+  private:
+  arrow::Status failure_;
+  std::atomic<int> resolve_calls_{0};
+};
+
+}  // namespace
 
 // ============================================================================
 // Diagnostic: Verify mock infrastructure
@@ -304,6 +603,1756 @@ TEST_F(S3ProviderTest, TestMockInfrastructure) {
                                    Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
   auto response2 = client->MakeRequest(request2);
   EXPECT_EQ(response2->GetResponseCode(), Aws::Http::HttpResponseCode::NOT_FOUND);
+}
+
+TEST_F(S3ProviderTest, DeleteDirReturnsOneConcreteFailureWithoutAggregation) {
+  constexpr const char* kBucket = "aggregation-test-bucket";
+
+  const std::string first_list_page = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>aggregation-test-bucket</Name>
+  <Prefix></Prefix>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>true</IsTruncated>
+  <Contents>
+    <Key>dir/file</Key>
+    <LastModified>2026-08-03T00:00:00.000Z</LastModified>
+    <ETag>&quot;etag&quot;</ETag>
+    <Size>1</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <NextContinuationToken>next-page</NextContinuationToken>
+</ListBucketResult>)xml";
+  const std::string delete_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Error>
+    <Key>dir/file</Key>
+    <Code>AccessDenied</Code>
+    <Message>delete denied by policy</Message>
+  </Error>
+</DeleteResult>)xml";
+  const std::string listing_error = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>SlowDown</Code>
+  <Message>listing throttled</Message>
+  <RequestId>request-id</RequestId>
+</Error>)xml";
+
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+  // Pagination and page deletes run concurrently. Either concrete failure may
+  // win, but the result must never synthesize a combined status.
+  std::promise<void> delete_started_promise;
+  auto delete_started = delete_started_promise.get_future().share();
+
+  mock_client_->EnqueueResponse("list-type=2", Aws::Http::HttpResponseCode::OK, first_list_page,
+                                xml_headers(first_list_page));
+  mock_client_->EnqueueResponse("list-type=2", Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE, listing_error,
+                                xml_headers(listing_error), [delete_started] {
+                                  EXPECT_EQ(delete_started.wait_for(std::chrono::seconds(5)), std::future_status::ready)
+                                      << "second listing failure arrived before the first page's delete started";
+                                });
+  mock_client_->EnqueueResponse("?delete", Aws::Http::HttpResponseCode::OK, delete_result, xml_headers(delete_result),
+                                [&delete_started_promise] { delete_started_promise.set_value(); });
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  auto status = fs->DeleteDirContents(kBucket, /*missing_dir_ok=*/false);
+
+  ASSERT_STATUS_NOT_OK(status);
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_TRUE(detail->code() == ExtendStatusCode::StorageAccessDenied ||
+              detail->code() == ExtendStatusCode::StorageTransientService ||
+              detail->code() == ExtendStatusCode::StorageTransientThrottling)
+      << status.ToString();
+  const bool has_delete_failure = status.message().find("AccessDenied") != std::string::npos;
+  const bool has_listing_failure = status.message().find("listing throttled") != std::string::npos;
+  EXPECT_NE(has_delete_failure, has_listing_failure) << status.ToString();
+}
+
+TEST_F(S3ProviderTest, DeleteObjectsSubmissionFailureDoesNotWaitForAcceptedChunks) {
+  constexpr const char* kBucket = "delete-submission-failure-bucket";
+
+  std::string list_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>delete-submission-failure-bucket</Name>
+  <Prefix></Prefix>
+  <KeyCount>1001</KeyCount>
+  <MaxKeys>1001</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+)xml";
+  for (int i = 0; i < 1001; ++i) {
+    list_result += "<Contents><Key>dir/file-" + std::to_string(i) +
+                   "</Key><LastModified>2026-08-11T00:00:00.000Z</LastModified>"
+                   "<ETag>&quot;etag&quot;</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>";
+  }
+  list_result += "</ListBucketResult>";
+
+  const std::string delete_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Error>
+    <Key>dir/file-0</Key>
+    <Code>AccessDenied</Code>
+    <Message>first accepted chunk was denied</Message>
+  </Error>
+</DeleteResult>)xml";
+
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+
+  ASSERT_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(2));
+  RejectAfterOneS3Executor executor(pool);
+  std::promise<void> first_delete_started_promise;
+  auto first_delete_started = first_delete_started_promise.get_future();
+  std::promise<void> release_first_delete_promise;
+  auto release_first_delete = release_first_delete_promise.get_future().share();
+
+  mock_client_->EnqueueResponse("list-type=2", Aws::Http::HttpResponseCode::OK, list_result, xml_headers(list_result),
+                                [&executor] { executor.Arm(); });
+  mock_client_->EnqueueResponse("?delete", Aws::Http::HttpResponseCode::OK, delete_result, xml_headers(delete_result),
+                                [&first_delete_started_promise, release_first_delete] {
+                                  first_delete_started_promise.set_value();
+                                  EXPECT_EQ(release_first_delete.wait_for(std::chrono::seconds(5)),
+                                            std::future_status::ready);
+                                });
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  arrow::io::IOContext io_context(&executor);
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  auto delete_future = fs->DeleteDirContentsAsync(kBucket, /*missing_dir_ok=*/false);
+
+  ASSERT_EQ(executor.rejection_observed().wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  ASSERT_EQ(first_delete_started.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  const bool finished_before_accepted_chunk = delete_future.is_finished();
+  release_first_delete_promise.set_value();
+  ASSERT_TRUE(finished_before_accepted_chunk) << "submission failure waited for an already accepted chunk";
+  auto status = delete_future.status();
+  ASSERT_STATUS_NOT_OK(status);
+  EXPECT_NE(status.message().find("executor rejected S3 delete task"), std::string::npos) << status.ToString();
+  EXPECT_EQ(status.message().find("first accepted chunk was denied"), std::string::npos) << status.ToString();
+}
+
+TEST_F(S3ProviderTest, DeleteObjectsResultFailureDoesNotWaitForSibling) {
+  constexpr const char* kBucket = "delete-result-failure-bucket";
+
+  std::string list_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>delete-result-failure-bucket</Name>
+  <Prefix></Prefix>
+  <KeyCount>1001</KeyCount>
+  <MaxKeys>1001</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+)xml";
+  for (int i = 0; i < 1001; ++i) {
+    list_result += "<Contents><Key>dir/file-" + std::to_string(i) +
+                   "</Key><LastModified>2026-08-18T00:00:00.000Z</LastModified>"
+                   "<ETag>&quot;etag&quot;</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>";
+  }
+  list_result += "</ListBucketResult>";
+
+  const std::string failed_delete_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Error>
+    <Key>dir/file-0</Key>
+    <Code>AccessDenied</Code>
+    <Message>first completed chunk was denied</Message>
+  </Error>
+</DeleteResult>)xml";
+  const std::string successful_delete_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />)xml";
+
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+
+  ASSERT_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(2));
+  std::promise<void> sibling_started_promise;
+  auto sibling_started = sibling_started_promise.get_future();
+  std::promise<void> release_sibling_promise;
+  auto release_sibling = release_sibling_promise.get_future().share();
+
+  mock_client_->EnqueueResponse("list-type=2", Aws::Http::HttpResponseCode::OK, list_result, xml_headers(list_result));
+  mock_client_->EnqueueResponse(
+      "?delete", Aws::Http::HttpResponseCode::OK, failed_delete_result, xml_headers(failed_delete_result),
+      [&sibling_started] { EXPECT_EQ(sibling_started.wait_for(std::chrono::seconds(5)), std::future_status::ready); });
+  mock_client_->EnqueueResponse("?delete", Aws::Http::HttpResponseCode::OK, successful_delete_result,
+                                xml_headers(successful_delete_result), [&sibling_started_promise, release_sibling] {
+                                  sibling_started_promise.set_value();
+                                  EXPECT_EQ(release_sibling.wait_for(std::chrono::seconds(10)),
+                                            std::future_status::ready);
+                                });
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  arrow::io::IOContext io_context(pool.get());
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  auto delete_future = fs->DeleteDirContentsAsync(kBucket, /*missing_dir_ok=*/false);
+
+  const auto sibling_state = sibling_started.wait_for(std::chrono::seconds(5));
+  const bool finished_before_sibling_release = sibling_state == std::future_status::ready && delete_future.Wait(5.0);
+  std::optional<arrow::Status> observed_status;
+  if (finished_before_sibling_release) {
+    observed_status = delete_future.status();
+  }
+  release_sibling_promise.set_value();
+  delete_future.Wait(5.0);
+
+  ASSERT_EQ(sibling_state, std::future_status::ready);
+  ASSERT_TRUE(finished_before_sibling_release) << "delete failure waited for a sibling request";
+  ASSERT_TRUE(observed_status.has_value());
+  ASSERT_STATUS_NOT_OK(*observed_status);
+  auto detail = ExtendStatusDetail::UnwrapStatus(*observed_status);
+  ASSERT_NE(detail, nullptr) << observed_status->ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied) << observed_status->ToString();
+  EXPECT_NE(observed_status->message().find("first completed chunk was denied"), std::string::npos)
+      << observed_status->ToString();
+}
+
+TEST_F(S3ProviderTest, DeleteObjectsPerKeyCredentialErrorsAreAuthenticationFailures) {
+  constexpr const char* kBucket = "expired-token-delete-bucket";
+
+  std::string list_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>expired-token-delete-bucket</Name>
+  <Prefix></Prefix>
+  <KeyCount>5</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+)xml";
+  const std::vector<std::string> credential_errors = {"ExpiredToken", "InvalidToken", "InvalidAccessKeyId",
+                                                      "SignatureDoesNotMatch", "InvalidSecurity"};
+  for (size_t i = 0; i < credential_errors.size(); ++i) {
+    list_result += "<Contents><Key>dir/file-" + std::to_string(i) +
+                   "</Key><LastModified>2026-08-03T00:00:00.000Z</LastModified>"
+                   "<ETag>&quot;etag&quot;</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents>";
+  }
+  list_result += "</ListBucketResult>";
+
+  std::string delete_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+)xml";
+  for (size_t i = 0; i < credential_errors.size(); ++i) {
+    delete_result += "<Error><Key>dir/file-" + std::to_string(i) + "</Key><Code>" + credential_errors[i] +
+                     "</Code><Message>credentials rejected</Message></Error>";
+  }
+  delete_result += "</DeleteResult>";
+
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+  mock_client_->EnqueueResponse("list-type=2", Aws::Http::HttpResponseCode::OK, list_result, xml_headers(list_result));
+  mock_client_->EnqueueResponse("?delete", Aws::Http::HttpResponseCode::OK, delete_result, xml_headers(delete_result));
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  auto status = fs->DeleteDirContents(kBucket, /*missing_dir_ok=*/false);
+
+  ASSERT_STATUS_NOT_OK(status);
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied) << status.ToString();
+  EXPECT_FALSE(detail->retryable());
+  EXPECT_NE(status.message().find(credential_errors.front()), std::string::npos) << status.ToString();
+  EXPECT_EQ(status.message().find(credential_errors.back()), std::string::npos) << status.ToString();
+}
+
+TEST_F(S3ProviderTest, KnownSizeGetObjectNotFoundIsMissingKeyWithoutProbe) {
+  auto make_fs = [this]() -> arrow::Result<std::shared_ptr<S3FileSystem>> {
+    S3Options options;
+    options.ConfigureAnonymousCredentials();
+    options.region = "us-east-1";
+    options.scheme = "http";
+    options.endpoint_override = "mock-s3.local";
+    options.cloud_provider = kCloudProviderAWS;
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+    options.use_crt_async_reads = false;
+    return S3FileSystem::Make(options);
+  };
+
+  auto read_known_size = [](const std::shared_ptr<S3FileSystem>& fs) -> arrow::Status {
+    arrow::fs::FileInfo info("bucket/key", arrow::fs::FileType::File);
+    info.set_size(1);
+    ARROW_ASSIGN_OR_RAISE(auto file, fs->OpenInputFile(info));
+    uint8_t byte = 0;
+    return file->ReadAt(0, 1, &byte).status();
+  };
+
+  // OpenInputFile(FileInfo) skips HeadObject by design. A bodyless GetObject
+  // 404 is reduced to a missing key directly -- exactly ONE request. No
+  // disambiguation probe follows: extra IO on the miss path is deliberately
+  // not spent, so a vanished bucket also reports as the missing object.
+  mock_client_->EnqueueResponse("mock-s3.local", Aws::Http::HttpResponseCode::NOT_FOUND, "");
+  ASSERT_AND_ASSIGN(auto missing_key_fs, make_fs());
+  auto missing_key = read_known_size(missing_key_fs);
+  ASSERT_STATUS_NOT_OK(missing_key);
+  auto key_detail = ExtendStatusDetail::UnwrapStatus(missing_key);
+  ASSERT_NE(key_detail, nullptr) << missing_key.ToString();
+  EXPECT_EQ(key_detail->code(), ExtendStatusCode::StorageNotFound) << missing_key.ToString();
+  EXPECT_EQ(CategoryForExtendStatusCode(key_detail->code()), ErrorCategory::System);
+  // Only the failing GetObject (plus SDK retries of it) -- a HeadBucket probe
+  // would show up as a HEAD request.
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    EXPECT_NE(request->GetMethod(), Aws::Http::HttpMethod::HTTP_HEAD) << "unexpected disambiguation probe";
+  }
+}
+
+TEST_F(S3ProviderTest, DeleteFileNotFoundDoesNotProbeBucket) {
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  mock_client_->EnqueueResponse("mock-s3.local", Aws::Http::HttpResponseCode::NOT_FOUND, "");
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  auto status = fs->DeleteFile("bucket/key");
+
+  ASSERT_STATUS_NOT_OK(status);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist) << status.ToString();
+  const auto requests = mock_client_->GetRecordedRequests();
+  ASSERT_EQ(requests.size(), 1u) << "a failed HeadObject must not trigger a HeadBucket diagnostic request";
+  EXPECT_EQ(requests.front()->GetMethod(), Aws::Http::HttpMethod::HTTP_HEAD);
+}
+
+TEST_F(S3ProviderTest, DeleteObjectsRequestNotFoundNamesTheBucket) {
+  const std::string list_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>bucket</Name>
+  <Prefix></Prefix>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>key</Key>
+    <LastModified>2026-08-06T00:00:00.000Z</LastModified>
+    <ETag>&quot;etag&quot;</ETag>
+    <Size>1</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+</ListBucketResult>)xml";
+  Aws::Http::HeaderValueCollection list_headers;
+  list_headers["content-type"] = "application/xml";
+  list_headers["content-length"] = std::to_string(list_result.size());
+  mock_client_->EnqueueResponse("list-type=2", Aws::Http::HttpResponseCode::OK, list_result, list_headers);
+  mock_client_->EnqueueResponse("?delete", Aws::Http::HttpResponseCode::NOT_FOUND, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  auto status = fs->DeleteDirContents("bucket", /*missing_dir_ok=*/false);
+
+  ASSERT_STATUS_NOT_OK(status);
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageBucketNotFound) << status.ToString();
+  EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::System);
+}
+
+TEST_F(S3ProviderTest, MultipartNotFoundReportsNoSuchUploadWithoutProbe) {
+  auto make_fs = []() -> arrow::Result<std::shared_ptr<S3FileSystem>> {
+    S3Options options;
+    options.ConfigureAnonymousCredentials();
+    options.region = "us-east-1";
+    options.scheme = "http";
+    options.endpoint_override = "mock-s3.local";
+    options.cloud_provider = kCloudProviderAWS;
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+    options.use_crt_async_reads = false;
+    options.background_writes = false;
+    return S3FileSystem::Make(options);
+  };
+
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  Aws::Http::HeaderValueCollection xml_headers;
+  xml_headers["content-type"] = "application/xml";
+  xml_headers["content-length"] = std::to_string(create_result.size());
+
+  auto write_one_part = [](const std::shared_ptr<S3FileSystem>& fs) -> arrow::Status {
+    ARROW_ASSIGN_OR_RAISE(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+    const uint8_t byte = 7;
+    return stream->Write(&byte, 1);
+  };
+
+  // A generic 404 on UploadPart is reported as NoSuchUpload directly -- no
+  // HeadBucket probe follows (extra IO on failure paths is deliberately not
+  // spent), so a vanished bucket reports the same way.
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers);
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::NOT_FOUND, "");
+  ASSERT_AND_ASSIGN(auto dead_upload_fs, make_fs());
+  auto dead_upload = write_one_part(dead_upload_fs);
+  ASSERT_STATUS_NOT_OK(dead_upload);
+  auto upload_detail = ExtendStatusDetail::UnwrapStatus(dead_upload);
+  ASSERT_NE(upload_detail, nullptr) << dead_upload.ToString();
+  EXPECT_EQ(upload_detail->code(), ExtendStatusCode::StorageNoSuchUpload) << dead_upload.ToString();
+  EXPECT_EQ(CategoryForExtendStatusCode(upload_detail->code()), ErrorCategory::Retryable);
+  EXPECT_TRUE(upload_detail->retryable());
+  // CreateMultipartUpload + the failing UploadPart (plus SDK retries) -- a
+  // HeadBucket probe would show up as a HEAD request.
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    EXPECT_NE(request->GetMethod(), Aws::Http::HttpMethod::HTTP_HEAD) << "unexpected disambiguation probe";
+  }
+}
+
+TEST_F(S3ProviderTest, BackgroundUploadSubmissionFailureSettlesFlush) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  Aws::Http::HeaderValueCollection xml_headers;
+  xml_headers["content-type"] = "application/xml";
+  xml_headers["content-length"] = std::to_string(create_result.size());
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers);
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  RejectingS3Executor executor;
+  arrow::io::IOContext io_context(&executor);
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+
+  const uint8_t byte = 7;
+  auto write_status = stream->Write(&byte, 1);
+  ASSERT_STATUS_NOT_OK(write_status);
+  EXPECT_NE(write_status.message().find("executor rejected S3 upload task"), std::string::npos);
+
+  auto flush_status = stream->Flush();
+  ASSERT_STATUS_NOT_OK(flush_status);
+  EXPECT_TRUE(flush_status.Equals(write_status));
+  ASSERT_STATUS_OK(stream->Abort());
+}
+
+TEST_F(S3ProviderTest, UnexpectedBackgroundUploadSubmissionExceptionDrainsBeforeDeferredAbort) {
+  AssertBackgroundUploadSubmissionExceptionDrains(S3SubmissionExceptionKind::kUnexpected);
+}
+
+TEST_F(S3ProviderTest, BackgroundUploadSubmissionBadAllocIsFailStop) {
+  PrepareS3DeathTest();
+  EXPECT_DEATH_IF_SUPPORTED(
+      { AssertBackgroundUploadSubmissionExceptionDrains(S3SubmissionExceptionKind::kBadAlloc); }, "");
+}
+
+// A credential failure that could NOT be reached and one that was REFUSED must
+// not land the same way. The distinction is not there to make the SDK retry
+// again -- the credential client's own budget is already spent by then -- it is
+// there so the layer above can re-run the whole operation later. Collapsing
+// both into StorageAccessDenied made a restarting metadata service fail a
+// query exactly as permanently as a role ARN that does not exist.
+TEST(StsCredentialResolutionTest, SeparatesUnreachableFromRefused) {
+  using Aws::Http::HttpResponseCode;
+
+  auto code_of = [](const arrow::Status& status) {
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    EXPECT_NE(detail, nullptr) << status.ToString();
+    return detail != nullptr ? detail->code() : ExtendStatusCode::StorageAccessDenied;
+  };
+
+  // Never left the process, or the http client returned nothing at all. These
+  // sit inside ordinary numeric ranges (444, 598, 599), so a classifier keyed
+  // on the range first would call a dead network a bad configuration.
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::REQUEST_NOT_MADE, "x")),
+            ExtendStatusCode::StorageTransientNetwork);
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::NO_RESPONSE, "x")),
+            ExtendStatusCode::StorageTransientNetwork);
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::NETWORK_CONNECT_TIMEOUT, "x")),
+            ExtendStatusCode::StorageTransientTimeout);
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::TOO_MANY_REQUESTS, "x")),
+            ExtendStatusCode::StorageTransientThrottling);
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::SERVICE_UNAVAILABLE, "x")),
+            ExtendStatusCode::StorageTransientService);
+
+  // The service identified us and said no. That one really is an access
+  // decision, and it must stay non-retryable.
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::FORBIDDEN, "x")),
+            ExtendStatusCode::StorageAccessDenied);
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::UNAUTHORIZED, "x")),
+            ExtendStatusCode::StorageAccessDenied);
+
+  // Refused, but not as an access decision.
+  EXPECT_EQ(code_of(ClassifyCredentialHttpFailure(HttpResponseCode::BAD_REQUEST, "x")),
+            ExtendStatusCode::StorageConfigInvalid);
+}
+
+TEST(StsCredentialResolutionTest, TransientCredentialFailuresStayRetryableAtTheBoundary) {
+  using Aws::Http::HttpResponseCode;
+
+  for (auto code :
+       {HttpResponseCode::REQUEST_NOT_MADE, HttpResponseCode::NO_RESPONSE, HttpResponseCode::SERVICE_UNAVAILABLE,
+        HttpResponseCode::TOO_MANY_REQUESTS, HttpResponseCode::NETWORK_CONNECT_TIMEOUT}) {
+    auto status = ClassifyCredentialHttpFailure(code, "transient");
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << "http_status=" << static_cast<int>(code);
+    EXPECT_TRUE(detail->retryable()) << "http_status=" << static_cast<int>(code);
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageTransientError)
+        << "http_status=" << static_cast<int>(code);
+  }
+
+  auto refused = ClassifyCredentialHttpFailure(HttpResponseCode::FORBIDDEN, "refused");
+  auto refused_detail = ExtendStatusDetail::UnwrapStatus(refused);
+  ASSERT_NE(refused_detail, nullptr);
+  EXPECT_FALSE(refused_detail->retryable());
+  EXPECT_EQ(ToSegcoreError(refused).get_error_code(), milvus::ConfigInvalid);
+}
+
+// Missing local configuration is the deployment's to fix, and must not read as
+// something a retry outlasts.
+TEST(StsCredentialResolutionTest, MissingLocalConfigurationIsNotRetryable) {
+  auto status = MakeCredentialConfigError("Cannot open the OIDC token file /var/run/secrets/token");
+  EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid);
+  EXPECT_FALSE(detail->retryable());
+}
+
+// The budget is asked AFTER the writer lock is acquired, so what it actually
+// answers is "did I spend my whole budget waiting for somebody else's failed
+// reload". A caller that just arrived still gets to try; one that waited longer
+// than the budget does not, which is what stops a queue of threads replaying
+// the same outage one after another.
+TEST(StsCredentialResolutionTest, AttemptIsAbandonedOnceTheBudgetIsSpentWaiting) {
+  EXPECT_TRUE(CredentialAttemptStillWorthMaking(std::chrono::steady_clock::now()));
+  EXPECT_FALSE(CredentialAttemptStillWorthMaking(std::chrono::steady_clock::now() - kCredentialResolutionBudget -
+                                                 std::chrono::milliseconds(1)));
+}
+
+// A body we could not use is neither a transport fault to wait out nor a
+// refusal. Left unclassified on purpose: the conservative landing is
+// non-retryable without claiming to know which it was.
+TEST(StsCredentialResolutionTest, AnUnusableResponseIsNotDressedAsAccessDenied) {
+  auto status = MakeCredentialResponseError("STS answered 200 with no <Credentials>");
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  EXPECT_NE(status.message().find("no <Credentials>"), std::string::npos);
+}
+
+TEST(StsCredentialResolutionTest, TemporaryCredentialsAreValidatedAtomically) {
+  const auto future = Aws::Utils::DateTime(std::chrono::system_clock::now() + std::chrono::hours(1));
+  const auto expired = Aws::Utils::DateTime(std::chrono::system_clock::now() - std::chrono::seconds(1));
+  const auto invalid = Aws::Utils::DateTime("not-an-expiration", Aws::Utils::DateFormat::ISO_8601);
+
+  EXPECT_TRUE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("ak", "sk", "token", future), "test STS").ok());
+  EXPECT_FALSE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("", "sk", "token", future), "test STS").ok());
+  EXPECT_FALSE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("ak", "", "token", future), "test STS").ok());
+  EXPECT_FALSE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("ak", "sk", "", future), "test STS").ok());
+  EXPECT_FALSE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("ak", "sk", "token"), "test STS").ok());
+  EXPECT_FALSE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("ak", "sk", "token", invalid), "test STS").ok());
+  EXPECT_FALSE(ValidateTemporaryCredentials(Aws::Auth::AWSCredentials("ak", "sk", "token", expired), "test STS").ok());
+}
+
+TEST_F(S3ProviderTest, VendorStsClassifiesHttpFailureBeforeParsingNonEmptyBody) {
+  auto config = MakeNoImdsClientConfiguration();
+  config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>("sts-status-test", 0);
+
+  {
+    ScopedEnvVar provider_arn("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456:oidc-provider/test");
+    for (long attempt = 0; attempt <= kCredentialRetryAttempts; ++attempt) {
+      mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::TOO_MANY_REQUESTS,
+                                    R"(<Error><Code>Throttling</Code><Message>busy but non-empty</Message></Error>)");
+    }
+    AliyunSTSCredentialsClient client(config);
+    AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{"session", "acs:ram::123456:role/test",
+                                                                            "identity-token"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectExtendStatusCode(result.status, ExtendStatusCode::StorageTransientThrottling);
+  }
+
+  {
+    for (long attempt = 0; attempt <= kCredentialRetryAttempts; ++attempt) {
+      mock_client_->EnqueueResponse("sts.tencentcloudapi.com", Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE,
+                                    R"({"Response":{"Error":{"Code":"InternalError","Message":"non-empty outage"}}})");
+    }
+    TencentCloudSTSCredentialsClient client(config);
+    TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
+        "ap-guangzhou", "provider", "identity-token", "qcs::cam::uin/1:roleName/test", "session"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectExtendStatusCode(result.status, ExtendStatusCode::StorageTransientService);
+  }
+
+  {
+    mock_client_->EnqueueResponse("sts.aliyuncs.com", Aws::Http::HttpResponseCode::FORBIDDEN,
+                                  R"(<Error><Code>AccessDenied</Code><Message>non-empty refusal</Message></Error>)");
+    AliyunRAMSTSClient client(config);
+    AliyunRAMSTSClient::AssumeRoleRequest request;
+    request.callerAccessKeyId = "caller-ak";
+    request.callerAccessKeySecret = "caller-sk";
+    request.callerSecurityToken = "caller-token";
+    request.roleArn = "acs:ram::123456:role/test";
+    request.roleSessionName = "session";
+
+    auto result = client.GetAssumeRoleCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectExtendStatusCode(result.status, ExtendStatusCode::StorageAccessDenied);
+  }
+}
+
+TEST_F(S3ProviderTest, AliyunStsClassifiesOnlyXmlThrottlingOnHttp302) {
+  auto config = MakeNoImdsClientConfiguration();
+  config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>("aliyun-302-test", 0);
+  constexpr auto redirected = static_cast<Aws::Http::HttpResponseCode>(302);
+
+  auto invoke = [&](bool oidc, std::string_view code) -> std::pair<Aws::Auth::AWSCredentials, arrow::Status> {
+    mock_client_->EnqueueResponse(
+        "sts.aliyuncs.com", redirected,
+        fmt::format("<Error><Code>{}</Code><Message>synthetic 302 response</Message></Error>", code));
+    if (oidc) {
+      ScopedEnvVar provider_arn("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456:oidc-provider/test");
+      AliyunSTSCredentialsClient client(config);
+      auto result =
+          client.GetAssumeRoleWithWebIdentityCredentials({"session", "acs:ram::123456:role/test", "identity-token"});
+      return {std::move(result.creds), std::move(result.status)};
+    }
+    AliyunRAMSTSClient client(config);
+    AliyunRAMSTSClient::AssumeRoleRequest request;
+    request.callerAccessKeyId = "caller-ak";
+    request.callerAccessKeySecret = "caller-sk";
+    request.roleArn = "acs:ram::123456:role/test";
+    request.roleSessionName = "session";
+    auto result = client.GetAssumeRoleCredentials(request);
+    return {std::move(result.creds), std::move(result.status)};
+  };
+
+  for (bool oidc : {true, false}) {
+    auto [throttled_creds, throttled_status] = invoke(oidc, "Throttling.User");
+    EXPECT_TRUE(throttled_creds.IsEmpty());
+    ExpectExtendStatusCode(throttled_status, ExtendStatusCode::StorageTransientThrottling);
+
+    auto [redirect_creds, redirect_status] = invoke(oidc, "EntityNotExist.Role");
+    EXPECT_TRUE(redirect_creds.IsEmpty());
+    EXPECT_TRUE(redirect_status.IsIOError()) << redirect_status.ToString();
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(redirect_status), nullptr) << redirect_status.ToString();
+  }
+}
+
+TEST_F(S3ProviderTest, TencentHttp200ErrorBodyKeepsTypedCause) {
+  auto config = MakeNoImdsClientConfiguration();
+  config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>("tencent-200-error-test", 0);
+  struct Case {
+    const char* code;
+    ExtendStatusCode expected;
+  };
+  const std::vector<Case> cases = {
+      {"AuthFailure", ExtendStatusCode::StorageAccessDenied},
+      {"AuthFailure.SignatureFailure", ExtendStatusCode::StorageAccessDenied},
+      {"AccessDenied.ResourceUnauthorized", ExtendStatusCode::StorageAccessDenied},
+      {"UnauthorizedOperation.AssumeRoleWithWebIdentity", ExtendStatusCode::StorageAccessDenied},
+      {"RequestLimitExceeded", ExtendStatusCode::StorageTransientThrottling},
+      {"RequestLimitExceeded.UinLimitExceeded", ExtendStatusCode::StorageTransientThrottling},
+      {"InvalidParameter.OverLimit", ExtendStatusCode::StorageTransientThrottling},
+      {"InternalError", ExtendStatusCode::StorageTransientService},
+      {"InternalError.StsInternalError", ExtendStatusCode::StorageTransientService},
+      {"ServiceUnavailable.StsService", ExtendStatusCode::StorageTransientService},
+      {"ResourceUnavailable", ExtendStatusCode::StorageTransientService},
+      {"ResourceUnavailable.RoleState", ExtendStatusCode::StorageConfigInvalid},
+      {"InvalidParameter.RoleArn", ExtendStatusCode::StorageConfigInvalid},
+  };
+
+  for (const auto& test_case : cases) {
+    SCOPED_TRACE(test_case.code);
+    const auto body = fmt::format(
+        R"({{"Response":{{"Error":{{"Code":"{}","Message":"synthetic typed error"}},"RequestId":"request"}}}})",
+        test_case.code);
+    mock_client_->EnqueueResponse("sts.tencentcloudapi.com", Aws::Http::HttpResponseCode::OK, body);
+    TencentCloudSTSCredentialsClient client(config);
+    TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
+        "ap-guangzhou", "provider", "identity-token", "qcs::cam::uin/1:roleName/test", "session"};
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectExtendStatusCode(result.status, test_case.expected);
+    EXPECT_TRUE(result.status.IsIOError()) << result.status.ToString();
+  }
+}
+
+TEST_F(S3ProviderTest, VendorStsRejectsEveryIncompleteTemporaryCredentialShape) {
+  auto config = MakeNoImdsClientConfiguration();
+  config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>("sts-partial-test", 0);
+
+  {
+    ScopedEnvVar provider_arn("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456:oidc-provider/test");
+    mock_client_->EnqueueResponse(
+        "sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK,
+        R"(<AssumeRoleWithOIDCResponse><Credentials><AccessKeyId>ak</AccessKeyId><AccessKeySecret>sk</AccessKeySecret><Expiration>2099-12-31T23:59:59Z</Expiration></Credentials></AssumeRoleWithOIDCResponse>)");
+    AliyunSTSCredentialsClient client(config);
+    AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{"session", "acs:ram::123456:role/test",
+                                                                            "identity-token"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    EXPECT_FALSE(result.status.ok());
+  }
+
+  {
+    mock_client_->EnqueueResponse(
+        "sts.tencentcloudapi.com", Aws::Http::HttpResponseCode::OK,
+        R"({"Response":{"Credentials":{"TmpSecretId":"ak","TmpSecretKey":"sk","Token":"token"},"Expiration":""}})");
+    TencentCloudSTSCredentialsClient client(config);
+    TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
+        "ap-guangzhou", "provider", "identity-token", "qcs::cam::uin/1:roleName/test", "session"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    EXPECT_FALSE(result.status.ok());
+  }
+
+  {
+    mock_client_->EnqueueResponse(
+        "sts.aliyuncs.com", Aws::Http::HttpResponseCode::OK,
+        R"(<AssumeRoleResponse><Credentials><AccessKeyId>ak</AccessKeyId><AccessKeySecret>sk</AccessKeySecret><SecurityToken>token</SecurityToken></Credentials></AssumeRoleResponse>)");
+    AliyunRAMSTSClient client(config);
+    AliyunRAMSTSClient::AssumeRoleRequest request;
+    request.callerAccessKeyId = "caller-ak";
+    request.callerAccessKeySecret = "caller-sk";
+    request.callerSecurityToken = "caller-token";
+    request.roleArn = "acs:ram::123456:role/test";
+    request.roleSessionName = "session";
+
+    auto result = client.GetAssumeRoleCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    EXPECT_FALSE(result.status.ok());
+  }
+}
+
+TEST_F(S3ProviderTest, StandardClientHolderStopsObjectRequestWhenCredentialResolutionFails) {
+  auto provider = std::make_shared<FailingRequestCredentialsProvider>(
+      MakeExtendErrorMsg(ExtendStatusCode::StorageTransientService, "runtime credential refresh failed"));
+  S3Options options;
+  options.credentials_provider = provider;
+  options.credentials_kind = S3CredentialsKind::Role;
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  auto file_info = fs->GetFileInfo("bucket/key");
+  ASSERT_FALSE(file_info.ok());
+  ExpectExtendStatusCode(file_info.status(), ExtendStatusCode::StorageTransientService);
+  EXPECT_EQ(provider->resolve_calls(), 1);
+  size_t s3_requests = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetURIString().find("mock-s3.local") != Aws::String::npos) {
+      ++s3_requests;
+    }
+  }
+  EXPECT_EQ(s3_requests, 0u) << "an object request must not be sent after credential refresh fails";
+}
+
+#ifdef WITH_CRT
+TEST_F(S3ProviderTest, CrtClientHolderStopsBeforeExposingClientWhenCredentialResolutionFails) {
+  auto provider = std::make_shared<FailingRequestCredentialsProvider>(
+      MakeExtendErrorMsg(ExtendStatusCode::StorageTransientNetwork, "runtime credential network failure"));
+  S3Options options;
+  options.credentials_provider = provider;
+  options.credentials_kind = S3CredentialsKind::Role;
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+
+  ClientBuilder<Aws::S3Crt::S3CrtClient> builder(options);
+  ASSERT_AND_ASSIGN(auto holder, builder.BuildClient());
+  auto acquired = holder->Acquire();
+  ASSERT_FALSE(acquired.ok());
+  ExpectExtendStatusCode(acquired.status(), ExtendStatusCode::StorageTransientNetwork);
+  EXPECT_EQ(provider->resolve_calls(), 1);
+  size_t s3_requests = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetURIString().find("mock-s3.local") != Aws::String::npos) {
+      ++s3_requests;
+    }
+  }
+  EXPECT_EQ(s3_requests, 0u) << "the CRT holder must not expose its S3 client after credential refresh fails";
+}
+#endif
+
+TEST_F(S3ProviderTest, UseIamConstructionPreflightReturnsTypedTencentFailure) {
+  TempFile token_file("tencent-identity-token");
+  ScopedEnvVar region("TKE_REGION", "ap-guangzhou");
+  ScopedEnvVar role("TKE_ROLE_ARN", "qcs::cam::uin/100000000001:roleName/test-role");
+  ScopedEnvVar token("TKE_WEB_IDENTITY_TOKEN_FILE", token_file.path());
+  ScopedEnvVar provider_id("TKE_PROVIDER_ID", "test-provider");
+
+  const std::string error_body = R"({"Response":{"Error":{"Code":"InternalError","Message":"non-empty STS outage"}}})";
+  for (long attempt = 0; attempt <= kCredentialRetryAttempts; ++attempt) {
+    mock_client_->EnqueueResponse("sts.tencentcloudapi.com", Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE,
+                                  error_body);
+  }
+
+  ArrowFileSystemConfig config;
+  config.cloud_provider = kCloudProviderTencent;
+  config.use_iam = true;
+  config.region = "ap-guangzhou";
+  config.use_ssl = false;
+  S3FileSystemProducer producer(config);
+
+  auto options = producer.CreateS3Options();
+  ASSERT_FALSE(options.ok());
+  ExpectExtendStatusCode(options.status(), ExtendStatusCode::StorageTransientService);
+  EXPECT_FALSE(mock_client_->GetRecordedRequests().empty())
+      << "use_iam must preflight its provider during construction";
+}
+
+namespace {
+
+class CountingHttpClient final : public Aws::Http::HttpClient {
+  public:
+  explicit CountingHttpClient(Aws::Http::HttpResponseCode code) : code_(code) {}
+
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* = nullptr) const override {
+    ++attempts_;
+    auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("CountingHttpClient", request);
+    response->SetResponseCode(code_);
+    return response;
+  }
+
+  int attempts() const { return attempts_; }
+
+  private:
+  Aws::Http::HttpResponseCode code_;
+  mutable int attempts_ = 0;
+};
+
+std::shared_ptr<Aws::Http::HttpRequest> MakeProbeRequest(
+    Aws::Http::HttpMethod method = Aws::Http::HttpMethod::HTTP_GET) {
+  auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(
+      "StsCredentialResolutionTest", Aws::Http::URI("http://credential-probe.local/"), method);
+  request->SetResponseStreamFactory(Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+  return request;
+}
+
+}  // namespace
+
+TEST(StsCredentialResolutionTest, RetriesAServiceFailureUpToTheSharedBudget) {
+  CountingHttpClient client(Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE);
+  auto response = MakeRequestWithCredentialRetry(client, MakeProbeRequest());
+
+  ASSERT_NE(response, nullptr);
+  EXPECT_EQ(response->GetResponseCode(), Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE);
+  // One initial attempt plus the budget.
+  EXPECT_EQ(client.attempts(), kCredentialRetryAttempts + 1);
+}
+
+// A retried POST must resend its body. Resending the same HttpRequest resends a
+// stream the previous attempt already drained, so without a rewind the retry
+// goes out empty and STS rejects it on its contents -- turning a retryable
+// outage into a bogus "malformed request". Huawei's second stage is a POST, so
+// this is not hypothetical.
+TEST(StsCredentialResolutionTest, ResendsTheRequestBodyOnEveryAttempt) {
+  class BodyRecordingHttpClient final : public Aws::Http::HttpClient {
+ public:
+    std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+        const std::shared_ptr<Aws::Http::HttpRequest>& request,
+        Aws::Utils::RateLimits::RateLimiterInterface* = nullptr,
+        Aws::Utils::RateLimits::RateLimiterInterface* = nullptr) const override {
+      // Drain the body exactly as a transport would.
+      std::ostringstream drained;
+      drained << request->GetContentBody()->rdbuf();
+      bodies_.push_back(drained.str());
+      auto response = Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("BodyRecordingHttpClient", request);
+      response->SetResponseCode(Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE);
+      return response;
+    }
+
+    const std::vector<std::string>& bodies() const { return bodies_; }
+
+ private:
+    mutable std::vector<std::string> bodies_;
+  };
+
+  BodyRecordingHttpClient client;
+  auto request = MakeProbeRequest(Aws::Http::HttpMethod::HTTP_POST);
+  auto body = Aws::MakeShared<Aws::StringStream>("test");
+  *body << R"({"auth":"payload"})";
+  request->AddContentBody(body);
+
+  (void)MakeRequestWithCredentialRetry(client, request);
+
+  ASSERT_EQ(client.bodies().size(), static_cast<size_t>(kCredentialRetryAttempts + 1));
+  for (size_t attempt = 0; attempt < client.bodies().size(); ++attempt) {
+    EXPECT_EQ(client.bodies()[attempt], R"({"auth":"payload"})") << "attempt " << attempt;
+  }
+}
+
+TEST(StsCredentialResolutionTest, DoesNotRetryARefusal) {
+  // A 4xx is the service answering on the merits. Repeating it changes nothing
+  // and only delays the operator learning the role is wrong.
+  CountingHttpClient client(Aws::Http::HttpResponseCode::FORBIDDEN);
+  auto response = MakeRequestWithCredentialRetry(client, MakeProbeRequest());
+
+  ASSERT_NE(response, nullptr);
+  EXPECT_EQ(client.attempts(), 1);
+}
+
+TEST(StsCredentialResolutionTest, StopsRetryingOnceItSucceeds) {
+  CountingHttpClient client(Aws::Http::HttpResponseCode::OK);
+  auto response = MakeRequestWithCredentialRetry(client, MakeProbeRequest());
+
+  ASSERT_NE(response, nullptr);
+  EXPECT_EQ(client.attempts(), 1);
+}
+
+TEST_F(S3ProviderTest, VendorCredentialClientsContainDependencyExceptions) {
+  auto config = MakeNoImdsClientConfiguration();
+  config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>("credential-exception-test", 0);
+
+  {
+    ScopedEnvVar provider_arn("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456:oidc-provider/test");
+    mock_client_->EnqueueException("sts.aliyuncs.com", MockExceptionKind::RuntimeError);
+    AliyunSTSCredentialsClient client(config);
+    AliyunSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{"session", "acs:ram::123456:role/test",
+                                                                            "identity-token"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectCredentialDependencyException(result.status);
+  }
+
+  {
+    mock_client_->EnqueueException("sts.tencentcloudapi.com", MockExceptionKind::RuntimeError);
+    TencentCloudSTSCredentialsClient client(config);
+    TencentCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
+        "ap-guangzhou", "provider", "identity-token", "qcs::cam::uin/1:roleName/test", "session"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectCredentialDependencyException(result.status);
+  }
+
+  {
+    mock_client_->EnqueueException("sts.aliyuncs.com", MockExceptionKind::RuntimeError);
+    AliyunRAMSTSClient client(config);
+    AliyunRAMSTSClient::AssumeRoleRequest request;
+    request.callerAccessKeyId = "caller-ak";
+    request.callerAccessKeySecret = "caller-sk";
+    request.callerSecurityToken = "caller-token";
+    request.roleArn = "acs:ram::123456:role/test";
+    request.roleSessionName = "session";
+
+    auto result = client.GetAssumeRoleCredentials(request);
+    EXPECT_TRUE(result.creds.IsEmpty());
+    ExpectCredentialDependencyException(result.status);
+  }
+
+  {
+    Aws::Http::HeaderValueCollection headers;
+    headers["x-subject-token"] = "subject-token";
+    mock_client_->EnqueueResponse("OS-AUTH/id-token/tokens", Aws::Http::HttpResponseCode::CREATED, "", headers);
+    mock_client_->EnqueueException("OS-CREDENTIAL/securitytokens", MockExceptionKind::RuntimeError);
+    HuaweiCloudSTSCredentialsClient client(config);
+    HuaweiCloudSTSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
+        "cn-north-4", "provider", "identity-token", "project-id", "session"};
+
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(request);
+    EXPECT_FALSE(result.success);
+    ExpectCredentialDependencyException(result.status);
+  }
+
+  {
+    ScopedEnvUnset metadata_disabled("ALIBABA_CLOUD_ECS_METADATA_DISABLED");
+    mock_client_->EnqueueException("latest/api/token", MockExceptionKind::RuntimeError);
+    AliyunRAMCredentialsProvider provider("acs:ram::123456:role/test", "session");
+
+    auto result = provider.ResolveForRequest();
+    ASSERT_FALSE(result.ok());
+    ExpectCredentialDependencyException(result.status());
+  }
+}
+
+TEST_F(S3ProviderTest, VendorCredentialClientsPreserveOutOfMemory) {
+  auto config = MakeNoImdsClientConfiguration();
+  config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>("credential-oom-test", 0);
+
+  {
+    ScopedEnvVar provider_arn("ALIBABA_CLOUD_OIDC_PROVIDER_ARN", "acs:ram::123456:oidc-provider/test");
+    mock_client_->EnqueueException("sts.aliyuncs.com", MockExceptionKind::BadAlloc);
+    AliyunSTSCredentialsClient client(config);
+    auto result =
+        client.GetAssumeRoleWithWebIdentityCredentials({"session", "acs:ram::123456:role/test", "identity-token"});
+    ExpectCredentialOutOfMemory(result.status);
+  }
+
+  {
+    mock_client_->EnqueueException("sts.tencentcloudapi.com", MockExceptionKind::BadAlloc);
+    TencentCloudSTSCredentialsClient client(config);
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(
+        {"ap-guangzhou", "provider", "identity-token", "qcs::cam::uin/1:roleName/test", "session"});
+    ExpectCredentialOutOfMemory(result.status);
+  }
+
+  {
+    mock_client_->EnqueueException("sts.aliyuncs.com", MockExceptionKind::BadAlloc);
+    AliyunRAMSTSClient client(config);
+    AliyunRAMSTSClient::AssumeRoleRequest request;
+    request.callerAccessKeyId = "caller-ak";
+    request.callerAccessKeySecret = "caller-sk";
+    request.callerSecurityToken = "caller-token";
+    request.roleArn = "acs:ram::123456:role/test";
+    request.roleSessionName = "session";
+    auto result = client.GetAssumeRoleCredentials(request);
+    ExpectCredentialOutOfMemory(result.status);
+  }
+
+  {
+    Aws::Http::HeaderValueCollection headers;
+    headers["x-subject-token"] = "subject-token";
+    mock_client_->EnqueueResponse("OS-AUTH/id-token/tokens", Aws::Http::HttpResponseCode::CREATED, "", headers);
+    mock_client_->EnqueueException("OS-CREDENTIAL/securitytokens", MockExceptionKind::BadAlloc);
+    HuaweiCloudSTSCredentialsClient client(config);
+    auto result = client.GetAssumeRoleWithWebIdentityCredentials(
+        {"cn-north-4", "provider", "identity-token", "project-id", "session"});
+    EXPECT_FALSE(result.success);
+    ExpectCredentialOutOfMemory(result.status);
+  }
+
+  {
+    ScopedEnvUnset metadata_disabled("ALIBABA_CLOUD_ECS_METADATA_DISABLED");
+    mock_client_->EnqueueException("latest/api/token", MockExceptionKind::BadAlloc);
+    AliyunRAMCredentialsProvider provider("acs:ram::123456:role/test", "session");
+    auto result = provider.ResolveForRequest();
+    ASSERT_FALSE(result.ok());
+    ExpectCredentialOutOfMemory(result.status());
+  }
+}
+
+TEST_F(S3ProviderTest, OneShotWriteFileAbortsTheUploadItCreated) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  const std::string failed_upload_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>AccessDenied</Code>
+  <Message>part was denied</Message>
+  <RequestId>request-id</RequestId>
+</Error>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::FORBIDDEN, failed_upload_result,
+                                xml_headers(failed_upload_result));
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = false;
+  // Every byte becomes its own part, so the very first write creates the
+  // multipart upload this test is about.
+  options.multi_part_upload_size = 1;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+
+  // The one-shot C API never returns a writer handle, so nothing the caller
+  // holds can release the upload afterwards. If this call does not abort it
+  // itself, the parts stay in the bucket where no listing can name them.
+  FileSystemWrapper fs_wrapper(fs);
+  const std::string path = "bucket/key";
+  const uint8_t bytes[] = {7, 8, 9};
+  auto result = loon_filesystem_write_file(reinterpret_cast<FileSystemHandle>(&fs_wrapper), path.data(),
+                                           static_cast<uint32_t>(path.size()), bytes, sizeof(bytes), nullptr, 0);
+  EXPECT_FALSE(loon_ffi_is_success(&result));
+  loon_ffi_free_result(&result);
+
+  size_t aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++aborts;
+    }
+  }
+  EXPECT_EQ(aborts, 1);
+}
+
+TEST_F(S3ProviderTest, BackgroundWriteStopsSubmittingAfterObservedPartFailure) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  const std::string failed_upload_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>AccessDenied</Code>
+  <Message>first part was denied</Message>
+  <RequestId>request-id</RequestId>
+</Error>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::FORBIDDEN, failed_upload_result,
+                                xml_headers(failed_upload_result));
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  // Run each accepted background task inline. The first part's failure is
+  // therefore recorded before the same Write() attempts its second part.
+  arrow::MockExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+
+  const uint8_t bytes[] = {7, 8, 9};
+  auto write_status = stream->Write(bytes, 3);
+
+  ASSERT_STATUS_NOT_OK(write_status);
+  auto detail = ExtendStatusDetail::UnwrapStatus(write_status);
+  ASSERT_NE(detail, nullptr) << write_status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied) << write_status.ToString();
+  EXPECT_NE(write_status.message().find("first part was denied"), std::string::npos) << write_status.ToString();
+
+  size_t upload_part_requests = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetURIString().find("partNumber=") != Aws::String::npos) {
+      ++upload_part_requests;
+    }
+  }
+  EXPECT_EQ(upload_part_requests, 1);
+  ASSERT_STATUS_OK(stream->Abort());
+}
+
+TEST_F(S3ProviderTest, BackgroundCloseFailureDoesNotWaitForSiblingPart) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  const std::string failed_upload_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>AccessDenied</Code>
+  <Message>first completed part was denied</Message>
+  <RequestId>request-id</RequestId>
+</Error>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+
+  std::promise<void> sibling_started_promise;
+  auto sibling_started = sibling_started_promise.get_future();
+  std::promise<void> release_sibling_promise;
+  auto release_sibling = release_sibling_promise.get_future().share();
+  std::atomic<bool> sibling_release_timed_out{false};
+
+  Aws::Http::HeaderValueCollection successful_upload_headers;
+  successful_upload_headers["etag"] = "\"etag-2\"";
+  successful_upload_headers["content-length"] = "0";
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse(
+      "?partNumber=1", Aws::Http::HttpResponseCode::FORBIDDEN, failed_upload_result, xml_headers(failed_upload_result),
+      [&sibling_started] { EXPECT_EQ(sibling_started.wait_for(std::chrono::seconds(5)), std::future_status::ready); });
+  mock_client_->EnqueueResponse("?partNumber=2", Aws::Http::HttpResponseCode::OK, "", successful_upload_headers,
+                                [&sibling_started_promise, release_sibling, &sibling_release_timed_out] {
+                                  sibling_started_promise.set_value();
+                                  if (release_sibling.wait_for(std::chrono::seconds(10)) != std::future_status::ready) {
+                                    sibling_release_timed_out.store(true, std::memory_order_release);
+                                  }
+                                });
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  ASSERT_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(2));
+  arrow::io::IOContext io_context(pool.get());
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+
+  const uint8_t bytes[] = {7, 8};
+  ASSERT_STATUS_OK(stream->Write(bytes, 2));
+  auto close_future = stream->CloseAsync();
+
+  const auto sibling_state = sibling_started.wait_for(std::chrono::seconds(5));
+  const bool finished_before_sibling_release = sibling_state == std::future_status::ready && close_future.Wait(5.0);
+  std::optional<arrow::Status> observed_status;
+  if (finished_before_sibling_release) {
+    observed_status = close_future.status();
+  }
+  release_sibling_promise.set_value();
+  pool->WaitForIdle();
+
+  ASSERT_EQ(sibling_state, std::future_status::ready);
+  ASSERT_TRUE(finished_before_sibling_release) << "upload failure waited for a sibling part";
+  ASSERT_TRUE(observed_status.has_value());
+  ASSERT_STATUS_NOT_OK(*observed_status);
+  auto detail = ExtendStatusDetail::UnwrapStatus(*observed_status);
+  ASSERT_NE(detail, nullptr) << observed_status->ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied) << observed_status->ToString();
+  EXPECT_NE(observed_status->message().find("first completed part was denied"), std::string::npos)
+      << observed_status->ToString();
+  EXPECT_FALSE(sibling_release_timed_out.load(std::memory_order_acquire));
+  size_t remote_aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++remote_aborts;
+    }
+  }
+  EXPECT_EQ(remote_aborts, 1) << "failed CloseAsync must release its multipart upload without a second Abort call";
+}
+
+TEST_F(S3ProviderTest, BackgroundAbortRunsAfterInFlightPartSettles) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  Aws::Http::HeaderValueCollection create_headers;
+  create_headers["content-type"] = "application/xml";
+  create_headers["content-length"] = std::to_string(create_result.size());
+
+  std::promise<void> upload_started_promise;
+  auto upload_started = upload_started_promise.get_future();
+  std::promise<void> release_upload_promise;
+  auto release_upload = release_upload_promise.get_future().share();
+  std::promise<void> abort_seen_promise;
+  auto abort_seen = abort_seen_promise.get_future();
+  std::atomic<bool> upload_release_timed_out{false};
+
+  Aws::Http::HeaderValueCollection upload_headers;
+  upload_headers["etag"] = "\"etag-1\"";
+  upload_headers["content-length"] = "0";
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, create_headers);
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::OK, "", upload_headers,
+                                [&upload_started_promise, release_upload, &upload_release_timed_out] {
+                                  upload_started_promise.set_value();
+                                  if (release_upload.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+                                    upload_release_timed_out.store(true, std::memory_order_release);
+                                  }
+                                });
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "", {},
+                                [&abort_seen_promise] { abort_seen_promise.set_value(); });
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  ASSERT_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(1));
+  arrow::io::IOContext io_context(pool.get());
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+  ASSERT_EQ(upload_started.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+  ASSERT_STATUS_OK(stream->Abort());
+  stream.reset();
+
+  auto count_remote_aborts = [this] {
+    size_t count = 0;
+    for (const auto& request : mock_client_->GetRecordedRequests()) {
+      if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+          request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+        ++count;
+      }
+    }
+    return count;
+  };
+  EXPECT_EQ(count_remote_aborts(), 0);
+
+  release_upload_promise.set_value();
+  ASSERT_EQ(abort_seen.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  pool->WaitForIdle();
+
+  EXPECT_FALSE(upload_release_timed_out.load(std::memory_order_acquire));
+  EXPECT_EQ(count_remote_aborts(), 1);
+}
+
+TEST_F(S3ProviderTest, RepeatedAbortCannotStealDeferredUploadIdentity) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  Aws::Http::HeaderValueCollection create_headers;
+  create_headers["content-type"] = "application/xml";
+  create_headers["content-length"] = std::to_string(create_result.size());
+
+  std::promise<void> upload_started_promise;
+  auto upload_started = upload_started_promise.get_future();
+  std::promise<void> release_upload_promise;
+  auto release_upload = release_upload_promise.get_future().share();
+  std::promise<void> completion_published_promise;
+  auto completion_published = completion_published_promise.get_future();
+  std::promise<void> release_completion_promise;
+  auto release_completion = release_completion_promise.get_future().share();
+  std::atomic<bool> upload_release_timed_out{false};
+  std::atomic<bool> completion_release_timed_out{false};
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, create_headers);
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::INTERNAL_SERVER_ERROR, "", {},
+                                [&upload_started_promise, release_upload, &upload_release_timed_out] {
+                                  upload_started_promise.set_value();
+                                  if (release_upload.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+                                    upload_release_timed_out.store(true, std::memory_order_release);
+                                  }
+                                });
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  ASSERT_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(1));
+  arrow::io::IOContext io_context(pool.get());
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+  ASSERT_EQ(upload_started.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+  // The failed UploadPart makes CloseAsync take only its error continuation,
+  // so it cannot complete the multipart upload. Its continuation is published
+  // synchronously by HandleUploadOutcome after uploads_in_progress reaches
+  // zero, but before that function calls AbortRecordedUpload. Block there to
+  // make the race with a repeated Abort deterministic.
+  auto close_future = stream->CloseAsync();
+  close_future.AddCallback(
+      [&completion_published_promise, release_completion, &completion_release_timed_out](const arrow::Status&) {
+        completion_published_promise.set_value();
+        if (release_completion.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+          completion_release_timed_out.store(true, std::memory_order_release);
+        }
+      });
+
+  ASSERT_STATUS_OK(stream->Abort());
+  release_upload_promise.set_value();
+  ASSERT_EQ(completion_published.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+  // The second Abort races the last upload completion after its counter is
+  // zero. It must consume the recorded identity itself, not erase it before
+  // the completion can issue the remote abort.
+  ASSERT_STATUS_OK(stream->Abort());
+  release_completion_promise.set_value();
+  pool->WaitForIdle();
+
+  size_t remote_aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++remote_aborts;
+    }
+  }
+  EXPECT_FALSE(upload_release_timed_out.load(std::memory_order_acquire));
+  EXPECT_FALSE(completion_release_timed_out.load(std::memory_order_acquire));
+  EXPECT_EQ(remote_aborts, 1);
+}
+
+TEST_F(S3ProviderTest, AbortAfterSuccessfulMultipartCloseDoesNotDeleteCompletedUpload) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  const std::string complete_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><ETag>"etag-1"</ETag>
+</CompleteMultipartUploadResult>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+  Aws::Http::HeaderValueCollection upload_headers;
+  upload_headers["etag"] = "\"etag-1\"";
+  upload_headers["content-length"] = "0";
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::OK, "", upload_headers);
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, complete_result,
+                                xml_headers(complete_result));
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+  ASSERT_STATUS_OK(stream->Close());
+  ASSERT_STATUS_OK(stream->Abort());
+  // Abort after a successful Close is a no-op in every respect: it must not
+  // poison the terminal result seen by a later idempotent Close.
+  ASSERT_STATUS_OK(stream->Close());
+
+  size_t remote_aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++remote_aborts;
+    }
+  }
+  EXPECT_EQ(remote_aborts, 0);
+}
+
+TEST_F(S3ProviderTest, FailedCloseAutomaticallyAbortsMultipartAndPreservesPrimaryFailure) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  const std::string complete_failure = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>complete was denied</Message><RequestId>request-id</RequestId></Error>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+  Aws::Http::HeaderValueCollection upload_headers;
+  upload_headers["etag"] = "\"etag-1\"";
+  upload_headers["content-length"] = "0";
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::OK, "", upload_headers);
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::FORBIDDEN, complete_failure,
+                                xml_headers(complete_failure));
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+
+  auto close_status = stream->Close();
+  ASSERT_STATUS_NOT_OK(close_status);
+  ExpectExtendStatusCode(close_status, ExtendStatusCode::StorageAccessDenied);
+  EXPECT_NE(close_status.message().find("complete was denied"), std::string::npos) << close_status.ToString();
+
+  size_t remote_aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++remote_aborts;
+    }
+  }
+  EXPECT_EQ(remote_aborts, 1);
+}
+
+TEST_F(S3ProviderTest, ExplicitAbortReturnsRemoteFailureAndKeepsUploadIdentityForRetry) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+  Aws::Http::HeaderValueCollection upload_headers;
+  upload_headers["etag"] = "\"etag-1\"";
+  upload_headers["content-length"] = "0";
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::OK, "", upload_headers);
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE, "");
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = false;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+
+  auto abort_status = stream->Abort();
+  ASSERT_STATUS_NOT_OK(abort_status);
+  ExpectExtendStatusCode(abort_status, ExtendStatusCode::StorageTransientService);
+  ASSERT_STATUS_OK(stream->Abort());
+
+  size_t remote_aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++remote_aborts;
+    }
+  }
+  EXPECT_EQ(remote_aborts, 2);
+}
+
+TEST_F(S3ProviderTest, FailedCloseAsyncAutomaticallyAbortsMultipartAndPreservesPrimaryFailure) {
+  const std::string create_result = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Bucket>bucket</Bucket><Key>key</Key><UploadId>upload-id</UploadId>
+</InitiateMultipartUploadResult>)xml";
+  const std::string complete_failure = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>async complete was denied</Message><RequestId>request-id</RequestId></Error>)xml";
+  auto xml_headers = [](const std::string& body) {
+    Aws::Http::HeaderValueCollection headers;
+    headers["content-type"] = "application/xml";
+    headers["content-length"] = std::to_string(body.size());
+    return headers;
+  };
+  Aws::Http::HeaderValueCollection upload_headers;
+  upload_headers["etag"] = "\"etag-1\"";
+  upload_headers["content-length"] = "0";
+
+  mock_client_->EnqueueResponse("?uploads", Aws::Http::HttpResponseCode::OK, create_result, xml_headers(create_result));
+  mock_client_->EnqueueResponse("?partNumber=1", Aws::Http::HttpResponseCode::OK, "", upload_headers);
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::FORBIDDEN, complete_failure,
+                                xml_headers(complete_failure));
+  mock_client_->EnqueueResponse("uploadId=upload-id", Aws::Http::HttpResponseCode::OK, "");
+
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  arrow::MockExecutor executor;
+  arrow::io::IOContext io_context(&executor);
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 1));
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+
+  auto close_status = stream->CloseAsync().status();
+  ASSERT_STATUS_NOT_OK(close_status);
+  ExpectExtendStatusCode(close_status, ExtendStatusCode::StorageAccessDenied);
+  EXPECT_NE(close_status.message().find("async complete was denied"), std::string::npos) << close_status.ToString();
+
+  size_t remote_aborts = 0;
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    if (request->GetMethod() == Aws::Http::HttpMethod::HTTP_DELETE &&
+        request->GetURIString().find("uploadId=upload-id") != Aws::String::npos) {
+      ++remote_aborts;
+    }
+  }
+  EXPECT_EQ(remote_aborts, 1);
+}
+
+TEST_F(S3ProviderTest, BackgroundCloseAsyncPreservesSubmissionFailure) {
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  RejectingS3Executor executor;
+  arrow::io::IOContext io_context(&executor);
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options, io_context));
+  // Keep the byte buffered so the first background submission happens inside
+  // CloseAsync(), exercising its synchronous submission-error path.
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 2));
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+
+  auto close_status = stream->CloseAsync().status();
+  ASSERT_STATUS_NOT_OK(close_status);
+  EXPECT_NE(close_status.message().find("executor rejected S3 upload task"), std::string::npos)
+      << close_status.ToString();
+  EXPECT_TRUE(stream->closed());
+}
+
+TEST_F(S3ProviderTest, BackgroundCloseAsyncPreservesSynchronousPrimaryFailure) {
+  S3Options options;
+  options.ConfigureAnonymousCredentials();
+  options.region = "us-east-1";
+  options.scheme = "http";
+  options.endpoint_override = "mock-s3.local";
+  options.cloud_provider = kCloudProviderAWS;
+  options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+  options.use_crt_async_reads = false;
+  options.background_writes = true;
+
+  ASSERT_AND_ASSIGN(auto fs, S3FileSystem::Make(options));
+  ASSERT_AND_ASSIGN(auto stream, fs->OpenOutputStreamWithUploadSize("bucket/key", nullptr, 2));
+  const uint8_t byte = 7;
+  ASSERT_STATUS_OK(stream->Write(&byte, 1));
+
+  ScopedFiuFault fault(FIUKEY_S3FS_WRITER_CLOSE_FAIL);
+  ASSERT_EQ(0, fault.enable_result());
+  auto close_status = stream->CloseAsync().status();
+
+  ASSERT_STATUS_NOT_OK(close_status);
+  EXPECT_NE(close_status.message().find(FIUKEY_S3FS_WRITER_CLOSE_FAIL), std::string::npos) << close_status.ToString();
+  auto detail = ExtendStatusDetail::UnwrapStatus(close_status);
+  ASSERT_NE(detail, nullptr) << close_status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientNetwork) << close_status.ToString();
+  EXPECT_TRUE(stream->closed());
+}
+
+TEST_F(S3ProviderTest, CopyObjectNotFoundReportsMissingObjectWithoutProbe) {
+  auto make_fs = []() -> arrow::Result<std::shared_ptr<S3FileSystem>> {
+    S3Options options;
+    options.ConfigureAnonymousCredentials();
+    options.region = "us-east-1";
+    options.scheme = "http";
+    options.endpoint_override = "mock-s3.local";
+    options.cloud_provider = kCloudProviderAWS;
+    options.retry_strategy = S3RetryStrategy::GetAwsDefaultRetryStrategy(/*max_attempts=*/0);
+    options.use_crt_async_reads = false;
+    return S3FileSystem::Make(options);
+  };
+
+  // CopyObject's generic 404 (missing source key, source bucket, or
+  // destination bucket) is reported as a missing object in ONE request; the
+  // per-bucket HeadBucket probes are deliberately not issued.
+  mock_client_->EnqueueResponse("mock-s3.local", Aws::Http::HttpResponseCode::NOT_FOUND, "");
+  ASSERT_AND_ASSIGN(auto missing_source_object_fs, make_fs());
+  auto missing_source_object =
+      missing_source_object_fs->CopyFile("source-bucket/source-key", "destination-bucket/destination-key");
+  ASSERT_STATUS_NOT_OK(missing_source_object);
+  auto object_detail = ExtendStatusDetail::UnwrapStatus(missing_source_object);
+  ASSERT_NE(object_detail, nullptr) << missing_source_object.ToString();
+  EXPECT_EQ(object_detail->code(), ExtendStatusCode::StorageNotFound) << missing_source_object.ToString();
+  EXPECT_EQ(CategoryForExtendStatusCode(object_detail->code()), ErrorCategory::System);
+  // Only the failing CopyObject (plus SDK retries) -- the per-bucket
+  // HeadBucket probes would show up as HEAD requests.
+  for (const auto& request : mock_client_->GetRecordedRequests()) {
+    EXPECT_NE(request->GetMethod(), Aws::Http::HttpMethod::HTTP_HEAD) << "unexpected disambiguation probe";
+  }
 }
 
 // ============================================================================
@@ -678,26 +2727,17 @@ class HuaweiCloudCredentialsProviderTestHelper {
   public:
   using Provider = HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider;
 
-  static void setLastReloadFailed(Provider& p,
-                                  bool failed,
-                                  std::chrono::steady_clock::time_point time = std::chrono::steady_clock::now()) {
-    p.m_lastReloadFailed = failed;
-    p.m_lastFailedReloadTime = time;
-  }
-
   static void setCredentials(Provider& p, const Aws::Auth::AWSCredentials& creds) { p.m_credentials = creds; }
 
   static void setTokenFile(Provider& p, const Aws::String& path) { p.m_tokenFile = path; }
 
   static void setInitialized(Provider& p, bool val) { p.m_initialized = val; }
-
-  static bool isInCooldown(const Provider& p) { return p.IsInCooldown(); }
 };
 
 using Helper = HuaweiCloudCredentialsProviderTestHelper;
 
 // ============================================================================
-// Huawei Cloud Provider — Cooldown & Resilience Tests
+// Huawei Cloud Provider — Resilience Tests
 // ============================================================================
 
 // Helper: count requests whose URL contains a given substring
@@ -710,88 +2750,6 @@ static size_t CountRequestsByUrl(const std::vector<std::shared_ptr<Aws::Http::Ht
     }
   }
   return count;
-}
-
-TEST_F(S3ProviderTest, TestHuaweiProviderCooldownBlocksRetry) {
-  // After STS failure, immediate retry should be blocked by cooldown.
-  TempFile token_file("mock_huawei_id_token");
-
-  ScopedEnvVar set_region("HUAWEICLOUD_SDK_REGION", "cn-north-4");
-  ScopedEnvVar set_project("HUAWEICLOUD_SDK_PROJECT_ID", "test-project-id");
-  ScopedEnvVar set_token("HUAWEICLOUD_SDK_ID_TOKEN_FILE", token_file.path());
-  ScopedEnvVar set_idp("HUAWEICLOUD_SDK_IDP_ID", "test-idp");
-
-  // Enqueue failure for step 1
-  mock_client_->EnqueueResponse("id-token/tokens", Aws::Http::HttpResponseCode::FORBIDDEN, "Access denied");
-
-  HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
-
-  // First call: attempts STS and fails
-  auto creds1 = provider.GetAWSCredentials();
-  EXPECT_TRUE(creds1.GetAWSAccessKeyId().empty());
-
-  size_t requests_after_first = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_GT(requests_after_first, 0u) << "First call should attempt STS";
-
-  // Second call immediately: cooldown should block new STS attempt
-  auto creds2 = provider.GetAWSCredentials();
-  EXPECT_TRUE(creds2.GetAWSAccessKeyId().empty());
-
-  size_t requests_after_second = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_EQ(requests_after_first, requests_after_second) << "Cooldown should prevent new STS requests";
-
-  // Third call also blocked
-  auto creds3 = provider.GetAWSCredentials();
-  EXPECT_TRUE(creds3.GetAWSAccessKeyId().empty());
-
-  size_t requests_after_third = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_EQ(requests_after_first, requests_after_third) << "Cooldown should still prevent STS requests";
-}
-
-TEST_F(S3ProviderTest, TestHuaweiProviderCooldownExpiresAndRetries) {
-  // Simulate cooldown expiry via helper (no sleep needed).
-  TempFile token_file("mock_huawei_id_token");
-
-  ScopedEnvVar set_region("HUAWEICLOUD_SDK_REGION", "cn-north-4");
-  ScopedEnvVar set_project("HUAWEICLOUD_SDK_PROJECT_ID", "test-project-id");
-  ScopedEnvVar set_token("HUAWEICLOUD_SDK_ID_TOKEN_FILE", token_file.path());
-  ScopedEnvVar set_idp("HUAWEICLOUD_SDK_IDP_ID", "test-idp");
-
-  // First call fails
-  mock_client_->EnqueueResponse("id-token/tokens", Aws::Http::HttpResponseCode::FORBIDDEN, "Access denied");
-
-  HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
-  auto creds1 = provider.GetAWSCredentials();
-  EXPECT_TRUE(creds1.GetAWSAccessKeyId().empty());
-
-  size_t requests_after_first = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-
-  // Manipulate the failure timestamp to simulate cooldown expiry (6s ago > 5s urgent cooldown)
-  Helper::setLastReloadFailed(provider, true, std::chrono::steady_clock::now() - std::chrono::seconds(6));
-
-  // Enqueue success responses for retry
-  Aws::Http::HeaderValueCollection step1_headers;
-  step1_headers["x-subject-token"] = "MOCK_SUBJECT_TOKEN";
-  mock_client_->EnqueueResponse("id-token/tokens", Aws::Http::HttpResponseCode::CREATED, "", step1_headers);
-
-  std::string step2_json = R"({
-    "credential": {
-      "access": "RECOVERED_AK",
-      "secret": "RECOVERED_SK",
-      "securitytoken": "RECOVERED_TOKEN",
-      "expires_at": "2099-12-31T23:59:59Z"
-    }
-  })";
-  mock_client_->EnqueueResponse("securitytokens", Aws::Http::HttpResponseCode::OK, step2_json);
-
-  // After cooldown expires, should retry and succeed
-  auto creds2 = provider.GetAWSCredentials();
-  EXPECT_EQ(creds2.GetAWSAccessKeyId(), "RECOVERED_AK");
-  EXPECT_EQ(creds2.GetAWSSecretKey(), "RECOVERED_SK");
-  EXPECT_EQ(creds2.GetSessionToken(), "RECOVERED_TOKEN");
-
-  size_t requests_after_retry = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_GT(requests_after_retry, requests_after_first) << "Should have made new STS request after cooldown expired";
 }
 
 TEST_F(S3ProviderTest, TestHuaweiProviderCachesValidCredentials) {
@@ -862,63 +2820,13 @@ TEST_F(S3ProviderTest, TestHuaweiProviderReturnsEmptyWhenCredsFullyExpired) {
 
   HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
 
-  // First call loads expired credentials, then RefreshIfExpired tries to reload but no more
-  // mock responses available. The credentials are stored but expired.
-  // Put provider in cooldown so RefreshIfExpired skips reload on subsequent calls.
+  // First call loads expired credentials. RefreshIfExpired will then try to
+  // reload, but no more mock responses are available.
   provider.GetAWSCredentials();
-  Helper::setLastReloadFailed(provider, true, std::chrono::steady_clock::now());
 
   // Now GetAWSCredentials should return empty, not the expired credentials
   auto creds = provider.GetAWSCredentials();
   EXPECT_TRUE(creds.IsEmpty()) << "Should return empty credentials instead of expired ones";
-}
-
-TEST_F(S3ProviderTest, TestHuaweiProviderCooldownRetainsCredsOnRefreshFailure) {
-  // When credentials expire soon and refresh fails, cooldown activates and existing creds are retained.
-  TempFile token_file("mock_huawei_id_token");
-
-  ScopedEnvVar set_region("HUAWEICLOUD_SDK_REGION", "cn-north-4");
-  ScopedEnvVar set_project("HUAWEICLOUD_SDK_PROJECT_ID", "test-project-id");
-  ScopedEnvVar set_token("HUAWEICLOUD_SDK_ID_TOKEN_FILE", token_file.path());
-  ScopedEnvVar set_idp("HUAWEICLOUD_SDK_IDP_ID", "test-idp");
-
-  // First call: success with short-lived expiration (expires in 60s, within 180s grace period)
-  Aws::Http::HeaderValueCollection step1_headers;
-  step1_headers["x-subject-token"] = "MOCK_SUBJECT_TOKEN";
-  mock_client_->EnqueueResponse("id-token/tokens", Aws::Http::HttpResponseCode::CREATED, "", step1_headers);
-
-  auto now = std::chrono::system_clock::now();
-  auto expires = now + std::chrono::seconds(60);
-  auto expire_time_t = std::chrono::system_clock::to_time_t(expires);
-  char expire_buf[64];
-  std::strftime(expire_buf, sizeof(expire_buf), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&expire_time_t));
-
-  std::string step2_json =
-      std::string(R"({"credential":{"access":"AK1","secret":"SK1","securitytoken":"TK1","expires_at":")") + expire_buf +
-      R"("}})";
-  mock_client_->EnqueueResponse("securitytokens", Aws::Http::HttpResponseCode::OK, step2_json);
-
-  HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
-  auto creds1 = provider.GetAWSCredentials();
-  EXPECT_EQ(creds1.GetAWSAccessKeyId(), "AK1");
-
-  // Second call: credentials expire soon (within grace period), refresh fails
-  mock_client_->EnqueueResponse("id-token/tokens", Aws::Http::HttpResponseCode::FORBIDDEN, "fail");
-
-  auto creds2 = provider.GetAWSCredentials();
-  // Should retain existing AK1 since it's not fully expired yet
-  EXPECT_EQ(creds2.GetAWSAccessKeyId(), "AK1");
-
-  // Third call immediately: should be in cooldown, still return AK1
-  auto creds3 = provider.GetAWSCredentials();
-  EXPECT_EQ(creds3.GetAWSAccessKeyId(), "AK1");
-
-  // Verify cooldown is blocking requests
-  size_t requests_before = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  auto creds4 = provider.GetAWSCredentials();
-  EXPECT_EQ(creds4.GetAWSAccessKeyId(), "AK1");
-  size_t requests_after = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_EQ(requests_before, requests_after) << "Cooldown should still block retry";
 }
 
 TEST_F(S3ProviderTest, TestHuaweiProviderStep2HttpFailure) {
@@ -941,17 +2849,10 @@ TEST_F(S3ProviderTest, TestHuaweiProviderStep2HttpFailure) {
   HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
   auto creds = provider.GetAWSCredentials();
   EXPECT_TRUE(creds.GetAWSAccessKeyId().empty());
-
-  // Subsequent call should be in cooldown
-  size_t requests_before = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  auto creds2 = provider.GetAWSCredentials();
-  EXPECT_TRUE(creds2.GetAWSAccessKeyId().empty());
-  size_t requests_after = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_EQ(requests_before, requests_after) << "Cooldown should block retry after Step 2 failure";
 }
 
 TEST_F(S3ProviderTest, TestHuaweiProviderStep2MissingCredentialField) {
-  // Step 2 returns JSON without "credential" field → empty credentials + cooldown.
+  // Step 2 returns JSON without "credential" field → empty credentials.
   TempFile token_file("mock_huawei_id_token");
 
   ScopedEnvVar set_region("HUAWEICLOUD_SDK_REGION", "cn-north-4");
@@ -969,12 +2870,6 @@ TEST_F(S3ProviderTest, TestHuaweiProviderStep2MissingCredentialField) {
   HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
   auto creds = provider.GetAWSCredentials();
   EXPECT_TRUE(creds.GetAWSAccessKeyId().empty());
-
-  // Verify cooldown is active
-  size_t requests_before = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  provider.GetAWSCredentials();
-  size_t requests_after = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_EQ(requests_before, requests_after) << "Cooldown should be active after missing credential field";
 }
 
 TEST_F(S3ProviderTest, TestHuaweiProviderDurationSeconds7200) {
@@ -1079,7 +2974,7 @@ TEST_F(S3ProviderTest, TestHuaweiProviderConcurrentAccessNoStorm) {
 }
 
 TEST_F(S3ProviderTest, TestHuaweiProviderStep2EmptySessionToken) {
-  // Step 2 returns valid ak/sk but empty securitytoken → should fail and activate cooldown.
+  // Step 2 returns valid ak/sk but empty securitytoken → should fail.
   TempFile token_file("mock_huawei_id_token");
 
   ScopedEnvVar set_region("HUAWEICLOUD_SDK_REGION", "cn-north-4");
@@ -1105,12 +3000,6 @@ TEST_F(S3ProviderTest, TestHuaweiProviderStep2EmptySessionToken) {
   HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider provider;
   auto creds = provider.GetAWSCredentials();
   EXPECT_TRUE(creds.GetAWSAccessKeyId().empty()) << "Empty session token should cause credential rejection";
-
-  // Verify cooldown is active
-  size_t requests_before = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  provider.GetAWSCredentials();
-  size_t requests_after = CountRequestsByUrl(mock_client_->GetRecordedRequests(), "id-token/tokens");
-  EXPECT_EQ(requests_before, requests_after) << "Cooldown should be active after empty session token";
 }
 
 TEST_F(S3ProviderTest, TestHuaweiProviderStep2MissingExpiresAt) {
@@ -1378,6 +3267,8 @@ TEST_F(S3ProviderTest, TestAliyunRAMProviderEndToEnd) {
 }
 
 TEST_F(S3ProviderTest, TestAliyunRAMProviderImdsV1Fallback) {
+  ScopedEnvUnset v1_disabled("ALIBABA_CLOUD_IMDSV1_DISABLED");
+  ScopedEnvUnset v1_disable("ALIBABA_CLOUD_IMDSV1_DISABLE");
   // V2 token PUT returns 403 (IMDSv2 disabled on this instance) → empty token
   // body; provider falls back to V1-style bare GETs. The rest of the chain
   // still succeeds.
@@ -1405,13 +3296,79 @@ TEST_F(S3ProviderTest, TestAliyunRAMProviderImdsV1Fallback) {
   }
 }
 
+TEST_F(S3ProviderTest, AliyunRamTransientImdsV2TokenFailureDoesNotDowngradeToV1) {
+  for (long attempt = 0; attempt <= kCredentialRetryAttempts; ++attempt) {
+    mock_client_->EnqueueResponse("latest/api/token", Aws::Http::HttpResponseCode::SERVICE_UNAVAILABLE, "");
+  }
+
+  AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess");
+  auto resolved = provider.ResolveForRequest();
+  ASSERT_FALSE(resolved.ok());
+  ExpectExtendStatusCode(resolved.status(), ExtendStatusCode::StorageTransientService);
+
+  const auto requests = mock_client_->GetRecordedRequests();
+  ASSERT_EQ(requests.size(), static_cast<size_t>(kCredentialRetryAttempts + 1));
+  for (const auto& request : requests) {
+    EXPECT_EQ(request->GetMethod(), Aws::Http::HttpMethod::HTTP_PUT)
+        << "a transient token failure must not be followed by an unauthenticated metadata GET";
+  }
+}
+
+TEST_F(S3ProviderTest, AliyunRamImdsV1DisabledRejectsTokenFallback) {
+  ScopedEnvUnset metadata_disabled("ALIBABA_CLOUD_ECS_METADATA_DISABLED");
+  ScopedEnvUnset v1_disable("ALIBABA_CLOUD_IMDSV1_DISABLE");
+  ScopedEnvVar v1_disabled("ALIBABA_CLOUD_IMDSV1_DISABLED", "TrUe");
+  mock_client_->EnqueueResponse("latest/api/token", Aws::Http::HttpResponseCode::FORBIDDEN, "");
+
+  AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess");
+  auto resolved = provider.ResolveForRequest();
+  ASSERT_FALSE(resolved.ok());
+  ExpectExtendStatusCode(resolved.status(), ExtendStatusCode::StorageAccessDenied);
+
+  const auto requests = mock_client_->GetRecordedRequests();
+  ASSERT_EQ(requests.size(), 1u);
+  EXPECT_EQ(requests.front()->GetMethod(), Aws::Http::HttpMethod::HTTP_PUT)
+      << "ALIBABA_CLOUD_IMDSV1_DISABLED must prevent a bare metadata GET";
+}
+
+TEST_F(S3ProviderTest, AliyunRamSingularImdsV1DisableRejectsTokenFallback) {
+  ScopedEnvUnset metadata_disabled("ALIBABA_CLOUD_ECS_METADATA_DISABLED");
+  ScopedEnvUnset v1_disabled("ALIBABA_CLOUD_IMDSV1_DISABLED");
+  ScopedEnvVar v1_disable("ALIBABA_CLOUD_IMDSV1_DISABLE", "TRUE");
+  mock_client_->EnqueueResponse("latest/api/token", Aws::Http::HttpResponseCode::FORBIDDEN, "");
+
+  AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess");
+  auto resolved = provider.ResolveForRequest();
+  ASSERT_FALSE(resolved.ok());
+  ExpectExtendStatusCode(resolved.status(), ExtendStatusCode::StorageAccessDenied);
+
+  const auto requests = mock_client_->GetRecordedRequests();
+  ASSERT_EQ(requests.size(), 1u);
+  EXPECT_EQ(requests.front()->GetMethod(), Aws::Http::HttpMethod::HTTP_PUT)
+      << "ALIBABA_CLOUD_IMDSV1_DISABLE must prevent a bare metadata GET";
+}
+
+TEST_F(S3ProviderTest, AliyunRamMetadataDisabledStopsBeforeHttp) {
+  ScopedEnvVar metadata_disabled("ALIBABA_CLOUD_ECS_METADATA_DISABLED", "TRUE");
+  ScopedEnvUnset v1_disabled("ALIBABA_CLOUD_IMDSV1_DISABLED");
+  ScopedEnvUnset v1_disable("ALIBABA_CLOUD_IMDSV1_DISABLE");
+
+  AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess");
+  auto resolved = provider.ResolveForRequest();
+  ASSERT_FALSE(resolved.ok());
+  ExpectExtendStatusCode(resolved.status(), ExtendStatusCode::StorageConfigInvalid);
+  EXPECT_TRUE(mock_client_->GetRecordedRequests().empty());
+}
+
 TEST_F(S3ProviderTest, TestAliyunRAMProviderImdsRoleListFails) {
   mock_client_->EnqueueResponse("latest/api/token", Aws::Http::HttpResponseCode::OK, "v2-token");
   mock_client_->EnqueueResponse("security-credentials/", Aws::Http::HttpResponseCode::NOT_FOUND, "");
 
   AliyunRAMCredentialsProvider provider("acs:ram::123456:role/target-role", "sess");
-  auto creds = provider.GetAWSCredentials();
-  EXPECT_TRUE(creds.IsEmpty());
+  auto resolved = provider.ResolveForRequest();
+  ASSERT_FALSE(resolved.ok());
+  EXPECT_TRUE(resolved.status().IsIOError()) << resolved.status().ToString();
+  ExpectExtendStatusCode(resolved.status(), ExtendStatusCode::StorageConfigInvalid);
 }
 
 TEST_F(S3ProviderTest, TestAliyunRAMProviderImdsRoleListEmpty) {


### PR DESCRIPTION
## Summary

Part 2 of the six-PR split of #603.

- Preserve typed S3, Azure, GCP, and repository-owned credential failures without guessing causes the AWS SDK does not expose.
- Validate partial static credentials and prevent GCP credential identity replacement.
- Put credential resolution, client construction, CRT callbacks, and SDK-owned builders inside safe shutdown lifetimes.
- Make failed S3 close clean up multipart state while preserving the first error; explicit public Abort reports the remote cleanup failure.
- Add a real WITH_CRT=ON CI build and focused lifecycle tests.

Refs #641.
Depends on #603 (taxonomy foundation).

## Review scope

This PR is intentionally limited to cloud filesystem, credential, and SDK lifecycle code. Writer composition and public FFI changes are in later stack entries.

## Validation

- WITH_CRT=True full C++ build.
- 134 focused CRT/S3/GCP tests: 131 passed, 3 environment/format skips.
- 204 focused native cloud tests: 173 passed, 31 environment skips.
- Default Release build passed.

## Stack

Review and merge in order:

1. #603 — taxonomy foundation
2. #647 — cloud filesystems, credentials, and lifecycle
3. #648 — Rust format error envelope
4. #649 — writer failure and output ownership
5. #650 — Packed metadata and missing-field projections
6. #651 — public API lifetime and consumer migration

Each PR is based on the preceding stack branch. After one PR merges, rebase the remaining stack onto the updated `main` (required for squash merges), update the synthetic branches with force-with-lease, and then retarget the next PR to `main`.
