### PR TITLE
fix: preserve typed errors across Rust format streams

### DIFF
--- a/cpp/benchmark/benchmark_format_read.cpp
+++ b/cpp/benchmark/benchmark_format_read.cpp
@@ -335,16 +335,12 @@ class FormatReadBenchmark : public FormatBenchFixtureBase<> {
   arrow::Result<PreparedReaderFile> PrepareIcebergReaderFile() const {
     ARROW_ASSIGN_OR_RAISE(auto table_uri, MakeIcebergTableUri(GetUniquePath("iceberg_read_test")));
 
-    iceberg::IcebergTestTableInfo table_info;
-    std::vector<iceberg::IcebergFileInfo> file_infos;
-    try {
-      auto storage_options = iceberg::ToStorageOptions(fs_config_);
-      table_info =
-          iceberg::CreateTestTable(table_uri, static_cast<uint64_t>(GetLoaderNumRows()), false, {}, storage_options);
-      file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
-    } catch (const std::exception& e) {
-      return arrow::Status::IOError("Failed to create Iceberg benchmark table: ", e.what());
-    }
+    auto storage_options = iceberg::ToStorageOptions(fs_config_);
+    ARROW_ASSIGN_OR_RAISE(
+        auto table_info,
+        iceberg::CreateTestTable(table_uri, static_cast<uint64_t>(GetLoaderNumRows()), false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
 
     if (file_infos.empty()) {
       return arrow::Status::Invalid("Iceberg PlanFiles returned no files");

--- a/cpp/include/milvus-storage/format/async_tasks.h
+++ b/cpp/include/milvus-storage/format/async_tasks.h
@@ -14,14 +14,24 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <memory>
+#include <new>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include <arrow/result.h>
+#include <arrow/status.h>
+#include <folly/futures/Future.h>
+#include <folly/futures/Promise.h>
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/properties.h"
 
 namespace milvus_storage::api {
@@ -34,6 +44,116 @@ enum class AsyncTaskSplitStrategy : size_t {
   kSplitToParallelism = 1,
   kSplitAll = 2,
 };
+
+// Collect Arrow Result futures in input order. The returned future completes
+// as soon as any child reports an error; already-started children remain owned
+// by the drain branch and may finish in the background. Exceptional child
+// futures are classified explicitly at this library boundary.
+template <typename T>
+folly::SemiFuture<arrow::Result<std::vector<T>>> CollectAllResultsFailFast(
+    std::vector<folly::SemiFuture<arrow::Result<T>>> futures,
+    std::string_view operation = "asynchronous reader fan-in") {
+  using ItemResult = arrow::Result<T>;
+  using OutputResult = arrow::Result<std::vector<T>>;
+
+  if (futures.empty()) {
+    return folly::makeSemiFuture(OutputResult(std::vector<T>{}));
+  }
+
+  struct FirstFailure {
+    explicit FirstFailure(std::string operation) : operation(std::move(operation)) {}
+
+    std::atomic<bool> fulfilled{false};
+    folly::Promise<OutputResult> promise;
+    std::string operation;
+
+    // Once a child has failed, formatting and publishing that failure are part
+    // of the fail-fast contract. They must not throw back into Folly before the
+    // promise is fulfilled: Folly would store that exception on the observed
+    // child and a blocked sibling could then keep both fan-in branches pending
+    // forever. A real allocation failure in either operation is therefore
+    // fail-stop rather than recoverable.
+    arrow::Status from_exception(const folly::exception_wrapper& exception) const noexcept {
+      return arrow::Status::UnknownError(operation,
+                                         " child future raised a C++ exception: ", exception.what().toStdString());
+    }
+
+    void set(const arrow::Status& status) noexcept {
+      if (!fulfilled.exchange(true, std::memory_order_relaxed)) {
+        promise.setValue(OutputResult(status));
+      }
+    }
+  };
+
+  auto first_failure = std::make_shared<FirstFailure>(std::string(operation));
+  auto first_failure_future = first_failure->promise.getSemiFuture();
+
+  std::vector<folly::SemiFuture<ItemResult>> observed;
+  observed.reserve(futures.size());
+  for (auto& future : futures) {
+    observed.push_back(std::move(future).defer([first_failure](folly::Try<ItemResult>&& child_try) -> ItemResult {
+      if (child_try.hasException()) {
+        // Keep our own exception handle. Publishing first_failure may run the
+        // downstream collectAny continuation inline and release the observed
+        // child's future state re-entrantly.
+        auto exception = child_try.exception();
+        if (exception.template is_compatible_with<std::bad_alloc>()) {
+          // OOM cannot safely allocate either an Arrow status or the promise
+          // state needed to publish one. Fail-stop is preferable to returning
+          // into Folly with first_failure unresolved while another child can
+          // remain pending forever.
+          std::terminate();
+        }
+
+        ItemResult child_result(first_failure->from_exception(exception));
+        first_failure->set(child_result.status());
+        return child_result;
+      }
+
+      ItemResult child_result = std::move(child_try.value());
+      if (!child_result.ok()) {
+        first_failure->set(child_result.status());
+      }
+      return child_result;
+    }));
+  }
+
+  auto all_success =
+      folly::collectAll(std::move(observed))
+          .deferValue([first_failure](std::vector<folly::Try<ItemResult>>&& child_tries) -> OutputResult {
+            std::vector<T> values;
+            values.reserve(child_tries.size());
+            for (auto& child_try : child_tries) {
+              if (child_try.hasException()) {
+                if (child_try.exception().template is_compatible_with<std::bad_alloc>()) {
+                  std::terminate();
+                }
+                return first_failure->from_exception(child_try.exception());
+              }
+              auto child_result = std::move(child_try.value());
+              if (!child_result.ok()) {
+                return child_result.status();
+              }
+              values.push_back(std::move(child_result).ValueUnsafe());
+            }
+            return values;
+          });
+
+  std::vector<folly::SemiFuture<OutputResult>> completion_futures;
+  completion_futures.reserve(2);
+  completion_futures.push_back(std::move(first_failure_future));
+  completion_futures.push_back(std::move(all_success));
+  return folly::collectAny(std::move(completion_futures))
+      .deferValue([first_failure](std::pair<size_t, folly::Try<OutputResult>>&& first) -> OutputResult {
+        if (first.second.hasException()) {
+          if (first.second.exception().template is_compatible_with<std::bad_alloc>()) {
+            std::terminate();
+          }
+          return first_failure->from_exception(first.second.exception());
+        }
+        return std::move(first.second.value());
+      });
+}
 
 // Resolve reader.async.task_split_strategy; unknown values use the default
 // split-to-parallelism policy.

--- a/cpp/include/milvus-storage/format/iceberg/iceberg_format_reader.h
+++ b/cpp/include/milvus-storage/format/iceberg/iceberg_format_reader.h
@@ -79,7 +79,8 @@ class IcebergFormatReader final : public FormatReader {
 
   private:
   /// Parse delete metadata JSON and read positional delete files.
-  [[nodiscard]] arrow::Result<std::shared_ptr<const std::unordered_set<int64_t>>> load_positional_deletes() const;
+  [[nodiscard]] arrow::Result<std::shared_ptr<const std::unordered_set<int64_t>>> load_positional_deletes(
+      uint64_t physical_row_count) const;
 
   /// Filter a RecordBatch by removing rows at deleted positions.
   /// chunk_start is the global physical offset of the first row in the batch.

--- a/cpp/include/milvus-storage/format/lance/lance_table_writer.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_writer.h
@@ -57,6 +57,10 @@ class LanceTableWriter final : public FormatWriter {
   std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches_;
   std::unique_ptr<BlockingDataset> dataset_;
   std::vector<uint64_t> origin_fids_;
+  /// Whether this writer created the dataset because the open reported it
+  /// missing. Only used to explain the failure if that verdict turns out to
+  /// have been wrong.
+  bool created_dataset_ = false;
   int64_t written_rows_ = 0;
 };
 }  // namespace milvus_storage::lance

--- a/cpp/include/milvus-storage/format/vortex/vortex_footer_internal.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_footer_internal.h
@@ -1,0 +1,78 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+#include "milvus-storage/format/vortex/vortex_types.h"
+
+namespace milvus_storage::vortex::internal {
+
+/// \brief Check a footer byte range against the file it came from.
+///
+/// Extracted from VortexFooterReader::Impl::LoadFooter so the rule can be
+/// tested. It could not be reached from a test where it lived: the range and
+/// the bound are both derived from the same `file_size`, and the range is only
+/// consulted after `VortexFile::OpenUnique` has already accepted that same
+/// `file_size` -- so tampering with it in either direction moves the failure
+/// earlier (inflate and the tail read runs past EOF into sparse zeroes, deflate
+/// and it lands mid-file; either way no EOF trailer parses and OpenUnique
+/// rejects the file first). Reaching this guard end-to-end needs a hand-built
+/// vortex file whose EOF trailer parses but whose footer descriptor lies, and
+/// there is no such fixture in the tree.
+///
+/// So this tests the rule, not the path to it. Stated plainly because the two
+/// are not the same thing, and a green test here does not prove a malformed
+/// Vortex file in production reaches this code.
+///
+/// \param footer_range as reported by the file's own footer descriptor:
+///        exactly two elements, {offset, length}
+/// \param file_size the size the file actually has
+/// \param path used only for the message
+/// \return OK when the range fits inside the file; a VortexDataFormat status
+///         otherwise.
+arrow::Status CheckVortexFooterRange(const std::vector<uint64_t>& footer_range,
+                                     uint64_t file_size,
+                                     const std::string& path);
+
+/// Convert the bridge's {offset, length} result to a byte range. An empty
+/// segment is legal; a result with any other arity is an internal bridge error.
+arrow::Result<ByteRange> FlatSegmentByteRangeFromBytes(const std::vector<uint64_t>& bytes, uint64_t flat_segment_id);
+
+/// \brief Validate the compact field-layout encoding read from a Vortex file.
+///
+/// The vector is persisted layout data, not a caller argument. It contains
+/// `{granularity, unit_count}` followed by `unit_count` records of
+/// `{unit_id, row_offset, row_count, segment_count, segment_ids...}`. Any
+/// unsupported granularity, impossible unit count, truncation, or trailing word
+/// means the encoded layout is invalid and therefore returns VortexDataFormat.
+arrow::Status ValidateVortexFieldLayoutEncoding(const std::vector<uint64_t>& raw_offsets,
+                                                uint64_t rows,
+                                                const std::string& field_name);
+
+/// Classify a segment lookup whose id came from the persisted Vortex layout.
+/// Ordinary lookup failures mean the layout contradicts the file and are
+/// DataFormat; an already-classified failure or caught panic keeps its original
+/// classification instead of being relabelled as DataFormat.
+arrow::Status ClassifyVortexLayoutSegmentLookupFailure(const arrow::Status& failure, uint64_t flat_segment_id);
+
+}  // namespace milvus_storage::vortex::internal

--- a/cpp/scripts/error_handling_baseline.tsv
+++ b/cpp/scripts/error_handling_baseline.tsv
@@ -1,8 +1,6 @@
 throw	cpp/src/common/metadata.cpp	4
 throw	cpp/src/ffi/ffi_fiu_c.cpp	1
 throw	cpp/src/ffi/v2_column_groups_builder.cpp	5
-throw	cpp/src/format/bridge/rust/src/iceberg_bridge.cpp	2
-throw	cpp/src/format/bridge/rust/src/lance_bridge.cpp	21
 throw	cpp/src/format/iceberg/iceberg_common.cpp	2
 throw	cpp/src/format/lance/lance_common.cpp	2
 throw	cpp/src/format/vortex/vortex_translater.cpp	6

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -7197,6 +7197,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-sts",
  "base64",
  "bytes",
  "chrono",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -83,6 +83,7 @@ uuid = { version = "1", features = ["v7"] }
 # AWS SDK (for Lance AssumeRole credential provider)
 aws-config = "1"
 aws-credential-types = "1"
+aws-sdk-sts = { version = "1", default-features = false }
 object_store = { version = "0.13", features = ["aws", "gcp"] }
 
 # HTTP client for the GCP Service Account Impersonation flow in

--- a/cpp/src/format/bridge/rust/include/bridge_error.h
+++ b/cpp/src/format/bridge/rust/include/bridge_error.h
@@ -1,0 +1,155 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <new>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <arrow/c/abi.h>
+#include <arrow/chunked_array.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+namespace milvus_storage::bridge {
+
+// THE decoder for classified errors coming out of the Rust cxx bridges
+// (vortex / lance / iceberg / paimon). One table, one implementation: a code
+// cannot mean one thing for one format and something else for another.
+//
+// One channel: the universal message marker
+// "__LOON_RUST_BRIDGE_ERRCODE__=<code>; message". The Rust side embeds the
+// code at the error's construction (BridgeError's Display, paimon's tagged
+// messages, vortex's LoonFfiError), the code rides wherever the error text
+// rides, and this decoder parses a frame at byte zero or after a fixed bridge
+// wrapper prefix and strips it. Marker text later in a diagnostic is ordinary
+// caller-controlled text.
+//
+// This replaced a thread-local side channel (record beside the error, take
+// after catching), which failed three independent ways: an unclassified
+// construction cleared a verdict recorded earlier in the same call; a verdict
+// recorded on a tokio worker thread was unreadable from the calling thread;
+// and a stale verdict could attach to a later failure. The marker has none of
+// those failure modes because the verdict travels INSIDE the error. The
+// Rust producers escape marker literals in ordinary diagnostics before they
+// enter this channel, so a caller-controlled URI/path cannot forge a code.
+//
+// The code is mapped as:
+//   * code 12 (LOON_FILE_NOT_FOUND)      -> IOError + ENOENT detail
+//   * ExtendStatusCode values (101-122, with reserved gaps)
+//                                           -> IOError + ExtendStatusDetail
+//   * bridge-private codes (>= 1000, never cross the C ABI):
+//       1001 data-corrupt   -> DataCorrupted detail (DataFormat category)
+//       1002 not-supported  -> Status::NotImplemented
+//   * no / unknown marker                -> plain IOError (conservative
+//     non-retriable fallback; never invent retriability)
+
+// Bridge-private marker codes; keep in sync with rust/src/bridge_error.rs.
+inline constexpr int kBridgeErrCodeDataCorrupt = 1001;
+inline constexpr int kBridgeErrCodeNotSupported = 1002;
+
+/// Status for a cxx exception: decode the marker out of `what()`.
+///
+/// The classification rides the universal marker the Rust side embedded in
+/// the error message; a message without a marker is the conservative
+/// non-retriable fallback.
+arrow::Status BridgeErrorStatusFromException(const char* what);
+
+template <typename Fn>
+auto CatchBridgeError(Fn&& fn) -> arrow::Result<decltype(fn())> {
+  try {
+    return fn();
+  } catch (const std::exception& e) {
+    return BridgeErrorStatusFromException(e.what());
+  } catch (...) {
+    return arrow::Status::UnknownError("Rust bridge failed unexpectedly");
+  }
+}
+
+/// Void-returning form.
+template <typename Fn>
+arrow::Status CatchBridgeStatus(Fn&& fn) {
+  try {
+    fn();
+    return arrow::Status::OK();
+  } catch (const std::exception& e) {
+    return BridgeErrorStatusFromException(e.what());
+  } catch (...) {
+    return arrow::Status::UnknownError("Rust bridge failed unexpectedly");
+  }
+}
+
+/// Build the status for a classification an asynchronous bridge I/O callback
+/// reported as an explicit code. THE decoder: every bridge -- vortex, lance,
+/// iceberg, paimon -- funnels through this one table, so a code cannot mean one
+/// thing for one format and something else for another.
+///
+/// `code` 0 means "no classification available" and yields the conservative
+/// IOError fallback, same as an unrecognised code. ExtendStatus details retain
+/// IOError because the callback is reporting an operation that already entered
+/// the bridge I/O path.
+arrow::Status MakeBridgeErrorStatus(int ffi_err_code, std::string_view message);
+
+/// Decode a raw bridge error message (marker stripped) into a structured
+/// arrow::Status per the table above. Use this only where the message is known
+/// to come from a Rust bridge; for anything that may already be an ordinary
+/// arrow::Status, use DecodeBridgeErrorStatus() so a non-bridge failure keeps
+/// its own classification.
+arrow::Status MakeBridgeErrorStatus(std::string_view message);
+
+/// Decode `message` only when it actually carries the bridge marker.
+///
+/// Returns nullopt otherwise, which is the whole point: a status that did not
+/// come from a Rust bridge (arrow's own Invalid/NotImplemented while importing
+/// a C stream, say) must keep the classification its producer gave it instead
+/// of being rewritten into a blanket IOError.
+std::optional<arrow::Status> DecodeBridgeErrorStatus(std::string_view message);
+
+/// Marker-free rendering of a raw bridge error message, for the few sites that
+/// keep their own StatusCode but must not leak the internal marker into a
+/// user-visible message.
+std::string StripBridgeErrorMarker(std::string_view message);
+
+/// Build the status for "these persisted bytes do not decode": DataCorrupted
+/// detail, DataFormat category. Thin alias for MakeExtendError so every format
+/// reports this one condition identically.
+arrow::Status MakeBridgeDataFormatStatus(std::string message);
+
+/// Prefix `context` onto `status`'s message, preserving its StatusCode and
+/// detail (ExtendStatusDetail / errno). OK statuses pass through.
+arrow::Status WithBridgeContext(std::string_view context, const arrow::Status& status);
+
+/// Translate any status that may carry an (encoded or already-structured)
+/// bridge error: already-classified statuses just gain context; otherwise the
+/// message is checked for a marker prefix and rebuilt.
+arrow::Status TranslateBridgeStatus(std::string_view context, const arrow::Status& status);
+
+/// Wrap a RecordBatchReader whose ReadNext/Close surface raw bridge error
+/// strings (arrow FFI stringification of Rust stream errors) so mid-scan
+/// errors are decoded too. `context` is prefixed onto translated errors.
+std::shared_ptr<arrow::RecordBatchReader> WrapBridgeRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner,
+                                                                      std::string context);
+
+/// Import a C stream produced by a Rust bridge and translate errors reported
+/// while pulling its batches.  Arrow's generic importer preserves the error
+/// text but not the bridge marker/detail, so callers that consume the whole
+/// stream as a ChunkedArray must use this helper.
+arrow::Result<std::shared_ptr<arrow::ChunkedArray>> ImportBridgeChunkedArray(ArrowArrayStream* stream,
+                                                                             std::string_view context);
+
+}  // namespace milvus_storage::bridge

--- a/cpp/src/format/bridge/rust/include/iceberg_bridge.h
+++ b/cpp/src/format/bridge/rust/include/iceberg_bridge.h
@@ -18,14 +18,9 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <stdexcept>
+#include <arrow/result.h>
 
 namespace milvus_storage::iceberg {
-
-class IcebergException : public std::runtime_error {
-  public:
-  explicit IcebergException(const std::string& message) : std::runtime_error(message) {}
-};
 
 /// Per-file info returned from PlanFiles
 struct IcebergFileInfo {
@@ -42,9 +37,10 @@ struct IcebergFileInfo {
 /// @param snapshot_id Which snapshot to scan
 /// @param storage_options S3/cloud config as key-value pairs
 /// @return Vector of file info, one per data file in the snapshot
-std::vector<IcebergFileInfo> PlanFiles(const std::string& metadata_location,
-                                       int64_t snapshot_id,
-                                       const std::unordered_map<std::string, std::string>& storage_options);
+arrow::Result<std::vector<IcebergFileInfo>> PlanFiles(
+    const std::string& metadata_location,
+    int64_t snapshot_id,
+    const std::unordered_map<std::string, std::string>& storage_options);
 
 /// Info returned after creating a test Iceberg table.
 struct IcebergTestTableInfo {
@@ -66,11 +62,12 @@ struct IcebergTestTableInfo {
 /// intending to read via native `gs://` with SA impersonation; the Rust side
 /// will byte-rewrite the embedded scheme across every level of the metadata
 /// tree so iceberg-rust's `plan_files` can traverse it under a `gs://` FileIO.
-IcebergTestTableInfo CreateTestTable(const std::string& table_dir,
-                                     uint64_t num_rows,
-                                     bool with_positional_deletes,
-                                     const std::vector<int64_t>& deleted_positions,
-                                     const std::unordered_map<std::string, std::string>& storage_options = {},
-                                     const std::string& record_scheme_override = "");
+arrow::Result<IcebergTestTableInfo> CreateTestTable(
+    const std::string& table_dir,
+    uint64_t num_rows,
+    bool with_positional_deletes,
+    const std::vector<int64_t>& deleted_positions,
+    const std::unordered_map<std::string, std::string>& storage_options = {},
+    const std::string& record_scheme_override = "");
 
 }  // namespace milvus_storage::iceberg

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include <stdexcept>
 #include <arrow/c/abi.h>
 #include <arrow/result.h>
 
@@ -38,11 +37,6 @@ namespace milvus_storage::lance {
 ///
 /// Violating any of the above leads to undefined behavior (use-after-free, data races).
 void ReplaceLanceRuntime(uint32_t num_threads);
-
-class LanceException : public std::runtime_error {
-  public:
-  explicit LanceException(const std::string& message) : std::runtime_error(message) {}
-};
 
 class BlockingFragmentReader;
 class BlockingScanner;
@@ -69,19 +63,21 @@ enum class LanceDataStorageFormat : uint8_t {
 
 class BlockingDataset {
   public:
-  static std::shared_ptr<BlockingDataset> Open(const std::string& uri, const StorageOptions& storage_options = {});
+  static arrow::Result<std::shared_ptr<BlockingDataset>> Open(const std::string& uri,
+                                                              const StorageOptions& storage_options = {});
 
-  static std::unique_ptr<BlockingDataset> OpenUnique(const std::string& uri,
-                                                     const StorageOptions& storage_options = {});
+  static arrow::Result<std::unique_ptr<BlockingDataset>> OpenUnique(const std::string& uri,
+                                                                    const StorageOptions& storage_options = {});
 
-  static std::unique_ptr<BlockingDataset> WriteDataset(const std::string& uri,
-                                                       struct ArrowArrayStream* stream,
-                                                       const StorageOptions& storage_options = {},
-                                                       LanceDataStorageFormat format = LanceDataStorageFormat::Stable);
+  static arrow::Result<std::unique_ptr<BlockingDataset>> WriteDataset(
+      const std::string& uri,
+      struct ArrowArrayStream* stream,
+      const StorageOptions& storage_options = {},
+      LanceDataStorageFormat format = LanceDataStorageFormat::Stable);
 
   explicit BlockingDataset(rust::Box<ffi::BlockingDataset> impl) : impl_(std::move(impl)) {}
 
-  void WriteArrowArrayStream(struct ArrowArrayStream* stream);
+  arrow::Status WriteArrowArrayStream(struct ArrowArrayStream* stream);
 
   BlockingDataset(BlockingDataset&&) noexcept = default;
   BlockingDataset& operator=(BlockingDataset&&) noexcept = default;
@@ -89,30 +85,30 @@ class BlockingDataset {
   BlockingDataset(const BlockingDataset&) = delete;
   BlockingDataset& operator=(const BlockingDataset&) = delete;
 
-  void DeleteRows(const std::string& predicate);
+  arrow::Status DeleteRows(const std::string& predicate);
 
-  std::vector<uint64_t> GetAllFragmentIds() const;
+  arrow::Result<std::vector<uint64_t>> GetAllFragmentIds() const;
 
-  std::vector<uint64_t> GetFragmentDeletionPositions(uint64_t fragment_id) const;
+  arrow::Result<std::vector<uint64_t>> GetFragmentDeletionPositions(uint64_t fragment_id) const;
 
-  uint64_t GetFragmentPhysicalRowCount(uint64_t fragment_id) const;
+  arrow::Result<uint64_t> GetFragmentPhysicalRowCount(uint64_t fragment_id) const;
 
-  uint64_t GetFragmentRowCount(uint64_t fragment_id) const;
+  arrow::Result<uint64_t> GetFragmentRowCount(uint64_t fragment_id) const;
 
   // Top-level dataset columns in schema order; returns NotImplemented when estimation is unavailable.
   arrow::Result<std::vector<uint64_t>> EstimateFragmentColumnMemory(uint64_t fragment_id) const;
 
-  uint64_t EstimateFragmentMemory(uint64_t fragment_id) const;
+  arrow::Result<uint64_t> EstimateFragmentMemory(uint64_t fragment_id) const;
 
   // Lance 7 exposes the current dataset schema through FileFragment::schema().
   // It can include evolved nullable columns that are not physically stored in this fragment.
-  void GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const;
+  arrow::Status GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const;
 
   // Dataset-level scan: create a scanner for projected columns
-  std::unique_ptr<BlockingScanner> Scan(ArrowSchema& schema, uint32_t batch_size);
+  arrow::Result<std::unique_ptr<BlockingScanner>> Scan(ArrowSchema& schema, uint32_t batch_size);
 
   // Dataset-level take: random access by global row indices
-  ArrowArrayStream Take(const std::vector<int64_t>& indices, ArrowSchema& schema);
+  arrow::Result<ArrowArrayStream> Take(const std::vector<int64_t>& indices, ArrowSchema& schema);
 
 #ifdef BUILD_GTEST
   /// Test-only instrumentation for Lance's ObjectStore counters.
@@ -130,9 +126,9 @@ class BlockingDataset {
 
 class BlockingFragmentReader {
   public:
-  static std::unique_ptr<BlockingFragmentReader> Open(const BlockingDataset& dataset,
-                                                      uint64_t fragment_id,
-                                                      ArrowSchema& schema);
+  static arrow::Result<std::unique_ptr<BlockingFragmentReader>> Open(const BlockingDataset& dataset,
+                                                                     uint64_t fragment_id,
+                                                                     ArrowSchema& schema);
 
   explicit BlockingFragmentReader(rust::Box<ffi::BlockingFragmentReader> impl) : impl_(std::move(impl)) {}
 
@@ -142,15 +138,17 @@ class BlockingFragmentReader {
   BlockingFragmentReader(const BlockingFragmentReader&) = delete;
   BlockingFragmentReader& operator=(const BlockingFragmentReader&) = delete;
 
-  uint64_t RowCount() const;
+  arrow::Result<uint64_t> RowCount() const;
 
-  void TakeAsSingleBatch(const std::vector<int64_t>& indices, ArrowArray& out_array);
+  arrow::Status TakeAsSingleBatch(const std::vector<int64_t>& indices, ArrowArray& out_array);
 
-  ArrowArrayStream TakeAsStream(const std::vector<int64_t>& indices, uint32_t batch_size);
+  arrow::Result<ArrowArrayStream> TakeAsStream(const std::vector<int64_t>& indices, uint32_t batch_size);
 
-  ArrowArrayStream ReadAllAsStream(uint32_t batch_size);
+  arrow::Result<ArrowArrayStream> ReadAllAsStream(uint32_t batch_size);
 
-  ArrowArrayStream ReadRangesAsStream(uint32_t row_range_start, uint32_t row_range_end, uint32_t batch_size);
+  arrow::Result<ArrowArrayStream> ReadRangesAsStream(uint32_t row_range_start,
+                                                     uint32_t row_range_end,
+                                                     uint32_t batch_size);
 
   private:
   rust::Box<ffi::BlockingFragmentReader> impl_;
@@ -166,9 +164,9 @@ class BlockingScanner {
   BlockingScanner(const BlockingScanner&) = delete;
   BlockingScanner& operator=(const BlockingScanner&) = delete;
 
-  uint64_t CountRows() const;
+  arrow::Result<uint64_t> CountRows() const;
 
-  ArrowArrayStream OpenStream();
+  arrow::Result<ArrowArrayStream> OpenStream();
 
   private:
   rust::Box<ffi::BlockingScanner> impl_;

--- a/cpp/src/format/bridge/rust/include/paimon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/paimon_bridge.h
@@ -44,8 +44,6 @@ struct PaimonTestTableInfo {
   std::vector<int64_t> snapshot_ids;
 };
 
-arrow::Status MakePaimonBridgeErrorStatus(std::string_view message);
-
 namespace internal {
 std::shared_ptr<arrow::RecordBatchReader> WrapPaimonRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner,
                                                                       std::shared_ptr<arrow::Schema> output_schema);

--- a/cpp/src/format/bridge/rust/include/vortex_bridge.h
+++ b/cpp/src/format/bridge/rust/include/vortex_bridge.h
@@ -24,8 +24,11 @@ class RecordBatchReader;
 namespace milvus_storage::vortex {
 
 arrow::Status MakeVortexBridgeErrorStatus(std::string_view message);
+arrow::Status MakeVortexBridgeErrorStatus(int ffi_err_code, std::string_view message);
 arrow::Status MakeVortexErrorStatus(std::string_view context, std::string_view message);
+arrow::Status MakeVortexErrorStatus(std::string_view context, int ffi_err_code, std::string_view message);
 arrow::Status MakeVortexErrorStatus(std::string_view context, const arrow::Status& status);
+arrow::Status TakeVortexErrorStatus(std::string_view context, const arrow::Status& fallback);
 namespace internal {
 std::shared_ptr<arrow::RecordBatchReader> WrapVortexRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner);
 }  // namespace internal
@@ -204,7 +207,15 @@ class VortexWriter {
   private:
   explicit VortexWriter(rust::Box<ffi::VortexWriter> impl) : impl_(std::move(impl)) {}
 
+  arrow::Status RecordFirstFailure(arrow::Status status) {
+    if (!status.ok() && status_.ok()) {
+      status_ = std::move(status);
+    }
+    return status_.ok() ? status : status_;
+  }
+
   rust::Box<ffi::VortexWriter> impl_;
+  arrow::Status status_ = arrow::Status::OK();
 };
 
 class VortexFile {
@@ -352,9 +363,10 @@ class ScanBuilder {
   rust::Box<ffi::VortexScanBuilder> impl_;
 };
 
-// Success supplies a stream/handle with null error_msg; failure supplies only error_msg.
-using VortexAsyncCallback = void (*)(void* ctx, ArrowArrayStream* out_stream, const char* error_msg);
-using VortexOpenAsyncCallback = void (*)(void* ctx, uintptr_t handle, const char* error_msg);
+// Success supplies a stream/handle with code 0 and null error_msg. Failure
+// supplies an explicit code plus the human-readable message.
+using VortexAsyncCallback = void (*)(void* ctx, ArrowArrayStream* out_stream, int error_code, const char* error_msg);
+using VortexOpenAsyncCallback = void (*)(void* ctx, uintptr_t handle, int error_code, const char* error_msg);
 
 extern "C" {
 

--- a/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aliyun_oss_provider.rs
@@ -367,6 +367,31 @@ async fn apply_oidc_chain_if_requested_with_expiration(
     Ok(expires_at_ms)
 }
 
+fn aliyun_sts_is_throttling_response(body: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let Some(code) = value.get("Code").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    code == "Throttling" || code.starts_with("Throttling.")
+}
+
+fn aliyun_sts_http_failure_message(status: u16, context: &str, body: &str) -> String {
+    if status == 302 && aliyun_sts_is_throttling_response(body) {
+        return crate::bridge_error::BridgeError::new_io(
+            Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING),
+            format!("credential resolution {context} failed: HTTP {status}: {body}"),
+        )
+        .to_string();
+    }
+
+    format!(
+        "{}: {body}",
+        crate::bridge_error::credential_http_failure_message(status, context)
+    )
+}
+
 /// Step 1 of the OIDC chain: `AssumeRoleWithOIDC` against same-account
 /// `role_arn` + `provider_arn` using a freshly-read OIDC `token`. Parses
 /// the JSON response (Format=JSON) into the same `AssumeRoleCreds` shape
@@ -401,14 +426,22 @@ async fn call_assume_role_with_oidc(
         .form(&form)
         .send()
         .await
-        .map_err(|e| format!("AssumeRoleWithOIDC POST: {e}"))?;
+        .map_err(|e| {
+            crate::bridge_error::credential_reqwest_error(e, "AssumeRoleWithOIDC POST").to_string()
+        })?;
     let status = resp.status();
-    let text = resp
-        .text()
-        .await
-        .map_err(|e| format!("AssumeRoleWithOIDC body read: {e}"))?;
+    let text = resp.text().await.map_err(|e| {
+        crate::bridge_error::credential_reqwest_error(e, "AssumeRoleWithOIDC body read").to_string()
+    })?;
     if !status.is_success() {
-        return Err(format!("AssumeRoleWithOIDC HTTP {status}: {text}"));
+        // The classification rides the marker in the message: this runs on a
+        // tokio worker, so no ambient state can carry the verdict back to the
+        // calling thread.
+        return Err(aliyun_sts_http_failure_message(
+            status.as_u16(),
+            "AssumeRoleWithOIDC",
+            &text,
+        ));
     }
 
     #[derive(serde::Deserialize)]
@@ -517,6 +550,28 @@ fn aliyun_object_store_error(message: impl Into<String>) -> object_store::Error 
     }
 }
 
+fn aliyun_credential_bridge_error(
+    context: &str,
+    error: String,
+) -> crate::bridge_error::BridgeError {
+    // The String-returning Aliyun credential helpers emit a complete frame at
+    // byte zero only for producer-classified HTTP failures. Preserve that
+    // verdict as a typed source before adding any outer diagnostic context.
+    let code = crate::bridge_error::marker_code_in(&error);
+    crate::bridge_error::BridgeError::with_transport(
+        code,
+        format!("{context}: {error}"),
+        crate::bridge_error::message_has_io_bridge_frame(&error),
+    )
+}
+
+fn aliyun_credential_object_store_error(context: &str, error: String) -> object_store::Error {
+    object_store::Error::Generic {
+        store: ALIYUN_OSS_STORE_NAME,
+        source: Box::new(aliyun_credential_bridge_error(context, error)),
+    }
+}
+
 #[derive(Clone)]
 struct CachedAliyunOssStore {
     config_map: HashMap<String, String>,
@@ -614,17 +669,19 @@ impl RefreshableAliyunOssStore {
             apply_ram_mode_if_requested_with_expiration(&mut config_map, duration_seconds)
                 .await
                 .map_err(|e| {
-                    aliyun_object_store_error(format!(
-                        "Aliyun RAM-mode credential refresh failed: {e}"
-                    ))
+                    aliyun_credential_object_store_error(
+                        "Aliyun RAM-mode credential refresh failed",
+                        e,
+                    )
                 })?;
         let oidc_expires_at_ms =
             apply_oidc_chain_if_requested_with_expiration(&mut config_map, duration_seconds)
                 .await
                 .map_err(|e| {
-                    aliyun_object_store_error(format!(
-                        "Aliyun OIDC chain credential refresh failed: {e}"
-                    ))
+                    aliyun_credential_object_store_error(
+                        "Aliyun OIDC chain credential refresh failed",
+                        e,
+                    )
                 })?;
         let expires_at_ms = ram_expires_at_ms.or(oidc_expires_at_ms).ok_or_else(|| {
             aliyun_object_store_error(
@@ -828,22 +885,21 @@ impl AliyunOssStoreProvider {
             .host_str()
             .ok_or_else(|| LanceError::invalid_input("OSS URL must contain bucket name"))?
             .to_string();
-        let config_map = build_oss_config_from_lance_opts(
-            bucket,
-            &base_path,
-            storage_options,
-        )
-        .map_err(LanceError::invalid_input)?;
-        let credential_duration = parse_oss_credential_duration(storage_options)
+        let config_map = build_oss_config_from_lance_opts(bucket, &base_path, storage_options)
             .map_err(LanceError::invalid_input)?;
+        let credential_duration =
+            parse_oss_credential_duration(storage_options).map_err(LanceError::invalid_input)?;
         let store = Arc::new(RefreshableAliyunOssStore::new(
             config_map,
             credential_duration,
         ));
-        store.current_store().await.map_err(|error| LanceError::IO {
-            source: Box::new(error),
-            location: location!(),
-        })?;
+        store
+            .current_store()
+            .await
+            .map_err(|error| LanceError::IO {
+                source: Box::new(error),
+                location: location!(),
+            })?;
         Ok(Self { store })
     }
 }
@@ -899,9 +955,7 @@ impl ObjectStoreProvider for AliyunOssStoreProvider {
 /// returned dataset instead of retaining static storage options process-wide.
 /// Cache sizes of zero match what the FFI entry points already pass to
 /// `BlockingDataset::open`.
-pub fn build_aliyun_oss_session(
-    provider: Arc<dyn ObjectStoreProvider>,
-) -> Arc<Session> {
+pub fn build_aliyun_oss_session(provider: Arc<dyn ObjectStoreProvider>) -> Arc<Session> {
     let registry = ObjectStoreRegistry::default();
     registry.insert("oss", provider);
     Arc::new(Session::new(0, 0, Arc::new(registry)))
@@ -945,12 +999,8 @@ impl AliyunOssStorageFactory {
                 )
             })?
             .to_string();
-        let config_map = build_oss_config_from_iceberg_opts(
-            bucket,
-            &base_path,
-            storage_options,
-        )
-        .map_err(|error| IcebergError::new(IcebergErrorKind::DataInvalid, error))?;
+        let config_map = build_oss_config_from_iceberg_opts(bucket, &base_path, storage_options)
+            .map_err(|error| IcebergError::new(IcebergErrorKind::DataInvalid, error))?;
         let credential_duration = parse_oss_credential_duration(storage_options)
             .map_err(|error| IcebergError::new(IcebergErrorKind::DataInvalid, error))?;
         let store = Arc::new(RefreshableAliyunOssStore::new(
@@ -1027,16 +1077,24 @@ impl AliyunOssStorage {
                 .map_err(|e| {
                     IcebergError::new(
                         IcebergErrorKind::Unexpected,
-                        format!("Aliyun RAM-mode credential resolution failed: {e}"),
+                        "Aliyun RAM-mode credential resolution failed",
                     )
+                    .with_source(aliyun_credential_bridge_error(
+                        "Aliyun RAM-mode credential resolution failed",
+                        e,
+                    ))
                 })?;
             apply_oidc_chain_if_requested(&mut config_map)
                 .await
                 .map_err(|e| {
                     IcebergError::new(
                         IcebergErrorKind::Unexpected,
-                        format!("Aliyun OIDC chain credential resolution failed: {e}"),
+                        "Aliyun OIDC chain credential resolution failed",
                     )
+                    .with_source(aliyun_credential_bridge_error(
+                        "Aliyun OIDC chain credential resolution failed",
+                        e,
+                    ))
                 })?;
             config_map
         };
@@ -1101,7 +1159,7 @@ impl IcebergStorage for AliyunOssStorage {
 
     async fn writer(&self, path: &str) -> IcebergResult<Box<dyn FileWrite>> {
         let (op, rel) = self.create_operator(path).await?;
-        Ok(Box::new(OpenDalWriter(
+        Ok(Box::new(OpenDalWriter::new(
             op.writer(&rel).await.map_err(from_opendal_error)?,
         )))
     }
@@ -1151,20 +1209,76 @@ impl FileRead for OpenDalReader {
 
 /// `FileWrite` wrapper around an opendal `Writer`. Same rationale as
 /// [`OpenDalReader`] — upstream's wrapper is `pub(crate)`.
-struct OpenDalWriter(opendal::Writer);
+struct OpenDalWriter {
+    inner: Option<opendal::Writer>,
+    failure: Option<String>,
+    closed: bool,
+}
+
+impl OpenDalWriter {
+    fn new(inner: opendal::Writer) -> Self {
+        Self {
+            inner: Some(inner),
+            failure: None,
+            closed: false,
+        }
+    }
+
+    fn check_failure(&self) -> IcebergResult<()> {
+        if let Some(error) = &self.failure {
+            debug_assert!(false, "stateful writer reused after a terminal failure");
+            return Err(IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                error.clone(),
+            ));
+        }
+        Ok(())
+    }
+}
 
 #[async_trait::async_trait]
 impl FileWrite for OpenDalWriter {
     async fn write(&mut self, bs: bytes::Bytes) -> IcebergResult<()> {
-        Ok(opendal::Writer::write(&mut self.0, bs)
-            .await
-            .map_err(from_opendal_error)?)
+        self.check_failure()?;
+        if self.closed {
+            return Err(IcebergError::new(
+                IcebergErrorKind::Unexpected,
+                "cannot write: OpenDalWriter is closed",
+            ));
+        }
+
+        let result = opendal::Writer::write(
+            self.inner
+                .as_mut()
+                .expect("open OpenDalWriter must retain its inner writer"),
+            bs,
+        )
+        .await;
+        if let Err(error) = result {
+            let error = from_opendal_error(error);
+            self.failure = Some(error.to_string());
+            self.inner = None;
+            return Err(error);
+        }
+        Ok(())
     }
 
     async fn close(&mut self) -> IcebergResult<()> {
-        let _ = opendal::Writer::close(&mut self.0)
-            .await
-            .map_err(from_opendal_error)?;
+        self.check_failure()?;
+        if self.closed {
+            return Ok(());
+        }
+
+        let mut inner = self
+            .inner
+            .take()
+            .expect("open OpenDalWriter must retain its inner writer");
+        if let Err(error) = opendal::Writer::close(&mut inner).await {
+            let error = from_opendal_error(error);
+            self.failure = Some(error.to_string());
+            return Err(error);
+        }
+        self.closed = true;
         Ok(())
     }
 }
@@ -1267,49 +1381,87 @@ pub(crate) mod ram {
             .map_err(|e| format!("build reqwest client: {e}"))
     }
 
-    /// IMDSv2: PUT returns a session token in the response body. Anything other
-    /// than 200 (404 on V1-only instances, 403 on some hardened variants) falls
-    /// back to V1 with an empty token. Callers treat that as "no V2, use plain
-    /// GETs".
-    async fn fetch_imds_v2_token(client: &reqwest::Client) -> String {
-        let resp = client
-            .put(format!("{IMDS_BASE}{IMDS_V2_TOKEN_PATH}"))
+    /// IMDSv2: PUT returns a session token in the response body. Only an
+    /// explicit unsupported endpoint response falls back to V1. A transport
+    /// outage, throttling response, or service error must not silently switch
+    /// the request to the weaker identity transport.
+    async fn fetch_imds_v2_token(
+        client: &reqwest::Client,
+        imds_base: &str,
+    ) -> Result<Option<String>, String> {
+        let response = client
+            .put(format!("{imds_base}{IMDS_V2_TOKEN_PATH}"))
             .header(
                 "X-aliyun-ecs-metadata-token-ttl-seconds",
                 IMDS_V2_TTL_SECS.to_string(),
             )
             .body("")
             .send()
-            .await;
-        match resp {
-            Ok(r) if r.status().is_success() => {
-                r.text().await.unwrap_or_default().trim().to_string()
-            }
-            _ => String::new(),
+            .await
+            .map_err(|error| {
+                crate::bridge_error::credential_reqwest_error(error, "Aliyun IMDSv2 token request")
+                    .to_string()
+            })?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND
+            || status == reqwest::StatusCode::METHOD_NOT_ALLOWED
+        {
+            return Ok(None);
         }
+        if !status.is_success() {
+            return Err(crate::bridge_error::credential_http_failure_message(
+                status.as_u16(),
+                "Aliyun IMDSv2 token request",
+            ));
+        }
+
+        let token = response
+            .text()
+            .await
+            .map_err(|error| {
+                crate::bridge_error::credential_reqwest_error(
+                    error,
+                    "Aliyun IMDSv2 token response body",
+                )
+                .to_string()
+            })?
+            .trim()
+            .to_string();
+        if token.is_empty() {
+            return Err("Aliyun IMDSv2 token response was empty".to_string());
+        }
+        Ok(Some(token))
     }
 
     async fn fetch_imds_credentials(client: &reqwest::Client) -> Result<AssumeRoleCreds, String> {
-        let v2 = fetch_imds_v2_token(client).await;
+        let v2 = fetch_imds_v2_token(client, IMDS_BASE).await?;
 
         // Step 1: role name listing. Aliyun returns a single line ("ecs-xxx");
         // multiple attached roles aren't a supported ECS concept.
         let list_url = format!("{IMDS_BASE}{IMDS_ROLE_LIST_PATH}");
         let mut req = client.get(&list_url);
-        if !v2.is_empty() {
-            req = req.header("X-aliyun-ecs-metadata-token", &v2);
+        if let Some(token) = &v2 {
+            req = req.header("X-aliyun-ecs-metadata-token", token);
         }
         let role_name = req
             .send()
             .await
-            .map_err(|e| format!("IMDS role-list request: {e}"))?
+            .map_err(|e| {
+                crate::bridge_error::credential_reqwest_error(e, "Aliyun IMDS role-list request")
+                    .to_string()
+            })?
             .error_for_status()
             .map_err(|e| {
-                format!("IMDS role-list HTTP error (no RAM role attached to this ECS?): {e}")
+                crate::bridge_error::credential_reqwest_error(e, "Aliyun IMDS role-list response")
+                    .to_string()
             })?
             .text()
             .await
-            .map_err(|e| format!("IMDS role-list body: {e}"))?
+            .map_err(|e| {
+                crate::bridge_error::credential_reqwest_error(e, "Aliyun IMDS role-list body")
+                    .to_string()
+            })?
             .trim()
             .to_string();
         if role_name.is_empty() {
@@ -1319,8 +1471,8 @@ pub(crate) mod ram {
         // Step 2: STS creds for that role.
         let creds_url = format!("{IMDS_BASE}{IMDS_ROLE_LIST_PATH}{role_name}");
         let mut req = client.get(&creds_url);
-        if !v2.is_empty() {
-            req = req.header("X-aliyun-ecs-metadata-token", &v2);
+        if let Some(token) = &v2 {
+            req = req.header("X-aliyun-ecs-metadata-token", token);
         }
         #[derive(Deserialize)]
         #[serde(rename_all = "PascalCase")]
@@ -1332,12 +1484,21 @@ pub(crate) mod ram {
         let parsed: ImdsCredsJson = req
             .send()
             .await
-            .map_err(|e| format!("IMDS creds request: {e}"))?
+            .map_err(|e| {
+                crate::bridge_error::credential_reqwest_error(e, "Aliyun IMDS credential request")
+                    .to_string()
+            })?
             .error_for_status()
-            .map_err(|e| format!("IMDS creds HTTP error: {e}"))?
+            .map_err(|e| {
+                crate::bridge_error::credential_reqwest_error(e, "Aliyun IMDS credential response")
+                    .to_string()
+            })?
             .json()
             .await
-            .map_err(|e| format!("IMDS creds JSON parse: {e}"))?;
+            .map_err(|e| {
+                crate::bridge_error::credential_reqwest_error(e, "Aliyun IMDS credential JSON")
+                    .to_string()
+            })?;
         Ok(AssumeRoleCreds {
             access_key_id: parsed.access_key_id,
             access_key_secret: parsed.access_key_secret,
@@ -1417,25 +1578,28 @@ pub(crate) mod ram {
         let signature = pop_sign(&caller.access_key_secret, &canonical_query);
         let body = format!("{canonical_query}&Signature={}", pop_encode(&signature));
 
-        // HTTP 4xx responses from STS carry the error message as raw body
-        // text; we surface it verbatim in the `Err` rather than parsing into
-        // a dedicated error struct, since nothing downstream branches on the
-        // STS error code. Success responses get parsed into typed structs
-        // below.
+        // Keep the raw error body for diagnostics. The shared Aliyun helper
+        // only inspects Code to recognize the documented HTTP 302 throttling
+        // response; all other statuses retain the common HTTP classification.
         let resp = client
             .post(STS_ENDPOINT)
             .header("Content-Type", "application/x-www-form-urlencoded")
             .body(body)
             .send()
             .await
-            .map_err(|e| format!("sts:AssumeRole POST: {e}"))?;
+            .map_err(|e| {
+                crate::bridge_error::credential_reqwest_error(e, "sts:AssumeRole POST").to_string()
+            })?;
         let status = resp.status();
-        let text = resp
-            .text()
-            .await
-            .map_err(|e| format!("sts:AssumeRole body read: {e}"))?;
+        let text = resp.text().await.map_err(|e| {
+            crate::bridge_error::credential_reqwest_error(e, "sts:AssumeRole body read").to_string()
+        })?;
         if !status.is_success() {
-            return Err(format!("sts:AssumeRole HTTP {status}: {text}"));
+            return Err(super::aliyun_sts_http_failure_message(
+                status.as_u16(),
+                "sts:AssumeRole",
+                &text,
+            ));
         }
 
         #[derive(Deserialize)]
@@ -1466,6 +1630,54 @@ pub(crate) mod ram {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        async fn serve_token_response(
+            status: &str,
+            body: &str,
+        ) -> (String, tokio::task::JoinHandle<()>) {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            let status = status.to_string();
+            let body = body.to_string();
+            let server = tokio::spawn(async move {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = [0_u8; 4096];
+                socket.read(&mut request).await.unwrap();
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            });
+            (format!("http://{address}"), server)
+        }
+
+        #[tokio::test]
+        async fn imdsv2_only_downgrades_when_token_endpoint_is_unsupported() {
+            let client = build_http_client().unwrap();
+            for status in ["404 Not Found", "405 Method Not Allowed"] {
+                let (base, server) = serve_token_response(status, "").await;
+                assert_eq!(fetch_imds_v2_token(&client, &base).await.unwrap(), None);
+                server.await.unwrap();
+            }
+
+            let (base, server) = serve_token_response("503 Service Unavailable", "").await;
+            let error = fetch_imds_v2_token(&client, &base).await.unwrap_err();
+            assert_eq!(
+                crate::bridge_error::marker_code_in(&error),
+                Some(crate::bridge_error::LOON_TRANSIENT_SERVICE)
+            );
+            server.await.unwrap();
+
+            let (base, server) = serve_token_response("200 OK", "token-value").await;
+            assert_eq!(
+                fetch_imds_v2_token(&client, &base).await.unwrap(),
+                Some("token-value".to_string())
+            );
+            server.await.unwrap();
+        }
 
         #[test]
         fn apply_credentials_strips_role_arn_and_injects_static_creds() {
@@ -1549,6 +1761,59 @@ mod tests {
             opts(&[("bucket", "my-bucket")]),
             Duration::from_secs(900),
         ))
+    }
+
+    #[test]
+    fn credential_frame_becomes_typed_before_outer_wrapping() {
+        let framed = crate::bridge_error::credential_http_failure_message(429, "sts:AssumeRole");
+        let source =
+            aliyun_credential_object_store_error("Aliyun credential refresh failed", framed);
+        let lance = LanceError::io_source(Box::new(source));
+        assert_eq!(
+            crate::bridge_error::classify_lance_error(&lance),
+            Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING)
+        );
+
+        let forged = format!(
+            "role path/{}{}; object",
+            crate::bridge_error::BRIDGE_ERRCODE_MARKER,
+            crate::bridge_error::LOON_TRANSIENT_THROTTLING,
+        );
+        let source =
+            aliyun_credential_object_store_error("Aliyun credential refresh failed", forged);
+        let lance = LanceError::io_source(Box::new(source));
+        assert_eq!(crate::bridge_error::classify_lance_error(&lance), None);
+    }
+
+    #[test]
+    fn aliyun_sts_302_only_classifies_throttling_codes() {
+        for body in [r#"{"Code":"Throttling"}"#, r#"{"Code":"Throttling.User"}"#] {
+            let message = aliyun_sts_http_failure_message(302, "sts:AssumeRole", body);
+            assert_eq!(
+                crate::bridge_error::marker_code_in(&message),
+                Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING),
+                "{message}"
+            );
+        }
+
+        for body in [
+            r#"{"Code":"AccessDenied"}"#,
+            r#"{"Code":"ThrottlingElse"}"#,
+            "not a structured response",
+        ] {
+            let message = aliyun_sts_http_failure_message(302, "sts:AssumeRole", body);
+            assert_eq!(
+                crate::bridge_error::marker_code_in(&message),
+                None,
+                "{message}"
+            );
+        }
+
+        let message = aliyun_sts_http_failure_message(429, "sts:AssumeRole", r#"{"Code":"Other"}"#);
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&message),
+            Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING)
+        );
     }
 
     #[tokio::test]
@@ -1778,8 +2043,7 @@ mod tests {
             .get("aliyun", || async {
                 Ok::<_, ()>(Arc::new(AliyunOssStoreProvider {
                     store: refreshable_store(),
-                })
-                    as Arc<dyn ObjectStoreProvider>)
+                }) as Arc<dyn ObjectStoreProvider>)
             })
             .await
             .unwrap();
@@ -1787,8 +2051,7 @@ mod tests {
             .get("aliyun", || async {
                 Ok::<_, ()>(Arc::new(AliyunOssStoreProvider {
                     store: refreshable_store(),
-                })
-                    as Arc<dyn ObjectStoreProvider>)
+                }) as Arc<dyn ObjectStoreProvider>)
             })
             .await
             .unwrap();
@@ -1853,10 +2116,7 @@ mod tests {
         let path = "oss://my-bucket/dir/a b/中文/%25/literal/../file+name.parquet";
         let (_, relative) = storage.create_operator(path).await.unwrap();
 
-        assert_eq!(
-            relative,
-            "dir/a b/中文/%25/literal/../file+name.parquet"
-        );
+        assert_eq!(relative, "dir/a b/中文/%25/literal/../file+name.parquet");
     }
 
     #[tokio::test]

--- a/cpp/src/format/bridge/rust/src/aws_arn_provider.rs
+++ b/cpp/src/format/bridge/rust/src/aws_arn_provider.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+use anyhow::Context;
 use aws_config::sts::AssumeRoleProvider;
 use aws_credential_types::provider::ProvideCredentials;
 use iceberg::io::StorageFactory;
@@ -82,14 +83,15 @@ impl CredentialProvider for SingleFlightAwsCredentialProvider {
             }
         }
 
-        let refreshed = self
-            .inner
-            .provide_credentials()
-            .await
-            .map_err(|source| object_store::Error::Generic {
+        let refreshed = self.inner.provide_credentials().await.map_err(|source| {
+            object_store::Error::Generic {
                 store: "AWS",
-                source: Box::new(source),
-            })?;
+                source: Box::new(crate::bridge_error::aws_credentials_error(
+                    source,
+                    "AWS AssumeRole",
+                )),
+            }
+        })?;
         let credential = Self::to_object_store_credential(&refreshed);
         *self.cached.write().await = Some(refreshed);
         Ok(credential)
@@ -116,12 +118,10 @@ impl AssumeRoleConfig {
             return Ok(None);
         }
         if credential_refresh_secs < 900 || credential_refresh_secs > 43200 {
-            return Err(LanceError::invalid_input(
-                format!(
-                    "credential_refresh_secs must be in [900, 43200], got {}",
-                    credential_refresh_secs
-                ),
-            ));
+            return Err(LanceError::invalid_input(format!(
+                "credential_refresh_secs must be in [900, 43200], got {}",
+                credential_refresh_secs
+            )));
         }
         Ok(Some(Self {
             role_arn: role_arn.to_string(),
@@ -206,7 +206,8 @@ impl AwsCredentialLoad for ObjectStoreAwsCredentialLoader {
             .provider
             .get_credential()
             .await
-            .map_err(|error| anyhow::anyhow!("AWS credential provider failed: {error}"))?;
+            .map_err(anyhow::Error::new)
+            .context("AWS credential provider failed")?;
         Ok(Some(AwsCredential {
             access_key_id: credential.key_id.clone(),
             secret_access_key: credential.secret_key.clone(),
@@ -335,7 +336,11 @@ mod tests {
         }))
         .await;
 
-        assert!(credentials.iter().all(|credential| credential.key_id == "key-0"));
+        assert!(
+            credentials
+                .iter()
+                .all(|credential| credential.key_id == "key-0")
+        );
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
@@ -344,17 +349,19 @@ mod tests {
         let cache: GlobalLruCache<Arc<dyn ObjectStoreProvider>> = GlobalLruCache::new(2);
         let first = cache
             .get("aws", || async {
-                Ok::<_, ()>(Arc::new(AwsArnStoreProvider::new(static_credentials(
-                    "first",
-                ))) as Arc<dyn ObjectStoreProvider>)
+                Ok::<_, ()>(
+                    Arc::new(AwsArnStoreProvider::new(static_credentials("first")))
+                        as Arc<dyn ObjectStoreProvider>,
+                )
             })
             .await
             .unwrap();
         let second = cache
             .get("aws", || async {
-                Ok::<_, ()>(Arc::new(AwsArnStoreProvider::new(static_credentials(
-                    "second",
-                ))) as Arc<dyn ObjectStoreProvider>)
+                Ok::<_, ()>(
+                    Arc::new(AwsArnStoreProvider::new(static_credentials("second")))
+                        as Arc<dyn ObjectStoreProvider>,
+                )
             })
             .await
             .unwrap();

--- a/cpp/src/format/bridge/rust/src/azure_sas_provider.rs
+++ b/cpp/src/format/bridge/rust/src/azure_sas_provider.rs
@@ -201,13 +201,19 @@ impl AzureBrokerClient {
             .json(&request)
             .send()
             .await
-            .map_err(|_| anyhow!("transport_error"))?;
-        let status = response.status();
-        if !status.is_success() {
-            bail!("http_status={}", status.as_u16());
-        }
-        let response: BrokerResponse =
-            response.json().await.map_err(|_| anyhow!("invalid_json"))?;
+            .and_then(reqwest::Response::error_for_status)
+            .map_err(|error| {
+                anyhow::Error::new(crate::bridge_error::credential_reqwest_error(
+                    error,
+                    "Azure SAS broker token fetch",
+                ))
+            })?;
+        let response: BrokerResponse = response.json().await.map_err(|error| {
+            anyhow::Error::new(crate::bridge_error::credential_reqwest_error(
+                error,
+                "Azure SAS broker response body",
+            ))
+        })?;
         if !response.success {
             bail!("business_failure");
         }
@@ -316,9 +322,7 @@ impl AzureSasStorageOptionsProvider {
     }
 
     fn lance_error(error: &anyhow::Error) -> LanceError {
-        LanceError::io_source(Box::new(std::io::Error::other(format!(
-            "Azure SAS credential broker failure: {error}"
-        ))))
+        LanceError::io_source(Box::new(azure_credential_bridge_error(error)))
     }
 
     pub(crate) async fn current_credential(&self) -> AnyResult<AzureSasCredential> {
@@ -345,18 +349,7 @@ impl AzureSasStorageOptionsProvider {
                 *cached = Some(credential.clone());
                 Ok(credential)
             }
-            Err(error) => {
-                let has_cached_sas = cached.is_some();
-                let cached_expired = cached
-                    .as_ref()
-                    .map(|credential| credential.expires_at <= now)
-                    .unwrap_or(false);
-                eprintln!(
-                    "Warning: Azure SAS credential broker refresh failed: {}, has_cached_sas={}, cached_expired={}",
-                    error, has_cached_sas, cached_expired
-                );
-                Err(error)
-            }
+            Err(error) => Err(error),
         }
     }
 }
@@ -375,11 +368,28 @@ impl StorageOptionsProvider for AzureSasStorageOptionsProvider {
     }
 }
 
+fn azure_credential_bridge_error(error: &anyhow::Error) -> crate::bridge_error::BridgeError {
+    let message = error.to_string();
+    // HTTP failures created by AzureBrokerClient use the exact bridge frame at
+    // byte zero. Other errors can still carry typed sources through anyhow.
+    let code = crate::bridge_error::classify_anyhow_error(error)
+        .or_else(|| crate::bridge_error::marker_code_in(&message));
+    let io_transport = crate::bridge_error::bridge_io_transport_in_anyhow(error)
+        || crate::bridge_error::message_has_io_bridge_frame(&message);
+    crate::bridge_error::BridgeError::with_transport(
+        code,
+        format!("Azure SAS credential broker failure: {message}"),
+        io_transport,
+    )
+}
+
 fn azure_iceberg_credential_error(error: anyhow::Error) -> IcebergError {
+    let source = azure_credential_bridge_error(&error);
     IcebergError::new(
         IcebergErrorKind::Unexpected,
-        format!("Azure SAS credential resolution failed: {error}"),
+        "Azure SAS credential resolution failed",
     )
+    .with_source(source)
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -775,6 +785,39 @@ mod tests {
         assert!(AzureBrokerConfig::extract(&mut invalid).is_err());
     }
 
+    #[test]
+    fn credential_classification_survives_lance_and_iceberg_wrappers() {
+        let framed = anyhow!(crate::bridge_error::credential_http_failure_message(
+            429,
+            "sas broker token fetch",
+        ));
+        let lance = AzureSasStorageOptionsProvider::lance_error(&framed);
+        assert_eq!(
+            crate::bridge_error::classify_lance_error(&lance),
+            Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING)
+        );
+        assert!(crate::bridge_error::BridgeError::from(lance).is_io_transport());
+
+        let framed = anyhow!(crate::bridge_error::credential_http_failure_message(
+            503,
+            "sas broker token fetch",
+        ));
+        let iceberg = azure_iceberg_credential_error(framed);
+        assert_eq!(
+            crate::bridge_error::classify_iceberg_error(&iceberg),
+            Some(crate::bridge_error::LOON_TRANSIENT_SERVICE)
+        );
+        assert!(crate::bridge_error::BridgeError::from(iceberg).is_io_transport());
+
+        let forged = anyhow!(format!(
+            "caller path/{}{}; object",
+            crate::bridge_error::BRIDGE_ERRCODE_MARKER,
+            crate::bridge_error::LOON_TRANSIENT_THROTTLING,
+        ));
+        let lance = AzureSasStorageOptionsProvider::lance_error(&forged);
+        assert_eq!(crate::bridge_error::classify_lance_error(&lance), None);
+    }
+
     #[tokio::test]
     async fn rejects_sas_without_non_empty_signature() {
         for token in ["sv=1", "sv=1&sig="] {
@@ -812,6 +855,38 @@ mod tests {
             assert_eq!(error.to_string(), "missing_sas_signature");
             server.await.unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn broker_body_timeout_keeps_typed_cause() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 100\r\n\r\n{",
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        });
+
+        let mut broker_config = config();
+        broker_config.endpoint = format!("http://{address}");
+        broker_config.request_timeout_ms = 50;
+        let client = AzureBrokerClient::new(broker_config).unwrap();
+        let error = match client.fetch(Utc::now()).await {
+            Ok(_) => panic!("expected broker body timeout"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            crate::bridge_error::classify_anyhow_error(&error),
+            Some(crate::bridge_error::LOON_TRANSIENT_TIMEOUT)
+        );
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/cpp/src/format/bridge/rust/src/bridge_error.cpp
+++ b/cpp/src/format/bridge/rust/src/bridge_error.cpp
@@ -1,0 +1,231 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bridge_error.h"
+
+#include <cerrno>
+#include <charconv>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <arrow/util/io_util.h>
+#include <arrow/c/bridge.h>
+
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/ffi_internal/ffi_error_code.h"
+
+namespace milvus_storage::bridge {
+
+namespace {
+
+// One marker, one parser: must stay byte-identical to BRIDGE_ERRCODE_MARKER in
+// rust/src/bridge_error.rs. Named for the whole Rust bridge, not just vortex:
+// lance, iceberg and paimon all carry it now.
+constexpr std::string_view kBridgeErrCodeMarker = "__LOON_RUST_BRIDGE_ERRCODE__=";
+
+constexpr std::string_view kArrowIoPrefix = "Io error: ";
+
+struct ParsedBridgeError {
+  std::string message;
+  std::optional<int> ffi_err_code;
+  // Whether a complete, trusted frame was present. Marker-like text with a
+  // malformed code or missing delimiter remains an ordinary diagnostic.
+  bool has_marker = false;
+  // The producer explicitly framed this as an IO operation. This matters for
+  // codes such as StorageConfigInvalid that can be detected before or after IO.
+  bool io_transport = false;
+};
+
+std::string StripBridgeMarker(std::string_view error, size_t code_end) {
+  auto message_start = code_end;
+  if (message_start < error.size() && error[message_start] == ';') {
+    ++message_start;
+  }
+  if (message_start < error.size() && error[message_start] == ' ') {
+    ++message_start;
+  }
+
+  std::string message;
+  message.reserve(error.size());
+  message.append(error.substr(message_start));
+  if (message.empty()) {
+    return "Unknown bridge error";
+  }
+  return message;
+}
+
+ParsedBridgeError ParseBridgeError(std::string_view error) {
+  size_t frame_start = 0;
+  bool io_transport = false;
+  if (error.starts_with(kBridgeErrCodeMarker)) {
+    frame_start = 0;
+  } else if (error.starts_with(kArrowIoPrefix) &&
+             error.substr(kArrowIoPrefix.size()).starts_with(kBridgeErrCodeMarker)) {
+    frame_start = kArrowIoPrefix.size();
+    io_transport = true;
+  } else {
+    // A marker anywhere else can be part of a caller-provided URI/path in an
+    // ordinary Lance, Paimon, or Vortex diagnostic and is not framing.
+    return {std::string(error), std::nullopt, false, false};
+  }
+
+  auto code_start = frame_start + kBridgeErrCodeMarker.size();
+  auto code_end = code_start;
+  while (code_end < error.size() && error[code_end] >= '0' && error[code_end] <= '9') {
+    ++code_end;
+  }
+  // A trusted frame is exactly "<marker><digits>; ...". Merely starting with
+  // marker-like text is not enough: malformed caller text must stay an
+  // ordinary diagnostic instead of entering the classification channel.
+  if (code_end == code_start || code_end >= error.size() || error[code_end] != ';') {
+    return {std::string(error), std::nullopt, false, false};
+  }
+
+  int ffi_err_code = 0;
+  auto parse_result = std::from_chars(error.data() + code_start, error.data() + code_end, ffi_err_code);
+  if (parse_result.ec != std::errc() || parse_result.ptr != error.data() + code_end) {
+    return {std::string(error), std::nullopt, false, false};
+  }
+
+  return {StripBridgeMarker(error, code_end), ffi_err_code, true, io_transport};
+}
+
+arrow::Status MakeBridgeErrorStatusImpl(int ffi_err_code, std::string_view message, bool io_transport) {
+  std::string text(message);
+  switch (ffi_err_code) {
+    case LOON_FILE_NOT_FOUND:
+      return arrow::Status::IOError(std::move(text)).WithDetail(arrow::internal::StatusDetailFromErrno(ENOENT));
+    case LOON_GOT_EXCEPTION:
+      return MakeExtendError(ExtendStatusCode::InternalInvariantViolated, text, text);
+    case kBridgeErrCodeDataCorrupt:
+      return MakeBridgeDataFormatStatus(std::move(text));
+    case kBridgeErrCodeNotSupported:
+      return arrow::Status::NotImplemented(std::move(text));
+    default:
+      break;
+  }
+  if (auto code = ExtendStatusCodeFromInt(ffi_err_code); code.has_value()) {
+    if (io_transport) {
+      return MakeExtendError(*code, arrow::StatusCode::IOError, text, text);
+    }
+    return MakeExtendError(*code, text, text);
+  }
+  return arrow::Status::IOError(std::move(text));
+}
+
+class BridgeErrorTranslatingReader final : public arrow::RecordBatchReader {
+  public:
+  BridgeErrorTranslatingReader(std::shared_ptr<arrow::RecordBatchReader> inner, std::string context)
+      : inner_(std::move(inner)), context_(std::move(context)) {}
+
+  [[nodiscard]] std::shared_ptr<arrow::Schema> schema() const override { return inner_->schema(); }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+    return TranslateBridgeStatus(context_, inner_->ReadNext(batch));
+  }
+
+  arrow::Status Close() override { return TranslateBridgeStatus(context_, inner_->Close()); }
+
+  private:
+  std::shared_ptr<arrow::RecordBatchReader> inner_;
+  std::string context_;
+};
+
+}  // namespace
+
+arrow::Status BridgeErrorStatusFromException(const char* what) {
+  return MakeBridgeErrorStatus(what == nullptr ? "Unknown bridge error" : what);
+}
+
+arrow::Status MakeBridgeErrorStatus(int ffi_err_code, std::string_view message) {
+  return MakeBridgeErrorStatusImpl(ffi_err_code, message, true);
+}
+
+arrow::Status MakeBridgeErrorStatus(std::string_view message) {
+  auto parsed = ParseBridgeError(message);
+  return MakeBridgeErrorStatusImpl(parsed.ffi_err_code.value_or(0), parsed.message, parsed.io_transport);
+}
+
+std::optional<arrow::Status> DecodeBridgeErrorStatus(std::string_view message) {
+  auto parsed = ParseBridgeError(message);
+  if (!parsed.has_marker) {
+    return std::nullopt;
+  }
+  return MakeBridgeErrorStatusImpl(parsed.ffi_err_code.value_or(0), parsed.message, parsed.io_transport);
+}
+
+std::string StripBridgeErrorMarker(std::string_view message) { return ParseBridgeError(message).message; }
+
+arrow::Status MakeBridgeDataFormatStatus(std::string message) {
+  // One fact, one construction. This used to build the status by hand with
+  // StatusCode::Invalid, which contradicted the rule MakeExtendError enforces:
+  // Invalid is reserved for failures detected BEFORE any IO, and bytes that do
+  // not decode are by definition detected after it. The result was the same
+  // condition reaching callers as Invalid from one format and IOError from
+  // another, so anything branching on the StatusCode saw a difference that
+  // does not exist. The detail -- and therefore the FFI code and the segcore
+  // landing -- is unchanged.
+  return MakeExtendError(ExtendStatusCode::DataCorrupted, message, message);
+}
+
+arrow::Status WithBridgeContext(std::string_view context, const arrow::Status& status) {
+  if (status.ok() || context.empty()) {
+    return status;
+  }
+  std::string message;
+  message.reserve(context.size() + 2 + status.message().size());
+  message.append(context);
+  message.append(": ");
+  message.append(status.message());
+  // Same StatusCode and detail (ExtendStatusDetail / errno) — only the message
+  // gains context; classification is never altered here.
+  return {status.code(), std::move(message), status.detail()};
+}
+
+arrow::Status TranslateBridgeStatus(std::string_view context, const arrow::Status& status) {
+  if (status.ok()) {
+    return status;
+  }
+  if (ExtendStatusDetail::UnwrapStatus(status) || arrow::internal::ErrnoFromStatus(status) == ENOENT) {
+    // Already structured — nothing to decode.
+    return WithBridgeContext(context, status);
+  }
+  auto parsed = ParseBridgeError(status.message());
+  if (parsed.has_marker) {
+    auto decoded = MakeBridgeErrorStatusImpl(parsed.ffi_err_code.value_or(0), parsed.message,
+                                             parsed.io_transport || status.IsIOError());
+    return WithBridgeContext(context, decoded);
+  }
+  // No marker: this failure did not come from a Rust bridge (arrow's own
+  // Invalid/NotImplemented while importing a C stream, for instance). Keep the
+  // producer's classification instead of flattening it into an IOError.
+  return WithBridgeContext(context, status);
+}
+
+std::shared_ptr<arrow::RecordBatchReader> WrapBridgeRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner,
+                                                                      std::string context) {
+  return std::make_shared<BridgeErrorTranslatingReader>(std::move(inner), std::move(context));
+}
+
+arrow::Result<std::shared_ptr<arrow::ChunkedArray>> ImportBridgeChunkedArray(ArrowArrayStream* stream,
+                                                                             std::string_view context) {
+  auto result = arrow::ImportChunkedArray(stream);
+  if (!result.ok()) {
+    return TranslateBridgeStatus(context, result.status());
+  }
+  return std::move(result).ValueOrDie();
+}
+
+}  // namespace milvus_storage::bridge

--- a/cpp/src/format/bridge/rust/src/bridge_error.rs
+++ b/cpp/src/format/bridge/rust/src/bridge_error.rs
@@ -1,0 +1,805 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared error classification for the Rust cxx bridges.
+//!
+//! The cxx boundary can only carry an error as a display string
+//! (`rust::Error::what()`), which used to destroy the typed error the Rust
+//! side already had (`lance::Error` distinguishes not-found / corruption /
+//! retryable contention; the C++ side then guessed a blanket classification).
+//! To keep the classification across the string-only channel, an error code is
+//! embedded into the message with a marker prefix that the C++ side parses and
+//! strips (see cpp `bridge_error.h`), the same mechanism the vortex bridge
+//! established in `filesystem_c.rs`.
+//!
+//! The marker is THE channel. It replaced an earlier thread-local side
+//! channel (record beside the error, take after catching), which failed three
+//! independent ways: an unclassified construction cleared a verdict recorded
+//! earlier in the same call; a verdict recorded on a tokio worker thread was
+//! unreadable from the calling thread; and a stale verdict could attach to a
+//! later failure on the same thread. The marker has none of those failure
+//! modes because the verdict travels INSIDE the error: wherever the message
+//! goes, the classification goes, and when the message is rewritten away the
+//! classification is lost together with the diagnostics it was derived from.
+//! Only a marker at byte zero, or immediately after one exact producer-owned
+//! bridge prefix, is a frame. Ordinary diagnostics escape marker literals
+//! before display, so a caller-controlled URI/path cannot dictate its own
+//! classification.
+//! Code space carried by the marker:
+//! * LOON / ExtendStatusCode values (`ffi_error_code.h`): 12 = file-not-found,
+//!   101-122 (with reserved gaps) = storage/transient/txn/invariant codes. The
+//!   C++ side rebuilds the matching `ExtendStatusDetail` (or an ENOENT detail
+//!   for 12).
+//! * Bridge-private values (>= 1000, never cross the C ABI): the C++ side
+//!   converts them straight into an arrow StatusCode and they cease to exist.
+//!
+//! Classification discipline ("producer owns classification", conservative):
+//! only signals the producer positively identifies are tagged; everything else
+//! stays untagged and lands in the consumer's non-retriable fallback bucket.
+//! Never invent retriability.
+
+use lance::Error as LanceError;
+
+/// Must stay byte-identical to `kBridgeErrCodeMarker` in cpp `bridge_error.cpp`
+/// — one marker, one parser. Named for the whole Rust bridge: lance, iceberg
+/// and paimon all carry it, not just the vortex bridge that first introduced it.
+pub const BRIDGE_ERRCODE_MARKER: &str = "__LOON_RUST_BRIDGE_ERRCODE__=";
+const BRIDGE_ERRCODE_ESCAPED: &str = "__LOON_RUST_BRIDGE_ESCAPED_ERRCODE__=";
+
+/// Make arbitrary diagnostic text inert in the string-only classification
+/// channel. The escaped spelling is deliberately not decoded by C++: decoding
+/// it into a prefix again would let a later translation pass reinterpret it.
+pub(crate) fn escape_bridge_error_message(message: &str) -> String {
+    message.replace(BRIDGE_ERRCODE_MARKER, BRIDGE_ERRCODE_ESCAPED)
+}
+
+/// The object/table/dataset named is not there -- the bridges' single
+/// not-found. LOON_FILE_NOT_FOUND (12) means the same thing but travels the
+/// errno channel, which belongs to the filesystem layer and to the vortex fork
+/// that already emits it; the C++ side still decodes 12 for those. No bridge
+/// emits it, because two numbers for one condition is not a second meaning,
+/// it is two places for every consumer to remember.
+pub const LOON_STORAGE_NOT_FOUND: i32 = 104;
+/// Mirror of the ExtendStatusCode transient tags (`ffi_error_code.h` 101-112).
+pub const LOON_STORAGE_CONFLICT: i32 = 102;
+pub const LOON_STORAGE_PRECONDITION_FAILED: i32 = 103;
+pub const LOON_STORAGE_ACCESS_DENIED: i32 = 105;
+pub const LOON_TRANSIENT_NETWORK: i32 = 107;
+pub const LOON_TRANSIENT_TIMEOUT: i32 = 108;
+pub const LOON_TRANSIENT_THROTTLING: i32 = 109;
+pub const LOON_TRANSIENT_SERVICE: i32 = 110;
+pub const LOON_STORAGE_CONFIG_INVALID: i32 = 115;
+
+/// Build the message for a failed credential-endpoint HTTP exchange.
+///
+/// Mirrors the credential-resolution table in docs/error-codes.md: 429 is
+/// throttling, 5xx is service, 401/403 is access-denied, any other 4xx is
+/// config. SDK-backed providers may override that fallback with a typed service
+/// code (for example, AWS STS ThrottlingException uses HTTP 400).
+/// `credential_reqwest_error` adds connect and timeout classification for
+/// failures that do not carry an HTTP status.
+///
+/// The classification rides the universal marker: the providers resolve on
+/// tokio workers, so nothing thread-local can carry the verdict back to the
+/// calling thread -- the message is the only channel that survives the hop.
+pub(crate) fn credential_http_failure_message(status: u16, context: &str) -> String {
+    let code = credential_http_failure_code(status);
+    BridgeError::new_io(
+        code,
+        format!("credential resolution {context} failed: HTTP {status}"),
+    )
+    .to_string()
+}
+
+fn credential_http_failure_code(status: u16) -> Option<i32> {
+    match status {
+        429 => Some(LOON_TRANSIENT_THROTTLING),
+        500..=599 => Some(LOON_TRANSIENT_SERVICE),
+        401 | 403 => Some(LOON_STORAGE_ACCESS_DENIED),
+        400..=499 => Some(LOON_STORAGE_CONFIG_INVALID),
+        _ => None,
+    }
+}
+
+/// Preserve reqwest's typed transport/status information before any provider
+/// turns the error into an object-store or anyhow diagnostic.
+pub(crate) fn credential_reqwest_error(error: reqwest::Error, context: &str) -> BridgeError {
+    let code = if error.is_timeout() {
+        Some(LOON_TRANSIENT_TIMEOUT)
+    } else if error.is_connect() {
+        Some(LOON_TRANSIENT_NETWORK)
+    } else {
+        error
+            .status()
+            .and_then(|status| credential_http_failure_code(status.as_u16()))
+    };
+    BridgeError::new_io(
+        code,
+        format!("credential resolution {context} failed: {error}"),
+    )
+}
+
+fn aws_sts_service_error_code(
+    error: &aws_sdk_sts::operation::assume_role::AssumeRoleError,
+    status: u16,
+) -> Option<i32> {
+    use aws_sdk_sts::error::ProvideErrorMetadata;
+
+    match error.code() {
+        Some("Throttling" | "ThrottlingException") => Some(LOON_TRANSIENT_THROTTLING),
+        _ => credential_http_failure_code(status),
+    }
+}
+
+fn aws_sts_sdk_error_code(
+    error: &aws_sdk_sts::error::SdkError<aws_sdk_sts::operation::assume_role::AssumeRoleError>,
+) -> Option<i32> {
+    use aws_sdk_sts::error::SdkError;
+
+    match error {
+        SdkError::TimeoutError(_) => Some(LOON_TRANSIENT_TIMEOUT),
+        SdkError::DispatchFailure(context) if context.is_timeout() => Some(LOON_TRANSIENT_TIMEOUT),
+        SdkError::DispatchFailure(context) if context.is_io() => Some(LOON_TRANSIENT_NETWORK),
+        SdkError::ServiceError(context) => {
+            aws_sts_service_error_code(context.err(), context.raw().status().as_u16())
+        }
+        SdkError::ResponseError(_) => error
+            .raw_response()
+            .and_then(|response| credential_http_failure_code(response.status().as_u16())),
+        _ => None,
+    }
+}
+
+/// Keep the AWS Rust SDK's credential verdict before object_store erases it
+/// behind `Error::Generic`. AssumeRole wraps its typed `SdkError` inside a
+/// `CredentialsError`, so inspect that source while both types are available
+/// instead of parsing either one's Display text later.
+pub(crate) fn aws_credentials_error(
+    error: aws_credential_types::provider::error::CredentialsError,
+    context: &str,
+) -> BridgeError {
+    use aws_credential_types::provider::error::CredentialsError;
+
+    let mut code = match &error {
+        CredentialsError::ProviderTimedOut(_) => Some(LOON_TRANSIENT_TIMEOUT),
+        CredentialsError::CredentialsNotLoaded(_) | CredentialsError::InvalidConfiguration(_) => {
+            Some(LOON_STORAGE_CONFIG_INVALID)
+        }
+        _ => None,
+    };
+
+    let mut source = std::error::Error::source(&error);
+    while code.is_none() {
+        let Some(current) = source else {
+            break;
+        };
+        if let Some(sdk_error) = current.downcast_ref::<aws_sdk_sts::error::SdkError<
+            aws_sdk_sts::operation::assume_role::AssumeRoleError,
+        >>() {
+            code = aws_sts_sdk_error_code(sdk_error);
+        }
+        source = current.source();
+    }
+
+    BridgeError::new_io(
+        code,
+        format!("credential resolution {context} failed: {error}"),
+    )
+}
+
+/// Extract the code the universal marker carries, if the text carries one at
+/// all. Mirrors the C++ parser (`ParseBridgeError` in bridge_error.cpp): the
+/// marker must be the prefix (possibly after the single Arrow IO wrapper), and
+/// the frame must be exactly `marker + digits + ';'`. Marker-like text that
+/// does not satisfy the complete frame is an ordinary diagnostic.
+pub(crate) fn marker_code_in(message: &str) -> Option<i32> {
+    let rest = if let Some(rest) = message.strip_prefix(BRIDGE_ERRCODE_MARKER) {
+        rest
+    } else if let Some(rest) = message.strip_prefix("Io error: ") {
+        rest.strip_prefix(BRIDGE_ERRCODE_MARKER)?
+    } else {
+        return None;
+    };
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    if end == 0 {
+        return None;
+    }
+    if rest.as_bytes().get(end) != Some(&b';') {
+        return None;
+    }
+    rest[..end].parse().ok()
+}
+
+/// Bridge-private codes (>= 1000): decoded by cpp `bridge_error.cpp` into an
+/// arrow StatusCode, never forwarded as an FFI error code.
+pub const BRIDGE_ERRCODE_DATA_CORRUPT: i32 = 1001;
+pub const BRIDGE_ERRCODE_NOT_SUPPORTED: i32 = 1002;
+
+/// Error type used by the cxx bridge functions. cxx renders it with `Display`
+/// into `rust::Error::what()`; the marker survives that trip.
+#[derive(Clone, Debug)]
+pub struct BridgeError {
+    pub code: Option<i32>,
+    pub msg: String,
+    io_transport: bool,
+}
+
+impl std::fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.io_transport {
+            write!(f, "Io error: ")?;
+        }
+        match self.code {
+            Some(code) => write!(f, "{BRIDGE_ERRCODE_MARKER}{code}; {}", self.msg),
+            None => write!(f, "{}", self.msg),
+        }
+    }
+}
+
+impl std::error::Error for BridgeError {}
+
+impl BridgeError {
+    /// Build the error. `Display` embeds the marker when a code is present;
+    /// that marker is the entire transport -- the cxx boundary stringifies
+    /// the error and the C++ decoder parses the code back out of the text.
+    pub fn new(code: Option<i32>, msg: String) -> Self {
+        Self::with_transport(code, msg, false)
+    }
+
+    pub(crate) fn new_io(code: Option<i32>, msg: String) -> Self {
+        Self::with_transport(code, msg, true)
+    }
+
+    pub(crate) fn with_transport(code: Option<i32>, msg: String, io_transport: bool) -> Self {
+        BridgeError {
+            code,
+            msg: escape_bridge_error_message(&msg),
+            io_transport,
+        }
+    }
+
+    pub(crate) fn is_io_transport(&self) -> bool {
+        self.io_transport
+    }
+}
+
+/// Alias used to switch a whole bridge impl module to classified errors: the
+/// `?` operator converts `lance::Error` (and `ArrowError`) via the `From`
+/// impls below.
+pub type BridgeResult<T> = std::result::Result<T, BridgeError>;
+
+/// Classify a `lance::Error` into a marker code. `None` = not positively
+/// identified -> stays untagged -> conservative non-retriable fallback on the
+/// consumer side.
+// TODO: this classifier cannot report a transient failure, and lance is the one
+// storage path in this repository that therefore cannot.
+//
+// Everything else classifies them: the C++ filesystems do it directly, vortex
+// inherits that verdict through the C-ABI filesystem's err_code, and paimon and
+// iceberg get it from opendal (RateLimited / is_temporary). lance is the
+// exception because it reads through `object_store`, whose error type has no
+// transient variant -- a dropped connection or a 503 arrives as `Error::Generic`
+// and falls to `None` below, i.e. unclassified, i.e. conservatively non-retryable.
+// So a metadata service that was restarting fails a lance read exactly as
+// permanently as a role that does not exist, and Milvus will not re-run the
+// operation.
+//
+// It cannot be fixed here. `object_store::client::retry` is `pub(crate)`, so
+// the `RequestError` that carries the HTTP status is unreachable from this
+// crate, and matching on the message text is the thing this file exists to
+// avoid.
+//
+// The four credential providers we own (aliyun_oss_provider, aws_arn_provider,
+// azure_sas_provider, gcp_impersonation) DO see the HTTP status of the
+// credential endpoints, so they classify their own failures through
+// `credential_http_failure_message` -- the verdict rides the universal marker
+// and reaches the caller no matter which format sits above it. That closes
+// the old inconsistency where the same credential failure was classified only
+// when the format above it happened to be iceberg. Transient failures of the
+// DATA path itself (object_store reads/writes under lance) remain the open
+// gap; patching lance itself is possible (lance-core/lance-io are already
+// pinned to a zilliztech fork in [patch.crates-io]) but unnecessary for the
+// credential half.
+pub fn classify_lance_error(e: &LanceError) -> Option<i32> {
+    match e {
+        // The object/dataset/index/ref/version is gone. Retrying hits the same
+        // store and fails identically; consumers can distinguish "data
+        // missing" from a generic storage failure.
+        LanceError::NotFound { .. }
+        | LanceError::DatasetNotFound { .. }
+        | LanceError::IndexNotFound { .. }
+        | LanceError::RefNotFound { .. }
+        | LanceError::VersionNotFound { .. } => Some(LOON_STORAGE_NOT_FOUND),
+        // Permanent data problems: retrying re-reads the same bytes.
+        LanceError::CorruptFile { .. } => Some(BRIDGE_ERRCODE_DATA_CORRUPT),
+        LanceError::NotSupported { .. } => Some(BRIDGE_ERRCODE_NOT_SUPPORTED),
+        // Lance lost a commit race. That is a Conflict, not throttling: the
+        // Conflict category exists so generic retry helpers do NOT blindly
+        // replay a commit whose contention budget may already be spent --
+        // whether and how to re-drive a commit is the operation owner's call.
+        LanceError::RetryableCommitConflict { .. } | LanceError::TooMuchWriteContention { .. } => {
+            Some(LOON_STORAGE_CONFLICT)
+        }
+        // IO wraps the underlying object_store error as a boxed source;
+        // downcast to recover the typed variant.
+        LanceError::IO { source, .. } => {
+            // Credential providers that we own retain their classification as
+            // a typed source. Recover that before looking at object_store's
+            // coarser outer variant.
+            if let Some(error) = source.downcast_ref::<BridgeError>() {
+                return error.code;
+            }
+            match source.downcast_ref::<object_store::Error>() {
+                Some(object_store::Error::NotFound { .. }) => Some(LOON_STORAGE_NOT_FOUND),
+                Some(
+                    object_store::Error::PermissionDenied { .. }
+                    | object_store::Error::Unauthenticated { .. },
+                ) => Some(LOON_STORAGE_ACCESS_DENIED),
+                Some(object_store::Error::Precondition { .. }) => {
+                    Some(LOON_STORAGE_PRECONDITION_FAILED)
+                }
+                Some(
+                    object_store::Error::NotSupported { .. }
+                    | object_store::Error::NotImplemented { .. },
+                ) => Some(BRIDGE_ERRCODE_NOT_SUPPORTED),
+                Some(object_store::Error::Generic { source, .. }) => source
+                    .downcast_ref::<BridgeError>()
+                    .and_then(|error| error.code),
+                _ => None,
+            }
+        }
+        // InvalidInput deliberately NOT tagged as caller input: the strings we
+        // feed lance are mostly assembled by this library itself, so blaming
+        // the caller would misroute retries (see the 2007/2020/2021
+        // demotions). Left untagged pending a producer-site audit.
+        _ => None,
+    }
+}
+
+fn classify_opendal_error(error: &opendal::Error) -> Option<i32> {
+    use opendal::ErrorKind;
+    match error.kind() {
+        ErrorKind::NotFound => Some(LOON_STORAGE_NOT_FOUND),
+        ErrorKind::PermissionDenied => Some(LOON_STORAGE_ACCESS_DENIED),
+        ErrorKind::RateLimited => Some(LOON_TRANSIENT_THROTTLING),
+        ErrorKind::Unsupported => Some(BRIDGE_ERRCODE_NOT_SUPPORTED),
+        _ if error.is_temporary() => Some(LOON_TRANSIENT_SERVICE),
+        _ => None,
+    }
+}
+
+fn classify_error_source_chain(
+    mut source: Option<&(dyn std::error::Error + 'static)>,
+) -> Option<i32> {
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<BridgeError>()
+            && error.code.is_some()
+        {
+            return error.code;
+        }
+        if let Some(error) = error.downcast_ref::<opendal::Error>()
+            && let Some(code) = classify_opendal_error(error)
+        {
+            return Some(code);
+        }
+        source = error.source();
+    }
+    None
+}
+
+fn bridge_io_transport_in_source_chain(
+    mut source: Option<&(dyn std::error::Error + 'static)>,
+) -> bool {
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<BridgeError>()
+            && error.is_io_transport()
+        {
+            return true;
+        }
+        source = error.source();
+    }
+    false
+}
+
+pub(crate) fn bridge_io_transport_in_anyhow(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<BridgeError>())
+        .any(BridgeError::is_io_transport)
+}
+
+pub(crate) fn message_has_io_bridge_frame(message: &str) -> bool {
+    message.starts_with("Io error: ") && marker_code_in(message).is_some()
+}
+
+/// Build the one Arrow C-stream transport envelope understood by C++.
+///
+/// `BridgeError` keeps the semantic code separate from its escaped diagnostic,
+/// so this does not need to parse a rendered error or trust marker-looking
+/// caller input. Arrow adds the sole `Io error: ` prefix when the stream reports
+/// the error through `get_last_error`.
+pub(crate) fn into_arrow_io_error(error: BridgeError) -> arrow58::error::ArrowError {
+    let message = match error.code {
+        Some(code) => format!("{BRIDGE_ERRCODE_MARKER}{code}; {}", error.msg),
+        None => error.msg,
+    };
+    arrow58::error::ArrowError::IoError(message.clone(), std::io::Error::other(message))
+}
+
+pub fn classify_iceberg_error(error: &iceberg::Error) -> Option<i32> {
+    use iceberg::ErrorKind;
+    let direct = match error.kind() {
+        ErrorKind::TableNotFound | ErrorKind::NamespaceNotFound => Some(LOON_STORAGE_NOT_FOUND),
+        ErrorKind::FeatureUnsupported => Some(BRIDGE_ERRCODE_NOT_SUPPORTED),
+        _ => None,
+    };
+    direct.or_else(|| classify_error_source_chain(std::error::Error::source(error)))
+}
+
+pub fn classify_anyhow_error(error: &anyhow::Error) -> Option<i32> {
+    for cause in error.chain() {
+        if let Some(error) = cause.downcast_ref::<BridgeError>() {
+            if error.code.is_some() {
+                return error.code;
+            }
+        }
+        if let Some(error) = cause.downcast_ref::<iceberg::Error>() {
+            if let Some(code) = classify_iceberg_error(error) {
+                return Some(code);
+            }
+        }
+        if let Some(error) = cause.downcast_ref::<opendal::Error>()
+            && let Some(code) = classify_opendal_error(error)
+        {
+            return Some(code);
+        }
+    }
+    None
+}
+
+impl From<LanceError> for BridgeError {
+    fn from(e: LanceError) -> Self {
+        let io_transport = bridge_io_transport_in_source_chain(Some(&e));
+        BridgeError::with_transport(classify_lance_error(&e), e.to_string(), io_transport)
+    }
+}
+
+impl From<iceberg::Error> for BridgeError {
+    fn from(error: iceberg::Error) -> Self {
+        let io_transport = bridge_io_transport_in_source_chain(Some(&error));
+        BridgeError::with_transport(
+            classify_iceberg_error(&error),
+            error.to_string(),
+            io_transport,
+        )
+    }
+}
+
+impl From<anyhow::Error> for BridgeError {
+    fn from(error: anyhow::Error) -> Self {
+        // Keep the producer's message. Do not build a second diagnostic chain
+        // while an error is already being propagated.
+        let msg = error
+            .downcast_ref::<BridgeError>()
+            .map(|bridge| bridge.msg.clone())
+            .unwrap_or_else(|| error.to_string());
+        let io_transport = bridge_io_transport_in_anyhow(&error);
+        BridgeError::with_transport(classify_anyhow_error(&error), msg, io_transport)
+    }
+}
+
+impl From<arrow58::error::ArrowError> for BridgeError {
+    fn from(e: arrow58::error::ArrowError) -> Self {
+        BridgeError::new(None, e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ErrorReader {
+        error: Option<arrow58::error::ArrowError>,
+        schema: arrow58::datatypes::SchemaRef,
+    }
+
+    impl Iterator for ErrorReader {
+        type Item = Result<arrow58::record_batch::RecordBatch, arrow58::error::ArrowError>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.error.take().map(Err)
+        }
+    }
+
+    impl arrow58::record_batch::RecordBatchReader for ErrorReader {
+        fn schema(&self) -> arrow58::datatypes::SchemaRef {
+            self.schema.clone()
+        }
+    }
+
+    fn ffi_stream_error(error: BridgeError) -> (i32, String) {
+        let reader = ErrorReader {
+            error: Some(into_arrow_io_error(error)),
+            schema: std::sync::Arc::new(arrow58::datatypes::Schema::empty()),
+        };
+        let mut stream = arrow58::ffi_stream::FFI_ArrowArrayStream::new(Box::new(reader));
+        let mut array = arrow58::ffi::FFI_ArrowArray::empty();
+        let code = unsafe { stream.get_next.unwrap()(&mut stream, &mut array) };
+        let message = unsafe {
+            let error = stream.get_last_error.unwrap()(&mut stream);
+            assert!(!error.is_null());
+            std::ffi::CStr::from_ptr(error)
+                .to_string_lossy()
+                .into_owned()
+        };
+        (code, message)
+    }
+
+    // A classified BridgeError that round-trips through anyhow (built, wrapped
+    // as anyhow::Error, re-wrapped by From<anyhow::Error>) must keep its code
+    // and must NOT leak the transport marker into the rebuilt message.
+    #[test]
+    fn anyhow_roundtrip_does_not_leak_marker() {
+        let inner = BridgeError::new(
+            Some(LOON_STORAGE_NOT_FOUND),
+            "snapshot 42 was not found".to_string(),
+        );
+        let rebuilt = BridgeError::from(anyhow::Error::from(inner));
+        assert_eq!(rebuilt.code, Some(LOON_STORAGE_NOT_FOUND));
+        assert!(
+            !rebuilt.msg.contains(BRIDGE_ERRCODE_MARKER),
+            "{}",
+            rebuilt.msg
+        );
+        assert!(rebuilt.msg.contains("snapshot 42 was not found"));
+    }
+
+    #[test]
+    fn anyhow_roundtrip_preserves_io_transport() {
+        let inner = BridgeError::new_io(
+            Some(LOON_STORAGE_CONFIG_INVALID),
+            "credential endpoint rejected the request".to_string(),
+        );
+        let rebuilt = BridgeError::from(anyhow::Error::from(inner).context("refresh token"));
+        assert!(rebuilt.is_io_transport());
+        assert!(rebuilt.to_string().starts_with("Io error: "));
+        assert_eq!(rebuilt.code, Some(LOON_STORAGE_CONFIG_INVALID));
+    }
+
+    #[test]
+    fn credential_http_statuses_use_io_framing() {
+        for (status, expected) in [
+            (403, LOON_STORAGE_ACCESS_DENIED),
+            (404, LOON_STORAGE_CONFIG_INVALID),
+            (429, LOON_TRANSIENT_THROTTLING),
+            (503, LOON_TRANSIENT_SERVICE),
+        ] {
+            let message = credential_http_failure_message(status, "test endpoint");
+            assert!(message.starts_with("Io error: "), "{message}");
+            assert_eq!(marker_code_in(&message), Some(expected), "{message}");
+        }
+    }
+
+    #[test]
+    fn classified_stream_error_has_one_arrow_io_envelope() {
+        for error in [
+            BridgeError::new_io(
+                Some(LOON_TRANSIENT_TIMEOUT),
+                "Lance request timed out".to_string(),
+            ),
+            BridgeError::new(
+                Some(BRIDGE_ERRCODE_DATA_CORRUPT),
+                "Vortex footer is corrupt".to_string(),
+            ),
+        ] {
+            let (code, message) = ffi_stream_error(error);
+            assert_eq!(code, 5, "{message}");
+            assert!(message.starts_with("Io error: __LOON_RUST_BRIDGE_ERRCODE__="));
+            assert!(!message.contains("External error:"), "{message}");
+            assert_eq!(message.matches("Io error: ").count(), 1, "{message}");
+            assert!(marker_code_in(&message).is_some(), "{message}");
+        }
+    }
+
+    #[tokio::test]
+    async fn credential_reqwest_errors_keep_connect_and_timeout_types() {
+        let unused = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let unused_address = unused.local_addr().unwrap();
+        drop(unused);
+        let connect_error = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .unwrap()
+            .get(format!("http://{unused_address}"))
+            .send()
+            .await
+            .unwrap_err();
+        let connect_error = credential_reqwest_error(connect_error, "connect test");
+        assert_eq!(connect_error.code, Some(LOON_TRANSIENT_NETWORK));
+        assert!(connect_error.is_io_transport());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        });
+        let timeout_error = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(20))
+            .build()
+            .unwrap()
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .unwrap_err();
+        let timeout_error = credential_reqwest_error(timeout_error, "timeout test");
+        assert_eq!(timeout_error.code, Some(LOON_TRANSIENT_TIMEOUT));
+        assert!(timeout_error.is_io_transport());
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn aws_credentials_errors_keep_typed_causes() {
+        use aws_credential_types::provider::error::CredentialsError;
+        use aws_sdk_sts::{error::ErrorMetadata, operation::assume_role::AssumeRoleError};
+
+        let timed_out = aws_credentials_error(
+            CredentialsError::provider_timed_out(std::time::Duration::from_secs(1)),
+            "AWS AssumeRole",
+        );
+        assert_eq!(timed_out.code, Some(LOON_TRANSIENT_TIMEOUT));
+
+        let invalid = aws_credentials_error(
+            CredentialsError::invalid_configuration("invalid role configuration"),
+            "AWS AssumeRole",
+        );
+        assert_eq!(invalid.code, Some(LOON_STORAGE_CONFIG_INVALID));
+
+        let sdk_timeout: aws_sdk_sts::error::SdkError<AssumeRoleError> =
+            aws_sdk_sts::error::SdkError::timeout_error(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "STS request timed out",
+            ));
+        let nested = aws_credentials_error(
+            CredentialsError::provider_error(sdk_timeout),
+            "AWS AssumeRole",
+        );
+        assert_eq!(nested.code, Some(LOON_TRANSIENT_TIMEOUT));
+
+        for service_code in ["Throttling", "ThrottlingException"] {
+            let throttled =
+                AssumeRoleError::generic(ErrorMetadata::builder().code(service_code).build());
+            assert_eq!(
+                aws_sts_service_error_code(&throttled, 400),
+                Some(LOON_TRANSIENT_THROTTLING)
+            );
+        }
+
+        let invalid =
+            AssumeRoleError::generic(ErrorMetadata::builder().code("ValidationError").build());
+        assert_eq!(
+            aws_sts_service_error_code(&invalid, 400),
+            Some(LOON_STORAGE_CONFIG_INVALID)
+        );
+    }
+
+    // Commit contention is a Conflict (102), never a retryable throttling
+    // code: generic retry helpers must not blindly replay a commit whose
+    // contention budget may already be spent.
+    #[test]
+    fn lance_commit_contention_classifies_as_conflict() {
+        let contention = LanceError::TooMuchWriteContention {
+            message: "too many concurrent writers".to_string(),
+            location: std::panic::Location::caller(),
+        };
+        assert_eq!(
+            classify_lance_error(&contention),
+            Some(LOON_STORAGE_CONFLICT)
+        );
+
+        let conflict = LanceError::RetryableCommitConflict {
+            version: 7,
+            source: "lost the commit race".into(),
+            location: std::panic::Location::caller(),
+        };
+        assert_eq!(classify_lance_error(&conflict), Some(LOON_STORAGE_CONFLICT));
+    }
+
+    // A classified error that is constructed and then handled INSIDE a guarded
+    // call cannot leak its verdict into a later failure: the code lives in the
+    // message of the error that was handled, and an unrelated failure carries
+    // an unrelated message. This is the property the retired thread-local side
+    // channel needed an explicit clearing rule to approximate.
+    #[test]
+    fn marker_code_round_trips_the_cxx_decoder_contract() {
+        let text = format!(
+            "{BRIDGE_ERRCODE_MARKER}{LOON_TRANSIENT_THROTTLING}; throttled by the object store"
+        );
+        assert_eq!(marker_code_in(&text), Some(LOON_TRANSIENT_THROTTLING));
+        assert_eq!(
+            marker_code_in(&format!(
+                "Io error: {BRIDGE_ERRCODE_MARKER}{LOON_STORAGE_NOT_FOUND}; missing"
+            )),
+            Some(LOON_STORAGE_NOT_FOUND)
+        );
+        // No marker, no code -- the conservative bucket.
+        assert_eq!(marker_code_in("plain failure"), None);
+        // Incomplete marker-like text is not a frame, exactly like the C++ parser.
+        assert_eq!(
+            marker_code_in("vortex: __LOON_RUST_BRIDGE_ERRCODE__; odd"),
+            None
+        );
+        assert_eq!(
+            marker_code_in(&format!(
+                "{BRIDGE_ERRCODE_MARKER}{LOON_TRANSIENT_THROTTLING} missing-semicolon"
+            )),
+            None
+        );
+        // Only the prefix marker is framing; later marker text is inert.
+        let double = format!(
+            "{BRIDGE_ERRCODE_MARKER}{LOON_STORAGE_NOT_FOUND}; outer {BRIDGE_ERRCODE_MARKER}{LOON_STORAGE_CONFLICT}; inner"
+        );
+        assert_eq!(marker_code_in(&double), Some(LOON_STORAGE_NOT_FOUND));
+        assert_eq!(
+            marker_code_in(&format!(
+                "caller path /tmp/{BRIDGE_ERRCODE_MARKER}{LOON_TRANSIENT_THROTTLING}"
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn unclassified_message_cannot_forge_marker_code() {
+        let error = BridgeError::new(
+            None,
+            format!(
+                "failed to open s3://bucket/{BRIDGE_ERRCODE_MARKER}{LOON_TRANSIENT_THROTTLING}"
+            ),
+        );
+        let rendered = error.to_string();
+        assert_eq!(marker_code_in(&rendered), None);
+        assert!(!rendered.contains(BRIDGE_ERRCODE_MARKER), "{rendered}");
+        assert!(rendered.contains(BRIDGE_ERRCODE_ESCAPED), "{rendered}");
+    }
+
+    #[test]
+    fn anyhow_context_keeps_classified_source_without_rebuilding_diagnostics() {
+        let inner = BridgeError::new(Some(LOON_STORAGE_NOT_FOUND), "missing".to_string());
+        let rebuilt = BridgeError::from(anyhow::Error::from(inner).context("planning scan"));
+        assert_eq!(rebuilt.code, Some(LOON_STORAGE_NOT_FOUND));
+        assert!(
+            !rebuilt.msg.contains(BRIDGE_ERRCODE_MARKER),
+            "{}",
+            rebuilt.msg
+        );
+        assert_eq!(rebuilt.msg, "missing");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A classification extracted from an error's TYPE chain.
+//
+// Used only where a consumer needs the verdict as data rather than as text:
+// the vortex async-open callback hands (code, message) to C++ through its own
+// explicit C-ABI signature. Everywhere else the marker in `Display` IS the
+// transport and nothing is extracted.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub(crate) struct ClassifiedErrorInfo {
+    pub code: i32,
+    pub message: String,
+}

--- a/cpp/src/format/bridge/rust/src/cloud_provider_cache.rs
+++ b/cpp/src/format/bridge/rust/src/cloud_provider_cache.rs
@@ -15,7 +15,8 @@ impl<V: Clone> GlobalLruCache<V> {
     pub(crate) fn new(capacity: usize) -> Self {
         Self {
             entries: Mutex::new(LruCache::new(
-                NonZeroUsize::new(capacity).expect("cloud provider cache capacity must be non-zero"),
+                NonZeroUsize::new(capacity)
+                    .expect("cloud provider cache capacity must be non-zero"),
             )),
         }
     }

--- a/cpp/src/format/bridge/rust/src/filesystem_c.rs
+++ b/cpp/src/format/bridge/rust/src/filesystem_c.rs
@@ -9,10 +9,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_compat::Compat;
+use futures::FutureExt;
 #[cfg(feature = "s3-crt-async")]
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
-use futures::FutureExt;
 
 use vortex::array::buffer::BufferHandle;
 #[cfg(feature = "s3-crt-async")]
@@ -289,21 +289,29 @@ unsafe extern "C" {
     ) -> LoonFFIResult;
 }
 
-const LOON_VORTEX_FFI_ERRCODE_MARKER: &str = "__LOON_VORTEX_FFI_ERRCODE__=";
-
 #[derive(Debug)]
-struct LoonFfiError {
-    err_code: i32,
-    context: String,
-    message: String,
+pub(crate) struct LoonFfiError {
+    pub(crate) err_code: i32,
+    pub(crate) context: String,
+    pub(crate) message: String,
 }
 
 impl std::fmt::Display for LoonFfiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The err_code rides the message: VortexError's Display delegates to
+        // this text through its External/Context/Shared/Arrow/Io variants, so
+        // wherever the error travels -- including across the cxx boundary as
+        // `what()` and through Arrow C streams -- the C++ decoder can parse
+        // the classification back out. One construction point, one transport.
+        let context = crate::bridge_error::escape_bridge_error_message(&self.context);
+        let message = crate::bridge_error::escape_bridge_error_message(&self.message);
         write!(
             f,
-            "{LOON_VORTEX_FFI_ERRCODE_MARKER}{}; {}: {}",
-            self.err_code, self.context, self.message
+            "{}{}; {}: {}",
+            crate::bridge_error::BRIDGE_ERRCODE_MARKER,
+            self.err_code,
+            context,
+            message
         )
     }
 }
@@ -316,6 +324,16 @@ fn ffi_err(err_code: i32, context: &str, message: String) -> VortexError {
         context: context.to_string(),
         message,
     })
+}
+
+/// Construct a classified Vortex error without encoding transport metadata in
+/// the human-readable message.
+pub(crate) fn classified_vortex_error(
+    err_code: i32,
+    context: &str,
+    message: String,
+) -> VortexError {
+    ffi_err(err_code, context, message)
 }
 
 // Helper to check LoonFFIResult and convert to VortexError if needed.
@@ -512,6 +530,7 @@ impl<T> Clone for ThreadSafePtr<T> {
 enum WriterSlot {
     Unopened,
     Open(ThreadSafePtr<c_void>),
+    Failed { error: Arc<VortexError> },
     Closed,
 }
 
@@ -552,14 +571,31 @@ impl ObjectStoreWriterInner {
         let mut writer = self.writer.lock().unwrap();
         let writer_ptr = match &mut *writer {
             WriterSlot::Unopened => {
-                let opened = self
-                    .open_writer()
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+                let opened = match self.open_writer() {
+                    Ok(opened) => opened,
+                    Err(error) => {
+                        let error = Arc::new(error);
+                        *writer = WriterSlot::Failed {
+                            error: Arc::clone(&error),
+                        };
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            VortexError::from(error),
+                        ));
+                    }
+                };
                 let writer_ptr = opened.as_ptr();
                 *writer = WriterSlot::Open(opened);
                 writer_ptr
             }
             WriterSlot::Open(writer) => writer.as_ptr(),
+            WriterSlot::Failed { error } => {
+                debug_assert!(false, "stateful writer reused after a terminal failure");
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    VortexError::from(Arc::clone(error)),
+                ));
+            }
             WriterSlot::Closed => {
                 return Err(io::Error::new(
                     io::ErrorKind::BrokenPipe,
@@ -570,19 +606,53 @@ impl ObjectStoreWriterInner {
 
         let mut result =
             unsafe { loon_filesystem_writer_write(writer_ptr, buf.as_ptr(), buf.len() as u64) };
-        check_loon_ffi_result(&mut result, "Failed to write data to ObjectStoreWriterCpp")
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        if let Err(error) =
+            check_loon_ffi_result(&mut result, "Failed to write data to ObjectStoreWriterCpp")
+        {
+            let error = Arc::new(error);
+            let failed_writer = match std::mem::replace(&mut *writer, WriterSlot::Closed) {
+                WriterSlot::Open(writer) => writer,
+                _ => unreachable!("writer must be open after a write attempt"),
+            };
+            unsafe { loon_filesystem_writer_destroy(failed_writer.as_raw_ptr()) };
+            *writer = WriterSlot::Failed {
+                error: Arc::clone(&error),
+            };
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                VortexError::from(error),
+            ));
+        }
 
         Ok(buf.len())
     }
 
     fn flush(&self) -> Result<(), VortexError> {
-        let writer = self.writer.lock().unwrap();
-        match &*writer {
+        let mut writer = self.writer.lock().unwrap();
+        match &mut *writer {
             WriterSlot::Unopened => Ok(()),
-            WriterSlot::Open(writer) => {
-                let mut result = unsafe { loon_filesystem_writer_flush(writer.as_ptr()) };
-                check_loon_ffi_result(&mut result, "Failed to flush data to ObjectStoreWriterCpp")
+            WriterSlot::Open(open_writer) => {
+                let mut result = unsafe { loon_filesystem_writer_flush(open_writer.as_ptr()) };
+                if let Err(error) = check_loon_ffi_result(
+                    &mut result,
+                    "Failed to flush data to ObjectStoreWriterCpp",
+                ) {
+                    let error = Arc::new(error);
+                    let failed_writer = match std::mem::replace(&mut *writer, WriterSlot::Closed) {
+                        WriterSlot::Open(writer) => writer,
+                        _ => unreachable!("writer must be open after a flush attempt"),
+                    };
+                    unsafe { loon_filesystem_writer_destroy(failed_writer.as_raw_ptr()) };
+                    *writer = WriterSlot::Failed {
+                        error: Arc::clone(&error),
+                    };
+                    return Err(VortexError::from(error));
+                }
+                Ok(())
+            }
+            WriterSlot::Failed { error } => {
+                debug_assert!(false, "stateful writer reused after a terminal failure");
+                Err(VortexError::from(Arc::clone(error)))
             }
             WriterSlot::Closed => Err(vortex_err!("cannot flush: ObjectStoreWriterCpp is closed")),
         }
@@ -592,13 +662,27 @@ impl ObjectStoreWriterInner {
         let mut writer = self.writer.lock().unwrap();
         match std::mem::replace(&mut *writer, WriterSlot::Closed) {
             WriterSlot::Unopened | WriterSlot::Closed => Ok(()),
-            WriterSlot::Open(writer) => {
-                let writer_raw = writer.as_raw_ptr();
+            WriterSlot::Open(open_writer) => {
+                let writer_raw = open_writer.as_raw_ptr();
                 let mut result = unsafe { loon_filesystem_writer_close(writer_raw) };
                 let close_result =
                     check_loon_ffi_result(&mut result, "Failed to close ObjectStoreWriterCpp");
                 unsafe { loon_filesystem_writer_destroy(writer_raw) };
-                close_result
+                if let Err(error) = close_result {
+                    let error = Arc::new(error);
+                    *writer = WriterSlot::Failed {
+                        error: Arc::clone(&error),
+                    };
+                    return Err(VortexError::from(error));
+                }
+                Ok(())
+            }
+            WriterSlot::Failed { error } => {
+                let returned_error = VortexError::from(&error);
+                *writer = WriterSlot::Failed { error };
+                drop(writer);
+                debug_assert!(false, "stateful writer reused after a terminal failure");
+                Err(returned_error)
             }
         }
     }
@@ -608,11 +692,14 @@ impl Drop for ObjectStoreWriterInner {
     fn drop(&mut self) {
         let mut writer = self.writer.lock().unwrap();
         let writer = std::mem::replace(&mut *writer, WriterSlot::Closed);
-        if let WriterSlot::Open(writer) = writer {
-            // Only explicit close may complete the object. Drop can run after writer
-            // errors, so calling close here would finalize partial data; release only
-            // the C++ wrapper.
-            unsafe { loon_filesystem_writer_destroy(writer.as_raw_ptr()) };
+        match writer {
+            WriterSlot::Open(writer) => {
+                // Only explicit close may complete the object. Drop can run after writer
+                // errors, so calling close here would finalize partial data; release only
+                // the C++ wrapper.
+                unsafe { loon_filesystem_writer_destroy(writer.as_raw_ptr()) };
+            }
+            WriterSlot::Unopened | WriterSlot::Failed { .. } | WriterSlot::Closed => {}
         }
     }
 }
@@ -699,7 +786,7 @@ impl Write for ObjectStoreWriterCpp {
         self.writer
             .inner
             .flush()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 }
 
@@ -738,7 +825,7 @@ impl VortexWrite for ObjectStoreWriterCpp {
         self.writer
             .flush()
             .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 
     async fn shutdown(&mut self) -> io::Result<()> {
@@ -787,9 +874,7 @@ impl Drop for ReaderHandle {
         unsafe {
             if !self.ptr.is_null() {
                 let mut result = loon_filesystem_reader_close(self.ptr);
-                if let Err(e) = check_loon_ffi_result(&mut result, "Failed to close ReaderHandle") {
-                    eprintln!("Warning: ReaderHandle close failed: {e}");
-                }
+                let _ = check_loon_ffi_result(&mut result, "Failed to close ReaderHandle");
                 loon_filesystem_reader_destroy(self.ptr);
             }
         }
@@ -831,12 +916,6 @@ impl ObjectStoreReadSourceCpp {
         let supports_async = match reader_supports_async(reader_raw) {
             Ok(supported) => supported,
             Err(e) => unsafe {
-                let mut result = loon_filesystem_reader_close(reader_raw);
-                if let Err(close_err) =
-                    check_loon_ffi_result(&mut result, "Failed to close ReaderHandle")
-                {
-                    eprintln!("Warning: ReaderHandle close failed: {close_err}");
-                }
                 loon_filesystem_reader_destroy(reader_raw);
                 return Err(e);
             },
@@ -879,7 +958,9 @@ impl VortexReadAt for ObjectStoreReadSourceCpp {
         Compat::new(async move {
             // Pass path as bytes to FFI (no allocation across FFI boundaries)
             let path_bytes = path.into_bytes();
-            // Return Result from blocking task to propagate errors cleanly
+            // Keep the structured filesystem error inside VortexError while it
+            // crosses the blocking-pool boundary. Stringifying it here loses the
+            // Loon code and makes the decoder layer mistake I/O for corrupt data.
             let task = handle.spawn_blocking(move || unsafe {
                 let mut out_size: u64 = 0;
                 let mut result = loon_filesystem_get_file_info(
@@ -891,12 +972,11 @@ impl VortexReadAt for ObjectStoreReadSourceCpp {
                 check_loon_ffi_result(
                     &mut result,
                     "Failed to get object size from ObjectStoreIoSourceCpp",
-                )
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+                )?;
 
-                Ok::<u64, std::io::Error>(out_size)
+                Ok::<u64, VortexError>(out_size)
             });
-            let size: u64 = Compat::new(task).await.map_err(|e| vortex_err!("{}", e))?;
+            let size: u64 = Compat::new(task).await?;
             Ok(size)
         })
         .boxed()

--- a/cpp/src/format/bridge/rust/src/gcp_impersonation.rs
+++ b/cpp/src/format/bridge/rust/src/gcp_impersonation.rs
@@ -64,16 +64,16 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use iceberg::io::{
-    FileMetadata, FileRead, FileWrite, GCS_DISABLE_CONFIG_LOAD, GCS_DISABLE_VM_METADATA,
-    GCS_TOKEN, InputFile, OutputFile, Storage as IcebergStorage, StorageConfig, StorageFactory,
+    FileMetadata, FileRead, FileWrite, GCS_DISABLE_CONFIG_LOAD, GCS_DISABLE_VM_METADATA, GCS_TOKEN,
+    InputFile, OutputFile, Storage as IcebergStorage, StorageConfig, StorageFactory,
 };
 use iceberg::{Error as IcebergError, ErrorKind as IcebergErrorKind, Result as IcebergResult};
 use iceberg_storage_opendal::OpenDalStorageFactory;
 use object_store::{
-    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
     CredentialProvider, ObjectStore as OSObjectStore, Result as ObjectStoreResult, RetryConfig,
+    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use snafu::location;
 use std::str::FromStr;
 use tokio::sync::RwLock;
@@ -194,6 +194,21 @@ struct GenerateAccessTokenResponse {
 /// token-fetch helper used by both Lance and Iceberg.
 const IMPERSONATION_STORE_NAME: &str = "gcp_impersonation";
 
+async fn decode_credential_json<T: DeserializeOwned>(
+    response: reqwest::Response,
+    context: &str,
+) -> ObjectStoreResult<T> {
+    response
+        .json()
+        .await
+        .map_err(|error| object_store::Error::Generic {
+            store: IMPERSONATION_STORE_NAME,
+            source: Box::new(crate::bridge_error::credential_reqwest_error(
+                error, context,
+            )),
+        })
+}
+
 /// Run the VM-SA → IAM `generateAccessToken(target_sa)` exchange end-to-end
 /// and return the raw `accessToken` + `expireTime` for the shared refreshable
 /// provider.
@@ -213,16 +228,13 @@ async fn fetch_impersonated_access_token(
         .and_then(|r| r.error_for_status())
         .map_err(|e| object_store::Error::Generic {
             store: IMPERSONATION_STORE_NAME,
-            source: format!(
-                "metadata server token request failed (this code path requires running on a \
-                 GCE VM with a default service account attached): {e}"
-            )
-            .into(),
+            source: Box::new(crate::bridge_error::credential_reqwest_error(
+                e,
+                "GCP metadata server token request (requires a GCE VM default service account)",
+            )),
         })?;
-    let vm_token: MetadataTokenResponse = vm_resp.json().await.map_err(|e| object_store::Error::Generic {
-        store: IMPERSONATION_STORE_NAME,
-        source: format!("metadata token response was not valid JSON: {e}").into(),
-    })?;
+    let vm_token: MetadataTokenResponse =
+        decode_credential_json(vm_resp, "GCP metadata server token response body").await?;
 
     // 2. Use the VM token as the bearer to call IAM `generateAccessToken`
     //    on the target SA. The VM SA needs `roles/iam.serviceAccountTokenCreator`
@@ -240,16 +252,15 @@ async fn fetch_impersonated_access_token(
         .and_then(|r| r.error_for_status())
         .map_err(|e| object_store::Error::Generic {
             store: IMPERSONATION_STORE_NAME,
-            source: format!(
-                "IAM generateAccessToken({target_sa}) failed (the VM SA likely lacks \
-                 roles/iam.serviceAccountTokenCreator on the target SA): {e}"
-            )
-            .into(),
+            source: Box::new(crate::bridge_error::credential_reqwest_error(
+                e,
+                &format!(
+                    "GCP IAM generateAccessToken({target_sa}); the VM service account needs \
+                     roles/iam.serviceAccountTokenCreator"
+                ),
+            )),
         })?;
-    iam_resp.json().await.map_err(|e| object_store::Error::Generic {
-        store: IMPERSONATION_STORE_NAME,
-        source: format!("generateAccessToken response was not valid JSON: {e}").into(),
-    })
+    decode_credential_json(iam_resp, "GCP IAM generateAccessToken response body").await
 }
 
 #[derive(Clone)]
@@ -345,9 +356,12 @@ impl ImpersonatingGcsCredentialProvider {
     }
 
     async fn fetch_impersonated_token(&self) -> ObjectStoreResult<CachedToken> {
-        let iam_body =
-            fetch_impersonated_access_token(&self.http_client, &self.target_sa, self.token_lifetime)
-                .await?;
+        let iam_body = fetch_impersonated_access_token(
+            &self.http_client,
+            &self.target_sa,
+            self.token_lifetime,
+        )
+        .await?;
 
         // Compute the expiry from IAM's RFC3339 `expireTime`. We rely on IAM's
         // clock rather than `now + lifetime` so clock skew between us and
@@ -517,8 +531,9 @@ pub(crate) fn build_lance_session(provider: Arc<dyn ObjectStoreProvider>) -> Arc
 fn gcp_iceberg_credential_error(error: object_store::Error) -> IcebergError {
     IcebergError::new(
         IcebergErrorKind::Unexpected,
-        format!("GCP impersonation credential resolution failed: {error}"),
+        "GCP impersonation credential resolution failed",
     )
+    .with_source(error)
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -684,20 +699,72 @@ mod tests {
 
     use futures::future::join_all;
     use iceberg::io::{StorageConfig, StorageFactory};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
     use tokio::sync::{Barrier, Notify};
 
     use super::*;
     use std::collections::HashMap;
 
     #[tokio::test]
+    async fn credential_body_timeout_keeps_typed_cause() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 100\r\n\r\n{",
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(50))
+            .build()
+            .unwrap();
+        let response = client
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .unwrap();
+        let error = match decode_credential_json::<MetadataTokenResponse>(
+            response,
+            "GCP metadata server token response body",
+        )
+        .await
+        {
+            Ok(_) => panic!("expected credential body timeout"),
+            Err(error) => error,
+        };
+        let object_store::Error::Generic { source, .. } = error else {
+            panic!("expected generic credential error");
+        };
+        let bridge = source
+            .downcast_ref::<crate::bridge_error::BridgeError>()
+            .expect("typed bridge cause");
+        assert_eq!(
+            bridge.code,
+            Some(crate::bridge_error::LOON_TRANSIENT_TIMEOUT)
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn impersonation_store_uses_aimd_throttle_when_client_retries_enabled() {
         let params = ObjectStoreParams {
             storage_options_accessor: Some(Arc::new(
-                lance_io::object_store::StorageOptionsAccessor::with_static_options(HashMap::from([
-                    ("client_max_retries".to_string(), "1".to_string()),
-                    ("lance_aimd_initial_rate".to_string(), "10".to_string()),
-                    ("lance_aimd_max_rate".to_string(), "10".to_string()),
-                ])),
+                lance_io::object_store::StorageOptionsAccessor::with_static_options(HashMap::from(
+                    [
+                        ("client_max_retries".to_string(), "1".to_string()),
+                        ("lance_aimd_initial_rate".to_string(), "10".to_string()),
+                        ("lance_aimd_max_rate".to_string(), "10".to_string()),
+                    ],
+                )),
             )),
             ..Default::default()
         };
@@ -717,11 +784,13 @@ mod tests {
     async fn impersonation_store_skips_aimd_when_client_retries_disabled() {
         let params = ObjectStoreParams {
             storage_options_accessor: Some(Arc::new(
-                lance_io::object_store::StorageOptionsAccessor::with_static_options(HashMap::from([
-                    ("client_max_retries".to_string(), "0".to_string()),
-                    ("lance_aimd_initial_rate".to_string(), "10".to_string()),
-                    ("lance_aimd_max_rate".to_string(), "10".to_string()),
-                ])),
+                lance_io::object_store::StorageOptionsAccessor::with_static_options(HashMap::from(
+                    [
+                        ("client_max_retries".to_string(), "0".to_string()),
+                        ("lance_aimd_initial_rate".to_string(), "10".to_string()),
+                        ("lance_aimd_max_rate".to_string(), "10".to_string()),
+                    ],
+                )),
             )),
             ..Default::default()
         };

--- a/cpp/src/format/bridge/rust/src/iceberg_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/iceberg_bridge.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "iceberg_bridge.h"
+#include "bridge_error.h"
 #include "bridge_util.h"
 
 #include "rust/cxx.h"
@@ -22,9 +23,10 @@ namespace milvus_storage::iceberg {
 
 using milvus_storage::ConvertStorageOptions;
 
-std::vector<IcebergFileInfo> PlanFiles(const std::string& metadata_location,
-                                       int64_t snapshot_id,
-                                       const std::unordered_map<std::string, std::string>& storage_options) {
+arrow::Result<std::vector<IcebergFileInfo>> PlanFiles(
+    const std::string& metadata_location,
+    int64_t snapshot_id,
+    const std::unordered_map<std::string, std::string>& storage_options) {
   try {
     rust::Vec<rust::String> keys, values;
     ConvertStorageOptions(storage_options, keys, values);
@@ -44,16 +46,16 @@ std::vector<IcebergFileInfo> PlanFiles(const std::string& metadata_location,
     }
     return result;
   } catch (const rust::cxxbridge1::Error& e) {
-    throw IcebergException(e.what());
+    return milvus_storage::bridge::BridgeErrorStatusFromException(e.what());
   }
 }
 
-IcebergTestTableInfo CreateTestTable(const std::string& table_dir,
-                                     uint64_t num_rows,
-                                     bool with_positional_deletes,
-                                     const std::vector<int64_t>& deleted_positions,
-                                     const std::unordered_map<std::string, std::string>& storage_options,
-                                     const std::string& record_scheme_override) {
+arrow::Result<IcebergTestTableInfo> CreateTestTable(const std::string& table_dir,
+                                                    uint64_t num_rows,
+                                                    bool with_positional_deletes,
+                                                    const std::vector<int64_t>& deleted_positions,
+                                                    const std::unordered_map<std::string, std::string>& storage_options,
+                                                    const std::string& record_scheme_override) {
   try {
     rust::Vec<int64_t> rust_positions;
     for (auto pos : deleted_positions) {
@@ -73,7 +75,7 @@ IcebergTestTableInfo CreateTestTable(const std::string& table_dir,
         std::string(result.data_file_uri.data(), result.data_file_uri.size()),
     };
   } catch (const rust::cxxbridge1::Error& e) {
-    throw IcebergException(e.what());
+    return milvus_storage::bridge::BridgeErrorStatusFromException(e.what());
   }
 }
 

--- a/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_bridgeimpl.rs
@@ -13,27 +13,26 @@
 // limitations under the License.
 
 use crate::TOKIO_RT;
+use crate::bridge_error::{BridgeError, BridgeResult};
 
 use arrow_array::Array;
 use futures::TryStreamExt;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
 
+use crate::aliyun_oss_provider::AliyunOssStorageFactory;
+use crate::aws_arn_provider::{AssumeRoleConfig, build_iceberg_factory};
+use crate::azure_sas_provider::{AzureBrokerConfig, AzureSasStorageFactory};
+use crate::cloud_provider_cache::{CACHE_CAPACITY, CACHE_KEY, GlobalLruCache};
+use crate::gcp_impersonation::{
+    GcpImpersonationConfig, GcpImpersonationStorageFactory, ICEBERG_TARGET_SERVICE_ACCOUNT,
+};
+use crate::iceberg_ffi::IcebergFileInfo;
 use iceberg::TableIdent;
 use iceberg::io::{FileIOBuilder, LocalFsStorageFactory, MemoryStorageFactory, StorageFactory};
 use iceberg::scan::FileScanTask;
 use iceberg::table::StaticTable;
 use iceberg_storage_opendal::OpenDalStorageFactory;
-use crate::aliyun_oss_provider::AliyunOssStorageFactory;
-use crate::aws_arn_provider::{AssumeRoleConfig, build_iceberg_factory};
-use crate::azure_sas_provider::{AzureBrokerConfig, AzureSasStorageFactory};
-use crate::cloud_provider_cache::{
-    CACHE_CAPACITY, CACHE_KEY, GlobalLruCache,
-};
-use crate::gcp_impersonation::{
-    GcpImpersonationConfig, GcpImpersonationStorageFactory, ICEBERG_TARGET_SERVICE_ACCOUNT,
-};
-use crate::iceberg_ffi::IcebergFileInfo;
 
 const CLOUD_PROVIDER_KEY: &str = "cloud_provider";
 
@@ -101,9 +100,7 @@ async fn upstream_opendal_factory(
         None
     };
     let assume_role = if cloud_provider.as_deref() == Some("aws") {
-        let role_arn = props
-            .remove("client.assume-role.arn")
-            .unwrap_or_default();
+        let role_arn = props.remove("client.assume-role.arn").unwrap_or_default();
         let session_name = props
             .remove("client.assume-role.session-name")
             .unwrap_or_default();
@@ -258,10 +255,7 @@ pub(crate) fn normalize_uri(uri: &str, props: &HashMap<String, String>) -> (Stri
                 let account = match props.get("adls.account-name") {
                     Some(a) if !a.is_empty() => a,
                     _ => {
-                        return (
-                            format!("{normalized_scheme}://{rest}"),
-                            "abfss".to_string(),
-                        );
+                        return (format!("{normalized_scheme}://{rest}"), "abfss".to_string());
                     }
                 };
                 let suffix = props
@@ -271,9 +265,7 @@ pub(crate) fn normalize_uri(uri: &str, props: &HashMap<String, String>) -> (Stri
                 if let Some(slash) = rest.find('/') {
                     let container = &rest[..slash];
                     let path = &rest[slash..];
-                    format!(
-                        "{normalized_scheme}://{container}@{account}.dfs.{suffix}{path}"
-                    )
+                    format!("{normalized_scheme}://{container}@{account}.dfs.{suffix}{path}")
                 } else {
                     format!("{normalized_scheme}://{rest}@{account}.dfs.{suffix}")
                 }
@@ -327,10 +319,11 @@ async fn count_positional_deletes(
     file_io: &iceberg::io::FileIO,
     data_file_path: &str,
     delete_refs: &[DeleteFileRef],
+    record_count: u64,
 ) -> Result<u64, anyhow::Error> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
-    let mut total = 0u64;
+    let mut positions = HashSet::new();
     for del_ref in delete_refs {
         if del_ref.file_type != "position" {
             continue;
@@ -339,28 +332,106 @@ async fn count_positional_deletes(
         // Read the delete file via FileIO
         let input = file_io.new_input(&del_ref.path)?;
         let bytes = input.read().await?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes)
+            .map_err(|error| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::DataInvalid,
+                    format!(
+                        "cannot read positional delete Parquet metadata {}: {error}",
+                        del_ref.path
+                    ),
+                )
+            })?
+            .build()
+            .map_err(|error| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::DataInvalid,
+                    format!(
+                        "cannot decode positional delete Parquet file {}: {error}",
+                        del_ref.path
+                    ),
+                )
+            })?;
 
         for batch in reader {
-            let batch = batch?;
+            let batch = batch.map_err(|error| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::DataInvalid,
+                    format!(
+                        "cannot decode positional delete batch {}: {error}",
+                        del_ref.path
+                    ),
+                )
+            })?;
             let schema = batch.schema();
-            let file_path_idx = schema.index_of("file_path").unwrap_or(0);
-
-            let file_path_col = batch
+            let file_path_idx = schema.index_of("file_path").map_err(|_| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::DataInvalid,
+                    format!(
+                        "positional delete file is missing file_path: {}",
+                        del_ref.path
+                    ),
+                )
+            })?;
+            let pos_idx = schema.index_of("pos").map_err(|_| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::DataInvalid,
+                    format!("positional delete file is missing pos: {}", del_ref.path),
+                )
+            })?;
+            let file_path_array = batch
                 .column(file_path_idx)
                 .as_any()
-                .downcast_ref::<arrow_array::StringArray>();
-
-            if let Some(file_path_array) = file_path_col {
-                for i in 0..file_path_array.len() {
-                    if !file_path_array.is_null(i) && file_path_array.value(i) == data_file_path {
-                        total += 1;
+                .downcast_ref::<arrow_array::StringArray>()
+                .ok_or_else(|| {
+                    iceberg::Error::new(
+                        iceberg::ErrorKind::DataInvalid,
+                        format!(
+                            "positional delete file_path must be string: {}",
+                            del_ref.path
+                        ),
+                    )
+                })?;
+            let pos_array = batch
+                .column(pos_idx)
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .ok_or_else(|| {
+                    iceberg::Error::new(
+                        iceberg::ErrorKind::DataInvalid,
+                        format!("positional delete pos must be int64: {}", del_ref.path),
+                    )
+                })?;
+            for i in 0..file_path_array.len() {
+                if file_path_array.is_null(i) || pos_array.is_null(i) {
+                    return Err(iceberg::Error::new(
+                        iceberg::ErrorKind::DataInvalid,
+                        format!(
+                            "positional delete contains null file_path/pos: {}",
+                            del_ref.path
+                        ),
+                    )
+                    .into());
+                }
+                if file_path_array.value(i) == data_file_path {
+                    let position = pos_array.value(i);
+                    if position < 0 || position as u64 >= record_count {
+                        return Err(iceberg::Error::new(
+                            iceberg::ErrorKind::DataInvalid,
+                            format!("positional delete position {position} is outside data file {data_file_path}"),
+                        ).into());
                     }
+                    // Deletes are a set: a snapshot may legally carry several
+                    // delete files naming the same (file_path, pos), so a
+                    // repeat is deduplicated rather than rejected. The
+                    // out-of-range case above stays an error -- it cannot be
+                    // applied to this data file at all.
+                    positions.insert(position);
                 }
             }
         }
     }
-    Ok(total)
+    Ok(positions.len() as u64)
 }
 
 fn build_delete_metadata(task: &FileScanTask) -> Vec<DeleteFileRef> {
@@ -388,12 +459,15 @@ pub fn iceberg_plan_files(
     snapshot_id: i64,
     storage_options_keys: Vec<String>,
     storage_options_values: Vec<String>,
-) -> Result<Vec<IcebergFileInfo>, anyhow::Error> {
+) -> BridgeResult<Vec<IcebergFileInfo>> {
     if metadata_location.is_empty() {
-        anyhow::bail!("metadata_location must not be empty");
+        return Err(BridgeError::new(
+            None,
+            "metadata_location must not be empty".to_string(),
+        ));
     }
 
-    TOKIO_RT.block_on(async {
+    let result: anyhow::Result<Vec<IcebergFileInfo>> = TOKIO_RT.block_on(async {
         let mut props = vec_to_hashmap(storage_options_keys, storage_options_values);
 
         // Normalize URI for opendal and detect FileIO scheme in one pass.
@@ -410,6 +484,13 @@ pub fn iceberg_plan_files(
         let table = table.into_table();
 
         // Build scan pinned to the specified snapshot
+        if table.metadata().snapshot_by_id(snapshot_id).is_none() {
+            return Err(BridgeError::new(
+                Some(crate::bridge_error::LOON_STORAGE_NOT_FOUND),
+                format!("Iceberg snapshot with id {snapshot_id} was not found"),
+            )
+            .into());
+        }
         let scan = table.scan().snapshot_id(snapshot_id).build()?;
 
         // Plan files — returns one FileScanTask per data file
@@ -424,22 +505,30 @@ pub fn iceberg_plan_files(
             // positional deletes before the manifest is committed.
             for del_ref in &delete_refs {
                 if del_ref.file_type == "equality" {
-                    anyhow::bail!(
-                        "Equality deletes are not supported. \
-                         Data file: {}, delete file: {}. \
-                         Equality deletes must be converted to positional deletes \
-                         before explore.",
-                        task.data_file_path,
-                        del_ref.path
-                    );
+                    return Err(iceberg::Error::new(
+                        iceberg::ErrorKind::FeatureUnsupported,
+                        format!(
+                            "Equality deletes are not supported. Data file: {}, delete file: {}. \
+                             Equality deletes must be converted to positional deletes before explore.",
+                            task.data_file_path, del_ref.path
+                        ),
+                    )
+                    .into());
                 }
             }
 
             // Count deleted rows by reading positional delete files
+            let record_count = task.record_count.ok_or_else(|| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::DataInvalid,
+                    format!("Iceberg data file has no record count: {}", task.data_file_path),
+                )
+            })?;
             let num_deleted_rows = if delete_refs.is_empty() {
                 0
             } else {
-                count_positional_deletes(&file_io, &task.data_file_path, &delete_refs).await?
+                count_positional_deletes(&file_io, &task.data_file_path, &delete_refs, record_count)
+                    .await?
             };
 
             // Denormalize delete file paths back to scheme://bucket/path for C++.
@@ -458,10 +547,6 @@ pub fn iceberg_plan_files(
                 serde_json::to_vec(&denorm_refs)?
             };
 
-            // record_count is required by Iceberg spec but Option in Rust.
-            // Fallback: 0 (caller should handle via Parquet metadata read).
-            let record_count = task.record_count.unwrap_or(0);
-
             // Denormalize data_file_path: strip Azure container@endpoint back to
             // scheme://container/path so C++ sees a uniform format across providers.
             result.push(IcebergFileInfo {
@@ -472,7 +557,8 @@ pub fn iceberg_plan_files(
             });
         }
         Ok(result)
-    })
+    });
+    result.map_err(BridgeError::from)
 }
 
 #[cfg(test)]

--- a/cpp/src/format/bridge/rust/src/iceberg_testutil.rs
+++ b/cpp/src/format/bridge/rust/src/iceberg_testutil.rs
@@ -34,9 +34,7 @@ use iceberg::spec::{
 };
 
 use crate::TOKIO_RT;
-use crate::iceberg_bridgeimpl::{
-    build_file_io, denormalize_uri, normalize_uri, vec_to_hashmap,
-};
+use crate::iceberg_bridgeimpl::{build_file_io, denormalize_uri, normalize_uri, vec_to_hashmap};
 use crate::iceberg_test_ffi::IcebergTestTableInfo;
 
 /// Write a Parquet record batch to bytes in memory.

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -13,99 +13,85 @@
 // limitations under the License.
 
 #include "lance_bridge.h"
+#include "bridge_error.h"
 #include "bridge_util.h"
 
 #include <memory>
+#include <utility>
 
 namespace milvus_storage::lance {
 
 void ReplaceLanceRuntime(uint32_t num_threads) {}
 
 using milvus_storage::ConvertStorageOptions;
+// Both guards live in bridge_error.h now: they run the call, and on a cxx
+// exception decode the classification out of the universal marker in the
+// error message.
+using milvus_storage::bridge::CatchBridgeError;
+using milvus_storage::bridge::CatchBridgeStatus;
 
-std::shared_ptr<BlockingDataset> BlockingDataset::Open(const std::string& uri, const StorageOptions& storage_options) {
-  try {
+arrow::Result<std::shared_ptr<BlockingDataset>> BlockingDataset::Open(const std::string& uri,
+                                                                      const StorageOptions& storage_options) {
+  return CatchBridgeError([&] {
     rust::Vec<rust::String> keys, values;
     ConvertStorageOptions(storage_options, keys, values);
     return std::make_shared<BlockingDataset>(
         ffi::open_dataset(rust::Str(uri.data(), uri.length()), std::move(keys), std::move(values)));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-std::unique_ptr<BlockingDataset> BlockingDataset::OpenUnique(const std::string& uri,
-                                                             const StorageOptions& storage_options) {
-  try {
+arrow::Result<std::unique_ptr<BlockingDataset>> BlockingDataset::OpenUnique(const std::string& uri,
+                                                                            const StorageOptions& storage_options) {
+  return CatchBridgeError([&] {
     rust::Vec<rust::String> keys, values;
     ConvertStorageOptions(storage_options, keys, values);
     return std::make_unique<BlockingDataset>(
         ffi::open_dataset(rust::Str(uri.data(), uri.length()), std::move(keys), std::move(values)));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-std::unique_ptr<BlockingDataset> BlockingDataset::WriteDataset(const std::string& uri,
-                                                               struct ArrowArrayStream* stream,
-                                                               const StorageOptions& storage_options,
-                                                               LanceDataStorageFormat format) {
-  try {
+arrow::Result<std::unique_ptr<BlockingDataset>> BlockingDataset::WriteDataset(const std::string& uri,
+                                                                              struct ArrowArrayStream* stream,
+                                                                              const StorageOptions& storage_options,
+                                                                              LanceDataStorageFormat format) {
+  return CatchBridgeError([&] {
     rust::Vec<rust::String> keys, values;
     ConvertStorageOptions(storage_options, keys, values);
     auto ffi_format = static_cast<ffi::LanceDataStorageFormat>(format);
     return std::make_unique<BlockingDataset>(ffi::write_dataset(rust::Str(uri.data(), uri.length()),
                                                                 reinterpret_cast<uint8_t*>(stream), std::move(keys),
                                                                 std::move(values), ffi_format));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-void BlockingDataset::DeleteRows(const std::string& predicate) {
-  try {
-    ffi::dataset_delete_rows(*impl_, rust::Str(predicate.data(), predicate.length()));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Status BlockingDataset::DeleteRows(const std::string& predicate) {
+  return CatchBridgeStatus([&] { ffi::dataset_delete_rows(*impl_, rust::Str(predicate.data(), predicate.length())); });
 }
 
-std::vector<uint64_t> BlockingDataset::GetAllFragmentIds() const {
-  try {
+arrow::Result<std::vector<uint64_t>> BlockingDataset::GetAllFragmentIds() const {
+  return CatchBridgeError([&] {
     auto fragment_ids = impl_->get_all_fragment_ids();
-    return {fragment_ids.begin(), fragment_ids.end()};
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+    return std::vector<uint64_t>{fragment_ids.begin(), fragment_ids.end()};
+  });
 }
 
-std::vector<uint64_t> BlockingDataset::GetFragmentDeletionPositions(uint64_t fragment_id) const {
-  try {
+arrow::Result<std::vector<uint64_t>> BlockingDataset::GetFragmentDeletionPositions(uint64_t fragment_id) const {
+  return CatchBridgeError([&] {
     auto positions = ffi::get_fragment_deletion_positions(*impl_, fragment_id);
-    return {positions.begin(), positions.end()};
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+    return std::vector<uint64_t>{positions.begin(), positions.end()};
+  });
 }
 
-uint64_t BlockingDataset::GetFragmentPhysicalRowCount(uint64_t fragment_id) const {
-  try {
-    return ffi::get_fragment_physical_row_count(*impl_, fragment_id);
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Result<uint64_t> BlockingDataset::GetFragmentPhysicalRowCount(uint64_t fragment_id) const {
+  return CatchBridgeError([&] { return ffi::get_fragment_physical_row_count(*impl_, fragment_id); });
 }
 
-uint64_t BlockingDataset::GetFragmentRowCount(uint64_t fragment_id) const {
-  try {
-    return ffi::get_fragment_row_count(*impl_, fragment_id);
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Result<uint64_t> BlockingDataset::GetFragmentRowCount(uint64_t fragment_id) const {
+  return CatchBridgeError([&] { return ffi::get_fragment_row_count(*impl_, fragment_id); });
 }
 
 arrow::Result<std::vector<uint64_t>> BlockingDataset::EstimateFragmentColumnMemory(uint64_t fragment_id) const {
-  try {
+  return CatchBridgeError([&] {
     auto estimates = ffi::estimate_fragment_column_memory(*impl_, fragment_id);
     std::vector<uint64_t> memory_sizes;
     memory_sizes.reserve(estimates.size());
@@ -113,105 +99,77 @@ arrow::Result<std::vector<uint64_t>> BlockingDataset::EstimateFragmentColumnMemo
       memory_sizes.push_back(estimate.memory_size);
     }
     return memory_sizes;
-  } catch (const rust::cxxbridge1::Error& e) {
-    return arrow::Status::NotImplemented("Lance column memory size estimation is not available: ", e.what());
-  }
+  });
 }
 
-uint64_t BlockingDataset::EstimateFragmentMemory(uint64_t fragment_id) const {
-  try {
-    return ffi::estimate_fragment_memory(*impl_, fragment_id);
-  } catch (const rust::cxxbridge1::Error&) {
-    return 0;
-  }
+arrow::Result<uint64_t> BlockingDataset::EstimateFragmentMemory(uint64_t fragment_id) const {
+  return CatchBridgeError([&] { return ffi::estimate_fragment_memory(*impl_, fragment_id); });
 }
 
-void BlockingDataset::GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const {
-  try {
-    ffi::get_fragment_schema(*impl_, fragment_id, reinterpret_cast<uint8_t*>(&out_schema));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Status BlockingDataset::GetFragmentSchema(uint64_t fragment_id, ArrowSchema& out_schema) const {
+  return CatchBridgeStatus(
+      [&] { ffi::get_fragment_schema(*impl_, fragment_id, reinterpret_cast<uint8_t*>(&out_schema)); });
 }
 
-void BlockingDataset::WriteArrowArrayStream(struct ArrowArrayStream* stream) {
-  try {
-    impl_->write_stream(reinterpret_cast<uint8_t*>(stream));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Status BlockingDataset::WriteArrowArrayStream(struct ArrowArrayStream* stream) {
+  return CatchBridgeStatus([&] { impl_->write_stream(reinterpret_cast<uint8_t*>(stream)); });
 }
 
-std::unique_ptr<BlockingFragmentReader> BlockingFragmentReader::Open(const BlockingDataset& dataset,
-                                                                     uint64_t fragment_id,
-                                                                     ArrowSchema& schema) {
-  try {
+arrow::Result<std::unique_ptr<BlockingFragmentReader>> BlockingFragmentReader::Open(const BlockingDataset& dataset,
+                                                                                    uint64_t fragment_id,
+                                                                                    ArrowSchema& schema) {
+  return CatchBridgeError([&] {
     auto impl = ffi::open_fragment_reader(dataset.Impl(), fragment_id, reinterpret_cast<uint8_t*>(&schema));
     return std::make_unique<BlockingFragmentReader>(std::move(impl));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-uint64_t BlockingFragmentReader::RowCount() const {
-  try {
-    return impl_->number_of_rows();
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Result<uint64_t> BlockingFragmentReader::RowCount() const {
+  return CatchBridgeError([&] { return impl_->number_of_rows(); });
 }
 
-void BlockingFragmentReader::TakeAsSingleBatch(const std::vector<int64_t>& indices, ArrowArray& out_array) {
-  try {
+arrow::Status BlockingFragmentReader::TakeAsSingleBatch(const std::vector<int64_t>& indices, ArrowArray& out_array) {
+  return CatchBridgeStatus([&] {
     std::vector<uint32_t> uint32_indices(indices.begin(), indices.end());
     rust::Slice<const uint32_t> indices_slice(uint32_indices.data(), uint32_indices.size());
     impl_->take_as_single_batch(indices_slice, reinterpret_cast<uint8_t*>(&out_array));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-ArrowArrayStream BlockingFragmentReader::TakeAsStream(const std::vector<int64_t>& indices, uint32_t batch_size) {
-  try {
+arrow::Result<ArrowArrayStream> BlockingFragmentReader::TakeAsStream(const std::vector<int64_t>& indices,
+                                                                     uint32_t batch_size) {
+  return CatchBridgeError([&] {
     ArrowArrayStream stream;
     std::vector<uint32_t> uint32_indices(indices.begin(), indices.end());
     rust::Slice<const uint32_t> indices_slice(uint32_indices.data(), uint32_indices.size());
     impl_->take_as_stream(indices_slice, batch_size, reinterpret_cast<uint8_t*>(&stream));
     return stream;
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-ArrowArrayStream BlockingFragmentReader::ReadAllAsStream(uint32_t batch_size) {
-  try {
+arrow::Result<ArrowArrayStream> BlockingFragmentReader::ReadAllAsStream(uint32_t batch_size) {
+  return CatchBridgeError([&] {
     ArrowArrayStream stream;
     impl_->read_all_as_stream(batch_size, reinterpret_cast<uint8_t*>(&stream));
     return stream;
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-ArrowArrayStream BlockingFragmentReader::ReadRangesAsStream(uint32_t row_range_start,
-                                                            uint32_t row_range_end,
-                                                            uint32_t batch_size) {
-  try {
+arrow::Result<ArrowArrayStream> BlockingFragmentReader::ReadRangesAsStream(uint32_t row_range_start,
+                                                                           uint32_t row_range_end,
+                                                                           uint32_t batch_size) {
+  return CatchBridgeError([&] {
     ArrowArrayStream stream;
     impl_->read_ranges_as_stream(row_range_start, row_range_end, batch_size, reinterpret_cast<uint8_t*>(&stream));
     return stream;
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-std::unique_ptr<BlockingScanner> BlockingDataset::Scan(ArrowSchema& schema, uint32_t batch_size) {
-  try {
+arrow::Result<std::unique_ptr<BlockingScanner>> BlockingDataset::Scan(ArrowSchema& schema, uint32_t batch_size) {
+  return CatchBridgeError([&] {
     auto impl = ffi::create_scanner(*impl_, reinterpret_cast<uint8_t*>(&schema), batch_size);
     return std::make_unique<BlockingScanner>(std::move(impl));
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
 #ifdef BUILD_GTEST
@@ -219,40 +177,32 @@ LanceIOStats BlockingDataset::IOStatsIncremental() {
   try {
     auto stats = impl_->io_stats_incremental();
     return {stats.read_iops, stats.read_bytes};
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
+  } catch (const rust::cxxbridge1::Error&) {
+    return {};
   }
 }
 #endif  // BUILD_GTEST
 
-ArrowArrayStream BlockingDataset::Take(const std::vector<int64_t>& indices, ArrowSchema& schema) {
-  try {
+arrow::Result<ArrowArrayStream> BlockingDataset::Take(const std::vector<int64_t>& indices, ArrowSchema& schema) {
+  return CatchBridgeError([&] {
     ArrowArrayStream stream;
     std::vector<uint64_t> uint64_indices(indices.begin(), indices.end());
     rust::Slice<const uint64_t> indices_slice(uint64_indices.data(), uint64_indices.size());
     ffi::dataset_take(*impl_, indices_slice, reinterpret_cast<uint8_t*>(&schema), reinterpret_cast<uint8_t*>(&stream));
     return stream;
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
-uint64_t BlockingScanner::CountRows() const {
-  try {
-    return impl_->count_rows();
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+arrow::Result<uint64_t> BlockingScanner::CountRows() const {
+  return CatchBridgeError([&] { return impl_->count_rows(); });
 }
 
-ArrowArrayStream BlockingScanner::OpenStream() {
-  try {
+arrow::Result<ArrowArrayStream> BlockingScanner::OpenStream() {
+  return CatchBridgeError([&] {
     ArrowArrayStream stream;
     impl_->open_stream(reinterpret_cast<uint8_t*>(&stream));
     return stream;
-  } catch (const rust::cxxbridge1::Error& e) {
-    throw LanceException(e.what());
-  }
+  });
 }
 
 }  // namespace milvus_storage::lance

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -21,8 +21,10 @@ use arrow58::datatypes::SchemaRef;
 use arrow58::error::ArrowError;
 use arrow58::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 
-use lance::dataset::builder::DatasetBuilder;
+use crate::bridge_error::{BridgeError, BridgeResult as Result, into_arrow_io_error};
+use lance::Error as LanceError;
 use lance::dataset::AutoCleanupParams;
+use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::cleanup::{CleanupPolicy, RemovalStats};
 use lance::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
 use lance::dataset::optimize::{CompactionOptions as RustCompactionOptions, compact_files};
@@ -31,7 +33,6 @@ use lance::dataset::scanner::Scanner;
 use lance::dataset::statistics::{DataStatistics, DatasetStatisticsExt};
 use lance::dataset::transaction::{Operation, Transaction};
 use lance::dataset::{CommitBuilder, Dataset, ReadParams, Version, WriteMode, WriteParams};
-use lance::{Error as LanceError, Result};
 use lance_encoding::version::LanceFileVersion;
 
 use crate::lance_ffi::{LanceColumnMemoryEstimate, LanceDataStorageFormat};
@@ -71,9 +72,8 @@ const MAX_LANCE_IO_PARALLELISM: usize = 256;
 
 static LANCE_PROVIDER_CACHE: LazyLock<GlobalLruCache<Arc<dyn ObjectStoreProvider>>> =
     LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
-static LANCE_AZURE_PROVIDER_CACHE: LazyLock<
-    GlobalLruCache<Arc<AzureSasStorageOptionsProvider>>,
-> = LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
+static LANCE_AZURE_PROVIDER_CACHE: LazyLock<GlobalLruCache<Arc<AzureSasStorageOptionsProvider>>> =
+    LazyLock::new(|| GlobalLruCache::new(CACHE_CAPACITY));
 
 // Keep only an opaque, process-local representation of storage options in the
 // scheduler registry. Two independent hashers make accidental collisions unlikely.
@@ -115,9 +115,9 @@ fn extract_lance_io_parallelism(
         ))
     })?;
     if parallelism > MAX_LANCE_IO_PARALLELISM {
-        return Err(LanceError::invalid_input(format!(
+        return Err(BridgeError::from(LanceError::invalid_input(format!(
             "{LANCE_IO_PARALLELISM_KEY} must be in [0, {MAX_LANCE_IO_PARALLELISM}], got {parallelism}"
-        )));
+        ))));
     }
     Ok((parallelism != 0).then_some(parallelism))
 }
@@ -268,15 +268,6 @@ impl BlockingDataset {
             })
             .clone();
         read_config.with_scan_scheduler(scan_scheduler)
-    }
-
-    pub fn write(
-        reader: impl RecordBatchReader + Send + 'static,
-        uri: &str,
-        params: Option<WriteParams>,
-    ) -> Result<Self> {
-        let inner = TOKIO_RT.block_on(Dataset::write(reader, uri, params))?;
-        Self::new(inner)
     }
 
     pub fn commit(
@@ -519,9 +510,9 @@ fn build_object_store_params(
     if let Some(cloud_provider) = cloud_provider.as_deref()
         && !matches!(cloud_provider, "aws" | "azure" | "gcp" | "aliyun")
     {
-        return Err(LanceError::invalid_input(format!(
+        return Err(BridgeError::from(LanceError::invalid_input(format!(
             "Unsupported Lance cloud provider: {cloud_provider}"
-        )));
+        ))));
     }
 
     // Configure each cloud provider's cross-tenant credential path in one
@@ -535,8 +526,13 @@ fn build_object_store_params(
             let session_name = storage_options
                 .remove("aws_session_name")
                 .unwrap_or_default();
-            let external_id = storage_options.remove("aws_external_id").unwrap_or_default();
-            let region = storage_options.get("aws_region").cloned().unwrap_or_default();
+            let external_id = storage_options
+                .remove("aws_external_id")
+                .unwrap_or_default();
+            let region = storage_options
+                .get("aws_region")
+                .cloned()
+                .unwrap_or_default();
             let refresh_secs_str = storage_options
                 .remove("aws_credential_refresh_secs")
                 .unwrap_or_default();
@@ -584,12 +580,11 @@ fn build_object_store_params(
                     ))?,
                     None => TOKIO_RT.block_on(build_azure_sas_provider(config))?,
                 };
-                store_params.storage_options_accessor = Some(Arc::new(
-                    StorageOptionsAccessor::with_initial_and_provider(
+                store_params.storage_options_accessor =
+                    Some(Arc::new(StorageOptionsAccessor::with_initial_and_provider(
                         storage_options.clone(),
                         provider,
-                    ),
-                ));
+                    )));
             }
         }
         Some("gcp") => {
@@ -764,8 +759,9 @@ impl Iterator for BatchFutStreamReader {
         self.runtime_handle
             .block_on(async { self.stream.next().await })
             .map(|res| {
-                // Convert Lance Error to Arrow Error
-                res.map_err(|e| ArrowError::from_external_error(Box::new(e)))
+                // Preserve typed classification across Arrow's string-only
+                // C stream boundary.
+                res.map_err(|e| into_arrow_io_error(BridgeError::from(e)))
             })
     }
 }
@@ -808,13 +804,6 @@ impl ToFFIArray for RecordBatch {
     }
 }
 
-pub async fn collect_stream_to_batches(
-    stream: ReadBatchFutStream,
-    concurrency: usize,
-) -> Result<Vec<RecordBatch>> {
-    stream.buffered(concurrency).try_collect::<Vec<_>>().await
-}
-
 #[derive(Clone)]
 pub struct BlockingFragmentReader {
     pub inner: FragmentReader,
@@ -846,7 +835,8 @@ impl BlockingFragmentReader {
             let dv = TOKIO_RT.block_on(fragment.get_deletion_vector())?;
             match dv {
                 Some(dv) => {
-                    let mut dels: Vec<u32> = dv.as_ref().clone().into_iter().map(|i| i as u32).collect();
+                    let mut dels: Vec<u32> =
+                        dv.as_ref().clone().into_iter().map(|i| i as u32).collect();
                     dels.sort();
                     dels
                 }
@@ -855,11 +845,8 @@ impl BlockingFragmentReader {
         };
 
         let meta_schema = fragment.schema();
-        let meta_columns: std::collections::HashSet<_> = meta_schema
-            .fields
-            .iter()
-            .map(|f| f.name.clone())
-            .collect();
+        let meta_columns: std::collections::HashSet<_> =
+            meta_schema.fields.iter().map(|f| f.name.clone()).collect();
 
         let columns: Vec<_> = arrow_projection
             .fields()
@@ -869,7 +856,8 @@ impl BlockingFragmentReader {
             .map(|n| n.clone())
             .collect();
 
-        let fragment_reader = TOKIO_RT.block_on(fragment.open(&meta_schema.project(&columns)?, read_config))?;
+        let fragment_reader =
+            TOKIO_RT.block_on(fragment.open(&meta_schema.project(&columns)?, read_config))?;
 
         Ok(Self {
             inner: fragment_reader,
@@ -900,7 +888,10 @@ impl BlockingFragmentReader {
         if self.sorted_deletions.is_empty() {
             return logical_indices.to_vec();
         }
-        logical_indices.iter().map(|&i| self.logical_to_physical(i)).collect()
+        logical_indices
+            .iter()
+            .map(|&i| self.logical_to_physical(i))
+            .collect()
     }
 
     pub fn number_of_rows(&self) -> Result<u64> {
@@ -926,12 +917,11 @@ impl BlockingFragmentReader {
         out_stream: *mut u8,
     ) -> Result<()> {
         let physical_indices = self.map_logical_indices(indices);
-        let read_batch_fut_stream = TOKIO_RT.block_on(self.inner.take(&physical_indices, batch_size, None));
+        let read_batch_fut_stream =
+            TOKIO_RT.block_on(self.inner.take(&physical_indices, batch_size, None));
 
-        let ffi_stream = read_batch_fut_stream?.to_ffi_stream(
-            Arc::new(self.projection.clone()),
-            TOKIO_RT.handle().clone(),
-        );
+        let ffi_stream = read_batch_fut_stream?
+            .to_ffi_stream(Arc::new(self.projection.clone()), TOKIO_RT.handle().clone());
         let out_stream = out_stream as *mut FFI_ArrowArrayStream;
         // # Safety
         // Arrow C stream interface
@@ -942,10 +932,8 @@ impl BlockingFragmentReader {
     pub unsafe fn read_all_as_stream(&self, batch_size: u32, out_stream: *mut u8) -> Result<()> {
         let read_batch_fut_stream = TOKIO_RT.block_on(self.inner.read_all(batch_size))?;
 
-        let ffi_stream = read_batch_fut_stream.to_ffi_stream(
-            Arc::new(self.projection.clone()),
-            TOKIO_RT.handle().clone(),
-        );
+        let ffi_stream = read_batch_fut_stream
+            .to_ffi_stream(Arc::new(self.projection.clone()), TOKIO_RT.handle().clone());
         let out_stream = out_stream as *mut FFI_ArrowArrayStream;
         unsafe { std::ptr::write(out_stream, ffi_stream) };
         Ok(())
@@ -959,10 +947,8 @@ impl BlockingFragmentReader {
     ) -> Result<()> {
         let read_batch_fut_stream = TOKIO_RT.block_on(self.inner.read_range(range, batch_size))?;
 
-        let ffi_stream = read_batch_fut_stream.to_ffi_stream(
-            Arc::new(self.projection.clone()),
-            TOKIO_RT.handle().clone(),
-        );
+        let ffi_stream = read_batch_fut_stream
+            .to_ffi_stream(Arc::new(self.projection.clone()), TOKIO_RT.handle().clone());
         let out_stream = out_stream as *mut FFI_ArrowArrayStream;
         unsafe { std::ptr::write(out_stream, ffi_stream) };
         Ok(())
@@ -993,17 +979,15 @@ pub unsafe fn open_fragment_reader(
     fragment_id: u64,
     schema_rawptr: *mut u8,
 ) -> Result<Box<BlockingFragmentReader>> {
-    let fragment = dataset
-        .get_fragment(fragment_id)
-        .ok_or_else(|| LanceError::InvalidInput {
+    let fragment = dataset.get_fragment(fragment_id).ok_or_else(|| {
+        BridgeError::from(LanceError::InvalidInput {
             source: format!("Fragment {} not found", fragment_id).into(),
             location: snafu::location!(),
-        })?;
+        })
+    })?;
 
     let ffi_schema = unsafe {
-        arrow58::ffi::FFI_ArrowSchema::from_raw(
-            schema_rawptr as *mut arrow58::ffi::FFI_ArrowSchema,
-        )
+        arrow58::ffi::FFI_ArrowSchema::from_raw(schema_rawptr as *mut arrow58::ffi::FFI_ArrowSchema)
     };
     let arrow_schema =
         ArrowSchema::try_from(&ffi_schema).map_err(|e| LanceError::InvalidInput {
@@ -1025,18 +1009,23 @@ pub fn dataset_delete_rows(dataset: &mut BlockingDataset, predicate: &str) -> Re
 }
 
 /// Get sorted deletion positions for a fragment. Returns empty vec if no deletions.
-pub fn get_fragment_deletion_positions(dataset: &BlockingDataset, fragment_id: u64) -> Result<Vec<u64>> {
-    let fragment_meta = dataset
-        .get_fragment(fragment_id)
-        .ok_or_else(|| LanceError::InvalidInput {
-            source: format!("Fragment {} not found", fragment_id).into(),
-            location: snafu::location!(),
-        })?;
+pub fn get_fragment_deletion_positions(
+    dataset: &BlockingDataset,
+    fragment_id: u64,
+) -> Result<Vec<u64>> {
+    let fragment_meta =
+        dataset
+            .get_fragment(fragment_id)
+            .ok_or_else(|| LanceError::InvalidInput {
+                source: format!("Fragment {} not found", fragment_id).into(),
+                location: snafu::location!(),
+            })?;
     let fragment = FileFragment::new(Arc::new(dataset.inner.clone()), fragment_meta);
     let dv = TOKIO_RT.block_on(fragment.get_deletion_vector())?;
     match dv {
         Some(dv) => {
-            let mut positions: Vec<u64> = dv.as_ref().clone().into_iter().map(|i| i as u64).collect();
+            let mut positions: Vec<u64> =
+                dv.as_ref().clone().into_iter().map(|i| i as u64).collect();
             positions.sort();
             Ok(positions)
         }
@@ -1045,12 +1034,12 @@ pub fn get_fragment_deletion_positions(dataset: &BlockingDataset, fragment_id: u
 }
 
 pub fn get_fragment_physical_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64> {
-    let fragment = dataset
-        .get_fragment(fragment_id)
-        .ok_or_else(|| LanceError::InvalidInput {
+    let fragment = dataset.get_fragment(fragment_id).ok_or_else(|| {
+        BridgeError::from(LanceError::InvalidInput {
             source: format!("Fragment {} not found", fragment_id).into(),
             location: snafu::location!(),
-        })?;
+        })
+    })?;
     fragment
         .physical_rows
         .map(|n| n as u64)
@@ -1058,6 +1047,7 @@ pub fn get_fragment_physical_row_count(dataset: &BlockingDataset, fragment_id: u
             source: format!("Fragment {} has no physical_rows metadata", fragment_id).into(),
             location: snafu::location!(),
         })
+        .map_err(BridgeError::from)
 }
 
 pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64> {
@@ -1074,6 +1064,7 @@ pub fn get_fragment_row_count(dataset: &BlockingDataset, fragment_id: u64) -> Re
             source: format!("Fragment {} has no row count metadata", fragment_id).into(),
             location: snafu::location!(),
         })
+        .map_err(BridgeError::from)
 }
 
 fn estimate_fragment_columns(
@@ -1102,13 +1093,15 @@ fn estimate_fragment_columns(
         .fragment_read_config(FragReadConfig::default())
         .scan_scheduler
         .expect("fragment_read_config always installs a scheduler");
-    TOKIO_RT.block_on(
-        crate::lance_memory_estimator::estimate_fragment_column_memory(
-            &dataset.inner,
-            &fragment,
-            scheduler,
-        ),
-    )
+    TOKIO_RT
+        .block_on(
+            crate::lance_memory_estimator::estimate_fragment_column_memory(
+                &dataset.inner,
+                &fragment,
+                scheduler,
+            ),
+        )
+        .map_err(BridgeError::from)
 }
 
 /// Estimate each top-level column's decoded Arrow buffer size in schema order.
@@ -1125,8 +1118,7 @@ pub fn estimate_fragment_column_memory(
 /// Estimate the decoded Arrow buffer size of a fragment without reading data pages.
 ///
 /// This compatibility API is the saturating sum of the per-column estimates.
-/// Errors are returned through cxx so the C++ best-effort wrapper can fall back
-/// to zero.
+/// Errors are returned through cxx without a value fallback.
 pub fn estimate_fragment_memory(dataset: &BlockingDataset, fragment_id: u64) -> Result<u64> {
     Ok(estimate_fragment_columns(dataset, fragment_id)?
         .into_iter()
@@ -1139,12 +1131,13 @@ pub unsafe fn get_fragment_schema(
     fragment_id: u64,
     out_schema_ptr: *mut u8,
 ) -> Result<()> {
-    let fragment_meta = dataset
-        .get_fragment(fragment_id)
-        .ok_or_else(|| LanceError::InvalidInput {
-            source: format!("Fragment {} not found", fragment_id).into(),
-            location: snafu::location!(),
-        })?;
+    let fragment_meta =
+        dataset
+            .get_fragment(fragment_id)
+            .ok_or_else(|| LanceError::InvalidInput {
+                source: format!("Fragment {} not found", fragment_id).into(),
+                location: snafu::location!(),
+            })?;
 
     // In Lance 7, FileFragment::schema() returns the current dataset schema. It
     // includes evolved nullable fields that may not be physically stored in this
@@ -1154,11 +1147,12 @@ pub unsafe fn get_fragment_schema(
     let lance_schema = file_fragment.schema();
     let arrow_schema: ArrowSchema = lance_schema.into();
 
-    let ffi_schema = arrow58::ffi::FFI_ArrowSchema::try_from(&arrow_schema)
-        .map_err(|e| LanceError::InvalidInput {
+    let ffi_schema = arrow58::ffi::FFI_ArrowSchema::try_from(&arrow_schema).map_err(|e| {
+        LanceError::InvalidInput {
             source: format!("Failed to export fragment schema: {}", e).into(),
             location: snafu::location!(),
-        })?;
+        }
+    })?;
 
     let out_ptr = out_schema_ptr as *mut arrow58::ffi::FFI_ArrowSchema;
     unsafe { std::ptr::write(out_ptr, ffi_schema) };
@@ -1220,9 +1214,7 @@ pub unsafe fn create_scanner(
     batch_size: u32,
 ) -> Result<Box<BlockingScanner>> {
     let ffi_schema = unsafe {
-        arrow58::ffi::FFI_ArrowSchema::from_raw(
-            schema_ptr as *mut arrow58::ffi::FFI_ArrowSchema,
-        )
+        arrow58::ffi::FFI_ArrowSchema::from_raw(schema_ptr as *mut arrow58::ffi::FFI_ArrowSchema)
     };
     let arrow_schema =
         ArrowSchema::try_from(&ffi_schema).map_err(|e| LanceError::InvalidInput {
@@ -1253,9 +1245,7 @@ pub unsafe fn dataset_take(
     out_stream: *mut u8,
 ) -> Result<()> {
     let ffi_schema = unsafe {
-        arrow58::ffi::FFI_ArrowSchema::from_raw(
-            schema_ptr as *mut arrow58::ffi::FFI_ArrowSchema,
-        )
+        arrow58::ffi::FFI_ArrowSchema::from_raw(schema_ptr as *mut arrow58::ffi::FFI_ArrowSchema)
     };
     let arrow_schema =
         ArrowSchema::try_from(&ffi_schema).map_err(|e| LanceError::InvalidInput {

--- a/cpp/src/format/bridge/rust/src/lance_memory_estimator.rs
+++ b/cpp/src/format/bridge/rust/src/lance_memory_estimator.rs
@@ -70,10 +70,9 @@ fn fixed_data_type_memory(data_type: &DataType, rows: u64) -> Option<u64> {
         DataType::Null => Some(0),
         DataType::Boolean => Some(bitmap_bytes(rows)),
         DataType::FixedSizeBinary(width) => Some((*width as u64).saturating_mul(rows)),
-        DataType::FixedSizeList(item, list_size) => fixed_data_type_memory(
-            item.data_type(),
-            rows.saturating_mul(*list_size as u64),
-        ),
+        DataType::FixedSizeList(item, list_size) => {
+            fixed_data_type_memory(item.data_type(), rows.saturating_mul(*list_size as u64))
+        }
         DataType::Dictionary(_, _) => None,
         data_type => data_type
             .primitive_width()
@@ -306,11 +305,7 @@ pub(crate) async fn estimate_fragment_column_memory(
 
             // Page metadata describes physical rows. Apply the fragment's live
             // row ratio once to obtain the estimate after deletions.
-            let bytes = mul_div_round(
-                estimate_page_column(column),
-                logical_rows,
-                physical_rows,
-            );
+            let bytes = mul_div_round(estimate_page_column(column), logical_rows, physical_rows);
             let estimate = estimates[top_level_index].get_or_insert(0_u64);
             *estimate = estimate.saturating_add(bytes);
         }

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -15,6 +15,7 @@
 mod aliyun_oss_provider;
 mod aws_arn_provider;
 mod azure_sas_provider;
+mod bridge_error;
 mod cloud_provider_cache;
 mod gcp_impersonation;
 mod iceberg_bridgeimpl;
@@ -136,10 +137,8 @@ pub mod lance_ffi {
             dataset: &BlockingDataset,
             fragment_id: u64,
         ) -> Result<Vec<LanceColumnMemoryEstimate>>;
-        pub fn estimate_fragment_memory(
-            dataset: &BlockingDataset,
-            fragment_id: u64,
-        ) -> Result<u64>;
+        pub fn estimate_fragment_memory(dataset: &BlockingDataset, fragment_id: u64)
+        -> Result<u64>;
         pub unsafe fn get_fragment_schema(
             dataset: &BlockingDataset,
             fragment_id: u64,
@@ -275,6 +274,11 @@ pub mod paimon_test_ffi {
         ) -> Result<PaimonTestTableInfo>;
     }
 }
+
+// Classified errors cross the cxx boundary inside the error message: the Rust
+// side embeds the code with the universal marker prefix, and the C++ decoder
+// (bridge_error.h) parses and strips it. One channel, no side state -- see
+// bridge_error.rs for why a thread-local side channel was retired.
 
 #[cxx::bridge(namespace = "milvus_storage::vortex::ffi")]
 pub mod vortex_ffi {

--- a/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/paimon_bridge.cpp
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 #include "paimon_bridge.h"
+#include "bridge_error.h"
 
 #include <cerrno>
 #include <string_view>
@@ -29,44 +30,28 @@
 namespace milvus_storage::paimon {
 namespace {
 
-// Keep these markers in sync with ERROR_*_PREFIX in paimon_bridgeimpl.rs.
-constexpr std::string_view kInvalidMarker = "[paimon:error=invalid]";
-constexpr std::string_view kNotImplementedMarker = "[paimon:error=not-implemented]";
-constexpr std::string_view kNotFoundMarker = "[paimon:error=not-found]";
-constexpr std::string_view kTransientThrottlingMarker = "[paimon:error=transient-throttling]";
-constexpr std::string_view kTransientServiceMarker = "[paimon:error=transient-service]";
-constexpr std::string_view kPaimonErrorMarker = "[paimon:error=";
-
-std::string StripMarker(std::string_view message, std::string_view marker) {
-  auto position = message.find(marker);
-  if (position == std::string_view::npos) {
-    return std::string(message);
-  }
-  auto suffix = position + marker.size();
-  if (suffix < message.size() && message[suffix] == ' ') {
-    ++suffix;
-  }
-  std::string result;
-  result.reserve(message.size() - marker.size());
-  result.append(message.substr(0, position));
-  result.append(message.substr(suffix));
-  return result.empty() ? "Unknown Paimon error" : result;
-}
-
 template <typename T, typename Fn>
 arrow::Result<T> CatchRustResult(Fn&& fn) {
   try {
     return fn();
   } catch (const rust::cxxbridge1::Error& error) {
-    return MakePaimonBridgeErrorStatus(error.what());
+    // THE shared decoder reads the universal transport marker the Rust side
+    // embeds in the error message and otherwise degrades to the conservative
+    // non-retriable IOError.
+    return milvus_storage::bridge::MakeBridgeErrorStatus(error.what());
   }
 }
 
 arrow::Status TranslatePaimonStreamStatus(arrow::Status status) {
-  if (status.ok() || status.message().find(kPaimonErrorMarker) == std::string_view::npos) {
+  if (status.ok()) {
     return status;
   }
-  return MakePaimonBridgeErrorStatus(status.message());
+  // Stream errors surface as strings through the Arrow C ABI; the Rust side
+  // embeds the same universal transport tag every other bridge uses.
+  if (auto decoded = milvus_storage::bridge::DecodeBridgeErrorStatus(status.message())) {
+    return *decoded;
+  }
+  return status;
 }
 
 class PaimonStreamReader final : public arrow::RecordBatchReader {
@@ -82,7 +67,8 @@ class PaimonStreamReader final : public arrow::RecordBatchReader {
       return arrow::Status::OK();
     }
     if ((*batch)->num_columns() != output_schema_->num_fields()) {
-      return arrow::Status::Invalid("Paimon data-split stream returned an unexpected column count");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Paimon data-split stream returned an unexpected column count");
     }
     for (int index = 0; index < output_schema_->num_fields(); ++index) {
       const auto& actual = (*batch)->schema()->field(index);
@@ -108,28 +94,6 @@ class PaimonStreamReader final : public arrow::RecordBatchReader {
 };
 
 }  // namespace
-
-arrow::Status MakePaimonBridgeErrorStatus(std::string_view message) {
-  if (message.find(kInvalidMarker) != std::string_view::npos) {
-    return arrow::Status::Invalid(StripMarker(message, kInvalidMarker));
-  }
-  if (message.find(kNotImplementedMarker) != std::string_view::npos) {
-    return arrow::Status::NotImplemented(StripMarker(message, kNotImplementedMarker));
-  }
-  if (message.find(kNotFoundMarker) != std::string_view::npos) {
-    return arrow::Status::IOError(StripMarker(message, kNotFoundMarker))
-        .WithDetail(arrow::internal::StatusDetailFromErrno(ENOENT));
-  }
-  if (message.find(kTransientThrottlingMarker) != std::string_view::npos) {
-    auto error = StripMarker(message, kTransientThrottlingMarker);
-    return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, error, error);
-  }
-  if (message.find(kTransientServiceMarker) != std::string_view::npos) {
-    auto error = StripMarker(message, kTransientServiceMarker);
-    return MakeExtendError(ExtendStatusCode::StorageTransientService, error, error);
-  }
-  return arrow::Status::IOError(message);
-}
 
 namespace internal {
 std::shared_ptr<arrow::RecordBatchReader> WrapPaimonRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner,
@@ -224,13 +188,17 @@ arrow::Result<std::shared_ptr<BlockingPaimonDataSplitReader>> BlockingPaimonData
 
 arrow::Status BlockingPaimonDataSplitReader::ExportSchema(ArrowSchema* schema) const {
   if (schema == nullptr) {
-    return arrow::Status::Invalid("cannot export Paimon schema into a null pointer");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "cannot export Paimon schema into a null pointer");
   }
   try {
     impl_->export_schema(reinterpret_cast<uint8_t*>(schema));
     return arrow::Status::OK();
   } catch (const rust::cxxbridge1::Error& error) {
-    return MakePaimonBridgeErrorStatus(error.what());
+    // No slot code: fall through to THE shared decoder, which reads the
+    // universal transport tag the Rust side embeds and otherwise degrades to
+    // the conservative non-retriable IOError.
+    return milvus_storage::bridge::MakeBridgeErrorStatus(error.what());
   }
 }
 

--- a/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/paimon_bridgeimpl.rs
@@ -35,11 +35,17 @@ use crate::TOKIO_RT;
 use crate::paimon_ffi::PaimonFileInfo;
 
 const METADATA_VERSION: u32 = 1;
-const ERROR_INVALID_PREFIX: &str = "[paimon:error=invalid]";
-const ERROR_NOT_IMPLEMENTED_PREFIX: &str = "[paimon:error=not-implemented]";
-const ERROR_NOT_FOUND_PREFIX: &str = "[paimon:error=not-found]";
-const ERROR_TRANSIENT_THROTTLING_PREFIX: &str = "[paimon:error=transient-throttling]";
-const ERROR_TRANSIENT_SERVICE_PREFIX: &str = "[paimon:error=transient-service]";
+
+/// Keep a producer-classified failure typed until the final display boundary.
+/// `BridgeError::Display` emits the universal frame that C++ decodes; retaining
+/// the code as a source prevents a later normalization pass from mistaking the
+/// frame for caller-controlled text and escaping it.
+fn tagged(code: i32, message: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::Error::new(crate::bridge_error::BridgeError::new(
+        Some(code),
+        message.to_string(),
+    ))
+}
 const DELETION_VECTOR_MAGIC: u32 = 1_581_511_376;
 /// Magic of Paimon's 64-bit deletion vectors, from Java
 /// `org.apache.paimon.deletionvectors.Bitmap64DeletionVector.MAGIC_NUMBER`.
@@ -48,70 +54,143 @@ const DELETION_VECTOR_MAGIC: u32 = 1_581_511_376;
 const DELETION_VECTOR_BITMAP64_MAGIC: u32 = 1_681_511_377;
 const MAX_DATA_SPLIT_METADATA_BYTES: usize = 12 * 1024 * 1024;
 
-// CXX carries Rust errors as strings. These stable markers are consumed only
-// by the C++ bridge, which converts them into Arrow statuses before returning
-// to format callers. Keep their spelling in sync with paimon_bridge.cpp and
-// paimon_format_reader.cpp.
-fn invalid_message(message: impl std::fmt::Display) -> String {
-    format!("{ERROR_INVALID_PREFIX} {message}")
+// These helpers keep their historical names so call sites read as before, but
+// return typed sources. BridgeError emits the shared marker only at Display,
+// allowing classify_bridge_error to distinguish producer verdicts from input.
+fn invalid_message(message: impl std::fmt::Display) -> crate::bridge_error::BridgeError {
+    crate::bridge_error::BridgeError::new(
+        Some(crate::bridge_error::LOON_STORAGE_CONFIG_INVALID),
+        message.to_string(),
+    )
 }
 
-fn not_implemented_message(message: impl std::fmt::Display) -> String {
-    format!("{ERROR_NOT_IMPLEMENTED_PREFIX} {message}")
+/// Local, explicit validation of PERSISTED paimon bytes (deletion-vector
+/// magic/length/cardinality, split metadata). Distinct from
+/// `paimon::Error::DataInvalid` downcasts, which also fire for conditions
+/// that are NOT corruption (a missing snapshot reuses that variant); only
+/// these local checks assert "the bytes on disk cannot be used", so they
+/// carry the DataCorrupt verdict.
+fn data_invalid_message(message: impl std::fmt::Display) -> crate::bridge_error::BridgeError {
+    crate::bridge_error::BridgeError::new(
+        Some(crate::bridge_error::BRIDGE_ERRCODE_DATA_CORRUPT),
+        message.to_string(),
+    )
+}
+
+fn not_implemented_message(message: impl std::fmt::Display) -> crate::bridge_error::BridgeError {
+    crate::bridge_error::BridgeError::new(
+        Some(crate::bridge_error::BRIDGE_ERRCODE_NOT_SUPPORTED),
+        message.to_string(),
+    )
+}
+
+// Paimon's Parquet adapter converts its typed FileRead error to String. Match
+// only the complete producer-owned prefix that adapter constructs; scanning
+// for the OpenDAL phrase anywhere would let a caller-controlled table path
+// forge a retry classification.
+const PAIMON_PARQUET_STORAGE_ERROR_PREFIX: &str = "Failed to read a Parquet file: External: \
+Paimon hitting unexpected error IO operation failed on underlying storage: ";
+
+fn classify_stringified_parquet_storage_error(message: &str) -> Option<i32> {
+    let storage_error = message.strip_prefix(PAIMON_PARQUET_STORAGE_ERROR_PREFIX)?;
+    let first_line = storage_error.lines().next().unwrap_or(storage_error);
+    let header = first_line
+        .split_once(" at ")
+        .map(|(header, _)| header)
+        .or_else(|| first_line.split_once(" => ").map(|(header, _)| header))
+        .unwrap_or(first_line);
+    let (kind, status) = header.rsplit_once(' ')?;
+    if !matches!(status, "(permanent)" | "(temporary)" | "(persistent)") {
+        return None;
+    }
+
+    // ErrorKind's spelling is producer-controlled. Keep the whitelist in sync
+    // with OpenDAL 0.58 so arbitrary text before "(temporary)" is never enough
+    // to manufacture a transient result.
+    const OPENDAL_ERROR_KINDS: &[&str] = &[
+        "Unexpected",
+        "Unsupported",
+        "ConfigInvalid",
+        "NotFound",
+        "PermissionDenied",
+        "IsADirectory",
+        "NotADirectory",
+        "AlreadyExists",
+        "RateLimited",
+        "IsSameFile",
+        "ConditionNotMatch",
+        "RangeNotSatisfied",
+    ];
+    if !OPENDAL_ERROR_KINDS.contains(&kind) {
+        return None;
+    }
+    if kind == "NotFound" {
+        Some(crate::bridge_error::LOON_STORAGE_NOT_FOUND)
+    } else if kind == "RateLimited" && status == "(temporary)" {
+        Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING)
+    } else if status == "(temporary)" {
+        Some(crate::bridge_error::LOON_TRANSIENT_SERVICE)
+    } else {
+        None
+    }
+}
+
+fn classify_paimon_error(error: &paimon::Error) -> Option<i32> {
+    match error {
+        paimon::Error::IoUnexpected { source, .. } => {
+            let kind = source.kind().into_static();
+            if kind == "NotFound" {
+                Some(crate::bridge_error::LOON_STORAGE_NOT_FOUND)
+            } else if source.is_temporary() && kind == "RateLimited" {
+                Some(crate::bridge_error::LOON_TRANSIENT_THROTTLING)
+            } else if source.is_temporary() {
+                Some(crate::bridge_error::LOON_TRANSIENT_SERVICE)
+            } else {
+                None
+            }
+        }
+        paimon::Error::ParquetDataUnexpected { message, .. } => {
+            classify_stringified_parquet_storage_error(message)
+        }
+        paimon::Error::Unsupported { .. } | paimon::Error::IoUnsupported { .. } => {
+            Some(crate::bridge_error::BRIDGE_ERRCODE_NOT_SUPPORTED)
+        }
+        paimon::Error::ConfigInvalid { .. } => {
+            Some(crate::bridge_error::LOON_STORAGE_CONFIG_INVALID)
+        }
+        _ => None,
+    }
 }
 
 fn classify_bridge_error(error: anyhow::Error) -> anyhow::Error {
-    let message = format!("{error:#}");
-    if [ERROR_INVALID_PREFIX, ERROR_NOT_IMPLEMENTED_PREFIX]
-        .iter()
-        .any(|marker| message.contains(marker))
+    let io_transport = crate::bridge_error::bridge_io_transport_in_anyhow(&error);
+    // A local producer may already have made the verdict explicit. Re-emit
+    // that typed source at the outer boundary before considering Paimon's
+    // coarser variants; never recover it by parsing arbitrary message text.
+    if let Some(bridge) = error.downcast_ref::<crate::bridge_error::BridgeError>()
+        && let Some(code) = bridge.code
     {
-        return error;
+        return anyhow::Error::new(crate::bridge_error::BridgeError::with_transport(
+            Some(code),
+            bridge.msg.clone(),
+            io_transport,
+        ));
     }
 
-    // Paimon's Parquet adapter stringifies FileRead errors before wrapping them.
-    if let Some((_, storage_error)) =
-        message.split_once("IO operation failed on underlying storage: ")
-    {
-        let marker = if storage_error.starts_with("NotFound (") {
-            Some(ERROR_NOT_FOUND_PREFIX)
-        } else if storage_error.starts_with("RateLimited (temporary)") {
-            Some(ERROR_TRANSIENT_THROTTLING_PREFIX)
-        } else if storage_error.contains("(temporary)") {
-            Some(ERROR_TRANSIENT_SERVICE_PREFIX)
-        } else {
-            None
-        };
-        return marker.map_or(error, |marker| anyhow!("{marker} {message}"));
-    }
-    let marker = error.chain().find_map(|cause| {
-        let error = cause.downcast_ref::<paimon::Error>()?;
-        match error {
-            paimon::Error::IoUnexpected { source, .. } => {
-                let kind = source.kind().into_static();
-                if kind == "NotFound" {
-                    Some(ERROR_NOT_FOUND_PREFIX)
-                } else if source.is_temporary() && kind == "RateLimited" {
-                    Some(ERROR_TRANSIENT_THROTTLING_PREFIX)
-                } else if source.is_temporary() {
-                    Some(ERROR_TRANSIENT_SERVICE_PREFIX)
-                } else {
-                    None
-                }
-            }
-            paimon::Error::Unsupported { .. } | paimon::Error::IoUnsupported { .. } => {
-                Some(ERROR_NOT_IMPLEMENTED_PREFIX)
-            }
-            paimon::Error::DataInvalid { .. }
-            | paimon::Error::DataTypeInvalid { .. }
-            | paimon::Error::ConfigInvalid { .. }
-            | paimon::Error::DataUnexpected { .. }
-            | paimon::Error::FileIndexFormatInvalid { .. }
-            | paimon::Error::ParquetDataUnexpected { .. } => Some(ERROR_INVALID_PREFIX),
-            _ => None,
-        }
+    let message = format!("{error:#}");
+    let code = error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<paimon::Error>()
+            .and_then(classify_paimon_error)
     });
-    marker.map_or(error, |marker| anyhow!("{marker} {message}"))
+    match code {
+        Some(code) => anyhow::Error::new(crate::bridge_error::BridgeError::with_transport(
+            Some(code),
+            message,
+            io_transport,
+        )),
+        None => anyhow!(crate::bridge_error::escape_bridge_error_message(&message)),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -255,19 +334,25 @@ fn pinned_metadata_result<T>(
 ) -> Result<T> {
     result.map_err(|error| {
         let not_found = match &error {
-            paimon::Error::IoUnexpected { source, .. } => {
-                source.kind().into_static() == "NotFound"
-            }
+            paimon::Error::IoUnexpected { source, .. } => source.kind().into_static() == "NotFound",
+            // A missing snapshot file is the one not-found paimon does not
+            // report through an IO error kind: SnapshotManager checks
+            // `exists()` itself and raises DataInvalid with this message. It is
+            // still a not-found, so it must not fall through to the
+            // unclassified branch.
             paimon::Error::DataInvalid { message, .. } => {
                 message.starts_with("snapshot file does not exist:")
             }
             _ => false,
         };
         if not_found {
-            anyhow!(invalid_message(format_args!(
+            // Paimon itself says NotFound; follow that classification instead
+            // of re-tagging it as an invalid configuration.
+            let message = format!(
                 "required metadata for Paimon snapshot {snapshot_id} was not found in table \
                  {table_location}; refresh the external collection"
-            )))
+            );
+            tagged(crate::bridge_error::LOON_STORAGE_NOT_FOUND, &message)
         } else {
             anyhow!(error).context(format!(
                 "cannot resolve Paimon snapshot {snapshot_id} for table {table_location}"
@@ -528,9 +613,8 @@ fn decide_route(
 }
 
 fn checked_non_negative(value: i64, name: &str) -> Result<u64> {
-    u64::try_from(value).with_context(|| {
-        invalid_message(format_args!("Paimon {name} is negative: {value}"))
-    })
+    u64::try_from(value)
+        .with_context(|| data_invalid_message(format_args!("Paimon {name} is negative: {value}")))
 }
 
 fn metadata_split_row_count(split: &DataSplit) -> Result<Option<u64>> {
@@ -668,7 +752,7 @@ fn validate_data_split_binding(
 fn deletion_descriptor(file: &DeletionFile) -> Result<DeletionFileDescriptor> {
     ensure!(
         !file.path().is_empty(),
-        invalid_message("Paimon deletion vector path is empty")
+        data_invalid_message("Paimon deletion vector path is empty")
     );
     Ok(DeletionFileDescriptor {
         path: file.path().to_string(),
@@ -677,7 +761,7 @@ fn deletion_descriptor(file: &DeletionFile) -> Result<DeletionFileDescriptor> {
             let length = checked_non_negative(file.length(), "deletion vector length")?;
             ensure!(
                 length > 0,
-                invalid_message("Paimon deletion vector length is zero")
+                data_invalid_message("Paimon deletion vector length is zero")
             );
             length
         },
@@ -758,7 +842,7 @@ pub fn paimon_plan_files(
                         };
                         ensure!(
                             deleted_rows <= physical_rows,
-                            invalid_message(format_args!(
+                            data_invalid_message(format_args!(
                                 "Paimon deletion cardinality {deleted_rows} exceeds physical row count \
                                  {physical_rows} for {}",
                                 file.file_name
@@ -814,13 +898,13 @@ async fn read_deletion_vector_at(
 ) -> Result<Vec<u64>> {
     ensure!(
         expected_cardinality >= -1,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector cardinality is invalid: {expected_cardinality}"
         ))
     );
     ensure!(
         length >= 4,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector length is too small: {length}"
         ))
     );
@@ -843,30 +927,24 @@ async fn read_deletion_vector_at(
         ))
     })?;
     let file_size = input.metadata().await?.size;
-    let total_length = length
-        .checked_add(8)
-        .ok_or_else(|| {
-            anyhow!(invalid_message(
-                "Paimon deletion vector range length overflow"
-            ))
-        })?;
-    let requested_end = offset
-        .checked_add(total_length)
-        .ok_or_else(|| {
-            anyhow!(invalid_message(
-                "Paimon deletion vector range end overflow"
-            ))
-        })?;
-    let header_end = offset
-        .checked_add(8)
-        .ok_or_else(|| {
-            anyhow!(invalid_message(
-                "Paimon deletion vector header range overflow"
-            ))
-        })?;
+    let total_length = length.checked_add(8).ok_or_else(|| {
+        anyhow!(data_invalid_message(
+            "Paimon deletion vector range length overflow"
+        ))
+    })?;
+    let requested_end = offset.checked_add(total_length).ok_or_else(|| {
+        anyhow!(data_invalid_message(
+            "Paimon deletion vector range end overflow"
+        ))
+    })?;
+    let header_end = offset.checked_add(8).ok_or_else(|| {
+        anyhow!(data_invalid_message(
+            "Paimon deletion vector header range overflow"
+        ))
+    })?;
     ensure!(
         header_end <= file_size,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector header range [{offset}, {header_end}) exceeds file size \
              {file_size}: {path}"
         ))
@@ -875,7 +953,7 @@ async fn read_deletion_vector_at(
     let bytes = reader.read(offset..requested_end.min(file_size)).await?;
     ensure!(
         bytes.len() >= 8,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector short header: expected 8 bytes, got {}",
             bytes.len()
         ))
@@ -891,24 +969,24 @@ async fn read_deletion_vector_at(
     {
         ensure!(
             declared_length.checked_add(8) == Some(length),
-            invalid_message(format_args!(
+            data_invalid_message(format_args!(
                 "Paimon bitmap64 deletion vector length mismatch: descriptor {length}, payload \
                  {declared_length} plus 8-byte envelope"
             ))
         );
-        let end = offset
-            .checked_add(length)
-            .ok_or_else(|| {
-                anyhow!(invalid_message(
-                    "Paimon bitmap64 deletion vector range end overflow"
-                ))
-            })?;
+        let end = offset.checked_add(length).ok_or_else(|| {
+            anyhow!(data_invalid_message(
+                "Paimon bitmap64 deletion vector range end overflow"
+            ))
+        })?;
         let bitmap64_length = usize::try_from(length).with_context(|| {
-            invalid_message("Paimon bitmap64 deletion vector length exceeds addressable memory")
+            data_invalid_message(
+                "Paimon bitmap64 deletion vector length exceeds addressable memory",
+            )
         })?;
         ensure!(
             end <= file_size && bytes.len() >= bitmap64_length,
-            invalid_message(format_args!(
+            data_invalid_message(format_args!(
                 "Paimon bitmap64 deletion vector range [{offset}, {end}) exceeds file size \
                  {file_size}: {path}"
             ))
@@ -921,14 +999,14 @@ async fn read_deletion_vector_at(
     }
     ensure!(
         big_endian_magic == DELETION_VECTOR_MAGIC,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "invalid Paimon deletion vector magic: expected {DELETION_VECTOR_MAGIC}, got \
              {big_endian_magic}"
         ))
     );
     ensure!(
         declared_length == length,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector length mismatch: descriptor {length}, payload \
              {declared_length}"
         ))
@@ -936,24 +1014,24 @@ async fn read_deletion_vector_at(
 
     ensure!(
         requested_end <= file_size,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector range [{offset}, {requested_end}) exceeds file size \
              {file_size}: {path}"
         ))
     );
     let expected_total_length = usize::try_from(total_length).with_context(|| {
-        invalid_message("Paimon deletion vector range length exceeds addressable memory")
+        data_invalid_message("Paimon deletion vector range length exceeds addressable memory")
     })?;
     ensure!(
         bytes.len() == expected_total_length,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector short read: expected {total_length} bytes, got {}",
             bytes.len()
         ))
     );
 
     let payload_end = usize::try_from(4 + length).with_context(|| {
-        invalid_message("Paimon deletion vector payload length exceeds addressable memory")
+        data_invalid_message("Paimon deletion vector payload length exceeds addressable memory")
     })?;
     let stored_crc = u32::from_be_bytes(bytes[payload_end..payload_end + 4].try_into()?);
     let mut crc = crc32fast::Hasher::new();
@@ -961,20 +1039,21 @@ async fn read_deletion_vector_at(
     let actual_crc = crc.finalize();
     ensure!(
         stored_crc == actual_crc,
-        invalid_message(format_args!(
+        data_invalid_message(format_args!(
             "Paimon deletion vector CRC mismatch: expected {stored_crc}, got {actual_crc}"
         ))
     );
     let mut bitmap_input = Cursor::new(&bytes[8..payload_end]);
-    let bitmap = RoaringBitmap::deserialize_from(&mut bitmap_input)
-        .with_context(|| invalid_message("cannot deserialize Paimon roaring deletion vector"))?;
+    let bitmap = RoaringBitmap::deserialize_from(&mut bitmap_input).with_context(|| {
+        data_invalid_message("cannot deserialize Paimon roaring deletion vector")
+    })?;
     if expected_cardinality >= 0 {
         let expected_cardinality = u64::try_from(expected_cardinality).with_context(|| {
-            invalid_message("Paimon deletion vector cardinality exceeds the supported range")
+            data_invalid_message("Paimon deletion vector cardinality exceeds the supported range")
         })?;
         ensure!(
             bitmap.len() == expected_cardinality,
-            invalid_message(format_args!(
+            data_invalid_message(format_args!(
                 "Paimon deletion vector cardinality mismatch: expected {expected_cardinality}, \
                  got {}",
                 bitmap.len()
@@ -994,14 +1073,15 @@ pub fn paimon_read_deletion_vector(
 ) -> Result<Vec<u64>> {
     let options = options_from_vecs(storage_options_keys, storage_options_values)
         .map_err(classify_bridge_error)?;
-    TOKIO_RT.block_on(read_deletion_vector_at(
-        path,
-        offset,
-        length,
-        expected_cardinality,
-        &options,
-    ))
-    .map_err(classify_bridge_error)
+    TOKIO_RT
+        .block_on(read_deletion_vector_at(
+            path,
+            offset,
+            length,
+            expected_cardinality,
+            &options,
+        ))
+        .map_err(classify_bridge_error)
 }
 
 type PaimonBatchStream = BoxStream<'static, paimon::Result<RecordBatch>>;
@@ -1013,14 +1093,11 @@ struct PaimonStreamReader {
 
 fn classify_stream_error(error: paimon::Error) -> ArrowError {
     let classified = classify_bridge_error(anyhow!(error));
-    let message = format!("{classified:#}");
-    if message.contains(ERROR_NOT_IMPLEMENTED_PREFIX) {
-        return ArrowError::NotYetImplemented(message);
-    }
-    if message.contains(ERROR_INVALID_PREFIX) {
-        return ArrowError::InvalidArgumentError(message);
-    }
-    ArrowError::IoError(message.clone(), std::io::Error::other(message))
+    // The verdict rides the marker inside the message: this runs on the
+    // stream path, where no ambient state can carry a code back to C++. Use
+    // the shared one-envelope transport; C++ derives semantic status from the
+    // typed marker rather than from an Arrow wrapper.
+    crate::bridge_error::into_arrow_io_error(crate::bridge_error::BridgeError::from(classified))
 }
 
 impl Iterator for PaimonStreamReader {
@@ -1061,10 +1138,12 @@ fn open_data_split_reader_impl(
 ) -> Result<Box<BlockingPaimonDataSplitReader>> {
     let options = options_from_vecs(storage_options_keys, storage_options_values)?;
     let (metadata, split) = decode_split_metadata(metadata_json).map_err(|error| {
-        anyhow!("{ERROR_INVALID_PREFIX} invalid Paimon data-split descriptor: {error:#}")
+        let message = format!("invalid Paimon data-split descriptor: {error:#}");
+        tagged(crate::bridge_error::BRIDGE_ERRCODE_DATA_CORRUPT, &message)
     })?;
     validate_data_split_binding(&metadata, &split, expected_table_location).map_err(|error| {
-        anyhow!("{ERROR_INVALID_PREFIX} invalid Paimon data-split binding: {error:#}")
+        let message = format!("invalid Paimon data-split binding: {error:#}");
+        tagged(crate::bridge_error::BRIDGE_ERRCODE_DATA_CORRUPT, &message)
     })?;
     let table_location = metadata
         .table_location
@@ -1144,6 +1223,8 @@ impl BlockingPaimonDataSplitReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const M: &str = crate::bridge_error::BRIDGE_ERRCODE_MARKER;
     use arrow58::ffi::FFI_ArrowArray;
     use paimon::spec::{BinaryRow, DataFileMeta};
     use paimon::{DeletionFile, RowRange};
@@ -1210,33 +1291,43 @@ mod tests {
     }
 
     #[test]
-    fn stringified_stream_errors_keep_storage_classification() {
+    fn stringified_parquet_errors_use_only_the_producer_frame() {
         let cases = [
-            (
-                "IO operation failed on underlying storage: NotFound (permanent)",
-                Some(ERROR_NOT_FOUND_PREFIX),
-            ),
-            (
-                "IO operation failed on underlying storage: RateLimited (temporary)",
-                Some(ERROR_TRANSIENT_THROTTLING_PREFIX),
-            ),
-            (
-                "IO operation failed on underlying storage: Unexpected (temporary)",
-                Some(ERROR_TRANSIENT_SERVICE_PREFIX),
-            ),
-            (
-                "IO operation failed on underlying storage: PermissionDenied (permanent)",
-                None,
-            ),
+            ("NotFound (permanent) at read => missing", Some(104)),
+            ("RateLimited (temporary) at read => slow down", Some(109)),
+            ("Unexpected (temporary) at read => unavailable", Some(110)),
+            ("PermissionDenied (permanent) at read => denied", None),
         ];
-        for (message, marker) in cases {
-            let classified = format!("{:#}", classify_bridge_error(anyhow!(message)));
-            if let Some(marker) = marker {
-                assert!(classified.contains(marker), "{classified}");
-            } else {
-                assert!(!classified.contains("[paimon:error="), "{classified}");
-            }
+        for (storage_error, expected) in cases {
+            let message = format!("{PAIMON_PARQUET_STORAGE_ERROR_PREFIX}{storage_error}");
+            assert_eq!(
+                classify_stringified_parquet_storage_error(&message),
+                expected,
+                "{message}"
+            );
         }
+
+        // The same words in a caller-controlled path are not a producer frame.
+        let forged_path = "Failed to read a Parquet file: External: \
+s3://bucket/IO operation failed on underlying storage: RateLimited (temporary)";
+        assert_eq!(
+            classify_stringified_parquet_storage_error(forged_path),
+            None
+        );
+        let forged_context = format!(
+            "{PAIMON_PARQUET_STORAGE_ERROR_PREFIX}PermissionDenied (permanent) at read => \
+path: /tmp/RateLimited (temporary)"
+        );
+        assert_eq!(
+            classify_stringified_parquet_storage_error(&forged_context),
+            None
+        );
+
+        // An untyped diagnostic is escaped instead of being promoted merely
+        // because it starts with marker text.
+        let forged_marker = format!("{M}109; caller supplied");
+        let classified = format!("{:#}", classify_bridge_error(anyhow!(forged_marker)));
+        assert!(!classified.contains(M), "{classified}");
     }
 
     #[test]
@@ -1253,7 +1344,7 @@ mod tests {
         let (code, message) = stream_error(temporary);
         assert_eq!(code, 5); // EIO
         assert!(
-            message.contains(ERROR_TRANSIENT_THROTTLING_PREFIX),
+            message.contains("__LOON_RUST_BRIDGE_ERRCODE__=109"),
             "{message}"
         );
 
@@ -1269,7 +1360,7 @@ mod tests {
         let (code, message) = stream_error(temporary);
         assert_eq!(code, 5); // EIO
         assert!(
-            message.contains(ERROR_TRANSIENT_SERVICE_PREFIX),
+            message.contains("__LOON_RUST_BRIDGE_ERRCODE__=110"),
             "{message}"
         );
 
@@ -1282,7 +1373,30 @@ mod tests {
         };
         let (code, message) = stream_error(not_found);
         assert_eq!(code, 5); // EIO
-        assert!(message.contains(ERROR_NOT_FOUND_PREFIX), "{message}");
+        assert!(
+            message.contains("__LOON_RUST_BRIDGE_ERRCODE__=104"),
+            "{message}"
+        );
+
+        let unsupported = paimon::Error::Unsupported {
+            message: "unsupported stream operation".to_string(),
+        };
+        let (code, message) = stream_error(unsupported);
+        assert_eq!(code, 5); // EIO: semantic classification is in the marker.
+        assert!(
+            message.contains("__LOON_RUST_BRIDGE_ERRCODE__=1002"),
+            "{message}"
+        );
+
+        let config_invalid = paimon::Error::ConfigInvalid {
+            message: "invalid stream configuration".to_string(),
+        };
+        let (code, message) = stream_error(config_invalid);
+        assert_eq!(code, 5); // EIO: semantic classification is in the marker.
+        assert!(
+            message.contains("__LOON_RUST_BRIDGE_ERRCODE__=115"),
+            "{message}"
+        );
 
         let permanent = paimon::Error::IoUnexpected {
             message: "stream read failed".to_string(),
@@ -1293,22 +1407,46 @@ mod tests {
         };
         let (code, message) = stream_error(permanent);
         assert_eq!(code, 5); // EIO
-        assert!(!message.contains(ERROR_INVALID_PREFIX), "{message}");
+        assert!(
+            !message.contains("__LOON_RUST_BRIDGE_ERRCODE__=115"),
+            "{message}"
+        );
 
+        // A DataInvalid raised mid-stream stays UNCLASSIFIED, and that is the
+        // point of this assertion rather than an omission.
+        //
+        // The only "invalid" marker we have maps to LOON_STORAGE_CONFIG_INVALID
+        // on the C++ side -- a verdict about the deployment's configuration. A
+        // record batch that will not decode says nothing about the deployment,
+        // so tagging it that way would send whoever is paged to go and fix
+        // storage settings that were fine. Paimon 0.3 also conflates "missing"
+        // and "corrupt" into this one variant, so we could not honestly claim
+        // DataCorrupted either. Unclassified lands in the conservative
+        // non-retryable bucket without asserting a cause nobody established.
+        //
+        // TODO: paimon has no data-format marker. Adding one would let a
+        // decode failure reach Milvus as DataFormat instead of as a bare IO
+        // error, which is what lets a caller quarantine a file rather than
+        // retry it forever.
         let invalid = paimon::Error::DataInvalid {
             message: "corrupt record batch".to_string(),
             source: None,
         };
         let (code, message) = stream_error(invalid);
-        assert_eq!(code, 22); // EINVAL
-        assert!(message.contains(ERROR_INVALID_PREFIX), "{message}");
+        assert_eq!(code, 5); // EIO -- unclassified, not EINVAL
+        assert!(
+            !message.contains("__LOON_RUST_BRIDGE_ERRCODE__=115"),
+            "a corrupt record batch must not be reported as a configuration fault: {message}"
+        );
     }
 
     #[test]
     fn scan_mode_errors_are_classified() {
         let invalid = ScanMode::parse("invalid-mode").unwrap_err();
         assert!(
-            invalid.to_string().contains(ERROR_INVALID_PREFIX),
+            invalid
+                .to_string()
+                .contains("__LOON_RUST_BRIDGE_ERRCODE__=115"),
             "{invalid}"
         );
 
@@ -1693,7 +1831,12 @@ mod tests {
         invalid_split["data_files"][0]["_ROW_COUNT"] = serde_json::Value::from(-1);
         let invalid_split: DataSplit = serde_json::from_value(invalid_split).unwrap();
         let error = encode_split_metadata("file:///tmp/table", &invalid_split, 10).unwrap_err();
-        assert!(error.to_string().contains(ERROR_INVALID_PREFIX), "{error}");
+        assert!(
+            error
+                .to_string()
+                .contains("__LOON_RUST_BRIDGE_ERRCODE__=115"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -1798,7 +1941,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_pinned_snapshot_requests_external_collection_refresh() {
+    fn missing_pinned_snapshot_is_reported_as_not_found() {
         let directory = tempfile::tempdir().unwrap();
         let table_location = directory.path().join("snap-table");
         let table_location = table_location.to_str().unwrap();
@@ -1829,9 +1972,15 @@ mod tests {
             Some(&expected_snapshot_id)
         );
 
-        // A confirmed-missing snapshot is a terminal input-state error with
-        // refresh advice (the C++ boundary keys the Invalid classification
-        // off that marker).
+        // A pinned snapshot that does not exist is the caller's input, not a
+        // storage incident: it must reach Milvus as not-found with something
+        // actionable, not as an unclassified failure the caller can only log.
+        //
+        // Paimon 0.3 gives us no typed way to tell "missing" from "corrupt" --
+        // both arrive as `Error::DataInvalid` -- so the arm in `load_table`
+        // matches the message SnapshotManager itself formats. That coupling is
+        // the reason this test asserts on the classification rather than on the
+        // wording: if paimon ever changes that string, this is what fails.
         let error = TOKIO_RT
             .block_on(load_table(
                 table_location,
@@ -1839,12 +1988,14 @@ mod tests {
                 Some(snapshot_id + 1000),
             ))
             .unwrap_err();
-        let message = format!("{error:#}");
-        assert!(message.contains("required metadata"), "{message}");
-        assert!(message.contains("was not found"), "{message}");
+        let message = format!("{:#}", classify_bridge_error(error));
+        assert!(
+            message.starts_with("__LOON_RUST_BRIDGE_ERRCODE__=104; "),
+            "a missing pinned snapshot must be tagged not-found, got: {message}"
+        );
         assert!(
             message.contains("refresh the external collection"),
-            "{message}"
+            "the not-found message must tell the operator what to do, got: {message}"
         );
     }
 
@@ -1879,10 +2030,13 @@ mod tests {
         let message = format!("{error:#}");
         assert!(message.contains("snapshot JSON invalid"), "{message}");
         assert!(!message.contains("was not found"), "{message}");
-        assert!(!message.contains("refresh the external collection"), "{message}");
+        assert!(
+            !message.contains("refresh the external collection"),
+            "{message}"
+        );
 
         let message = format!("{:#}", classify_bridge_error(error));
-        assert!(message.contains(ERROR_INVALID_PREFIX), "{message}");
+        assert!(message.contains("snapshot JSON invalid"), "{message}");
     }
 
     #[test]
@@ -1899,15 +2053,20 @@ mod tests {
             message: "cannot read snapshot".to_string(),
             source: Box::new(source),
         };
-        let error = pinned_metadata_result::<()>(Err(error), "s3://bucket/table", 7)
-            .unwrap_err();
+        let error = pinned_metadata_result::<()>(Err(error), "s3://bucket/table", 7).unwrap_err();
         let message = format!("{:#}", classify_bridge_error(error));
         assert!(
-            message.contains(ERROR_TRANSIENT_SERVICE_PREFIX),
+            message.contains("__LOON_RUST_BRIDGE_ERRCODE__=110"),
             "{message}"
         );
-        assert!(!message.contains(ERROR_INVALID_PREFIX), "{message}");
-        assert!(!message.contains("refresh the external collection"), "{message}");
+        assert!(
+            !message.contains("__LOON_RUST_BRIDGE_ERRCODE__=115"),
+            "{message}"
+        );
+        assert!(
+            !message.contains("refresh the external collection"),
+            "{message}"
+        );
     }
 
     #[test]
@@ -1950,7 +2109,9 @@ mod tests {
             ))
             .unwrap_err();
         assert!(
-            cardinality_error.to_string().contains(ERROR_INVALID_PREFIX),
+            cardinality_error
+                .to_string()
+                .contains("cardinality mismatch"),
             "{cardinality_error}"
         );
 
@@ -1965,7 +2126,7 @@ mod tests {
             ))
             .unwrap_err();
         assert!(
-            short_read_error.to_string().contains(ERROR_INVALID_PREFIX),
+            short_read_error.to_string().contains("exceeds file size"),
             "{short_read_error}"
         );
 
@@ -1984,7 +2145,7 @@ mod tests {
             ))
             .unwrap_err();
         assert!(
-            crc_error.to_string().contains(ERROR_INVALID_PREFIX),
+            crc_error.to_string().contains("CRC mismatch"),
             "{crc_error}"
         );
     }

--- a/cpp/src/format/bridge/rust/src/predicate_parser.rs
+++ b/cpp/src/format/bridge/rust/src/predicate_parser.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use sqlparser::ast::{BinaryOperator, Expr as SqlExpr, UnaryOperator, Value};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
@@ -44,8 +44,14 @@ enum LitType {
 
 enum Out {
     Ok(Expression),
-    OkCol { expr: Expression, col_ty: ColumnType },
-    OkLit { expr: Expression, lit_ty: LitType },
+    OkCol {
+        expr: Expression,
+        col_ty: ColumnType,
+    },
+    OkLit {
+        expr: Expression,
+        lit_ty: LitType,
+    },
     Drop,
 }
 
@@ -74,8 +80,7 @@ pub fn parse_predicate_with_schema(
         bail!("unexpected trailing input after expression: {}", next.token);
     }
 
-    let cols: HashMap<&str, ColumnType> =
-        schema.iter().map(|(n, t)| (n.as_str(), *t)).collect();
+    let cols: HashMap<&str, ColumnType> = schema.iter().map(|(n, t)| (n.as_str(), *t)).collect();
     let schema_present = !schema.is_empty();
     let out = convert_expr(&sql_expr, &cols, schema_present)?;
     Ok(match out {
@@ -153,9 +158,11 @@ fn convert_expr(
             }
         }
         SqlExpr::Nested(inner) => convert_expr(inner, cols, schema_present),
-        SqlExpr::InList { expr: target, list, negated } => {
-            convert_in_list(target, list, *negated, cols, schema_present)
-        }
+        SqlExpr::InList {
+            expr: target,
+            list,
+            negated,
+        } => convert_in_list(target, list, *negated, cols, schema_present),
         SqlExpr::Function(f) => {
             warn(format!("unsupported function call: {}", f.name));
             Ok(Out::Drop)
@@ -213,7 +220,11 @@ fn convert_in_list(
         });
     }
     let combined = acc.expect("non-empty IN list checked above");
-    Ok(Out::Ok(if negated { expr::not(combined) } else { combined }))
+    Ok(Out::Ok(if negated {
+        expr::not(combined)
+    } else {
+        combined
+    }))
 }
 
 fn combine_and(lhs: Out, rhs: Out) -> Out {
@@ -301,7 +312,10 @@ fn convert_value(val: &Value) -> Out {
     match val {
         Value::Number(s, _) => {
             if let Ok(i) = s.parse::<i64>() {
-                return Out::OkLit { expr: expr::lit(i), lit_ty: LitType::Int };
+                return Out::OkLit {
+                    expr: expr::lit(i),
+                    lit_ty: LitType::Int,
+                };
             }
             if let Ok(f) = s.parse::<f64>() {
                 let lit_ty = if f.fract() == 0.0 {
@@ -309,7 +323,10 @@ fn convert_value(val: &Value) -> Out {
                 } else {
                     LitType::Float
                 };
-                return Out::OkLit { expr: expr::lit(f), lit_ty };
+                return Out::OkLit {
+                    expr: expr::lit(f),
+                    lit_ty,
+                };
             }
             Out::Drop
         }
@@ -592,10 +609,7 @@ mod tests {
 
     #[test]
     fn edge_column_eq_column_compatible() {
-        let schema = vec![
-            ("a".into(), ColumnType::Int),
-            ("b".into(), ColumnType::Int),
-        ];
+        let schema = vec![("a".into(), ColumnType::Int), ("b".into(), ColumnType::Int)];
         let expr = must_parse_with("a = b", &schema);
         assert_eq!(count_nodes(&expr), 5);
     }

--- a/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/vortex_bridge.cpp
@@ -3,117 +3,13 @@
 
 #include "vortex_bridge.h"
 
-#include <cerrno>
-#include <charconv>
-#include <optional>
+#include "bridge_error.h"
+
 #include <string>
 #include <string_view>
 
-#include <arrow/record_batch.h>
-#include <arrow/util/io_util.h>
-
-#include "milvus-storage/common/extend_status.h"
-#include "milvus-storage/ffi_c.h"
-
 namespace milvus_storage::vortex {
 namespace {
-
-constexpr std::string_view kVortexFfiErrCodeMarker = "__LOON_VORTEX_FFI_ERRCODE__=";
-
-std::string StripBridgeMarker(std::string_view error, size_t marker_pos, size_t code_end) {
-  auto message_start = code_end;
-  if (message_start < error.size() && error[message_start] == ';') {
-    ++message_start;
-  }
-  if (message_start < error.size() && error[message_start] == ' ') {
-    ++message_start;
-  }
-
-  std::string message;
-  message.reserve(error.size());
-  message.append(error.substr(0, marker_pos));
-  message.append(error.substr(message_start));
-  if (message.empty()) {
-    return "Unknown Vortex error";
-  }
-  return message;
-}
-
-struct ParsedVortexBridgeError {
-  std::string message;
-  std::optional<int> ffi_err_code;
-};
-
-class VortexErrorTranslatingReader final : public arrow::RecordBatchReader {
-  public:
-  explicit VortexErrorTranslatingReader(std::shared_ptr<arrow::RecordBatchReader> inner) : inner_(std::move(inner)) {}
-
-  std::shared_ptr<arrow::Schema> schema() const override { return inner_->schema(); }
-
-  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
-    return MakeVortexErrorStatus("Failed to read vortex record batch", inner_->ReadNext(batch));
-  }
-
-  arrow::Status Close() override {
-    return MakeVortexErrorStatus("Failed to close vortex record batch reader", inner_->Close());
-  }
-
-  private:
-  std::shared_ptr<arrow::RecordBatchReader> inner_;
-};
-
-ParsedVortexBridgeError ParseVortexBridgeError(std::string_view error) {
-  auto marker_pos = error.find(kVortexFfiErrCodeMarker);
-  if (marker_pos == std::string_view::npos) {
-    return {std::string(error), std::nullopt};
-  }
-
-  auto code_start = marker_pos + kVortexFfiErrCodeMarker.size();
-  auto code_end = code_start;
-  while (code_end < error.size() && error[code_end] >= '0' && error[code_end] <= '9') {
-    ++code_end;
-  }
-  if (code_end == code_start) {
-    return {std::string(error), std::nullopt};
-  }
-
-  int ffi_err_code = 0;
-  auto parse_result = std::from_chars(error.data() + code_start, error.data() + code_end, ffi_err_code);
-  if (parse_result.ec != std::errc()) {
-    return {std::string(error), std::nullopt};
-  }
-
-  return {StripBridgeMarker(error, marker_pos, code_end), ffi_err_code};
-}
-
-std::string JoinContextAndMessage(std::string_view context, std::string_view message) {
-  if (context.empty()) {
-    return std::string(message);
-  }
-  if (message.empty()) {
-    return std::string(context);
-  }
-  std::string result;
-  result.reserve(context.size() + 2 + message.size());
-  result.append(context);
-  result.append(": ");
-  result.append(message);
-  return result;
-}
-
-arrow::Status MakeExtendErrorWithContext(std::string_view context, const arrow::Status& status) {
-  auto detail = ExtendStatusDetail::UnwrapStatus(status);
-  auto full_message = JoinContextAndMessage(context, status.message());
-  return MakeExtendError(detail->code(), full_message, full_message);
-}
-
-arrow::Status MakeIOErrorWithContext(std::string_view context, const arrow::Status& status) {
-  auto result = arrow::Status::IOError(JoinContextAndMessage(context, status.message()));
-  if (arrow::internal::ErrnoFromStatus(status) == ENOENT) {
-    return result.WithDetail(arrow::internal::StatusDetailFromErrno(ENOENT));
-  }
-  return result;
-}
 
 template <typename T, typename Fn>
 arrow::Result<T> CatchRustResult(Fn&& fn) {
@@ -136,44 +32,40 @@ arrow::Status CatchRustStatus(Fn&& fn) {
 
 }  // namespace
 
+// Both forms defer to the shared decoder in bridge_error.cpp. There used to be
+// a second copy of its table here; two copies of one table is two tables, and
+// they had already drifted (this one knew about caught panics, the other knew
+// about the bridge-private data-format code).
 arrow::Status MakeVortexBridgeErrorStatus(std::string_view message) {
-  auto parsed = ParseVortexBridgeError(message);
-  if (parsed.ffi_err_code.has_value()) {
-    if (*parsed.ffi_err_code == LOON_FILE_NOT_FOUND) {
-      return arrow::Status::IOError(parsed.message).WithDetail(arrow::internal::StatusDetailFromErrno(ENOENT));
-    }
-    if (auto code = ExtendStatusCodeFromInt(*parsed.ffi_err_code); code.has_value()) {
-      return MakeExtendError(*code, parsed.message, parsed.message);
-    }
-  }
-  return arrow::Status::IOError(parsed.message);
+  // The classification rides the universal marker the Rust side embeds in the
+  // error text (vortex's LoonFfiError). A message without a marker is the
+  // conservative non-retriable fallback.
+  return milvus_storage::bridge::MakeBridgeErrorStatus(message);
+}
+
+arrow::Status MakeVortexBridgeErrorStatus(int ffi_err_code, std::string_view message) {
+  return milvus_storage::bridge::MakeBridgeErrorStatus(ffi_err_code, message);
 }
 
 arrow::Status MakeVortexErrorStatus(std::string_view context, std::string_view message) {
   return MakeVortexErrorStatus(context, MakeVortexBridgeErrorStatus(message));
 }
 
+arrow::Status MakeVortexErrorStatus(std::string_view context, int ffi_err_code, std::string_view message) {
+  return MakeVortexErrorStatus(context, MakeVortexBridgeErrorStatus(ffi_err_code, message));
+}
+
 arrow::Status MakeVortexErrorStatus(std::string_view context, const arrow::Status& status) {
-  if (status.ok()) {
-    return arrow::Status::OK();
-  }
-  if (ExtendStatusDetail::UnwrapStatus(status)) {
-    return MakeExtendErrorWithContext(context, status);
-  }
-  if (arrow::internal::ErrnoFromStatus(status) == ENOENT) {
-    return MakeIOErrorWithContext(context, status);
-  }
-  auto message = status.message();
-  auto parsed_status = MakeVortexBridgeErrorStatus(message);
-  if (ExtendStatusDetail::UnwrapStatus(parsed_status)) {
-    return MakeExtendErrorWithContext(context, parsed_status);
-  }
-  return MakeIOErrorWithContext(context, parsed_status);
+  return milvus_storage::bridge::TranslateBridgeStatus(context, status);
+}
+
+arrow::Status TakeVortexErrorStatus(std::string_view context, const arrow::Status& fallback) {
+  return MakeVortexErrorStatus(context, fallback);
 }
 
 namespace internal {
 std::shared_ptr<arrow::RecordBatchReader> WrapVortexRecordBatchReader(std::shared_ptr<arrow::RecordBatchReader> inner) {
-  return std::make_shared<VortexErrorTranslatingReader>(std::move(inner));
+  return milvus_storage::bridge::WrapBridgeRecordBatchReader(std::move(inner), "Vortex record batch reader");
 }
 }  // namespace internal
 
@@ -338,16 +230,31 @@ arrow::Result<VortexWriter> VortexWriter::Open(
 }
 
 arrow::Status VortexWriter::Write(ArrowSchema& in_schema, ArrowArray& in_array) {
-  return CatchRustStatus(
+  ARROW_RETURN_NOT_OK(status_);
+  auto status = CatchRustStatus(
       [&]() { impl_->write(reinterpret_cast<uint8_t*>(&in_schema), reinterpret_cast<uint8_t*>(&in_array)); });
+  if (!status.ok()) {
+    status = TakeVortexErrorStatus("", status);
+  }
+  return RecordFirstFailure(std::move(status));
 }
 
 arrow::Status VortexWriter::Flush() {
-  return CatchRustStatus([&]() { impl_->flush(); });
+  ARROW_RETURN_NOT_OK(status_);
+  auto status = CatchRustStatus([&]() { impl_->flush(); });
+  if (!status.ok()) {
+    status = TakeVortexErrorStatus("", status);
+  }
+  return RecordFirstFailure(std::move(status));
 }
 
 arrow::Result<ffi::VortexWriteSummary> VortexWriter::Close() {
-  return CatchRustResult<ffi::VortexWriteSummary>([&]() { return impl_->close(); });
+  ARROW_RETURN_NOT_OK(status_);
+  auto result = CatchRustResult<ffi::VortexWriteSummary>([&]() { return impl_->close(); });
+  if (!result.ok()) {
+    return RecordFirstFailure(TakeVortexErrorStatus("", result.status()));
+  }
+  return result;
 }
 
 arrow::Result<VortexFile> VortexFile::Open(uint8_t* fs_rawptr,

--- a/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_bridgeimpl.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::ffi::c_void;
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
@@ -15,9 +16,9 @@ use arrow_array58::{
     Array, ArrayRef as ArrowArrayRef, FixedSizeBinaryArray, FixedSizeListArray, RecordBatch,
     RecordBatchReader, StructArray, UInt8Array, make_array,
 };
+use arrow_schema58::{ArrowError, DataType, Field, Schema, SchemaRef};
 use arrow58::array::ArrayData;
 use arrow58::ffi::FFI_ArrowArray;
-use arrow_schema58::{ArrowError, DataType, Field, Schema, SchemaRef};
 
 use vortex::array::ArrayRef;
 use vortex::array::VortexSessionExecute;
@@ -49,6 +50,18 @@ use crate::vortex_layout_strategy_v2::{LAYOUT_ID, build_row_group_strategy};
 const VORTEX_ZONED_LAYOUT_ID: &str = "vortex.stats";
 const VORTEX_HEADER_SIZE: u64 = 4;
 
+/// Build a typed error only at checks that have already established that the
+/// persisted Vortex footer/layout is inconsistent.  This keeps transport and
+/// caller-owned failures out of `VortexDataFormat` without relying on message
+/// matching at the FFI boundary.
+fn persisted_data_format_error(message: String) -> anyhow::Error {
+    anyhow::Error::new(crate::filesystem_c::classified_vortex_error(
+        LOON_VORTEX_DATA_FORMAT,
+        "vortex persisted data",
+        message,
+    ))
+}
+
 fn footer_start_from_segments(segments: &[SegmentSpec]) -> Result<u64, VortexError> {
     segments
         .iter()
@@ -67,6 +80,33 @@ fn footer_start_from_segments(segments: &[SegmentSpec]) -> Result<u64, VortexErr
         })
 }
 
+fn footer_size_from_bounds(file_size: u64, footer_start: u64) -> Result<u64, VortexError> {
+    if footer_start > file_size {
+        return Err(vortex::error::vortex_err!(
+            "Vortex footer start {} exceeds file size {}",
+            footer_start,
+            file_size
+        ));
+    }
+
+    let tail_size = file_size - footer_start;
+    let eof_size = vortex::file::EOF_SIZE as u64;
+    if tail_size < eof_size {
+        return Err(vortex::error::vortex_err!(
+            "Vortex footer tail size {} is smaller than EOF size {}",
+            tail_size,
+            eof_size
+        ));
+    }
+    Ok(tail_size - eof_size)
+}
+
+fn footer_start_from_persisted_segments(segments: &[SegmentSpec]) -> Result<u64> {
+    footer_start_from_segments(segments).map_err(|error| {
+        persisted_data_format_error(format!("Invalid persisted Vortex segment map: {error}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,6 +121,169 @@ mod tests {
         }];
 
         assert!(footer_start_from_segments(&segments).is_err());
+    }
+
+    #[test]
+    fn invalid_write_summary_bounds_are_rejected() {
+        assert!(footer_size_from_bounds(10, 11).is_err());
+        assert!(footer_size_from_bounds(10, 10).is_err());
+
+        let eof_size = vortex::file::EOF_SIZE as u64;
+        assert_eq!(footer_size_from_bounds(20 + eof_size, 10).unwrap(), 10);
+    }
+
+    #[test]
+    fn persisted_segment_overflow_is_typed_data_format() {
+        let segments = [SegmentSpec {
+            offset: u64::MAX,
+            length: 1,
+            alignment: Alignment::none(),
+        }];
+
+        let error = footer_start_from_persisted_segments(&segments).unwrap_err();
+        assert_eq!(
+            classified_error_info_from_anyhow(&error).map(|info| info.code),
+            Some(LOON_VORTEX_DATA_FORMAT)
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid persisted Vortex segment map")
+        );
+    }
+
+    #[test]
+    fn caught_decoder_panic_is_internal_not_data_format() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("decoder invariant"));
+        let err = panic_to_internal_error(&payload, "test decode");
+
+        // A panic is an unexpected decoder failure, not an ordinary
+        // data-format rejection. The guard must keep the process alive without
+        // assigning the healthy input a format verdict.
+        assert_eq!(
+            classified_error_info_from_vortex(&err).map(|info| info.code),
+            Some(LOON_INTERNAL_INVARIANT)
+        );
+        // The wrapper text is not a trusted transport frame. The typed source
+        // retains the verdict until the stream boundary rebuilds one frame.
+        assert_eq!(crate::bridge_error::marker_code_in(&err.to_string()), None);
+        assert!(err.to_string().contains("decoder invariant"));
+    }
+
+    // Wrapped Vortex/anyhow diagnostics are not transport frames. Typed source
+    // traversal carries the verdict until the final Arrow stream boundary.
+    #[test]
+    fn classified_error_carries_typed_code_through_wrappers() {
+        let classified = anyhow::Error::new(crate::filesystem_c::classified_vortex_error(
+            777,
+            "test filesystem",
+            "typed failure".to_string(),
+        ));
+        let rendered = classified.to_string();
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&rendered),
+            None,
+            "rendered Vortex error: {rendered}"
+        );
+        assert_eq!(
+            classified_error_info_from_anyhow(&classified).map(|info| info.code),
+            Some(777)
+        );
+        // An arbitrary anyhow context is not trusted framing. Its flattened
+        // text must not make an embedded marker authoritative; boundaries
+        // that have an explicit code channel recover the typed source instead.
+        let contextualized = classified.context("planning scan");
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&format!("{contextualized:#}")),
+            None
+        );
+        assert_eq!(
+            classified_error_info_from_anyhow(&contextualized).map(|info| info.code),
+            Some(777)
+        );
+
+        // The writer's boxing chain retains the typed source without making
+        // its Display string trusted framing.
+        let classified = Arc::new(crate::filesystem_c::classified_vortex_error(
+            779,
+            "writer filesystem",
+            "write failed".to_string(),
+        ));
+        let io_error =
+            std::io::Error::new(std::io::ErrorKind::Other, VortexError::from(classified));
+        let boxed: Box<dyn StdError> = Box::new(VortexError::from(io_error));
+        let rendered = boxed.to_string();
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&rendered),
+            None,
+            "rendered boxed Vortex error: {rendered}"
+        );
+        assert_eq!(
+            classified_error_info_from_source(boxed.as_ref()).map(|info| info.code),
+            Some(779)
+        );
+        assert!(rendered.contains("write failed"));
+    }
+
+    #[test]
+    fn sync_open_boundary_rebuilds_one_trusted_frame() {
+        let classified = anyhow::Error::new(crate::filesystem_c::classified_vortex_error(
+            crate::bridge_error::LOON_TRANSIENT_NETWORK,
+            "test filesystem",
+            "read failed".to_string(),
+        ))
+        .context("opening vortex file");
+
+        let rendered = frame_sync_open_error(classified).to_string();
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&rendered),
+            Some(crate::bridge_error::LOON_TRANSIENT_NETWORK)
+        );
+        assert!(rendered.starts_with("Io error: __LOON_RUST_BRIDGE_ERRCODE__=107;"));
+        assert_eq!(rendered.matches("Io error: ").count(), 1);
+        assert!(!rendered.contains("External error:"), "{rendered}");
+    }
+
+    #[test]
+    fn only_explicit_decoder_errors_get_data_format_classification() {
+        let io_error = VortexError::from(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "object read timed out",
+        ));
+        let io_result = classify_vortex_as_data_format(io_error);
+        assert!(matches!(io_result, VortexError::Io(..)));
+        // A plain IO failure carries no marker: unclassified stays
+        // unclassified, and the C++ side lands it in the conservative bucket.
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&io_result.to_string()),
+            None
+        );
+
+        let decode_error = vortex::error::vortex_err!(Serde: "malformed serialized metadata");
+        let decode_result = classify_vortex_as_data_format(decode_error);
+        assert_eq!(
+            classified_error_info_from_vortex(&decode_result).map(|info| info.code),
+            Some(LOON_VORTEX_DATA_FORMAT)
+        );
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&decode_result.to_string()),
+            None
+        );
+    }
+
+    #[test]
+    fn anyhow_wrapper_does_not_relabel_plain_io_as_data_format() {
+        let error = anyhow::Error::new(VortexError::from(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset",
+        )));
+
+        let result = classify_anyhow_as_data_format(error);
+        assert!(result.downcast_ref::<VortexError>().is_some());
+        assert_eq!(
+            crate::bridge_error::marker_code_in(&result.to_string()),
+            None
+        );
     }
 }
 
@@ -935,7 +1138,6 @@ pub const VORTEX_BASIC_STATS: &[Stat] = &[
 
 pub const VORTEX_NON_STATS: &[Stat] = &[Stat::UncompressedSizeInBytes];
 
-const VORTEX_FORMAT_V1: u32 = 1;
 const VORTEX_FORMAT_V2: u32 = 2;
 
 pub(crate) struct VortexWriter {
@@ -971,127 +1173,123 @@ pub(crate) unsafe fn open_writer(
 
 impl VortexWriter {
     pub(crate) unsafe fn write(&mut self, in_schema: *mut u8, in_array: *mut u8) -> Result<()> {
-        let ffi_array = unsafe { FFI_ArrowArray::from_raw(in_array as *mut FFI_ArrowArray) };
+        let result = (|| {
+            let ffi_array = unsafe { FFI_ArrowArray::from_raw(in_array as *mut FFI_ArrowArray) };
 
-        let ffi_schema = unsafe { FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema) };
-        let arrow_schema = Schema::try_from(&ffi_schema)?;
+            let ffi_schema =
+                unsafe { FFI_ArrowSchema::from_raw(in_schema as *mut FFI_ArrowSchema) };
+            let arrow_schema = Schema::try_from(&ffi_schema)?;
 
-        let arrow_array_data = arrow_array58::array::StructArray::from(
-            unsafe { arrow_array58::ffi::from_ffi(ffi_array, &ffi_schema) }
-                .map_err(|e| VortexError::from(e))?,
-        );
+            let arrow_array_data = arrow_array58::array::StructArray::from(
+                unsafe { arrow_array58::ffi::from_ffi(ffi_array, &ffi_schema) }
+                    .map_err(VortexError::from)?,
+            );
 
-        let (converted_schema, converted_array) = if let Some(conversion) =
-            convert_schema_for_vortex(&arrow_schema)?
-        {
-            let converted_array = convert_struct_array_for_vortex(&arrow_array_data, &conversion)?;
-            (conversion.schema, converted_array)
-        } else {
-            (arrow_schema, arrow_array_data)
-        };
-        let vortex_schema = RustDType::from_arrow(&converted_schema);
+            let (converted_schema, converted_array) =
+                if let Some(conversion) = convert_schema_for_vortex(&arrow_schema)? {
+                    let converted_array =
+                        convert_struct_array_for_vortex(&arrow_array_data, &conversion)?;
+                    (conversion.schema, converted_array)
+                } else {
+                    (arrow_schema, arrow_array_data)
+                };
+            let vortex_schema = RustDType::from_arrow(&converted_schema);
 
-        // lazy init the inner_writer
-        if self.inner_writer.is_none() {
-            let (objw, writer_handle) = ObjectStoreWriterCpp::new(
-                self.fswrapper_ptr as *mut c_void,
-                &self.path,
-                VORTEX_RT.handle(),
-            )
-            .map_err(|e| VortexError::from(e))?;
-            self.writer_handle = Some(writer_handle);
-
-            // stats options
-            let stats_options = if self.enable_stats {
-                VORTEX_BASIC_STATS.to_vec()
-            } else {
-                VORTEX_NON_STATS.to_vec()
-            };
-            let strategy = if self.format_version == VORTEX_FORMAT_V2 {
-                build_row_group_strategy(
-                    self.row_group_max_size,
-                    self.enable_stats,
-                    Arc::<[Stat]>::from(stats_options.clone()),
+            // lazy init the inner_writer
+            if self.inner_writer.is_none() {
+                let (objw, writer_handle) = ObjectStoreWriterCpp::new(
+                    self.fswrapper_ptr as *mut c_void,
+                    &self.path,
+                    VORTEX_RT.handle(),
                 )
-            } else {
-                WriteStrategyBuilder::default()
-                    .with_inline_array_node(true)
-                    .build()
-            };
+                .map_err(VortexError::from)?;
+                self.writer_handle = Some(writer_handle);
 
-            let writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
-                .with_file_statistics(stats_options)
-                .with_strategy(strategy)
-                .writer(objw, vortex_schema);
+                // stats options
+                let stats_options = if self.enable_stats {
+                    VORTEX_BASIC_STATS.to_vec()
+                } else {
+                    VORTEX_NON_STATS.to_vec()
+                };
+                let strategy = if self.format_version == VORTEX_FORMAT_V2 {
+                    build_row_group_strategy(
+                        self.row_group_max_size,
+                        self.enable_stats,
+                        Arc::<[Stat]>::from(stats_options.clone()),
+                    )
+                } else {
+                    WriteStrategyBuilder::default()
+                        .with_inline_array_node(true)
+                        .build()
+                };
 
-            self.inner_writer = Some(writer);
-        }
-        let mut inner_writer = self.inner_writer.take().unwrap();
+                let writer = VortexWriteOptions::new(VORTEX_SESSION.clone())
+                    .with_file_statistics(stats_options)
+                    .with_strategy(strategy)
+                    .writer(objw, vortex_schema);
 
-        let converted_array = ArrayRef::from_arrow(&converted_array, false)?;
-        VORTEX_RT
-            .block_on(inner_writer.push(converted_array))
-            .map_err(|e| Box::new(VortexError::from(e)))?;
+                self.inner_writer = Some(writer);
+            }
+            let mut inner_writer = self.inner_writer.take().unwrap();
 
-        self.inner_writer = Some(inner_writer);
-        Ok(())
+            let converted_array = ArrayRef::from_arrow(&converted_array, false)?;
+            VORTEX_RT
+                .block_on(inner_writer.push(converted_array))
+                .map_err(|e| Box::new(VortexError::from(e)))?;
+
+            self.inner_writer = Some(inner_writer);
+            Ok(())
+        })();
+        result
     }
 
     pub(crate) unsafe fn flush(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        if let Some(writer_handle) = self.writer_handle.as_ref() {
-            VORTEX_RT
-                .block_on(writer_handle.flush())
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
-        }
-        Ok(())
+        let result = (|| {
+            if let Some(writer_handle) = self.writer_handle.as_ref() {
+                VORTEX_RT
+                    .block_on(writer_handle.flush())
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+            }
+            Ok(())
+        })();
+        result
     }
 
     pub(crate) unsafe fn close(
         &mut self,
     ) -> Result<crate::vortex_ffi::VortexWriteSummary, Box<dyn std::error::Error>> {
-        if let Some(w) = self.inner_writer.take() {
-            let summary = VORTEX_RT
-                .block_on(w.finish())
-                .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
-            if let Some(writer_handle) = self.writer_handle.take() {
-                VORTEX_RT
-                    .block_on(writer_handle.close())
+        let result = (|| {
+            if let Some(w) = self.inner_writer.take() {
+                let summary = VORTEX_RT
+                    .block_on(w.finish())
+                    .map_err(|e| Box::new(VortexError::from(e)) as Box<dyn std::error::Error>)?;
+                let file_size = summary.size();
+                let footer = summary.footer();
+                let footer_start = footer_start_from_segments(footer.segment_map())
                     .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+                let footer_size = footer_size_from_bounds(file_size, footer_start)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+
+                // Validate the summary while the output stream is still
+                // abortable. Once close succeeds the object is committed and a
+                // later C++ Abort cannot undo it.
+                if let Some(writer_handle) = self.writer_handle.take() {
+                    VORTEX_RT
+                        .block_on(writer_handle.close())
+                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+                }
+
+                return Ok(crate::vortex_ffi::VortexWriteSummary {
+                    file_size,
+                    footer_size,
+                });
             }
-            let file_size = summary.size();
-
-            let footer = summary.footer();
-            let footer_start = footer_start_from_segments(footer.segment_map())
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
-
-            if footer_start > file_size {
-                return Err(Box::new(vortex::error::vortex_err!(
-                    "Vortex footer start {} exceeds file size {}",
-                    footer_start,
-                    file_size
-                )));
-            }
-
-            let tail_size = file_size - footer_start;
-            let eof_size = vortex::file::EOF_SIZE as u64;
-            if tail_size < eof_size {
-                return Err(Box::new(vortex::error::vortex_err!(
-                    "Vortex footer tail size {} is smaller than EOF size {}",
-                    tail_size,
-                    eof_size
-                )));
-            }
-            let footer_size = tail_size - eof_size;
-
-            return Ok(crate::vortex_ffi::VortexWriteSummary {
-                file_size,
-                footer_size,
-            });
-        }
-        Ok(crate::vortex_ffi::VortexWriteSummary {
-            file_size: 0,
-            footer_size: 0,
-        })
+            Ok(crate::vortex_ffi::VortexWriteSummary {
+                file_size: 0,
+                footer_size: 0,
+            })
+        })();
+        result
     }
 }
 
@@ -1193,9 +1391,87 @@ impl VortexFile {
         &self,
         window: crate::vortex_ffi::CoalescingWindow,
     ) -> Result<Box<VortexScanBuilder>> {
+        guard_decoder_panic(&self.path, "scan_builder", || {
+            self.scan_builder_unguarded(window)
+        })
+    }
+
+    pub(crate) fn scan_builder_with_schema(
+        &self,
+        in_schema: *mut u8,
+    ) -> Result<Box<VortexScanBuilder>> {
+        guard_decoder_panic(&self.path, "scan_builder_with_schema", || {
+            self.scan_builder_with_schema_unguarded(in_schema)
+        })
+    }
+
+    pub(crate) unsafe fn get_schema(&self, out_schema: *mut u8) -> Result<()> {
+        guard_decoder_panic(&self.path, "get_schema", || unsafe {
+            self.get_schema_unguarded(out_schema)
+        })
+    }
+
+    pub(crate) fn splits(&self) -> Result<Vec<u64>> {
+        guard_decoder_panic(&self.path, "splits", || self.splits_unguarded())
+    }
+
+    pub(crate) fn row_group_zone_map_count(&self) -> Result<u64> {
+        guard_decoder_panic(&self.path, "row_group_zone_map_count", || {
+            self.row_group_zone_map_count_unguarded()
+        })
+    }
+
+    pub(crate) fn row_group_zone_map_data_before_zones(&self) -> Result<bool> {
+        guard_decoder_panic(&self.path, "row_group_zone_map_data_before_zones", || {
+            self.row_group_zone_map_data_before_zones_unguarded()
+        })
+    }
+
+    pub(crate) fn zone_map_segment_ids(&self) -> Result<Vec<u64>> {
+        guard_decoder_panic(&self.path, "zone_map_segment_ids", || {
+            self.zone_map_segment_ids_unguarded()
+        })
+    }
+
+    pub(crate) fn footer_byte_range(&self, file_size: u64) -> Result<Vec<u64>> {
+        guard_decoder_panic(&self.path, "footer_byte_range", || {
+            self.footer_byte_range_unguarded(file_size)
+        })
+    }
+
+    pub(crate) fn segment_bytes(&self, flat_segment_id: u64) -> Result<Vec<u64>> {
+        guard_decoder_panic(&self.path, "segment_bytes", || {
+            self.segment_bytes_unguarded(flat_segment_id)
+        })
+    }
+
+    pub(crate) fn field_layout_units(&self, field_name: &str) -> Result<Vec<u64>> {
+        guard_decoder_panic(&self.path, "field_layout_units", || {
+            self.field_layout_units_unguarded(field_name)
+        })
+    }
+
+    pub(crate) fn prune_row_groups(
+        &self,
+        predicate: &str,
+        candidate_row_group_ids: &[u64],
+    ) -> Result<Vec<u64>> {
+        guard_decoder_panic(&self.path, "prune_row_groups", || {
+            self.prune_row_groups_unguarded(predicate, candidate_row_group_ids)
+        })
+    }
+
+    fn scan_builder_unguarded(
+        &self,
+        window: crate::vortex_ffi::CoalescingWindow,
+    ) -> Result<Box<VortexScanBuilder>> {
         let file = self.open_with_coalescing_window(window)?;
-        let num_natural_splits = file.splits().map_err(VortexError::from)?.len();
+        let num_natural_splits = file
+            .splits()
+            .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?
+            .len();
         Ok(Box::new(VortexScanBuilder {
+            path: self.path.clone(),
             inner: file.scan()?,
             filter: None,
             output_schema: None,
@@ -1208,7 +1484,7 @@ impl VortexFile {
         }))
     }
 
-    pub(crate) fn scan_builder_with_schema(
+    fn scan_builder_with_schema_unguarded(
         &self,
         in_schema: *mut u8,
     ) -> Result<Box<VortexScanBuilder>> {
@@ -1220,9 +1496,14 @@ impl VortexFile {
             .as_ref()
             .map(|conversion| Arc::new(conversion.schema.clone()))
             .unwrap_or_else(|| original_schema.clone());
-        let num_natural_splits = self.inner.splits().map_err(VortexError::from)?.len();
+        let num_natural_splits = self
+            .inner
+            .splits()
+            .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?
+            .len();
 
         Ok(Box::new(VortexScanBuilder {
+            path: self.path.clone(),
             inner: self.inner.scan()?,
             filter: None,
             output_schema: Some(converted_schema),
@@ -1235,7 +1516,7 @@ impl VortexFile {
         }))
     }
 
-    pub(crate) unsafe fn get_schema(&self, out_schema: *mut u8) -> Result<()> {
+    unsafe fn get_schema_unguarded(&self, out_schema: *mut u8) -> Result<()> {
         let dtype = self.inner.dtype();
         let arrow_schema = VORTEX_SESSION.arrow().to_arrow_schema(&dtype)?;
         let ffi_schema = FFI_ArrowSchema::try_from(&arrow_schema)?;
@@ -1243,9 +1524,12 @@ impl VortexFile {
         Ok(())
     }
 
-    pub(crate) fn splits(&self) -> Result<Vec<u64>> {
+    fn splits_unguarded(&self) -> Result<Vec<u64>> {
         // get the Vec<Range<u64>> from the inner file
-        let ranges = self.inner.splits().map_err(|e| VortexError::from(e))?;
+        let ranges = self
+            .inner
+            .splits()
+            .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?;
 
         // map each Range<u64> to its end (right-hand side)
         let ends = ranges
@@ -1287,22 +1571,24 @@ impl VortexFile {
             .to_string()
     }
 
-    pub(crate) fn row_group_zone_map_count(&self) -> Result<u64> {
+    fn row_group_zone_map_count_unguarded(&self) -> Result<u64> {
         let root = self.inner.footer().layout();
         if root.encoding_id().as_ref() != LAYOUT_ID {
             return Ok(0);
         }
-        Ok(root.child(1)?.row_count())
+        Ok(zone_map_child(root, LAYOUT_ID)?.row_count())
     }
 
-    pub(crate) fn row_group_zone_map_data_before_zones(&self) -> Result<bool> {
+    fn row_group_zone_map_data_before_zones_unguarded(&self) -> Result<bool> {
         let root = self.inner.footer().layout();
         if root.encoding_id().as_ref() != LAYOUT_ID {
             return Ok(false);
         }
 
-        let data_child = root.child(0)?;
-        let zones_child = root.child(1)?;
+        let zones_child = zone_map_child(root, LAYOUT_ID)?;
+        let data_child = root.child(0).map_err(|error| {
+            anyhow::Error::new(classify_vortex_as_data_format(VortexError::from(error)))
+        })?;
         let mut data_segment_ids = Vec::new();
         collect_layout_segment_ids(&data_child, &mut data_segment_ids)?;
         let mut zones_segment_ids = Vec::new();
@@ -1313,21 +1599,31 @@ impl VortexFile {
         }
 
         let segments = self.inner.footer().segment_map();
-        let max_data_offset = data_segment_ids
-            .iter()
-            .map(|idx| segments[*idx].offset)
-            .max()
-            .expect("checked non-empty data segments");
-        let min_zones_offset = zones_segment_ids
-            .iter()
-            .map(|idx| segments[*idx].offset)
-            .min()
-            .expect("checked non-empty zones segments");
+        let mut max_data_offset = 0;
+        for idx in data_segment_ids {
+            let segment = segments.get(idx).ok_or_else(|| {
+                persisted_data_format_error(format!(
+                    "Vortex data layout references segment {idx}, but the footer has {} segments",
+                    segments.len()
+                ))
+            })?;
+            max_data_offset = max_data_offset.max(segment.offset);
+        }
+        let mut min_zones_offset = u64::MAX;
+        for idx in zones_segment_ids {
+            let segment = segments.get(idx).ok_or_else(|| {
+                persisted_data_format_error(format!(
+                    "Vortex zonemap layout references segment {idx}, but the footer has {} segments",
+                    segments.len()
+                ))
+            })?;
+            min_zones_offset = min_zones_offset.min(segment.offset);
+        }
 
         Ok(max_data_offset < min_zones_offset)
     }
 
-    pub(crate) fn zone_map_segment_ids(&self) -> Result<Vec<u64>> {
+    fn zone_map_segment_ids_unguarded(&self) -> Result<Vec<u64>> {
         let root = self.inner.footer().layout();
         let mut segment_ids = Vec::new();
         collect_zone_map_segment_ids(root, &mut segment_ids)?;
@@ -1335,22 +1631,21 @@ impl VortexFile {
     }
 
     /// Returns [offset, length] for the full footer/tail region.
-    pub(crate) fn footer_byte_range(&self, file_size: u64) -> Result<Vec<u64>> {
+    fn footer_byte_range_unguarded(&self, file_size: u64) -> Result<Vec<u64>> {
         let footer = self.inner.footer();
-        let footer_start = footer_start_from_segments(footer.segment_map())?;
+        let footer_start = footer_start_from_persisted_segments(footer.segment_map())?;
         if footer_start > file_size {
-            anyhow::bail!(
+            return Err(persisted_data_format_error(format!(
                 "Vortex footer start {} exceeds file size {}",
-                footer_start,
-                file_size
-            );
+                footer_start, file_size
+            )));
         } else {
             Ok(vec![footer_start, file_size - footer_start])
         }
     }
 
     /// Returns [offset, length] for a given flat segment ID.
-    pub(crate) fn segment_bytes(&self, flat_segment_id: u64) -> Result<Vec<u64>> {
+    fn segment_bytes_unguarded(&self, flat_segment_id: u64) -> Result<Vec<u64>> {
         let footer = self.inner.footer();
         let segment_map = footer.segment_map();
         let idx = flat_segment_id as usize;
@@ -1373,7 +1668,7 @@ impl VortexFile {
     ///                 flat_segment_id0, flat_segment_id1, ...]
     ///
     /// V2 units use row-group granularity. V1 units use field/flat granularity.
-    pub(crate) fn field_layout_units(&self, field_name: &str) -> Result<Vec<u64>> {
+    fn field_layout_units_unguarded(&self, field_name: &str) -> Result<Vec<u64>> {
         let footer = self.inner.footer();
         let root = footer.layout();
 
@@ -1386,7 +1681,7 @@ impl VortexFile {
         Ok(units)
     }
 
-    pub(crate) fn prune_row_groups(
+    fn prune_row_groups_unguarded(
         &self,
         predicate: &str,
         candidate_row_group_ids: &[u64],
@@ -1406,7 +1701,10 @@ impl VortexFile {
             &expr,
             candidate_row_group_ids,
         )
-        .map_err(Into::into)
+        // Pruning decodes zone-map segments, so ordinary FlatBuffers/Serde
+        // failures here are data-format errors too. Into::into used to
+        // stringify them into a generic 2044.
+        .map_err(|e| anyhow::Error::new(classify_vortex_as_data_format(e)))
     }
 }
 
@@ -1415,7 +1713,11 @@ fn collect_layout_segment_ids(
     out: &mut Vec<usize>,
 ) -> Result<()> {
     for segment_id in layout.segment_ids() {
-        out.push(usize::try_from(*segment_id)?);
+        out.push(usize::try_from(*segment_id).map_err(|_| {
+            persisted_data_format_error(format!(
+                "Vortex layout segment id {segment_id} does not fit this platform"
+            ))
+        })?);
     }
     for child in layout.children()? {
         collect_layout_segment_ids(&child, out)?;
@@ -1430,7 +1732,9 @@ fn collect_zone_map_segment_ids(layout: &LayoutRef, out: &mut Vec<usize>) -> Res
         let zones_child = zone_map_child(layout, encoding_id)?;
         collect_layout_segment_ids(&zones_child, out)?;
 
-        let data_child = layout.child(0)?;
+        let data_child = layout.child(0).map_err(|error| {
+            anyhow::Error::new(classify_vortex_as_data_format(VortexError::from(error)))
+        })?;
         collect_zone_map_segment_ids(&data_child, out)?;
         return Ok(());
     }
@@ -1444,13 +1748,13 @@ fn collect_zone_map_segment_ids(layout: &LayoutRef, out: &mut Vec<usize>) -> Res
 fn zone_map_child(layout: &LayoutRef, encoding_id: &str) -> Result<LayoutRef> {
     let child_count = layout.nchildren();
     if child_count != 2 {
-        anyhow::bail!(
-            "Vortex zonemap layout {} expected 2 children, got {}",
-            encoding_id,
-            child_count
-        );
+        return Err(persisted_data_format_error(format!(
+            "Vortex zonemap layout {encoding_id} expected 2 children, got {child_count}"
+        )));
     }
-    Ok(layout.child(1)?)
+    layout.child(1).map_err(|error| {
+        anyhow::Error::new(classify_vortex_as_data_format(VortexError::from(error)))
+    })
 }
 
 fn sorted_u64_segment_ids(mut segment_ids: Vec<usize>) -> Result<Vec<u64>> {
@@ -1465,7 +1769,9 @@ fn sorted_u64_segment_ids(mut segment_ids: Vec<usize>) -> Result<Vec<u64>> {
 fn find_field_layout(layout: &LayoutRef, field_name: &str) -> Result<Option<LayoutRef>> {
     for i in 0..layout.nchildren() {
         let child_type = layout.child_type(i);
-        let child = layout.child(i).map_err(VortexError::from)?;
+        let child = layout
+            .child(i)
+            .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?;
         if let LayoutChildType::Field(ref name) = child_type {
             if name.as_ref() == field_name {
                 return Ok(Some(child));
@@ -1509,7 +1815,9 @@ fn collect_v2_row_group_units(
 ) -> Result<()> {
     for i in 0..layout.nchildren() {
         let child_type = layout.child_type(i);
-        let child = layout.child(i).map_err(VortexError::from)?;
+        let child = layout
+            .child(i)
+            .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?;
         match child_type {
             LayoutChildType::Chunk((row_group_idx, row_offset)) => {
                 if find_field_layout(&child, field_name)?.is_some() {
@@ -1533,7 +1841,13 @@ fn collect_v2_row_group_units(
 }
 
 fn build_v2_row_group_units(root: &LayoutRef, field_name: &str) -> Result<Vec<u64>> {
-    let data = root.child(0).map_err(VortexError::from)?;
+    // Validate the persisted wrapper shape even though this path only needs the
+    // data child. Otherwise a malformed child count can surface later as a
+    // generic decoder error instead of a data-format error.
+    let _ = zone_map_child(root, LAYOUT_ID)?;
+    let data = root
+        .child(0)
+        .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?;
     let mut result = vec![2, 0];
     let mut total_units = 0u64;
 
@@ -1560,6 +1874,146 @@ fn build_v1_flat_units(root: &LayoutRef, field_name: &str) -> Result<Vec<u64>> {
         result[1] = 1;
     }
     Ok(result)
+}
+
+/// These constants mirror ffi_error_code.h. check_error_table.py verifies that
+/// the values do not drift across the Rust/C++ boundary.
+pub(crate) const LOON_INTERNAL_INVARIANT: i32 = 122;
+pub(crate) const LOON_VORTEX_DATA_FORMAT: i32 = 119;
+
+// A classification extracted from an error's TYPE chain: code + clean message.
+// The async-open callback carries it as explicit (code, message) arguments. The
+// sync CXX boundary rebuilds one trusted BridgeError frame before the typed
+// source chain is flattened into rust::Error::what().
+pub(crate) use crate::bridge_error::ClassifiedErrorInfo;
+
+fn classified_error_info_from_source(
+    error: &(dyn StdError + 'static),
+) -> Option<ClassifiedErrorInfo> {
+    let mut source = Some(error);
+    while let Some(current) = source {
+        if let Some(error) = current.downcast_ref::<crate::filesystem_c::LoonFfiError>() {
+            // The message is built from the fields, NOT from Display: Display
+            // embeds the transport marker, and this message crosses with the
+            // code as an explicit pair -- a marker here would leak into
+            // user-visible text once C++ re-renders it.
+            return Some(ClassifiedErrorInfo {
+                code: error.err_code,
+                message: format!("{}: {}", error.context, error.message),
+            });
+        }
+        source = current.source();
+    }
+    None
+}
+
+fn classified_error_info_from_vortex(error: &VortexError) -> Option<ClassifiedErrorInfo> {
+    match error {
+        VortexError::External(source, _) => classified_error_info_from_source(source.as_ref()),
+        VortexError::Context(_, inner) => classified_error_info_from_vortex(inner),
+        VortexError::Shared(inner) => classified_error_info_from_vortex(inner),
+        VortexError::Arrow(ArrowError::ExternalError(source), _) => {
+            classified_error_info_from_source(source.as_ref())
+        }
+        _ => error.source().and_then(classified_error_info_from_source),
+    }
+}
+
+fn classified_error_info_from_anyhow(error: &anyhow::Error) -> Option<ClassifiedErrorInfo> {
+    if let Some(vortex) = error.downcast_ref::<VortexError>() {
+        if let Some(info) = classified_error_info_from_vortex(vortex) {
+            return Some(info);
+        }
+    }
+    classified_error_info_from_source(error.as_ref())
+}
+
+fn frame_sync_open_error(error: anyhow::Error) -> anyhow::Error {
+    let Some(info) = classified_error_info_from_anyhow(&error) else {
+        return error;
+    };
+    anyhow::Error::new(crate::bridge_error::BridgeError::new_io(
+        Some(info.code),
+        info.message,
+    ))
+}
+
+/// Only decoder variants that explicitly report a serialized representation
+/// failure may become `VortexDataFormat`.  In particular, do not infer
+/// corruption from `Io`, Arrow conversion, caller arguments, or generic
+/// Vortex errors at a format-reader call site.
+fn is_vortex_data_format_error(error: &VortexError) -> bool {
+    match error {
+        VortexError::Serde(..) | VortexError::Prost(..) => true,
+        VortexError::FlatBuffers(..) => true,
+        VortexError::Context(_, inner) => is_vortex_data_format_error(inner),
+        VortexError::Shared(inner) => is_vortex_data_format_error(inner),
+        VortexError::Arrow(ArrowError::ExternalError(source), _) => source
+            .downcast_ref::<VortexError>()
+            .is_some_and(is_vortex_data_format_error),
+        _ => false,
+    }
+}
+
+fn is_anyhow_data_format_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<VortexError>())
+        .any(is_vortex_data_format_error)
+}
+
+/// Turn a panic escaping the Vortex decoder into an unexpected/internal error.
+/// The catch prevents unwinding across CXX. The typed source retains the
+/// verdict until the final stream boundary creates the single marker frame.
+fn panic_to_internal_error(payload: &Box<dyn std::any::Any + Send>, op: &str) -> VortexError {
+    let detail = payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "non-string panic payload".to_string());
+    crate::filesystem_c::classified_vortex_error(
+        LOON_INTERNAL_INVARIANT,
+        "vortex",
+        format!("vortex decoder panicked in {op}: {detail}"),
+    )
+}
+
+fn guard_decoder_panic<T>(path: &str, op: &str, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        // The guarded operation may reject a caller-owned argument (schema,
+        // predicate, segment id, ...). Catch panics here, but let ordinary
+        // errors keep the verdict assigned at their actual producer.
+        Ok(result) => result,
+        Err(payload) => Err(anyhow::Error::new(panic_to_internal_error(
+            &payload,
+            &format!("{op} for {path}"),
+        ))),
+    }
+}
+
+fn classify_anyhow_as_data_format(err: anyhow::Error) -> anyhow::Error {
+    if classified_error_info_from_anyhow(&err).is_some() || !is_anyhow_data_format_error(&err) {
+        err
+    } else {
+        let text = err.to_string();
+        anyhow::Error::new(crate::filesystem_c::classified_vortex_error(
+            LOON_VORTEX_DATA_FORMAT,
+            "vortex",
+            text,
+        ))
+    }
+}
+
+fn classify_vortex_as_data_format(err: VortexError) -> VortexError {
+    if classified_error_info_from_vortex(&err).is_some() || !is_vortex_data_format_error(&err) {
+        err
+    } else {
+        crate::filesystem_c::classified_vortex_error(
+            LOON_VORTEX_DATA_FORMAT,
+            "vortex",
+            err.to_string(),
+        )
+    }
 }
 
 async fn open_file_impl(
@@ -1591,7 +2045,7 @@ async fn open_file_impl(
     let file = open_options
         .open(Arc::new(read_source))
         .await
-        .map_err(VortexError::from)?;
+        .map_err(|e| classify_vortex_as_data_format(VortexError::from(e)))?;
 
     Ok(Box::new(VortexFile {
         inner: file,
@@ -1609,26 +2063,62 @@ pub(crate) unsafe fn open_file(
     file_size: u64,
     footer_size: u64,
 ) -> Result<Box<VortexFile>> {
-    VORTEX_RT.block_on(open_file_impl(
-        fswrapper_ptr as usize,
-        path.to_string(),
-        file_size,
-        footer_size,
-    ))
+    guard_decoder_panic(path, "open_file", || {
+        VORTEX_RT.block_on(open_file_impl(
+            fswrapper_ptr as usize,
+            path.to_string(),
+            file_size,
+            footer_size,
+        ))
+    })
+    .map_err(frame_sync_open_error)
 }
 
-type VortexOpenAsyncCallback =
-    unsafe extern "C" fn(ctx: *mut c_void, handle: usize, error_msg: *const std::ffi::c_char);
+type VortexOpenAsyncCallback = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    handle: usize,
+    error_code: i32,
+    error_msg: *const std::ffi::c_char,
+);
 
 fn open_callback_error(
     callback: VortexOpenAsyncCallback,
     ctx: *mut c_void,
+    error_code: i32,
     message: impl ToString,
 ) {
     let message = message.to_string();
     let c_message = std::ffi::CString::new(message)
         .unwrap_or_else(|_| std::ffi::CString::new("vortex async open error").unwrap());
-    unsafe { callback(ctx, 0, c_message.into_raw()) };
+    unsafe { callback(ctx, 0, error_code, c_message.into_raw()) };
+}
+
+fn open_callback_error_from_anyhow(
+    callback: VortexOpenAsyncCallback,
+    ctx: *mut c_void,
+    error: anyhow::Error,
+) {
+    let info = classified_error_info_from_anyhow(&error);
+    open_callback_error(
+        callback,
+        ctx,
+        info.as_ref().map_or(0, |info| info.code),
+        info.map_or_else(|| error.to_string(), |info| info.message),
+    );
+}
+
+fn open_callback_error_from_vortex(
+    callback: VortexOpenAsyncCallback,
+    ctx: *mut c_void,
+    error: VortexError,
+) {
+    let info = classified_error_info_from_vortex(&error);
+    open_callback_error(
+        callback,
+        ctx,
+        info.as_ref().map_or(0, |info| info.code),
+        info.map_or_else(|| error.to_string(), |info| info.message),
+    );
 }
 
 /// Asynchronously open a Vortex file on the shared Tokio runtime and invoke
@@ -1649,7 +2139,7 @@ pub unsafe extern "C" fn vortex_open_file_async(
     ctx: *mut c_void,
 ) {
     if path.is_null() && path_len != 0 {
-        open_callback_error(callback, ctx, "vortex async open received a null path");
+        open_callback_error(callback, ctx, 0, "vortex async open received a null path");
         return;
     }
 
@@ -1660,7 +2150,7 @@ pub unsafe extern "C" fn vortex_open_file_async(
         match std::str::from_utf8(path_bytes) {
             Ok(path) => path.to_string(),
             Err(error) => {
-                open_callback_error(callback, ctx, format!("invalid UTF-8 path: {error}"));
+                open_callback_error(callback, ctx, 0, format!("invalid UTF-8 path: {error}"));
                 return;
             }
         }
@@ -1682,19 +2172,30 @@ pub unsafe extern "C" fn vortex_open_file_async(
         {
             Ok(Ok(file)) => {
                 let handle = Box::into_raw(file) as usize;
-                unsafe { callback(ctx_addr as *mut c_void, handle, std::ptr::null()) };
+                unsafe { callback(ctx_addr as *mut c_void, handle, 0, std::ptr::null()) };
             }
-            Ok(Err(error)) => open_callback_error(callback, ctx_addr as *mut c_void, error),
-            Err(_) => open_callback_error(
+            Ok(Err(error)) => {
+                open_callback_error_from_anyhow(callback, ctx_addr as *mut c_void, error)
+            }
+            // Same verdict the sync path reaches through guard_decoder_panic:
+            // the same three smashed bytes must not classify differently just
+            // because milvus opened the file asynchronously. Dropping the
+            // payload also threw away the only clue about where it died.
+            Err(payload) => open_callback_error_from_vortex(
                 callback,
                 ctx_addr as *mut c_void,
-                "vortex async open panicked",
+                panic_to_internal_error(&payload, "open_file_async"),
             ),
         }
     });
 }
 
 pub(crate) struct VortexScanBuilder {
+    // The file this builder was derived from. Carried so the scan can name it:
+    // every other decoder entry point reports panics as "<op> for <path>", and
+    // a scan that dies without naming the object leaves the reader knowing a
+    // file is bad but not which one.
+    path: String,
     inner: ScanBuilder<ArrayRef>,
     filter: Option<Expression>,
     output_schema: Option<SchemaRef>, // Converted schema for Vortex (FixedSizeList<u8>)
@@ -1831,11 +2332,39 @@ impl std::iter::Iterator for VortexRecordBatchReader {
     type Item = Result<RecordBatch, ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.iter.next() {
-            Some(result) => Some(result.map_err(|e| ArrowError::ExternalError(Box::new(e)))),
+        // The pull itself is guarded, not just its error. Decoding happens
+        // lazily inside iter.next(), so a panic there fires BEFORE any map_err
+        // and unwinds straight out of the Arrow C stream callback -- the
+        // entry-point guards never see this boundary, and a malformed file
+        // that opens cleanly could abort the process on its first batch.
+        let pulled =
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.iter.next())) {
+                Ok(item) => item,
+                Err(payload) => {
+                    let error = panic_to_internal_error(&payload, "record batch stream");
+                    return Some(Err(vortex_stream_error(error)));
+                }
+            };
+        match pulled {
+            Some(Ok(batch)) => Some(Ok(batch)),
+            Some(Err(error)) => {
+                // The verdict rides the marker in the error's Display: this
+                // surfaces through the Arrow C stream as the error text, which
+                // the C++ translating reader parses.
+                let error = classify_vortex_as_data_format(error);
+                Some(Err(vortex_stream_error(error)))
+            }
             None => None,
         }
     }
+}
+
+fn vortex_stream_error(error: VortexError) -> ArrowError {
+    let bridge = match classified_error_info_from_vortex(&error) {
+        Some(info) => crate::bridge_error::BridgeError::new(Some(info.code), info.message),
+        None => crate::bridge_error::BridgeError::new(None, error.to_string()),
+    };
+    crate::bridge_error::into_arrow_io_error(bridge)
 }
 
 impl RecordBatchReader for VortexRecordBatchReader {
@@ -1926,12 +2455,42 @@ pub(crate) fn scan_builder_into_raw_handle(builder: Box<VortexScanBuilder>) -> u
 
 /// # Safety
 ///
-/// out_stream should be properly aligned according to the Arrow C stream interface and valid for write.
+/// Same contract as `scan_builder_into_stream_unguarded`, which this wraps.
+//
+// Guarded because this is a cxx entry point that decodes persisted bytes:
+// `prepare()` and `execute_stream()` below run the vortex layout decoder, and a
+// panic unwinding out of an `extern "Rust"` fn is a process abort, not an error.
+// The inner catch_unwind around the per-chunk decode task is NOT a substitute --
+// it only covers work the runtime has already accepted, and its own comment says
+// so. Keep both: the inner one recovers the real cause before the runtime's
+// secondary panic masks it, this one keeps any panic from crossing the boundary.
+//
+// Safe to catch here because `out_stream` is written exactly once, at the very
+// end, after every fallible step. A panic therefore leaves it untouched and the
+// caller sees an error instead of a half-initialised FFI_ArrowArrayStream.
 pub(crate) unsafe fn scan_builder_into_stream(
     builder: Box<VortexScanBuilder>,
     out_stream: *mut u8,
 ) -> Result<()> {
+    let path = builder.path.clone();
+    guard_decoder_panic(&path, "scan_builder_into_stream", move || unsafe {
+        scan_builder_into_stream_unguarded(builder, out_stream)
+    })
+}
+
+/// # Safety
+///
+/// out_stream should be properly aligned according to the Arrow C stream interface and valid for write.
+// Every decoder error before the reader exists goes through classify_vortex_as_data_format,
+// same as the batch iterator after it -- a Serde/FlatBuffers failure while
+// PREPARING the scan is the same data-format failure as one while streaming
+// it, and untagged it stringified into a generic 2044.
+unsafe fn scan_builder_into_stream_unguarded(
+    builder: Box<VortexScanBuilder>,
+    out_stream: *mut u8,
+) -> Result<()> {
     let VortexScanBuilder {
+        path: _,
         mut inner,
         filter,
         output_schema,
@@ -1951,8 +2510,13 @@ pub(crate) unsafe fn scan_builder_into_stream(
             (Some(vs), Some(os), plan) => (vs, os, plan),
             (Some(vs), None, _) => (vs.clone(), vs, None),
             (None, _, _) => {
-                let dtype = inner.dtype()?;
-                let arrow_schema = Arc::new(VORTEX_SESSION.arrow().to_arrow_schema(&dtype)?);
+                let dtype = inner.dtype().map_err(classify_vortex_as_data_format)?;
+                let arrow_schema = Arc::new(
+                    VORTEX_SESSION
+                        .arrow()
+                        .to_arrow_schema(&dtype)
+                        .map_err(classify_vortex_as_data_format)?,
+                );
                 (arrow_schema.clone(), arrow_schema, None)
             }
         };
@@ -1966,33 +2530,53 @@ pub(crate) unsafe fn scan_builder_into_stream(
     // part of large takes onto the caller thread. ScanBuilder::map runs on the spawned split task,
     // preserving the scan's parallelism while producing the same Arrow batches.
     let inner = inner.map(move |chunk| {
-        // This is a synthetic root field: Arrow arrays do not carry a top-level field name.
-        // The Struct child fields in `data_type` retain their original names and metadata.
-        let target = Field::new("", data_type.clone(), chunk.dtype().is_nullable());
-        let mut ctx = VORTEX_SESSION.create_execution_ctx();
-        let arrow = VORTEX_SESSION
-            .arrow()
-            .execute_arrow(chunk, Some(&target), &mut ctx)?;
-        Ok(RecordBatch::from(arrow.as_struct().clone()))
+        // Caught HERE, inside the decode task, because the outer guard on the
+        // stream pull only ever sees the runtime's secondary panic ("Runtime
+        // dropped task without completing it") once this task has already died.
+        // The real cause -- "range end index N out of range", "output buffer
+        // sized too small" -- exists only on this side; without this it reached
+        // the caller as stderr noise while the returned error said nothing
+        // about what actually broke.
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // This is a synthetic root field: Arrow arrays do not carry a top-level field name.
+            // The Struct child fields in `data_type` retain their original names and metadata.
+            let target = Field::new("", data_type.clone(), chunk.dtype().is_nullable());
+            let mut ctx = VORTEX_SESSION.create_execution_ctx();
+            let arrow = VORTEX_SESSION
+                .arrow()
+                .execute_arrow(chunk, Some(&target), &mut ctx)?;
+            Ok::<RecordBatch, VortexError>(RecordBatch::from(arrow.as_struct().clone()))
+        })) {
+            Ok(result) => result,
+            Err(payload) => Err(panic_to_internal_error(&payload, "record batch decode")),
+        }
     });
 
     let iter: Box<dyn Iterator<Item = vortex::error::VortexResult<RecordBatch>> + Send> =
         if empty_selection {
             Box::new(std::iter::empty())
         } else if let Some(row_ranges) = row_ranges {
-            let scan = inner.prepare()?;
+            let scan = inner.prepare().map_err(classify_vortex_as_data_format)?;
             let mut iters: Vec<
                 Box<dyn Iterator<Item = vortex::error::VortexResult<RecordBatch>> + Send>,
             > = Vec::with_capacity(row_ranges.len());
             for row_range in row_ranges {
                 iters.push(Box::new(
-                    VORTEX_RT.block_on_stream(scan.execute_stream(Some(row_range))?),
+                    VORTEX_RT.block_on_stream(
+                        scan.execute_stream(Some(row_range))
+                            .map_err(classify_vortex_as_data_format)?,
+                    ),
                 ));
             }
             Box::new(iters.into_iter().flatten())
         } else {
-            let scan = inner.prepare()?;
-            Box::new(VORTEX_RT.block_on_stream(scan.execute_stream(row_range)?))
+            let scan = inner.prepare().map_err(classify_vortex_as_data_format)?;
+            Box::new(
+                VORTEX_RT.block_on_stream(
+                    scan.execute_stream(row_range)
+                        .map_err(classify_vortex_as_data_format)?,
+                ),
+            )
         };
     let reader = VortexRecordBatchReader {
         iter,
@@ -2020,14 +2604,46 @@ pub(crate) unsafe fn scan_builder_into_stream(
 type VortexAsyncCallback = unsafe extern "C" fn(
     ctx: *mut c_void,
     out_stream: *mut FFI_ArrowArrayStream,
+    error_code: i32,
     error_msg: *const std::ffi::c_char,
 );
 
-fn callback_error(callback: VortexAsyncCallback, ctx: *mut c_void, message: impl ToString) {
+fn callback_error(
+    callback: VortexAsyncCallback,
+    ctx: *mut c_void,
+    error_code: i32,
+    message: impl ToString,
+) {
     let message = message.to_string();
     let c_message = std::ffi::CString::new(message)
         .unwrap_or_else(|_| std::ffi::CString::new("vortex async error").unwrap());
-    unsafe { callback(ctx, std::ptr::null_mut(), c_message.into_raw()) };
+    unsafe { callback(ctx, std::ptr::null_mut(), error_code, c_message.into_raw()) };
+}
+
+fn callback_error_from_anyhow(
+    callback: VortexAsyncCallback,
+    ctx: *mut c_void,
+    error: anyhow::Error,
+) {
+    let error = classify_anyhow_as_data_format(error);
+    let info = classified_error_info_from_anyhow(&error);
+    callback_error(
+        callback,
+        ctx,
+        info.as_ref().map_or(0, |info| info.code),
+        info.map_or_else(|| error.to_string(), |info| info.message),
+    );
+}
+
+fn callback_error_from_vortex(callback: VortexAsyncCallback, ctx: *mut c_void, error: VortexError) {
+    let error = classify_vortex_as_data_format(error);
+    let info = classified_error_info_from_vortex(&error);
+    callback_error(
+        callback,
+        ctx,
+        info.as_ref().map_or(0, |info| info.code),
+        info.map_or_else(|| error.to_string(), |info| info.message),
+    );
 }
 
 /// Free an error string previously allocated by vortex_scan_collect_async.
@@ -2059,6 +2675,7 @@ pub unsafe extern "C" fn vortex_scan_collect_async(
 ) {
     let builder = unsafe { Box::from_raw(handle as *mut VortexScanBuilder) };
     let VortexScanBuilder {
+        path,
         mut inner,
         filter,
         output_schema,
@@ -2085,12 +2702,12 @@ pub unsafe extern "C" fn vortex_scan_collect_async(
                         (schema.clone(), schema, None)
                     }
                     Err(e) => {
-                        callback_error(callback, ctx, format!("schema error: {e}"));
+                        callback_error_from_vortex(callback, ctx, e);
                         return;
                     }
                 },
                 Err(e) => {
-                    callback_error(callback, ctx, format!("dtype error: {e}"));
+                    callback_error_from_vortex(callback, ctx, e);
                     return;
                 }
             },
@@ -2154,13 +2771,18 @@ pub unsafe extern "C" fn vortex_scan_collect_async(
                 let out_stream = send_stream as *mut FFI_ArrowArrayStream;
                 let ctx = send_ctx as *mut c_void;
                 unsafe { std::ptr::write(out_stream, stream) };
-                unsafe { callback(ctx, out_stream, std::ptr::null()) };
+                unsafe { callback(ctx, out_stream, 0, std::ptr::null()) };
             }
-            Ok(Err(error)) => callback_error(callback, send_ctx as *mut c_void, error),
-            Err(_) => callback_error(
+            Ok(Err(error)) => callback_error_from_anyhow(callback, send_ctx as *mut c_void, error),
+            // Same verdict and same detail the sync stream produces. Keep the
+            // panic payload and carry its typed internal-error code separately.
+            Err(payload) => callback_error_from_vortex(
                 callback,
                 send_ctx as *mut c_void,
-                "vortex async scan panicked",
+                // Named the same way the sync path names it: a panic that does
+                // not say which object it decoded tells the reader a file is
+                // bad without telling it which file.
+                panic_to_internal_error(&payload, &format!("async scan for {path}")),
             ),
         }
     });

--- a/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
+++ b/cpp/src/format/bridge/rust/src/vortex_layout_strategy_v2.rs
@@ -7,10 +7,6 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use futures::{StreamExt as _, pin_mut};
 use vortex::array::ArrayContext;
-use vortex::array::arrays::{
-    Chunked, ChunkedArray, Constant, Decimal, Dict, Extension, FixedSizeList, List, ListView,
-    Masked, Primitive, PrimitiveArray, Struct, StructArray, VarBin, VarBinView,
-};
 use vortex::array::arrays::chunked::ChunkedArrayExt;
 use vortex::array::arrays::decimal::DecimalArrayExt;
 use vortex::array::arrays::dict::DictArraySlotsExt;
@@ -22,6 +18,10 @@ use vortex::array::arrays::masked::MaskedArraySlotsExt;
 use vortex::array::arrays::primitive::PrimitiveArrayExt;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::arrays::varbin::VarBinArrayExt;
+use vortex::array::arrays::{
+    Chunked, ChunkedArray, Constant, Decimal, Dict, Extension, FixedSizeList, List, ListView,
+    Masked, Primitive, PrimitiveArray, Struct, StructArray, VarBin, VarBinView,
+};
 use vortex::array::stats::{as_stat_bitset_bytes, stats_from_bitset_bytes};
 use vortex::array::validity::Validity;
 use vortex::array::{
@@ -33,7 +33,9 @@ use vortex::dtype::{
     DType, DecimalType, Field, FieldName, FieldNames, FieldPath, FieldPathSet, Nullability, PType,
     StructFields,
 };
-use vortex::error::{VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_err};
+use vortex::error::{
+    VortexError, VortexExpect, VortexResult, vortex_bail, vortex_ensure, vortex_err,
+};
 use vortex::expr::pruning::{checked_pruning_expr, field_path_stat_field_name};
 use vortex::expr::stats::Stat;
 use vortex::expr::{Expression, get_item, root};
@@ -83,6 +85,13 @@ pub(crate) fn row_group_zone_map_pruning_stats() -> (u64, u64) {
         ROW_GROUP_ZONE_MAP_PRUNE_EVAL_COUNT.load(std::sync::atomic::Ordering::Relaxed),
         ROW_GROUP_ZONE_MAP_PRUNED_ROW_GROUP_COUNT.load(std::sync::atomic::Ordering::Relaxed),
     )
+}
+
+fn metadata_err(message: String) -> VortexError {
+    // Serde, not Other: the bridge's `is_vortex_data_format_error` classifies
+    // Serde as DataFormat, which is what "persisted zone-map metadata does not
+    // decode" is. Other would surface as an unclassified System failure.
+    vortex_err!(Serde: "{}", message)
 }
 
 vtable!(RowGroupZoneMap);
@@ -135,8 +144,34 @@ impl DeserializeMetadata for RowGroupZoneMapMetadata {
         let mut reader = MetadataReader::new(metadata);
         let version = reader.read_u16()?;
         let stats_version = reader.read_u16()?;
+        // Version BEFORE any structural check. A newer writer appending fields
+        // makes the trailing-bytes check below fire first if this runs late,
+        // and "Trailing bytes in metadata" tells the operator the bytes are
+        // corrupt when the truth is "your reader is old". The version check
+        // must win that race. (The ensure! in build() stays as a backstop for
+        // any path that constructs the metadata struct another way.)
+        if version != METADATA_VERSION {
+            return Err(metadata_err(format!(
+                "Unsupported {LAYOUT_ID} metadata version: {version}"
+            )));
+        }
+        if stats_version != STATS_VERSION {
+            return Err(metadata_err(format!(
+                "Unsupported {LAYOUT_ID} stats version: {stats_version}"
+            )));
+        }
         let rg_count = reader.read_u64()?;
         let column_count = reader.read_u32()? as usize;
+        // Every column needs at least two u16 lengths (field name and stats).
+        // Reject an impossible persisted count before using it as an allocation
+        // size; malformed metadata must produce a data-format error, not try to
+        // reserve attacker-controlled memory.
+        if column_count > reader.remaining() / 4 {
+            return Err(metadata_err(format!(
+                "Invalid {LAYOUT_ID} metadata column count {column_count} for {} remaining bytes",
+                reader.remaining()
+            )));
+        }
         let mut columns = Vec::with_capacity(column_count);
 
         for _ in 0..column_count {
@@ -149,11 +184,12 @@ impl DeserializeMetadata for RowGroupZoneMapMetadata {
             });
         }
 
-        vortex_ensure!(
-            reader.is_done(),
-            "Trailing bytes in {LAYOUT_ID} metadata: {}",
-            reader.remaining()
-        );
+        if !reader.is_done() {
+            return Err(metadata_err(format!(
+                "Trailing bytes in {LAYOUT_ID} metadata: {}",
+                reader.remaining()
+            )));
+        }
 
         Ok(Self {
             version,
@@ -211,7 +247,7 @@ impl<'a> MetadataReader<'a> {
     fn read_string(&mut self) -> VortexResult<String> {
         let bytes = self.read_bytes()?;
         String::from_utf8(bytes.to_vec())
-            .map_err(|e| vortex_err!("Invalid UTF-8 in {LAYOUT_ID} metadata: {e}"))
+            .map_err(|e| metadata_err(format!("Invalid UTF-8 in {LAYOUT_ID} metadata: {e}")))
     }
 
     fn read_bytes(&mut self) -> VortexResult<&'a [u8]> {
@@ -223,9 +259,9 @@ impl<'a> MetadataReader<'a> {
         let end = self
             .pos
             .checked_add(len)
-            .ok_or_else(|| vortex_err!("Invalid {LAYOUT_ID} metadata length"))?;
+            .ok_or_else(|| metadata_err(format!("Invalid {LAYOUT_ID} metadata length")))?;
         if end > self.bytes.len() {
-            vortex_bail!("Truncated {LAYOUT_ID} metadata");
+            return Err(metadata_err(format!("Truncated {LAYOUT_ID} metadata")));
         }
         let out = &self.bytes[self.pos..end];
         self.pos = end;
@@ -333,11 +369,18 @@ impl VTable for RowGroupZoneMap {
             "Unsupported {LAYOUT_ID} stats version: {}",
             metadata.stats_version
         );
-        vortex_ensure!(
-            children.nchildren() == 2,
-            "{LAYOUT_ID} expected 2 children, got {}",
-            children.nchildren()
-        );
+        if children.nchildren() != 2 {
+            return Err(metadata_err(format!(
+                "{LAYOUT_ID} expected 2 children, got {}",
+                children.nchildren()
+            )));
+        }
+        // `dtype` and `metadata` are both persisted in the file. A metadata
+        // column that the persisted dtype does not contain is therefore a
+        // contradiction in the bytes, not a caller-side projection mistake.
+        // Validate it while the layout is being built so the data-format
+        // classification is not lost in a later child()/reader call.
+        let _ = zones_dtype_from_persisted_metadata(dtype, metadata)?;
 
         Ok(RowGroupZoneMapLayout {
             dtype: dtype.clone(),
@@ -439,6 +482,17 @@ fn zones_dtype(dtype: &DType, metadata: &RowGroupZoneMapMetadata) -> VortexResul
         StructFields::new(FieldNames::from(names), dtypes),
         Nullability::NonNullable,
     ))
+}
+
+fn zones_dtype_from_persisted_metadata(
+    dtype: &DType,
+    metadata: &RowGroupZoneMapMetadata,
+) -> VortexResult<DType> {
+    zones_dtype(dtype, metadata).map_err(|err| {
+        metadata_err(format!(
+            "Invalid {LAYOUT_ID} metadata for data dtype: {err}"
+        ))
+    })
 }
 
 fn boundary_dtype() -> DType {
@@ -548,8 +602,7 @@ impl RowGroupZoneMapReader {
             let mut ctx = session.create_execution_ctx();
             let zone_array = zone_eval.await?.execute::<StructArray>(&mut ctx)?;
             Self::validate_stats_table(&column_dtype, &zone_array, &present_stats)?;
-            let stats_view =
-                Self::build_root_stats_view_for_column(&zone_array, &required_stats)?;
+            let stats_view = Self::build_root_stats_view_for_column(&zone_array, &required_stats)?;
             let rg_prune_mask = stats_view.apply(&predicate)?.execute::<Mask>(&mut ctx)?;
             Ok::<Mask, vortex::error::VortexError>(rg_prune_mask)
         })?;
@@ -674,8 +727,7 @@ impl LayoutReader for RowGroupZoneMapReader {
             // Validate that the stored per-column stats table still matches Vortex ZoneMap
             // shape before evaluating the root-scope pruning predicate against it.
             Self::validate_stats_table(&column_dtype, &zone_array, &present_stats)?;
-            let stats_view =
-                Self::build_root_stats_view_for_column(&zone_array, &required_stats)?;
+            let stats_view = Self::build_root_stats_view_for_column(&zone_array, &required_stats)?;
             let rg_prune_mask = stats_view.apply(&predicate)?.execute::<Mask>(&mut ctx)?;
             ROW_GROUP_ZONE_MAP_PRUNE_EVAL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             ROW_GROUP_ZONE_MAP_PRUNED_ROW_GROUP_COUNT.fetch_add(
@@ -1069,10 +1121,7 @@ fn estimated_listview_size_range(
                 saturating_sum([
                     primitive_range_width(offsets, len),
                     primitive_range_width(sizes, len),
-                    estimated_logical_uncompressed_size_range(
-                        listview.elements(),
-                        start..end,
-                    ),
+                    estimated_logical_uncompressed_size_range(listview.elements(), start..end),
                 ]),
                 array,
                 len,
@@ -1249,9 +1298,11 @@ fn estimated_logical_uncompressed_size_range(
     }
 
     if let Some(struct_array) = array.as_opt::<Struct>() {
-        let field_bytes = saturating_sum(struct_array.iter_unmasked_fields().map(|field| {
-            estimated_logical_uncompressed_size_range(field, range.clone())
-        }));
+        let field_bytes = saturating_sum(
+            struct_array
+                .iter_unmasked_fields()
+                .map(|field| estimated_logical_uncompressed_size_range(field, range.clone())),
+        );
         return add_estimated_validity_nbytes(field_bytes, array, len);
     }
 
@@ -1390,12 +1441,8 @@ impl RowGroupBuffer {
 
                 if rows_to_take < chunk_len {
                     let right = chunk.slice(rows_to_take..chunk_len)?;
-                    let right_est = estimated_split_remainder_size(
-                        &chunk,
-                        &right,
-                        est_bytes,
-                        chunk_len,
-                    );
+                    let right_est =
+                        estimated_split_remainder_size(&chunk, &right, est_bytes, chunk_len);
                     self.nbytes = self.nbytes.saturating_add(right_est);
                     self.data.push_front((right, right_est));
                 }
@@ -1993,8 +2040,7 @@ fn build_data_strategy() -> Arc<dyn LayoutStrategy> {
     let validity = CollectStrategy::new(compress_flat);
     let struct_inner = TableStrategy::new(Arc::new(validity), Arc::new(chunked_inner));
     Arc::new(
-        ChunkedLayoutStrategy::new(struct_inner)
-            .with_max_concurrent_children(NonZeroUsize::MIN),
+        ChunkedLayoutStrategy::new(struct_inner).with_max_concurrent_children(NonZeroUsize::MIN),
     )
 }
 
@@ -2017,8 +2063,8 @@ mod tests {
     use vortex::array::arrays::{ChunkedArray, ConstantArray, FixedSizeListArray};
     use vortex::array::stream::ArrayStreamExt;
     use vortex::buffer::{BitBufferMut, ByteBufferMut};
-    use vortex::expr::{and, gt_eq, lit, lt};
     use vortex::expr::stats::StatsProvider;
+    use vortex::expr::{and, gt_eq, lit, lt};
     use vortex::file::{OpenOptionsSessionExt, VortexWriteOptions};
 
     #[test]
@@ -2034,6 +2080,68 @@ mod tests {
         let roundtrip =
             RowGroupZoneMapMetadata::deserialize(&metadata.clone().serialize()).unwrap();
         assert_eq!(roundtrip, metadata);
+    }
+
+    #[test]
+    fn damaged_metadata_is_rejected() {
+        let good = RowGroupZoneMapMetadata::new(
+            3,
+            vec![ColumnZoneMetadata {
+                field_name: "a".into(),
+                present_stats: Arc::from([Stat::Max, Stat::Min]),
+            }],
+        )
+        .serialize();
+
+        // The file claims more than it holds.
+        let truncated = good[..good.len() - 1].to_vec();
+        // It holds more than it claims.
+        let mut trailing = good.clone();
+        trailing.push(0xAB);
+        // A field name that is not text. The single-byte name "a" sits right
+        // after the fixed header (version + stats_version + rg_count +
+        // column_count = 16 bytes) and its own u16 length, so overwriting it
+        // with a lone continuation byte hits from_utf8 and nothing else.
+        let mut bad_utf8 = good.clone();
+        bad_utf8[16 + 2] = 0x80;
+        // An impossible persisted count must be rejected before Vec allocation.
+        let mut impossible_count = good.clone();
+        impossible_count[12..16].copy_from_slice(&u32::MAX.to_le_bytes());
+
+        for (what, bytes) in [
+            ("truncated", truncated),
+            ("trailing", trailing),
+            ("invalid utf-8", bad_utf8),
+            ("impossible column count", impossible_count),
+        ] {
+            assert!(
+                RowGroupZoneMapMetadata::deserialize(&bytes).is_err(),
+                "{what} metadata was accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_column_missing_from_persisted_dtype_is_rejected() {
+        let dtype = DType::Struct(
+            StructFields::new(
+                FieldNames::from(["present"]),
+                vec![DType::Primitive(PType::I32, Nullability::NonNullable)],
+            ),
+            Nullability::NonNullable,
+        );
+        let metadata = RowGroupZoneMapMetadata::new(
+            1,
+            vec![ColumnZoneMetadata {
+                field_name: "missing".into(),
+                present_stats: Arc::from([Stat::Max, Stat::Min]),
+            }],
+        );
+
+        assert!(
+            zones_dtype_from_persisted_metadata(&dtype, &metadata).is_err(),
+            "metadata that references a missing dtype column was accepted"
+        );
     }
 
     #[test]
@@ -2119,10 +2227,7 @@ mod tests {
         )?
         .into_array();
 
-        assert_eq!(
-            estimated_logical_uncompressed_size(&array),
-            u64::MAX
-        );
+        assert_eq!(estimated_logical_uncompressed_size(&array), u64::MAX);
         Ok(())
     }
 

--- a/cpp/src/format/column_group_lazy_reader.cpp
+++ b/cpp/src/format/column_group_lazy_reader.cpp
@@ -42,6 +42,7 @@
 #include "milvus-storage/format/paimon/paimon_format_reader.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::api {
 
@@ -149,8 +150,9 @@ arrow::Status ColumnGroupLazyReaderImpl<ReaderT>::validate_row_indices(const std
 template <typename ReaderT>
 arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupLazyReaderImpl<ReaderT>::open_reader_for_file(size_t file_index) {
   if (file_index >= column_group_->files.size()) {
-    return arrow::Status::Invalid("Column group file index out of range: ", file_index,
-                                  " >= ", column_group_->files.size());
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Column group file index out of range: ", file_index,
+                              " >= ", column_group_->files.size());
   }
 
   auto file = column_group_->files[file_index];
@@ -349,7 +351,7 @@ arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> ColumnGroupLazyReader::cre
     const std::function<std::string(const std::string&)>& key_retriever,
     const milvus_storage::MetadataCache& cache) {
   if (!column_group) {
-    return arrow::Status::Invalid("Column group cannot be null");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "Column group cannot be null");
   }
   const bool cache_enabled =
       cache.enabled() && GetValueNoError<bool>(properties, PROPERTY_READER_METADATA_CACHE_ENABLE);
@@ -379,7 +381,8 @@ arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> ColumnGroupLazyReader::cre
     return metadata_cache.dispatch(
         column_group->format, [&](auto typed_cache) -> arrow::Result<std::unique_ptr<ColumnGroupLazyReader>> {
           if (!typed_cache) {
-            return arrow::Status::Invalid("Format reader metadata cache is null");
+            return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                      "Format reader metadata cache is null");
           }
 
           using TypedCache = typename decltype(typed_cache)::element_type;

--- a/cpp/src/format/column_group_reader.cpp
+++ b/cpp/src/format/column_group_reader.cpp
@@ -14,6 +14,8 @@
 
 #include "milvus-storage/format/column_group_reader.h"
 
+#include "milvus-storage/common/extend_status.h"
+
 #include <algorithm>
 #include <future>
 #include <numeric>
@@ -43,6 +45,7 @@
 #include "milvus-storage/common/macro.h"  // for UNLIKELY
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/async_tasks.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/paimon/paimon_format_reader.h"
@@ -229,8 +232,9 @@ arrow::Status ColumnGroupReaderImpl<ReaderT>::append_file_metadata(size_t file_i
 template <typename ReaderT>
 arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupReaderImpl<ReaderT>::open_reader_for_file(size_t file_index) {
   if (file_index >= column_group_->files.size()) {
-    return arrow::Status::Invalid("Column group file index out of range: ", file_index,
-                                  " >= ", column_group_->files.size());
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Column group file index out of range: ", file_index,
+                              " >= ", column_group_->files.size());
   }
 
   auto file = column_group_->files[file_index];
@@ -254,7 +258,8 @@ arrow::Result<std::shared_ptr<ReaderT>> ColumnGroupReaderImpl<ReaderT>::open_rea
     return FormatReader::create_from_metadata<ReaderT>(metadata, file, schema_, needed_columns_, predicate_);
   }
 
-  return arrow::Status::Invalid("Unreachable code");
+  return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                            "ColumnGroupReader reached a branch documented as unreachable");
 }
 
 template <typename ReaderT>
@@ -371,34 +376,34 @@ folly::SemiFuture<arrow::Status> ColumnGroupReaderImpl<ReaderT>::open_async() {
   }
 
   // File results stay tagged with their manifest index so shared reader state is
-  // assembled deterministically after the fan-in.
-  return folly::collectAll(std::move(futures))
-      .deferValue([this, file_count = cg_files.size()](auto&& open_results) -> arrow::Status {
-        chunk_infos_.clear();
-        row_group_infos_.clear();
-        row_group_infos_.resize(file_count);
-        file_schema_.reset();
-        format_readers_.clear();
-        format_readers_.resize(file_count);
+  // assembled deterministically after the fan-in. A failed open returns
+  // immediately; accepted sibling opens keep their callback-owned lifetimes and
+  // may finish in the background.
+  return CollectAllResultsFailFast(std::move(futures), "column-group asynchronous open")
+      .deferValue(
+          [this, file_count = cg_files.size()](arrow::Result<std::vector<OpenedFile>>&& open_result) -> arrow::Status {
+            ARROW_ASSIGN_OR_RAISE(auto open_results, std::move(open_result));
+            chunk_infos_.clear();
+            row_group_infos_.clear();
+            row_group_infos_.resize(file_count);
+            file_schema_.reset();
+            format_readers_.clear();
+            format_readers_.resize(file_count);
 
-        size_t rows_in_all_files = 0;
-        for (auto& try_result : open_results) {
-          if (try_result.hasException()) {
-            return arrow::Status::IOError(try_result.exception().what().toStdString());
-          }
-          ARROW_ASSIGN_OR_RAISE(auto opened_file, std::move(try_result.value()));
-          if (!file_schema_ && opened_file.file_schema) {
-            file_schema_ = std::move(opened_file.file_schema);
-          }
-          format_readers_[opened_file.file_index] = std::move(opened_file.reader);
-          ARROW_RETURN_NOT_OK(append_file_metadata(opened_file.file_index, opened_file.file,
-                                                   opened_file.row_group_infos, rows_in_all_files));
-        }
+            size_t rows_in_all_files = 0;
+            for (auto& opened_file : open_results) {
+              if (!file_schema_ && opened_file.file_schema) {
+                file_schema_ = std::move(opened_file.file_schema);
+              }
+              format_readers_[opened_file.file_index] = std::move(opened_file.reader);
+              ARROW_RETURN_NOT_OK(append_file_metadata(opened_file.file_index, opened_file.file,
+                                                       opened_file.row_group_infos, rows_in_all_files));
+            }
 
-        total_rows_ = rows_in_all_files;
-        opened_ = true;
-        return arrow::Status::OK();
-      });
+            total_rows_ = rows_in_all_files;
+            opened_ = true;
+            return arrow::Status::OK();
+          });
 }
 
 template <typename ReaderT>
@@ -426,7 +431,8 @@ arrow::Result<std::vector<int64_t>> ColumnGroupReaderImpl<ReaderT>::get_chunk_in
                                [](int64_t a, const ChunkInfo& b) { return a < b.global_row_end; });
     auto chunk_index = std::distance(chunk_infos_.begin(), it);
     if (chunk_index >= chunk_infos_.size()) {
-      return arrow::Status::Invalid(fmt::format("Row index out of range: {}", row_index));
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                fmt::format("Row index out of range: {}", row_index));
     }
 
     if (unique_chunk_indices.find(chunk_index) == unique_chunk_indices.end()) {
@@ -802,7 +808,7 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     const std::string& predicate,
     const milvus_storage::MetadataCache& cache) {
   if (!column_group) {
-    return arrow::Status::Invalid("Column group cannot be null");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "Column group cannot be null");
   }
   const bool cache_enabled =
       cache.enabled() && GetValueNoError<bool>(properties, PROPERTY_READER_METADATA_CACHE_ENABLE);
@@ -834,7 +840,8 @@ arrow::Result<std::unique_ptr<ColumnGroupReader>> ColumnGroupReader::create(
     return metadata_cache.dispatch(
         column_group->format, [&](auto typed_cache) -> arrow::Result<std::unique_ptr<ColumnGroupReader>> {
           if (!typed_cache) {
-            return arrow::Status::Invalid("Format reader metadata cache is null");
+            return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                      "Format reader metadata cache is null");
           }
 
           using TypedCache = typename decltype(typed_cache)::element_type;
@@ -863,7 +870,8 @@ folly::SemiFuture<arrow::Result<std::unique_ptr<ColumnGroupReader>>> ColumnGroup
     const milvus_storage::MetadataCache& cache) {
   using ResultType = arrow::Result<std::unique_ptr<ColumnGroupReader>>;
   if (!column_group) {
-    return folly::makeSemiFuture(ResultType(arrow::Status::Invalid("Column group cannot be null")));
+    return folly::makeSemiFuture(
+        ResultType(MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "Column group cannot be null")));
   }
   const bool cache_enabled =
       cache.enabled() && GetValueNoError<bool>(properties, PROPERTY_READER_METADATA_CACHE_ENABLE);
@@ -896,7 +904,8 @@ folly::SemiFuture<arrow::Result<std::unique_ptr<ColumnGroupReader>>> ColumnGroup
         column_group->format,
         [&](auto typed_cache) -> folly::SemiFuture<arrow::Result<std::unique_ptr<ColumnGroupReader>>> {
           if (!typed_cache) {
-            return folly::makeSemiFuture(ResultType(arrow::Status::Invalid("Format reader metadata cache is null")));
+            return folly::makeSemiFuture(ResultType(MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                                                       "Format reader metadata cache is null")));
           }
 
           using TypedCache = typename decltype(typed_cache)::element_type;

--- a/cpp/src/format/iceberg/iceberg_format.cpp
+++ b/cpp/src/format/iceberg/iceberg_format.cpp
@@ -18,6 +18,9 @@
 #include "milvus-storage/format/iceberg/iceberg_common.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "iceberg_bridge.h"
+#include "milvus-storage/common/extend_status.h"
+
+#include <charconv>
 
 namespace milvus_storage {
 
@@ -27,7 +30,13 @@ arrow::Result<std::vector<api::ColumnGroupFile>> IcebergFormat::explore(const st
   auto storage_options = iceberg::ToStorageOptions(fs_config);
 
   ARROW_ASSIGN_OR_RAISE(auto snapshot_str, api::GetValue<std::string>(properties, PROPERTY_ICEBERG_SNAPSHOT_ID));
-  int64_t snapshot_id = std::stoll(snapshot_str);
+  int64_t snapshot_id = 0;
+  const auto* begin = snapshot_str.data();
+  const auto* end = begin + snapshot_str.size();
+  const auto [ptr, ec] = std::from_chars(begin, end, snapshot_id);
+  if (ec != std::errc{} || ptr != end) {
+    return arrow::Status::Invalid(PROPERTY_ICEBERG_SNAPSHOT_ID, " must be an int64, got '", snapshot_str, "'");
+  }
 
   // Convert Milvus URI (scheme://address/bucket/path) to scheme://bucket/path.
   // For S3 this is the final format; for Azure ABFSS, the Rust bridge further
@@ -35,7 +44,7 @@ arrow::Result<std::vector<api::ColumnGroupFile>> IcebergFormat::explore(const st
   ARROW_ASSIGN_OR_RAISE(auto parsed_uri, StorageUri::Parse(explore_dir));
   ARROW_ASSIGN_OR_RAISE(auto iceberg_uri, StorageUri::Make(parsed_uri, false));
 
-  auto file_infos = iceberg::PlanFiles(iceberg_uri, snapshot_id, storage_options);
+  ARROW_ASSIGN_OR_RAISE(auto file_infos, iceberg::PlanFiles(iceberg_uri, snapshot_id, storage_options));
 
   std::vector<api::ColumnGroupFile> files;
   files.reserve(file_infos.size());
@@ -43,6 +52,12 @@ arrow::Result<std::vector<api::ColumnGroupFile>> IcebergFormat::explore(const st
     // Convert data file path from standard format back to Milvus format
     auto milvus_path = iceberg::ToMilvusUri(info.data_file_path, fs_config.address);
 
+    if (info.num_deleted_rows > info.record_count) {
+      return MakeExtendErrorMsg(
+          ExtendStatusCode::DataCorrupted,
+          "Iceberg positional delete count exceeds record count for data file: ", info.data_file_path,
+          " (records=", info.record_count, ", deletes=", info.num_deleted_rows, ")");
+    }
     api::ColumnGroupFile cgf{
         std::move(milvus_path), 0, static_cast<int64_t>(info.record_count - info.num_deleted_rows), {}};
     if (!info.delete_metadata_json.empty()) {

--- a/cpp/src/format/iceberg/iceberg_format_reader.cpp
+++ b/cpp/src/format/iceberg/iceberg_format_reader.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
+#include "milvus-storage/common/extend_status.h"
+#include "bridge_error.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -72,9 +74,10 @@ uint64_t EstimateDeleteChargeBytes(const std::vector<uint8_t>& delete_metadata,
 arrow::Status ReadPositionalDeleteFile(const std::string& delete_file_path,
                                        const std::string& data_file_uri,
                                        const api::Properties& properties,
+                                       uint64_t physical_row_count,
                                        std::unordered_set<int64_t>* deleted_positions) {
   if (!deleted_positions) {
-    return arrow::Status::Invalid("Deleted positions output cannot be null");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "Deleted positions output cannot be null");
   }
 
   // Get filesystem for the delete file
@@ -97,8 +100,14 @@ arrow::Status ReadPositionalDeleteFile(const std::string& delete_file_path,
   int pos_idx = schema->GetFieldIndex("pos");
 
   if (file_path_idx < 0 || pos_idx < 0) {
-    return arrow::Status::Invalid(
-        fmt::format("Positional delete file missing required columns (file_path, pos): {}", delete_file_path));
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                              "Positional delete file missing required columns (file_path, pos): ", delete_file_path);
+  }
+  if (schema->field(file_path_idx)->type()->id() != arrow::Type::STRING ||
+      schema->field(pos_idx)->type()->id() != arrow::Type::INT64) {
+    return MakeExtendErrorMsg(
+        ExtendStatusCode::DataCorrupted,
+        "Positional delete file has invalid column types (file_path=string, pos=int64): ", delete_file_path);
   }
 
   std::shared_ptr<arrow::Table> table;
@@ -116,20 +125,37 @@ arrow::Status ReadPositionalDeleteFile(const std::string& delete_file_path,
   auto pos_col = table->column(1);        // pos (second in our projection)
 
   for (int chunk_idx = 0; chunk_idx < file_path_col->num_chunks(); ++chunk_idx) {
-    auto file_path_array = std::static_pointer_cast<arrow::StringArray>(file_path_col->chunk(chunk_idx));
-    auto pos_array = std::static_pointer_cast<arrow::Int64Array>(pos_col->chunk(chunk_idx));
+    auto file_path_array = std::dynamic_pointer_cast<arrow::StringArray>(file_path_col->chunk(chunk_idx));
+    auto pos_array = std::dynamic_pointer_cast<arrow::Int64Array>(pos_col->chunk(chunk_idx));
+    if (!file_path_array || !pos_array) {
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Positional delete file column type changed while reading: ", delete_file_path);
+    }
 
     for (int64_t row = 0; row < file_path_array->length(); ++row) {
-      if (!file_path_array->IsNull(row)) {
+      if (file_path_array->IsNull(row) || pos_array->IsNull(row)) {
+        return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                  "Positional delete file contains null file_path/pos: ", delete_file_path);
+      }
+      {
         std::string row_file_path(file_path_array->GetView(row));
         // Match by: 1) exact match with original URI,
         //           2) direct match after Milvus address stripping (S3/GCS),
         //           3) match after ABFSS @endpoint stripping (Azure).
         if (row_file_path == data_file_uri || row_file_path == normalized_data_uri ||
             StripAbfssEndpoint(row_file_path) == normalized_data_uri) {
-          if (!pos_array->IsNull(row)) {
-            deleted_positions->insert(pos_array->Value(row));
+          const auto position = pos_array->Value(row);
+          if (position < 0 || static_cast<uint64_t>(position) >= physical_row_count) {
+            return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Positional delete position out of range in ",
+                                      delete_file_path, ": ", position, " (physical_rows=", physical_row_count, ")");
           }
+          // Deletes are a set, not a count: the Iceberg spec only orders rows
+          // within one delete file, and a snapshot may legally carry several
+          // delete files that name the same (file_path, pos). Other engines
+          // read those tables fine, so a repeat is deduplicated, never an
+          // error. Out-of-range above is different -- that one cannot be
+          // applied at all.
+          deleted_positions->insert(position);
         }
       }
     }
@@ -139,7 +165,10 @@ arrow::Status ReadPositionalDeleteFile(const std::string& delete_file_path,
 }
 
 arrow::Result<std::shared_ptr<const std::unordered_set<int64_t>>> LoadPositionalDeletes(
-    const std::vector<uint8_t>& delete_metadata, const std::string& data_file_uri, const api::Properties& properties) {
+    const std::vector<uint8_t>& delete_metadata,
+    const std::string& data_file_uri,
+    const api::Properties& properties,
+    uint64_t physical_row_count) {
   auto deleted_positions = std::make_shared<std::unordered_set<int64_t>>();
   if (delete_metadata.empty()) {
     return std::static_pointer_cast<const std::unordered_set<int64_t>>(deleted_positions);
@@ -149,29 +178,53 @@ arrow::Result<std::shared_ptr<const std::unordered_set<int64_t>>> LoadPositional
   folly::dynamic parsed;
   try {
     parsed = folly::parseJson(json_str);
-  } catch (const std::exception& e) {
-    return arrow::Status::Invalid(fmt::format("Failed to parse delete metadata JSON: {}", e.what()));
+  } catch (const folly::json::parse_error&) {
+    return bridge::MakeBridgeDataFormatStatus("Delete metadata JSON is invalid");
+  } catch (...) {
+    return arrow::Status::UnknownError("Delete metadata JSON parsing failed unexpectedly");
   }
 
   if (!parsed.isArray()) {
-    return arrow::Status::Invalid("Delete metadata JSON must be an array");
+    return bridge::MakeBridgeDataFormatStatus("Delete metadata JSON must be an array");
   }
 
+  size_t entry_index = 0;
   for (const auto& entry : parsed) {
-    auto file_type = entry.getDefault("file_type", "").asString();
-    auto path = entry.getDefault("path", "").asString();
+    if (!entry.isObject()) {
+      return bridge::MakeBridgeDataFormatStatus(fmt::format("Delete metadata entry {} must be an object", entry_index));
+    }
+
+    std::string file_type;
+    if (const auto* value = entry.get_ptr("file_type")) {
+      if (!value->isString()) {
+        return bridge::MakeBridgeDataFormatStatus(
+            fmt::format("Delete metadata entry {} field 'file_type' must be a string", entry_index));
+      }
+      file_type = value->getString();
+    }
+
+    std::string path;
+    if (const auto* value = entry.get_ptr("path")) {
+      if (!value->isString()) {
+        return bridge::MakeBridgeDataFormatStatus(
+            fmt::format("Delete metadata entry {} field 'path' must be a string", entry_index));
+      }
+      path = value->getString();
+    }
 
     if (file_type == "equality") {
-      return arrow::Status::Invalid(
+      return arrow::Status::NotImplemented(
           fmt::format("Equality deletes not supported at read time. Delete file: {}. "
                       "Equality deletes must be converted to positional deletes before explore.",
                       path));
     }
 
     if (file_type == "position") {
-      ARROW_RETURN_NOT_OK(ReadPositionalDeleteFile(path, data_file_uri, properties, deleted_positions.get()));
+      ARROW_RETURN_NOT_OK(
+          ReadPositionalDeleteFile(path, data_file_uri, properties, physical_row_count, deleted_positions.get()));
     }
     // Skip unknown types (forward compatibility for deletion vectors, etc.)
+    ++entry_index;
   }
 
   return std::static_pointer_cast<const std::unordered_set<int64_t>>(deleted_positions);
@@ -202,7 +255,10 @@ arrow::Result<IcebergFormatReader::MetaTrait::MetadataPtr> IcebergFormatReader::
   }
 
   auto delete_metadata = GetDeleteMetadataBytes(file);
-  ARROW_ASSIGN_OR_RAISE(auto deleted_positions, LoadPositionalDeletes(delete_metadata, file.path, properties));
+  const auto physical_row_count =
+      data_metadata->row_group_infos.empty() ? 0 : data_metadata->row_group_infos.back().end_offset;
+  ARROW_ASSIGN_OR_RAISE(auto deleted_positions,
+                        LoadPositionalDeletes(delete_metadata, file.path, properties, physical_row_count));
   auto sorted_deletions = MakeSortedDeletions(deleted_positions);
   ARROW_ASSIGN_OR_RAISE(auto logical_row_group_infos,
                         build_logical_row_group_infos(data_metadata->row_group_infos, *sorted_deletions));
@@ -233,7 +289,8 @@ arrow::Result<std::shared_ptr<IcebergFormatReader>> IcebergFormatReader::MetaTra
     const std::vector<std::string>& needed_columns,
     const std::string& predicate) {
   if (!metadata) {
-    return arrow::Status::Invalid("Cannot open Iceberg reader from null metadata");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Cannot open Iceberg reader from null metadata");
   }
   if (!metadata->payload.data_metadata) {
     return arrow::Status::Invalid(
@@ -294,17 +351,20 @@ IcebergFormatReader::IcebergFormatReader(std::shared_ptr<parquet::ParquetFormatR
 arrow::Status IcebergFormatReader::open() {
   ARROW_RETURN_NOT_OK(inner_reader_->open());
   ARROW_ASSIGN_OR_RAISE(projected_schema_, build_projected_schema(inner_reader_->get_schema(), needed_columns_));
-  ARROW_ASSIGN_OR_RAISE(deleted_positions_, load_positional_deletes());
-  sorted_deletions_ = MakeSortedDeletions(deleted_positions_);
-
   ARROW_ASSIGN_OR_RAISE(auto physical_row_group_infos, inner_reader_->get_row_group_infos());
+  ARROW_ASSIGN_OR_RAISE(
+      deleted_positions_,
+      LoadPositionalDeletes(delete_metadata_, data_file_uri_, properties_,
+                            physical_row_group_infos.empty() ? 0 : physical_row_group_infos.back().end_offset));
+  sorted_deletions_ = MakeSortedDeletions(deleted_positions_);
   ARROW_ASSIGN_OR_RAISE(logical_row_group_infos_,
                         build_logical_row_group_infos(physical_row_group_infos, *sorted_deletions_));
   return arrow::Status::OK();
 }
 
-arrow::Result<std::shared_ptr<const std::unordered_set<int64_t>>> IcebergFormatReader::load_positional_deletes() const {
-  return LoadPositionalDeletes(delete_metadata_, data_file_uri_, properties_);
+arrow::Result<std::shared_ptr<const std::unordered_set<int64_t>>> IcebergFormatReader::load_positional_deletes(
+    uint64_t physical_row_count) const {
+  return LoadPositionalDeletes(delete_metadata_, data_file_uri_, properties_, physical_row_count);
 }
 
 arrow::Result<std::shared_ptr<arrow::Schema>> IcebergFormatReader::build_projected_schema(
@@ -374,7 +434,8 @@ arrow::Result<std::vector<RowGroupInfo>> IcebergFormatReader::build_logical_row_
   uint64_t logical_offset = 0;
   for (const auto& prg : physical_row_group_infos) {
     if (prg.end_offset < prg.start_offset) {
-      return arrow::Status::Invalid(fmt::format("Invalid physical row group offsets: {}", prg.ToString()));
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Invalid physical row group offsets: ", prg.ToString());
     }
 
     // Count deletions within this physical row group range
@@ -384,8 +445,9 @@ arrow::Result<std::vector<RowGroupInfo>> IcebergFormatReader::build_logical_row_
     auto deletions_in_rg = static_cast<uint64_t>(std::distance(lo, hi));
     auto physical_rows = static_cast<uint64_t>(prg.end_offset - prg.start_offset);
     if (deletions_in_rg > physical_rows) {
-      return arrow::Status::Invalid(fmt::format("Invalid deletion count for physical row group: deletions={}, rows={}",
-                                                deletions_in_rg, physical_rows));
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Invalid deletion count for physical row group: deletions=", deletions_in_rg,
+                                ", rows=", physical_rows);
     }
     uint64_t logical_rows = physical_rows - deletions_in_rg;
 
@@ -442,12 +504,14 @@ arrow::Result<std::vector<uint64_t>> IcebergFormatReader::get_rg_column_memsz(in
 }
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> IcebergFormatReader::get_chunk(const int& row_group_index) {
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= logical_row_group_infos_.size()) {
+    return arrow::Status::Invalid(fmt::format("Iceberg row group index out of range: {}", row_group_index));
+  }
+
   // Check if this logical row group has zero rows (e.g. all rows deleted)
-  if (row_group_index >= 0 && static_cast<size_t>(row_group_index) < logical_row_group_infos_.size()) {
-    const auto& lrg = logical_row_group_infos_[row_group_index];
-    if (lrg.start_offset == lrg.end_offset) {
-      return arrow::RecordBatch::MakeEmpty(output_schema());
-    }
+  const auto& lrg = logical_row_group_infos_[row_group_index];
+  if (lrg.start_offset == lrg.end_offset) {
+    return arrow::RecordBatch::MakeEmpty(output_schema());
   }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, inner_reader_->get_chunk(row_group_index));
@@ -459,7 +523,8 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> IcebergFormatReader::get_chun
   // Determine the global physical offset for this row group
   ARROW_ASSIGN_OR_RAISE(auto rg_infos, inner_reader_->get_row_group_infos());
   if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= rg_infos.size()) {
-    return arrow::Status::Invalid(fmt::format("Row group index out of range: {}", row_group_index));
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              fmt::format("Row group index out of range: {}", row_group_index));
   }
 
   return filter_batch(batch, rg_infos[row_group_index].start_offset);
@@ -467,6 +532,12 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> IcebergFormatReader::get_chun
 
 arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> IcebergFormatReader::get_chunks(
     const std::vector<int>& rg_indices_in_file) {
+  for (const auto row_group_index : rg_indices_in_file) {
+    if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= logical_row_group_infos_.size()) {
+      return arrow::Status::Invalid(fmt::format("Iceberg row group index out of range: {}", row_group_index));
+    }
+  }
+
   ARROW_ASSIGN_OR_RAISE(auto batches, inner_reader_->get_chunks(rg_indices_in_file));
 
   if (!deleted_positions_ || deleted_positions_->empty()) {

--- a/cpp/src/format/lance/lance_common.cpp
+++ b/cpp/src/format/lance/lance_common.cpp
@@ -16,6 +16,8 @@
 
 #include <cstdlib>
 #include <fmt/format.h>
+
+#include <charconv>
 #include "milvus-storage/common/log.h"
 
 namespace milvus_storage::lance {
@@ -172,9 +174,11 @@ arrow::Result<std::pair<std::string, uint64_t>> ParseLanceUri(const std::string&
   }
 
   uint64_t fragment_id = 0;
-  try {
-    fragment_id = std::stoull(uri.substr(pos + kLanceUriDelimiter.length()));
-  } catch (const std::exception& e) {
+  const auto fragment_text = std::string_view(uri).substr(pos + kLanceUriDelimiter.length());
+  const auto* begin = fragment_text.data();
+  const auto* end = begin + fragment_text.size();
+  const auto [ptr, ec] = std::from_chars(begin, end, fragment_id);
+  if (ec != std::errc{} || ptr != end) {
     return arrow::Status::Invalid(fmt::format("Invalid fragment_id in uri: {}", uri));
   }
 

--- a/cpp/src/format/lance/lance_format.cpp
+++ b/cpp/src/format/lance/lance_format.cpp
@@ -33,12 +33,12 @@ arrow::Result<std::vector<api::ColumnGroupFile>> LanceFormat::explore(const std:
   ARROW_ASSIGN_OR_RAISE(auto lance_base_uri, lance::BuildLanceBaseUri(fs_config, explore_uri.key));
   auto storage_options = lance::ToStorageOptions(fs_config);
 
-  auto dataset = lance::BlockingDataset::Open(lance_base_uri, storage_options);
-  auto fragment_ids = dataset->GetAllFragmentIds();
+  ARROW_ASSIGN_OR_RAISE(auto dataset, lance::BlockingDataset::Open(lance_base_uri, storage_options));
+  ARROW_ASSIGN_OR_RAISE(auto fragment_ids, dataset->GetAllFragmentIds());
 
   std::vector<api::ColumnGroupFile> files;
   for (auto frag_id : fragment_ids) {
-    auto row_count = dataset->GetFragmentRowCount(frag_id);
+    ARROW_ASSIGN_OR_RAISE(auto row_count, dataset->GetFragmentRowCount(frag_id));
     // Store Milvus-format URI (scheme://address/bucket/key) so the reader
     // can resolve the right extfs.<alias>.* by address+bucket. The reader
     // strips address back to standard form before handing to Lance.

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -35,6 +35,8 @@
 #include "milvus-storage/common/log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/lance/lance_common.h"
+#include "bridge_error.h"
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::lance {
 
@@ -177,32 +179,17 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
   ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, base_uri));
   auto lance_uri = ToStandardLanceUri(base_uri);
 
-  std::shared_ptr<BlockingDataset> dataset;
-  try {
-    dataset = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config));
-  } catch (const std::exception& e) {
-    return arrow::Status::IOError("Failed to open Lance dataset for metadata: ", e.what());
-  }
+  ARROW_ASSIGN_OR_RAISE(auto dataset, BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config)));
 
   std::shared_ptr<arrow::Schema> file_schema;
   {
     ArrowSchema c_fragment_schema;
-    try {
-      dataset->GetFragmentSchema(fragment_id, c_fragment_schema);
-    } catch (const LanceException& e) {
-      return arrow::Status::IOError(fmt::format("Failed to get fragment schema: {}", e.what()));
-    }
+    ARROW_RETURN_NOT_OK(dataset->GetFragmentSchema(fragment_id, c_fragment_schema));
     ARROW_ASSIGN_OR_RAISE(file_schema, arrow::ImportSchema(&c_fragment_schema));
   }
 
-  uint64_t logical_rows = 0;
-  uint64_t physical_rows = 0;
-  try {
-    logical_rows = dataset->GetFragmentRowCount(fragment_id);
-    physical_rows = dataset->GetFragmentPhysicalRowCount(fragment_id);
-  } catch (const LanceException& e) {
-    return arrow::Status::IOError("Failed to get row counts for Lance fragment ", fragment_id, ": ", e.what());
-  }
+  ARROW_ASSIGN_OR_RAISE(uint64_t logical_rows, dataset->GetFragmentRowCount(fragment_id));
+  ARROW_ASSIGN_OR_RAISE(uint64_t physical_rows, dataset->GetFragmentPhysicalRowCount(fragment_id));
   if (physical_rows < logical_rows) {
     return arrow::Status::Invalid("Fragment ", fragment_id, " has inconsistent metadata: physical_rows (",
                                   physical_rows, ") < logical_rows (", logical_rows, ")");
@@ -213,17 +200,13 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
 
   auto column_memory_sizes_result =
       estimate_fragment_column_memory_sizes(*dataset, fragment_id, static_cast<size_t>(file_schema->num_fields()));
+  if (!column_memory_sizes_result.ok() && !column_memory_sizes_result.status().IsNotImplemented()) {
+    return column_memory_sizes_result.status();
+  }
   const bool memory_size_available = column_memory_sizes_result.ok();
   std::vector<uint64_t> fragment_column_memory_sizes;
   if (memory_size_available) {
     fragment_column_memory_sizes = std::move(column_memory_sizes_result).ValueOrDie();
-  } else {
-    // Memory statistics are optional. Do not retain the underlying failure in
-    // metadata: estimate APIs return a generic NotImplemented status instead.
-    // Keep the detailed reason in the debug log for diagnostics only.
-    LOG_STORAGE_DEBUG_ << "Lance column memory estimation is unavailable while loading metadata"
-                       << ", fragment_id=" << fragment_id
-                       << ", status=" << column_memory_sizes_result.status().ToString();
   }
   ARROW_ASSIGN_OR_RAISE(
       auto row_group_infos,
@@ -265,10 +248,12 @@ arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::cr
   (void)file;
   (void)predicate;
   if (!metadata) {
-    return arrow::Status::Invalid("Cannot open Lance reader from null metadata");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Cannot open Lance reader from null metadata");
   }
   if (!metadata->payload.dataset) {
-    return arrow::Status::Invalid("Cannot open Lance reader from metadata with null dataset");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Cannot open Lance reader from metadata with null dataset");
   }
 
   auto reader = std::make_shared<LanceTableReader>(metadata->payload.dataset, metadata->payload.fragment_id,
@@ -284,16 +269,15 @@ arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::cr
   ArrowSchema c_arrow_schema;
   ARROW_RETURN_NOT_OK(arrow::ExportSchema(*requested_schema, &c_arrow_schema));
 
-  try {
-    reader->fragment_reader_ =
-        BlockingFragmentReader::Open(*metadata->payload.dataset, metadata->payload.fragment_id, c_arrow_schema);
-  } catch (const LanceException& e) {
+  auto fragment_reader =
+      BlockingFragmentReader::Open(*metadata->payload.dataset, metadata->payload.fragment_id, c_arrow_schema);
+  if (!fragment_reader.ok()) {
     if (c_arrow_schema.release) {
       c_arrow_schema.release(&c_arrow_schema);
     }
-    return arrow::Status::IOError("Failed to open Lance fragment reader for fragment ", metadata->payload.fragment_id,
-                                  ": ", e.what());
+    return fragment_reader.status();
   }
+  reader->fragment_reader_ = std::move(*fragment_reader);
 
   return reader;
 }
@@ -312,17 +296,13 @@ arrow::Status LanceTableReader::open() {
                        << ", role_arn=" << (fs_config.role_arn.empty() ? "(empty)" : fs_config.role_arn)
                        << ", external_id_set=" << (fs_config.external_id.empty() ? "false" : "true")
                        << ", use_iam=" << fs_config.use_iam;
-    dataset_ = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config));
+    ARROW_ASSIGN_OR_RAISE(dataset_, BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config)));
   }
 
   // Lance 7 exposes the current dataset schema through FileFragment::schema().
   {
     ArrowSchema c_fragment_schema;
-    try {
-      dataset_->GetFragmentSchema(fragment_id_, c_fragment_schema);
-    } catch (const LanceException& e) {
-      return arrow::Status::IOError(fmt::format("Failed to get fragment schema: {}", e.what()));
-    }
+    ARROW_RETURN_NOT_OK(dataset_->GetFragmentSchema(fragment_id_, c_fragment_schema));
     ARROW_ASSIGN_OR_RAISE(file_schema_, arrow::ImportSchema(&c_fragment_schema));
   }
 
@@ -335,38 +315,32 @@ arrow::Status LanceTableReader::open() {
   ArrowSchema c_arrow_schema;
   ARROW_RETURN_NOT_OK(arrow::ExportSchema(*read_schema, &c_arrow_schema));
 
-  fragment_reader_ = BlockingFragmentReader::Open(*dataset_, fragment_id_, c_arrow_schema);
+  ARROW_ASSIGN_OR_RAISE(fragment_reader_, BlockingFragmentReader::Open(*dataset_, fragment_id_, c_arrow_schema));
 
   // Lance's read_range accepts logical indices (post-deletion) and internally
   // patches the range to skip deleted rows. So row_group_infos uses logical row count.
   // However, read_range's batch_size is applied to the *physical* range after
   // patch_range_for_deletions, so we add num_deletions_ to batch_size to ensure
   // each read produces a single output batch.
-  auto logical_rows = fragment_reader_->RowCount();
-  try {
-    auto physical_rows = dataset_->GetFragmentPhysicalRowCount(fragment_id_);
+  ARROW_ASSIGN_OR_RAISE(auto logical_rows, fragment_reader_->RowCount());
+  {
+    ARROW_ASSIGN_OR_RAISE(auto physical_rows, dataset_->GetFragmentPhysicalRowCount(fragment_id_));
     if (physical_rows < logical_rows) {
       return arrow::Status::Invalid("Fragment ", fragment_id_, " has inconsistent metadata: physical_rows (",
                                     physical_rows, ") < logical_rows (", logical_rows, ")");
     }
     num_deletions_ = physical_rows - logical_rows;
-  } catch (const lance::LanceException& e) {
-    return arrow::Status::IOError("Failed to get physical row count for fragment ", fragment_id_, ": ", e.what());
   }
 
   auto column_memory_sizes_result =
       estimate_fragment_column_memory_sizes(*dataset_, fragment_id_, static_cast<size_t>(file_schema_->num_fields()));
+  if (!column_memory_sizes_result.ok() && !column_memory_sizes_result.status().IsNotImplemented()) {
+    return column_memory_sizes_result.status();
+  }
   const bool memory_size_available = column_memory_sizes_result.ok();
   std::vector<uint64_t> fragment_column_memory_sizes;
   if (memory_size_available) {
     fragment_column_memory_sizes = std::move(column_memory_sizes_result).ValueOrDie();
-  } else {
-    // Memory statistics are optional. Do not retain the underlying failure in
-    // row-group metadata: estimate APIs return a generic NotImplemented status
-    // instead. Keep the detailed reason in the debug log for diagnostics only.
-    LOG_STORAGE_DEBUG_ << "Lance column memory estimation is unavailable while opening the reader"
-                       << ", fragment_id=" << fragment_id_
-                       << ", status=" << column_memory_sizes_result.status().ToString();
   }
   ARROW_ASSIGN_OR_RAISE(row_group_infos_, create_row_group_infos(logical_rows, logical_chunk_rows_,
                                                                  fragment_column_memory_sizes, memory_size_available));
@@ -396,6 +370,9 @@ arrow::Result<std::vector<uint64_t>> LanceTableReader::get_rg_column_memsz(int64
 
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> LanceTableReader::get_chunk(const int& row_group_index) {
   assert(fragment_reader_);
+  if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+    return arrow::Status::Invalid("Lance row group index out of range: ", row_group_index);
+  }
   auto start_idx = row_group_infos_[row_group_index].start_offset;
   auto end_idx = row_group_infos_[row_group_index].end_offset;
   // FIXME: Lance's read_range may produce multiple output batches for two reasons:
@@ -405,9 +382,10 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> LanceTableReader::get_chunk(c
   // We add num_deletions_ to mitigate (1), but (2) is not addressed — if Lance
   // splits at page boundaries, chunk(0) will silently lose trailing rows in Release
   // builds (assert is a no-op). A robust fix would combine all chunks here.
-  ArrowArrayStream array_stream =
-      fragment_reader_->ReadRangesAsStream(start_idx, end_idx, end_idx - start_idx + num_deletions_);
-  ARROW_ASSIGN_OR_RAISE(auto chunkedarray, arrow::ImportChunkedArray(&array_stream));
+  ARROW_ASSIGN_OR_RAISE(auto array_stream,
+                        fragment_reader_->ReadRangesAsStream(start_idx, end_idx, end_idx - start_idx + num_deletions_));
+  ARROW_ASSIGN_OR_RAISE(auto chunkedarray,
+                        milvus_storage::bridge::ImportBridgeChunkedArray(&array_stream, "reading Lance chunk"));
   assert(chunkedarray != nullptr && chunkedarray->num_chunks() == 1);
   return arrow::RecordBatch::FromStructArray(chunkedarray->chunk(0));
 }
@@ -416,6 +394,12 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> LanceTableReader
     const std::vector<int>& rg_indices_in_file) {
   assert(fragment_reader_);
   std::vector<std::shared_ptr<arrow::RecordBatch>> rbs;
+
+  for (const auto row_group_index : rg_indices_in_file) {
+    if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+      return arrow::Status::Invalid("Lance row group index out of range: ", row_group_index);
+    }
+  }
 
 #ifndef NDEBUG
   // verify rg_indices_in_file have been sorted
@@ -446,10 +430,11 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> LanceTableReader
     const auto& end_rg_info = row_group_infos_[rg_range.second];
 
     // batch_size adds num_deletions_ for the same reason as get_chunk — see comment there.
-    ArrowArrayStream array_stream =
-        fragment_reader_->ReadRangesAsStream(start_rg_info.start_offset, end_rg_info.end_offset,
-                                             end_rg_info.end_offset - start_rg_info.start_offset + num_deletions_);
-    ARROW_ASSIGN_OR_RAISE(auto chunkedarray, arrow::ImportChunkedArray(&array_stream));
+    ARROW_ASSIGN_OR_RAISE(auto array_stream, fragment_reader_->ReadRangesAsStream(
+                                                 start_rg_info.start_offset, end_rg_info.end_offset,
+                                                 end_rg_info.end_offset - start_rg_info.start_offset + num_deletions_));
+    ARROW_ASSIGN_OR_RAISE(auto chunkedarray,
+                          milvus_storage::bridge::ImportBridgeChunkedArray(&array_stream, "reading Lance chunks"));
     assert(chunkedarray != nullptr);
 
     // assign to rbs
@@ -464,12 +449,14 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> LanceTableReader
 
 arrow::Result<std::shared_ptr<arrow::Table>> LanceTableReader::take(const std::vector<int64_t>& row_indices) {
   assert(fragment_reader_);
-  ArrowArrayStream array_stream = fragment_reader_->TakeAsStream(row_indices, row_indices.size());
-  ARROW_ASSIGN_OR_RAISE(auto chunkedarray, arrow::ImportChunkedArray(&array_stream));
+  ARROW_ASSIGN_OR_RAISE(auto array_stream, fragment_reader_->TakeAsStream(row_indices, row_indices.size()));
+  ARROW_ASSIGN_OR_RAISE(auto chunkedarray,
+                        milvus_storage::bridge::ImportBridgeChunkedArray(&array_stream, "taking Lance rows"));
 
   // out of range
   if (chunkedarray->num_chunks() == 0) {
-    return arrow::Status::Invalid(fmt::format("out of row range [0, {}]", fragment_reader_->RowCount()));
+    ARROW_ASSIGN_OR_RAISE(auto row_count, fragment_reader_->RowCount());
+    return arrow::Status::Invalid(fmt::format("out of row range [0, {}]", row_count));
   }
 
   std::vector<std::shared_ptr<arrow::RecordBatch>> rbs;
@@ -486,9 +473,10 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> LanceTableReader::read_
   assert(fragment_reader_);
   // Lance's read_range accepts logical indices directly.
   // batch_size adds num_deletions_ for the same reason as get_chunk — see comment there.
-  ArrowArrayStream array_stream =
-      fragment_reader_->ReadRangesAsStream(start_offset, end_offset, end_offset - start_offset + num_deletions_);
-  return arrow::ImportRecordBatchReader(&array_stream);
+  ARROW_ASSIGN_OR_RAISE(auto array_stream, fragment_reader_->ReadRangesAsStream(
+                                               start_offset, end_offset, end_offset - start_offset + num_deletions_));
+  ARROW_ASSIGN_OR_RAISE(auto reader, arrow::ImportRecordBatchReader(&array_stream));
+  return milvus_storage::bridge::WrapBridgeRecordBatchReader(std::move(reader), "reading Lance range");
 }
 
 arrow::Result<std::shared_ptr<FormatReader>> LanceTableReader::clone_reader() {

--- a/cpp/src/format/lance/lance_table_writer.cpp
+++ b/cpp/src/format/lance/lance_table_writer.cpp
@@ -29,8 +29,10 @@
 #include <arrow/type.h>
 #include <arrow/status.h>
 #include <arrow/result.h>
+#include <arrow/util/io_util.h>
 #include <fmt/format.h>
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/format/lance/lance_common.h"
 
 namespace milvus_storage::lance {
@@ -93,6 +95,27 @@ bool fids_contains(const std::vector<uint64_t>& origin, const std::vector<uint64
   return true;
 }
 
+/// Whether a failed open means "there is nothing here yet", so the first write
+/// must create the dataset rather than fail.
+///
+/// ONLY a positively identified not-found qualifies. This used to also accept
+/// any unclassified IO failure, on the theory that a store whose not-found we
+/// failed to classify would otherwise break first-write. The cost of that
+/// tolerance was not a worse error message: taking this branch against a
+/// dataset that DOES exist makes the writer believe it started from zero
+/// fragments, and everything downstream is computed from that belief (see the
+/// guard in Close). A transient open failure would have been laundered
+/// into a manifest entry pointing at somebody else's fragment. Failing the
+/// first write is recoverable; that is not.
+bool IsMissingDatasetStatus(const arrow::Status& status) {
+  if (auto detail = ExtendStatusDetail::UnwrapStatus(status); detail != nullptr) {
+    return detail->code() == ExtendStatusCode::StorageNotFound;
+  }
+  // The filesystem layer reports a missing object through errno rather than the
+  // extend taxonomy; the bridges report it through the taxonomy above.
+  return arrow::internal::ErrnoFromStatus(status) == ENOENT;
+}
+
 std::vector<uint64_t> fids_diff(const std::vector<uint64_t>& origin, const std::vector<uint64_t>& current) {
   assert(current.size() > origin.size());
 
@@ -113,6 +136,15 @@ arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
 
   auto batch_iterator = std::make_shared<BatchIterator>(schema_, record_batches_);
   ARROW_RETURN_NOT_OK(ExportRecordBatchReader(batch_iterator, &array_stream));
+  // The write calls below consume the stream and null its release; if we bail
+  // out before reaching one (open/config failure), release it here instead of
+  // leaking the exported reader and every buffered batch.
+  auto stream_guard = [](ArrowArrayStream* stream) {
+    if (stream->release != nullptr) {
+      stream->release(stream);
+    }
+  };
+  std::unique_ptr<ArrowArrayStream, decltype(stream_guard)> release_on_exit(&array_stream, stream_guard);
 
   // Get storage options from properties for cloud storage support
   ArrowFileSystemConfig fs_config;
@@ -123,23 +155,27 @@ arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
   ARROW_ASSIGN_OR_RAISE(auto lance_uri, BuildLanceBaseUri(fs_config, base_path_));
 
   if (!dataset_) {
-    try {
-      dataset_ = BlockingDataset::OpenUnique(lance_uri, storage_options);
-      origin_fids_ = dataset_->GetAllFragmentIds();
-      dataset_->WriteArrowArrayStream(&array_stream);
-    } catch (std::exception& e) {
-      // dataset does not exist
+    auto opened = BlockingDataset::OpenUnique(lance_uri, storage_options);
+    if (opened.ok()) {
+      dataset_ = std::move(*opened);
+      ARROW_ASSIGN_OR_RAISE(origin_fids_, dataset_->GetAllFragmentIds());
+      ARROW_RETURN_NOT_OK(dataset_->WriteArrowArrayStream(&array_stream));
+    } else if (IsMissingDatasetStatus(opened.status())) {
       origin_fids_.clear();
-      dataset_ = BlockingDataset::WriteDataset(lance_uri, &array_stream, storage_options, data_storage_format_);
+      created_dataset_ = true;
+      ARROW_ASSIGN_OR_RAISE(
+          dataset_, BlockingDataset::WriteDataset(lance_uri, &array_stream, storage_options, data_storage_format_));
+    } else {
+      return opened.status();
     }
   } else {
-    dataset_->WriteArrowArrayStream(&array_stream);
+    ARROW_RETURN_NOT_OK(dataset_->WriteArrowArrayStream(&array_stream));
   }
   record_batches_.clear();
 
   std::vector<uint64_t> append_fids;
   std::vector<uint64_t> current_fids;
-  current_fids = dataset_->GetAllFragmentIds();
+  ARROW_ASSIGN_OR_RAISE(current_fids, dataset_->GetAllFragmentIds());
 
   if (current_fids.size() < origin_fids_.size()) {
     return arrow::Status::Invalid(
@@ -159,11 +195,27 @@ arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
   }
 
   if (!fids_contains(origin_fids_, current_fids)) {
-    return arrow::Status::Invalid("LanceTableWriter: current fragment ids is not a superset of origin fragment ids");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "LanceTableWriter: current fragment ids is not a superset of origin fragment ids");
   }
 
+  // Everything below is derived from origin_fids_ being an accurate picture of
+  // the dataset before this write. When the dataset was created here, "before"
+  // means empty -- and an empty origin makes both checks above vacuous, because
+  // every set contains the empty set. So a wrong not-found verdict on an
+  // EXISTING dataset would sail through them and hand back the oldest existing
+  // fragment as if this writer had just produced it, with this writer's row
+  // count attached: the rows written here referenced by nothing, and the entry
+  // pointing at somebody else's data. Assert did not cover it -- release builds
+  // compile it out, which is exactly where this would have shipped.
   append_fids = fids_diff(origin_fids_, current_fids);
-  assert(append_fids.size() == 1);
+  if (append_fids.size() != 1) {
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "LanceTableWriter: expected exactly one appended fragment, got ", append_fids.size(),
+                              created_dataset_ ? " after creating the dataset (it already existed, so the open failure "
+                                                 "that led here was not a missing dataset)"
+                                               : "");
+  }
 
   dataset_.reset();
   closed_ = true;

--- a/cpp/src/format/paimon/paimon_format.cpp
+++ b/cpp/src/format/paimon/paimon_format.cpp
@@ -14,10 +14,12 @@
 
 #include <nlohmann/json.hpp>
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/paimon/paimon_common.h"
 #include "milvus-storage/format/paimon/paimon_format_reader.h"
 #include "paimon_bridge.h"
+#include "bridge_error.h"
 
 namespace milvus_storage {
 
@@ -37,20 +39,32 @@ arrow::Result<std::vector<api::ColumnGroupFile>> PaimonFormat::explore(const std
     int64_t record_count = -1;
     std::string read_path;
     try {
+      // OUR invariant, not the user's data. info.metadata_json was produced by
+      // paimon::PlanFiles a few lines above and has never been persisted, so a
+      // malformed descriptor here means the bridge or the planner is broken.
+      // Reporting it as DataFormat told an operator their table was corrupt and
+      // sent them to re-ingest data that was fine; InternalInvariantViolated
+      // lands on segcore's UnexpectedError, which is what a defect of ours is
+      // (D2). Bytes read back from the table are classified as DataFormat by
+      // the readers that actually parse them.
       auto metadata = nlohmann::json::parse(info.metadata_json);
       if (!metadata.is_object()) {
-        return arrow::Status::Invalid("Paimon planning metadata must be a JSON object");
+        return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                  "Paimon planning metadata must be a JSON object");
       }
       read_path = metadata.value(paimon::kReadPathKey, std::string{});
       record_count = metadata.value(paimon::kRecordCountKey, int64_t{-1});
     } catch (const nlohmann::json::exception& error) {
-      return arrow::Status::Invalid("Invalid Paimon planning metadata: ", error.what());
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Invalid Paimon planning metadata: ", error.what());
     }
     if (read_path != paimon::kDirectFileReadPath && read_path != paimon::kDataSplitReadPath) {
-      return arrow::Status::Invalid("Paimon planning metadata has an invalid read_path: ", read_path);
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Paimon planning metadata has an invalid read_path: ", read_path);
     }
     if (record_count < 0) {
-      return arrow::Status::Invalid("Paimon planning metadata has an invalid record_count");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Paimon planning metadata has an invalid record_count");
     }
     if (record_count == 0) {
       continue;

--- a/cpp/src/format/paimon/paimon_format_reader.cpp
+++ b/cpp/src/format/paimon/paimon_format_reader.cpp
@@ -12,6 +12,8 @@
 
 #include "milvus-storage/format/paimon/paimon_format_reader.h"
 
+#include "milvus-storage/common/extend_status.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -54,7 +56,7 @@ arrow::Result<ParsedMetadata> ParseMetadata(const std::string& json) {
   try {
     auto value = nlohmann::json::parse(json);
     if (!value.is_object()) {
-      return arrow::Status::Invalid("Paimon metadata must be a JSON object");
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon metadata must be a JSON object");
     }
     version = value.value("version", int64_t{0});
     read_path = value.value(kReadPathKey, std::string{});
@@ -62,17 +64,18 @@ arrow::Result<ParsedMetadata> ParseMetadata(const std::string& json) {
     data_format = value.value("data_format", std::string{});
     deletion_file = value.value("deletion_file", nlohmann::json(nullptr));
   } catch (const nlohmann::json::exception& error) {
-    return arrow::Status::Invalid("Paimon metadata has invalid JSON or field types: ", error.what());
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                              "Paimon metadata has invalid JSON or field types: ", error.what());
   }
   LOG_STORAGE_DEBUG_ << "Paimon metadata version=" << version;
   if (read_path != kDirectFileReadPath && read_path != kDataSplitReadPath) {
-    return arrow::Status::Invalid("Invalid Paimon metadata read_path: ", read_path);
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Invalid Paimon metadata read_path: ", read_path);
   }
   if (record_count < 0) {
-    return arrow::Status::Invalid("Paimon metadata has negative record_count");
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon metadata has negative record_count");
   }
   if (read_path == kDataSplitReadPath && record_count == 0) {
-    return arrow::Status::Invalid("Paimon data-split metadata has zero record_count");
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon data-split metadata has zero record_count");
   }
   return ParsedMetadata{
       .read_path = std::move(read_path),
@@ -105,14 +108,16 @@ arrow::Result<std::vector<RowGroupInfo>> MakeDirectLogicalRowGroups(const std::v
   uint64_t logical_start = 0;
   for (const auto& group : physical) {
     if (group.end_offset < group.start_offset) {
-      return arrow::Status::Invalid("Invalid physical Paimon row group: ", group.ToString());
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Invalid physical Paimon row group: ", group.ToString());
     }
     auto first = std::lower_bound(deletions.begin(), deletions.end(), group.start_offset);
     auto last = std::lower_bound(deletions.begin(), deletions.end(), group.end_offset);
     auto deleted = static_cast<uint64_t>(std::distance(first, last));
     auto physical_rows = static_cast<uint64_t>(group.end_offset - group.start_offset);
     if (deleted > physical_rows) {
-      return arrow::Status::Invalid("Paimon deletion count exceeds physical row group size");
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Paimon deletion count exceeds physical row group size");
     }
     auto logical_rows = physical_rows - deleted;
     uint64_t logical_memory_size = 0;
@@ -428,11 +433,11 @@ arrow::Result<PaimonFormatReader::MetaTrait::MetadataPtr> PaimonFormatReader::Me
     const api::ColumnGroupFile& file, const api::Properties& properties, const KeyRetriever& key_retriever) {
   const auto metadata_json = file.Get<std::string>(api::kPropertyMetadata);
   if (metadata_json.empty()) {
-    return arrow::Status::Invalid("Paimon column group is missing metadata");
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon column group is missing metadata");
   }
   if (metadata_json.size() > kMaxPaimonMetadataBytes) {
-    return arrow::Status::Invalid("Paimon metadata is too large: ", metadata_json.size(), " bytes exceeds ",
-                                  kMaxPaimonMetadataBytes);
+    return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon metadata is too large: ", metadata_json.size(),
+                              " bytes exceeds ", kMaxPaimonMetadataBytes);
   }
   ARROW_ASSIGN_OR_RAISE(auto parsed, ParseMetadata(metadata_json));
   ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, file.path));
@@ -471,7 +476,7 @@ arrow::Result<PaimonFormatReader::MetaTrait::MetadataPtr> PaimonFormatReader::Me
     auto deletions = std::make_shared<std::vector<uint64_t>>();
     if (!parsed.deletion_file.is_null()) {
       if (!parsed.deletion_file.is_object()) {
-        return arrow::Status::Invalid("Paimon deletion_file must be an object");
+        return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon deletion_file must be an object");
       }
       std::string path;
       int64_t offset = -1;
@@ -483,10 +488,11 @@ arrow::Result<PaimonFormatReader::MetaTrait::MetadataPtr> PaimonFormatReader::Me
         length = parsed.deletion_file.value("length", int64_t{-1});
         cardinality = parsed.deletion_file.value("cardinality", int64_t{-1});
       } catch (const nlohmann::json::exception& error) {
-        return arrow::Status::Invalid("Paimon deletion_file has invalid field types: ", error.what());
+        return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                  "Paimon deletion_file has invalid field types: ", error.what());
       }
       if (path.empty() || offset < 0 || length < 0) {
-        return arrow::Status::Invalid("Paimon deletion_file has invalid path or range");
+        return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon deletion_file has invalid path or range");
       }
       ARROW_ASSIGN_OR_RAISE(auto positions,
                             ReadDeletionVector(path, static_cast<uint64_t>(offset), static_cast<uint64_t>(length),
@@ -494,21 +500,23 @@ arrow::Result<PaimonFormatReader::MetaTrait::MetadataPtr> PaimonFormatReader::Me
       deletions->reserve(positions.size());
       for (auto position : positions) {
         if (position >= physical_rows) {
-          return arrow::Status::Invalid("Paimon deletion position exceeds physical row count");
+          return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                    "Paimon deletion position exceeds physical row count");
         }
         deletions->push_back(position);
       }
     }
     std::sort(deletions->begin(), deletions->end());
     if (std::adjacent_find(deletions->begin(), deletions->end()) != deletions->end()) {
-      return arrow::Status::Invalid("Paimon deletion vector contains duplicate positions");
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted, "Paimon deletion vector contains duplicate positions");
     }
     metadata->payload.sorted_deletions = deletions;
     ARROW_ASSIGN_OR_RAISE(metadata->row_group_infos, MakeDirectLogicalRowGroups(physical_groups, *deletions));
     auto logical_rows = metadata->row_group_infos.empty() ? 0 : metadata->row_group_infos.back().end_offset;
     if (logical_rows != parsed.record_count) {
-      return arrow::Status::Invalid("Paimon direct-file row count mismatch: descriptor=", parsed.record_count,
-                                    ", reader=", logical_rows);
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Paimon direct-file row count mismatch: descriptor=", parsed.record_count,
+                                ", reader=", logical_rows);
     }
     metadata->cache_size = direct_cache_size + deletions->size() * sizeof(uint64_t) + metadata_json.size() +
                            physical_groups.size() * sizeof(RowGroupInfo);
@@ -540,7 +548,8 @@ arrow::Result<std::shared_ptr<PaimonFormatReader>> PaimonFormatReader::MetaTrait
     const std::vector<std::string>& needed_columns,
     const std::string& /*predicate*/) {
   if (!metadata) {
-    return arrow::Status::Invalid("Cannot create Paimon reader from null metadata");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Cannot create Paimon reader from null metadata");
   }
   ARROW_ASSIGN_OR_RAISE(auto output_schema, ProjectSchema(metadata->file_schema, read_schema, needed_columns));
   if (metadata->payload.read_path == kDataSplitReadPath) {
@@ -670,6 +679,10 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> PaimonFormatReader::get_chunk
   if (group.start_offset == group.end_offset) {
     return arrow::RecordBatch::MakeEmpty(output_schema_);
   }
+  if (static_cast<size_t>(row_group_index) >= metadata_->payload.direct_physical_row_groups.size()) {
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Paimon logical row group has no direct-file physical row group: ", row_group_index);
+  }
   const auto& physical = metadata_->payload.direct_physical_row_groups[row_group_index];
   ARROW_ASSIGN_OR_RAISE(auto batch, direct_file_reader_->get_chunk(row_group_index));
   return filter_direct_batch(batch, physical.start_offset);
@@ -700,13 +713,18 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> PaimonFormatRead
     return output;
   }
   for (auto index : indices) {
-    if (index < 0 || static_cast<size_t>(index) >= metadata_->payload.direct_physical_row_groups.size()) {
-      return arrow::Status::Invalid("Paimon direct-file row group index out of range");
+    if (index < 0 || static_cast<size_t>(index) >= metadata_->row_group_infos.size()) {
+      return arrow::Status::Invalid("Paimon row group index out of range: ", index);
+    }
+    if (static_cast<size_t>(index) >= metadata_->payload.direct_physical_row_groups.size()) {
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Paimon logical row group has no direct-file physical row group: ", index);
     }
   }
   ARROW_ASSIGN_OR_RAISE(auto batches, direct_file_reader_->get_chunks(indices));
   if (batches.size() != indices.size()) {
-    return arrow::Status::Invalid("Direct-file reader returned an unexpected Paimon chunk count");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Direct-file reader returned an unexpected Paimon chunk count");
   }
   for (size_t i = 0; i < batches.size(); ++i) {
     const auto& physical = metadata_->payload.direct_physical_row_groups[indices[i]];
@@ -727,7 +745,9 @@ arrow::Result<std::vector<int64_t>> PaimonFormatReader::logical_to_physical(
   physical_offsets.reserve(logical_offsets.size());
   for (auto logical_offset : logical_offsets) {
     if (logical_offset < 0 || static_cast<uint64_t>(logical_offset) >= metadata_->payload.record_count) {
-      return arrow::Status::Invalid("Paimon direct-file take index is out of range");
+      // Caller-owned indices: a bad index is the caller's error, not an
+      // invariant of ours and not corruption of the persisted bytes.
+      return arrow::Status::Invalid("Paimon direct-file take index is out of range: ", logical_offset);
     }
     auto physical = static_cast<uint64_t>(logical_offset) + static_cast<uint64_t>(deletion_index);
     while (deletion_index < deletions.size() && deletions[deletion_index] <= physical) {
@@ -736,7 +756,8 @@ arrow::Result<std::vector<int64_t>> PaimonFormatReader::logical_to_physical(
     }
     if (physical >= metadata_->payload.physical_row_count ||
         physical > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-      return arrow::Status::Invalid("Paimon direct-file physical index is out of range");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Paimon direct-file physical index is out of range");
     }
     physical_offsets.push_back(static_cast<int64_t>(physical));
   }

--- a/cpp/src/format/parquet/file_reader.cpp
+++ b/cpp/src/format/parquet/file_reader.cpp
@@ -33,6 +33,7 @@
 #include <fmt/format.h>
 
 #include "milvus-storage/format/parquet/file_reader.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/common/arrow_util.h"
@@ -101,7 +102,13 @@ arrow::Status FileRowGroupReader::init(std::shared_ptr<arrow::fs::FileSystem> fs
     schema_ = file_schema;
     // FieldIDList::Make fails when a field lacks PARQUET:field_id metadata;
     // ValueOrDie here aborted the whole process on such (data-dependent) files.
-    ARROW_ASSIGN_OR_RAISE(field_id_list_, FieldIDList::Make(schema_));
+    auto field_ids = FieldIDList::Make(schema_);
+    if (!field_ids.ok()) {
+      return WrapExtendError(ExtendStatusCode::PackedMetadataCorrupted,
+                             fmt::format("Invalid packed parquet field metadata. [path={}]", path_),
+                             field_ids.status());
+    }
+    field_id_list_ = std::move(*field_ids);
     for (size_t i = 0; i < field_id_list_.size(); ++i) {
       needed_columns_.emplace_back(i);
     }

--- a/cpp/src/format/parquet/folly_arrow_executor.cpp
+++ b/cpp/src/format/parquet/folly_arrow_executor.cpp
@@ -15,6 +15,7 @@
 #include "milvus-storage/format/parquet/folly_arrow_executor.h"
 
 #include <exception>
+#include <new>
 #include <utility>
 
 #include <arrow/status.h>

--- a/cpp/src/format/vortex/vortex_footer_reader.cpp
+++ b/cpp/src/format/vortex/vortex_footer_reader.cpp
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/format/vortex/vortex_footer_reader.h"
 
+#include "milvus-storage/format/vortex/vortex_footer_internal.h"
+
 #include <algorithm>
+#include <cerrno>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -27,6 +31,7 @@
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/io/interfaces.h>
 #include <arrow/type.h>
+#include <arrow/util/io_util.h>
 #include <fmt/format.h>
 
 #include "milvus-storage/common/log.h"
@@ -41,7 +46,8 @@ namespace milvus_storage::vortex {
 arrow::Result<std::shared_ptr<VortexRangeFile>> GetVortexRangeFile(const std::shared_ptr<arrow::fs::FileSystem>& fs,
                                                                    const std::string& path) {
   if (!fs) {
-    return arrow::Status::Invalid("GetVortexRangeFile requires a non-null filesystem");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "GetVortexRangeFile requires a non-null filesystem");
   }
   auto provider = std::dynamic_pointer_cast<VortexRangeFileProvider>(fs);
   if (!provider) {
@@ -58,10 +64,12 @@ arrow::Status FillVortexRangeFile(const std::shared_ptr<arrow::io::RandomAccessF
     return arrow::Status::OK();
   }
   if (!source_file) {
-    return arrow::Status::Invalid("FillVortexRangeFile requires a non-null source file");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "FillVortexRangeFile requires a non-null source file");
   }
   if (!range_file) {
-    return arrow::Status::Invalid("FillVortexRangeFile requires a non-null range file");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "FillVortexRangeFile requires a non-null range file");
   }
   if (length > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
       offset > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
@@ -110,8 +118,8 @@ std::vector<ByteRange> MergeByteRanges(std::vector<ByteRange> ranges) {
 
 namespace {
 
-// Used only when the caller does not know the footer size. Vortex footer open
-// retries with a larger tail if this initial speculative read is insufficient.
+// Used only when the caller does not know the footer size. This is the single
+// speculative tail read; failure is returned without expanding the range.
 constexpr uint64_t kDefaultFooterReadSize = 2 * 1024 * 1024;
 
 static arrow::Result<uint64_t> ResolveInitialFooterBodySize(uint64_t file_size,
@@ -123,9 +131,16 @@ static arrow::Result<uint64_t> ResolveInitialFooterBodySize(uint64_t file_size,
 
   if (footer_size != 0) {
     if (file_size < eof_size || footer_size > file_size - eof_size) {
-      return arrow::Status::Invalid(
-          fmt::format("Vortex footer body size exceeds file size, file_size={}, footer_size={}, eof_size={}", file_size,
-                      footer_size, eof_size));
+      // A recorded footer size that cannot fit inside the file it describes is
+      // the metadata contradicting itself -- nothing was read, so this says
+      // nothing about the object's bytes. Left as a bare Invalid it reached
+      // segcore as a generic 2044. DataCorrupted points at the thing that
+      // is wrong.
+      return MakeExtendErrorMsg(
+          ExtendStatusCode::DataCorrupted,
+          fmt::format("Recorded vortex footer size cannot fit in the file it describes: file_size={}, footer_size={}, "
+                      "eof_size={}. The object was never read, so this is the metadata that needs attention.",
+                      file_size, footer_size, eof_size));
     }
     return footer_size;
   }
@@ -141,6 +156,97 @@ static uint64_t ResolveTailReadSize(uint64_t file_size, uint64_t footer_body_siz
   return std::min<uint64_t>(file_size, footer_body_size + eof_size);
 }
 
+}  // namespace
+
+namespace internal {
+
+arrow::Result<ByteRange> FlatSegmentByteRangeFromBytes(const std::vector<uint64_t>& bytes, uint64_t flat_segment_id) {
+  if (bytes.size() != 2) {
+    return arrow::Status::Invalid("Vortex bridge returned ", bytes.size(), " values for flat segment ", flat_segment_id,
+                                  ", expected 2");
+  }
+  return ByteRange{bytes[0], bytes[1]};
+}
+
+arrow::Status ValidateVortexFieldLayoutEncoding(const std::vector<uint64_t>& raw_offsets,
+                                                uint64_t rows,
+                                                const std::string& field_name) {
+  auto data_format_error = [&field_name](auto&&... message) {
+    return MakeExtendErrorMsg(ExtendStatusCode::VortexDataFormat, std::forward<decltype(message)>(message)...,
+                              " for field ", field_name);
+  };
+
+  if (raw_offsets.size() < 2) {
+    return data_format_error("Vortex field layout units are malformed (", raw_offsets.size(),
+                             " offsets, need at least 2)");
+  }
+
+  const auto granularity = raw_offsets[0];
+  if (granularity != static_cast<uint64_t>(VortexPhysicalGranularity::kFlat) &&
+      granularity != static_cast<uint64_t>(VortexPhysicalGranularity::kRowGroup)) {
+    return data_format_error("Invalid vortex physical unit granularity ", granularity);
+  }
+
+  const auto total_units = raw_offsets[1];
+  if (total_units == 0) {
+    if (rows != 0) {
+      return data_format_error("Non-empty vortex file has no physical units");
+    }
+    if (raw_offsets.size() != 2) {
+      return data_format_error("Trailing words after an empty vortex field layout (", raw_offsets.size() - 2,
+                               " extra)");
+    }
+    return arrow::Status::OK();
+  }
+
+  // Every unit consumes at least four words. Reject an impossible persisted
+  // count before entering a potentially enormous loop.
+  const auto available_words = raw_offsets.size() - 2;
+  if (total_units > available_words / 4) {
+    return data_format_error("Truncated vortex field layout units: declares ", total_units, " units in ",
+                             available_words, " words");
+  }
+
+  size_t cursor = 2;
+  for (uint64_t i = 0; i < total_units; ++i) {
+    if (raw_offsets.size() - cursor < 4) {
+      return data_format_error("Truncated vortex field layout unit ", i);
+    }
+    const auto row_offset = raw_offsets[cursor + 1];
+    const auto row_count = raw_offsets[cursor + 2];
+    if (row_offset > rows || row_count > rows - row_offset) {
+      return data_format_error("Vortex field layout unit ", i, " has row range [", row_offset, ", ", row_offset, " + ",
+                               row_count, ") outside file row count ", rows);
+    }
+    const auto num_segments = raw_offsets[cursor + 3];
+    cursor += 4;
+    if (num_segments > raw_offsets.size() - cursor) {
+      return data_format_error("Truncated vortex segment list in unit ", i, ": declares ", num_segments,
+                               " segments with ", raw_offsets.size() - cursor, " words remaining");
+    }
+    cursor += static_cast<size_t>(num_segments);
+  }
+
+  if (cursor != raw_offsets.size()) {
+    return data_format_error("Trailing words after vortex field layout units (", raw_offsets.size() - cursor,
+                             " extra)");
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status ClassifyVortexLayoutSegmentLookupFailure(const arrow::Status& failure, uint64_t flat_segment_id) {
+  const auto context = fmt::format("Vortex layout names a segment the file does not have: id={}", flat_segment_id);
+  if (ExtendStatusDetail::UnwrapStatus(failure) != nullptr || failure.IsUnknownError() ||
+      arrow::internal::ErrnoFromStatus(failure) == ENOENT) {
+    return MakeVortexErrorStatus(context, failure);
+  }
+  return MakeExtendErrorMsg(ExtendStatusCode::VortexDataFormat, context, " (", failure.message(), ")");
+}
+
+}  // namespace internal
+
+namespace {
+
 struct ParsedFieldUnit {
   uint64_t physical_unit_index = 0;
   uint64_t row_offset = 0;
@@ -153,13 +259,17 @@ struct ParsedFieldUnits {
   std::vector<ParsedFieldUnit> units;
 };
 
+// Classified here rather than in the bridge, because THIS is the layer that
+// knows where the segment id came from. Down in segment_bytes an out-of-range
+// id is indistinguishable from a caller passing a bad number -- an API misuse,
+// not a data-format failure. The ids reaching this function were read out of
+// the file's own layout, so a range the file cannot satisfy is a format error.
 static arrow::Result<ByteRange> ReadFlatSegmentByteRange(const VortexFile& vxfile, uint64_t flat_segment_id) {
-  ARROW_ASSIGN_OR_RAISE(auto bytes, vxfile.SegmentBytes(flat_segment_id));
-  if (bytes.size() != 2 || bytes[1] == 0) {
-    return arrow::Status::Invalid(
-        fmt::format("Invalid vortex flat segment byte range for segment {}", flat_segment_id));
+  auto bytes_result = vxfile.SegmentBytes(flat_segment_id);
+  if (!bytes_result.ok()) {
+    return internal::ClassifyVortexLayoutSegmentLookupFailure(bytes_result.status(), flat_segment_id);
   }
-  return ByteRange{bytes[0], bytes[1]};
+  return internal::FlatSegmentByteRangeFromBytes(std::move(bytes_result).ValueOrDie(), flat_segment_id);
 }
 
 static arrow::Status LoadFlatSegments(const std::shared_ptr<arrow::io::RandomAccessFile>& input_file,
@@ -181,6 +291,14 @@ static arrow::Result<ParsedFieldUnits> ParseFieldUnits(const VortexFile& vxfile,
                                                        const std::shared_ptr<arrow::Schema>& file_schema,
                                                        uint64_t rows,
                                                        const std::string& field_name) {
+  // A requested field name is a caller input. Check it before asking the Rust
+  // bridge for persisted layout units: the bridge deliberately represents an
+  // absent field as an empty layout, which is also the representation of a
+  // malformed non-empty persisted layout. Only the schema can distinguish them.
+  if (file_schema && !file_schema->GetFieldByName(field_name)) {
+    return arrow::Status::KeyError(fmt::format("Vortex field not found: {}", field_name));
+  }
+
   auto raw_offsets_result = vxfile.FieldLayoutUnits(field_name);
   if (!raw_offsets_result.ok()) {
     return MakeVortexErrorStatus(fmt::format("Failed to get vortex field layout units for {}", field_name),
@@ -188,13 +306,7 @@ static arrow::Result<ParsedFieldUnits> ParseFieldUnits(const VortexFile& vxfile,
   }
   auto raw_offsets = std::move(raw_offsets_result).ValueOrDie();
 
-  if (raw_offsets.size() < 2) {
-    return arrow::Status::Invalid(fmt::format("Invalid vortex field layout units for {}", field_name));
-  }
-
-  if (file_schema && !file_schema->GetFieldByName(field_name)) {
-    return arrow::Status::KeyError(fmt::format("Vortex field not found: {}", field_name));
-  }
+  ARROW_RETURN_NOT_OK(internal::ValidateVortexFieldLayoutEncoding(raw_offsets, rows, field_name));
 
   const auto granularity_value = raw_offsets[0];
   VortexPhysicalGranularity granularity = VortexPhysicalGranularity::kUnknown;
@@ -202,17 +314,11 @@ static arrow::Result<ParsedFieldUnits> ParseFieldUnits(const VortexFile& vxfile,
     granularity = VortexPhysicalGranularity::kFlat;
   } else if (granularity_value == static_cast<uint64_t>(VortexPhysicalGranularity::kRowGroup)) {
     granularity = VortexPhysicalGranularity::kRowGroup;
-  } else {
-    return arrow::Status::Invalid(
-        fmt::format("Invalid vortex physical unit granularity {} for {}", granularity_value, field_name));
   }
 
   const auto total_units = raw_offsets[1];
   if (total_units == 0) {
-    if (rows == 0) {
-      return ParsedFieldUnits{granularity, {}};
-    }
-    return arrow::Status::Invalid(fmt::format("Vortex field {} has no physical units", field_name));
+    return ParsedFieldUnits{granularity, {}};
   }
 
   std::vector<ParsedFieldUnit> units;
@@ -220,19 +326,12 @@ static arrow::Result<ParsedFieldUnits> ParseFieldUnits(const VortexFile& vxfile,
 
   size_t cursor = 2;
   for (uint64_t i = 0; i < total_units; ++i) {
-    if (cursor + 4 > raw_offsets.size()) {
-      return arrow::Status::Invalid(fmt::format("Truncated vortex field layout units for {}", field_name));
-    }
-
     ParsedFieldUnit unit;
     unit.physical_unit_index = raw_offsets[cursor++];
     unit.row_offset = raw_offsets[cursor++];
     unit.row_count = raw_offsets[cursor++];
     const auto num_segments = raw_offsets[cursor++];
 
-    if (cursor + num_segments > raw_offsets.size()) {
-      return arrow::Status::Invalid(fmt::format("Truncated vortex segment list for {}", field_name));
-    }
     unit.flat_segments.reserve(num_segments);
     for (uint64_t j = 0; j < num_segments; ++j) {
       const auto flat_segment_id = raw_offsets[cursor++];
@@ -248,6 +347,7 @@ static arrow::Result<ParsedFieldUnits> ParseFieldUnits(const VortexFile& vxfile,
 
 struct VortexFooterReader::Impl {
   arrow::Status ResolveFileSize(const std::shared_ptr<arrow::fs::FileSystem>& fs);
+  arrow::Status CheckFileLongEnough() const;
   arrow::Status PrepareRangeFile();
   arrow::Status OpenSparseVortexFile();
   arrow::Status LoadFooter(const std::shared_ptr<arrow::io::RandomAccessFile>& input_file);
@@ -288,19 +388,37 @@ arrow::Status VortexFooterReader::Impl::ResolveFileSize(const std::shared_ptr<ar
   return arrow::Status::OK();
 }
 
+arrow::Status VortexFooterReader::Impl::CheckFileLongEnough() const {
+  // A vortex file cannot be shorter than its EOF trailer. Checked here rather
+  // than left to the Rust side: this is the zero-length object a failed or
+  // aborted write leaves behind -- a common malformed object shape -- and
+  // vortex reports it as "Initial read must be at least EOF_SIZE". The intent
+  // is unambiguous here and is not at the generic bridge boundary.
+  //
+  if (file_size < VortexEofSize()) {
+    return MakeExtendErrorMsg(ExtendStatusCode::VortexDataFormat,
+                              "Vortex file is too short to hold its trailer: ", path, " (", file_size,
+                              " bytes, minimum ", VortexEofSize(), ")");
+  }
+  return arrow::Status::OK();
+}
+
 arrow::Status VortexFooterReader::Impl::PrepareRangeFile() {
   if (!sparse_fs) {
-    return arrow::Status::Invalid("VortexFooterReader requires a non-null range filesystem");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexFooterReader requires a non-null range filesystem");
   }
   if (sparse_path.empty()) {
-    return arrow::Status::Invalid("VortexFooterReader requires a non-empty sparse path");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexFooterReader requires a non-empty sparse path");
   }
 
   if (!range_file) {
     ARROW_ASSIGN_OR_RAISE(range_file, GetVortexRangeFile(sparse_fs, sparse_path));
   }
   if (!range_file) {
-    return arrow::Status::Invalid("VortexFooterReader requires a non-null range file");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexFooterReader requires a non-null range file");
   }
   range_file->Resize(file_size);
   fs_holder = std::make_shared<FileSystemWrapper>(sparse_fs);
@@ -317,84 +435,53 @@ arrow::Status VortexFooterReader::Impl::OpenSparseVortexFile() {
   return arrow::Status::OK();
 }
 
+namespace internal {
+
+arrow::Status CheckVortexFooterRange(const std::vector<uint64_t>& footer_range,
+                                     uint64_t file_size,
+                                     const std::string& path) {
+  // Three ways the descriptor can contradict the file it describes: it is not a
+  // {offset, length} pair at all, the offset starts past the end, or the length
+  // runs off the end from that offset. The last is written as
+  // `length > file_size - offset` rather than `offset + length > file_size`
+  // because both are uint64 and the sum wraps.
+  if (footer_range.size() != 2 || footer_range[0] > file_size || footer_range[1] > file_size - footer_range[0]) {
+    return MakeExtendErrorMsg(ExtendStatusCode::VortexDataFormat,
+                              fmt::format("Invalid vortex footer byte range for {}", path));
+  }
+  return arrow::Status::OK();
+}
+
+}  // namespace internal
+
 arrow::Status VortexFooterReader::Impl::LoadFooter(const std::shared_ptr<arrow::io::RandomAccessFile>& input_file) {
   const auto eof_size = VortexEofSize();
-  auto finish_opened_footer = [&]() -> arrow::Status {
-    ARROW_ASSIGN_OR_RAISE(auto footer_range, vxfile->FooterByteRange(file_size));
-    if (footer_range.size() != 2 || footer_range[0] > file_size || footer_range[1] > file_size - footer_range[0]) {
-      return arrow::Status::Invalid(fmt::format("Invalid vortex footer byte range for {}", path));
-    }
-    footer_size = footer_range[1] > eof_size ? footer_range[1] - eof_size : 0;
-    rows = vxfile->RowCount();
-    return arrow::Status::OK();
-  };
+  const auto supplied_footer_size = footer_size;
+  ARROW_ASSIGN_OR_RAISE(const auto footer_body_size,
+                        ResolveInitialFooterBodySize(file_size, supplied_footer_size, eof_size));
+  const auto tail_read_size = ResolveTailReadSize(file_size, footer_body_size, eof_size);
+  ARROW_RETURN_NOT_OK(FillVortexRangeFile(input_file, range_file, file_size - tail_read_size, tail_read_size));
 
-  uint64_t footer_body_size = 0;
-  uint64_t loaded_tail_read_size = 0;
-
-  if (footer_size != 0) {
-    ARROW_ASSIGN_OR_RAISE(auto cached_footer_body_size, ResolveInitialFooterBodySize(file_size, footer_size, eof_size));
-    footer_body_size = cached_footer_body_size;
-    const auto tail_read_size = ResolveTailReadSize(file_size, footer_body_size, eof_size);
-    ARROW_RETURN_NOT_OK(FillVortexRangeFile(input_file, range_file, file_size - tail_read_size, tail_read_size));
-    auto open_result =
-        VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder.get()), sparse_path, file_size, footer_body_size);
-    if (open_result.ok()) {
-      vxfile = std::move(open_result).ValueOrDie();
-    } else {
-      LOG_STORAGE_WARNING_ << fmt::format(
-          "[VortexFooterReader] cached footer body size {} failed for {}, fallback to expanding retry: {}",
-          footer_body_size, path, open_result.status().ToString());
-      ARROW_ASSIGN_OR_RAISE(auto retry_footer_body_size, ResolveInitialFooterBodySize(file_size, 0, eof_size));
-      footer_body_size = std::max<uint64_t>(retry_footer_body_size, footer_body_size);
-      loaded_tail_read_size = tail_read_size;
-    }
-    if (vxfile) {
-      ARROW_RETURN_NOT_OK(finish_opened_footer());
-      if (footer_size <= footer_body_size) {
-        return arrow::Status::OK();
-      }
-      LOG_STORAGE_WARNING_ << fmt::format(
-          "[VortexFooterReader] cached footer body size {} is smaller than actual {} for {}, fallback to expanding "
-          "retry",
-          footer_body_size, footer_size, path);
-      footer_body_size = footer_size;
-      loaded_tail_read_size = tail_read_size;
-    }
-  } else {
-    ARROW_ASSIGN_OR_RAISE(auto initial_footer_body_size,
-                          ResolveInitialFooterBodySize(file_size, footer_size, eof_size));
-    footer_body_size = initial_footer_body_size;
+  auto open_result =
+      VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder.get()), sparse_path, file_size, footer_body_size);
+  if (!open_result.ok()) {
+    return MakeVortexErrorStatus(fmt::format("Failed to open vortex file {}", path), open_result.status());
   }
+  vxfile = std::move(open_result).ValueOrDie();
 
-  const auto max_footer_body_size = file_size > eof_size ? file_size - eof_size : file_size;
-  while (footer_body_size <= max_footer_body_size) {
-    const auto tail_read_size = ResolveTailReadSize(file_size, footer_body_size, eof_size);
-    if (tail_read_size > loaded_tail_read_size) {
-      const uint64_t new_bytes = tail_read_size - loaded_tail_read_size;
-      const uint64_t tail_offset = file_size - tail_read_size;
-      ARROW_RETURN_NOT_OK(FillVortexRangeFile(input_file, range_file, tail_offset, new_bytes));
-      loaded_tail_read_size = tail_read_size;
+  ARROW_ASSIGN_OR_RAISE(auto footer_range, vxfile->FooterByteRange(file_size));
+  ARROW_RETURN_NOT_OK(internal::CheckVortexFooterRange(footer_range, file_size, path));
+  const auto actual_footer_size = footer_range[1] > eof_size ? footer_range[1] - eof_size : 0;
+  if (actual_footer_size > footer_body_size) {
+    if (supplied_footer_size != 0) {
+      return MakeExtendErrorMsg(ExtendStatusCode::DataCorrupted,
+                                "Recorded vortex footer size is smaller than the actual footer");
     }
-
-    vxfile.reset();
-    auto open_result =
-        VortexFile::OpenUnique(reinterpret_cast<uint8_t*>(fs_holder.get()), sparse_path, file_size, footer_body_size);
-    if (open_result.ok()) {
-      vxfile = std::move(open_result).ValueOrDie();
-      return finish_opened_footer();
-    }
-    if (footer_body_size == max_footer_body_size) {
-      return MakeVortexErrorStatus(fmt::format("Failed to open vortex file {}", path), open_result.status());
-    }
-    const auto doubled = footer_body_size > max_footer_body_size / 2 ? max_footer_body_size : footer_body_size * 2;
-    const auto incremented = footer_body_size == max_footer_body_size ? max_footer_body_size : footer_body_size + 1;
-    footer_body_size = std::min<uint64_t>(max_footer_body_size, std::max<uint64_t>(doubled, incremented));
+    return arrow::Status::IOError("Vortex footer exceeds the single-read window");
   }
-
-  return arrow::Status::Invalid(fmt::format(
-      "Vortex initial footer body size exceeds file size, path={}, footer_body_size={}, max_footer_body_size={}", path,
-      footer_body_size, max_footer_body_size));
+  footer_size = actual_footer_size;
+  rows = vxfile->RowCount();
+  return arrow::Status::OK();
 }
 
 arrow::Status VortexFooterReader::Impl::LoadZoneMaps(const std::shared_ptr<arrow::io::RandomAccessFile>& input_file) {
@@ -441,13 +528,17 @@ VortexFooterReader::~VortexFooterReader() = default;
 
 arrow::Status VortexFooterReader::Open(const std::shared_ptr<arrow::fs::FileSystem>& fs, bool load_zonemap) {
   if (impl_->vxfile) {
-    return arrow::Status::Invalid("VortexFooterReader is already opened; create a new reader for another read mode");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexFooterReader is already opened; create a new reader for another read mode");
   }
   if (!fs) {
-    return arrow::Status::Invalid("VortexFooterReader::Open requires a non-null filesystem");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexFooterReader::Open requires a non-null filesystem");
   }
 
   ARROW_RETURN_NOT_OK(impl_->ResolveFileSize(fs));
+
+  ARROW_RETURN_NOT_OK(impl_->CheckFileLongEnough());
   ARROW_RETURN_NOT_OK(impl_->PrepareRangeFile());
   ARROW_ASSIGN_OR_RAISE(auto input_file, fs->OpenInputFile(impl_->path));
 
@@ -477,7 +568,7 @@ uint64_t VortexFooterReader::footer_size() const { return impl_->footer_size; }
 
 arrow::Result<VortexFieldLayout> VortexFooterReader::GetFieldLayout(const std::string& field_name) const {
   if (!impl_->vxfile) {
-    return arrow::Status::Invalid("VortexFooterReader is not opened");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "VortexFooterReader is not opened");
   }
   {
     std::lock_guard<std::mutex> lock(impl_->field_layout_cache_mutex);
@@ -523,7 +614,7 @@ arrow::Result<VortexFieldLayout> VortexFooterReader::GetFieldLayout(const std::s
 arrow::Result<std::vector<uint64_t>> VortexFooterReader::PruneRowGroups(
     const std::string& predicate, const std::vector<uint64_t>& candidate_row_group_ids) const {
   if (!impl_->vxfile) {
-    return arrow::Status::Invalid("VortexFooterReader is not opened");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "VortexFooterReader is not opened");
   }
   if (predicate.empty() || candidate_row_group_ids.empty()) {
     return candidate_row_group_ids;

--- a/cpp/src/format/vortex/vortex_format_reader.cpp
+++ b/cpp/src/format/vortex/vortex_format_reader.cpp
@@ -14,12 +14,16 @@
 
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 
+#include "milvus-storage/common/extend_status.h"
+
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/format/vortex/vortex_planner.h"
+#include "bridge_error.h"
 #include "vortex_bridge.h"
 
 #include <functional>
 #include <memory>
+#include <new>
 #include <optional>
 #include <string>
 #include <utility>
@@ -94,7 +98,8 @@ static arrow::Result<std::optional<expr::Expr>> parse_predicate_for_schema(
     return std::nullopt;
   }
   if (!file_schema) {
-    return arrow::Status::Invalid("Vortex predicate requires an opened reader with file schema");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Vortex predicate requires an opened reader with file schema");
   }
 
   std::vector<expr::PredicateColumn> schema;
@@ -113,7 +118,8 @@ static arrow::Result<std::optional<expr::Expr>> parse_predicate_for_schema(
 static arrow::Result<std::shared_ptr<arrow::Schema>> project_schema(const std::shared_ptr<arrow::Schema>& schema,
                                                                     const std::vector<std::string>& columns) {
   if (!schema) {
-    return arrow::Status::Invalid("Vortex output schema requires an opened reader");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Vortex output schema requires an opened reader");
   }
   if (columns.empty()) {
     return schema;
@@ -258,7 +264,8 @@ static arrow::Result<std::vector<RowGroupInfo>> create_row_group_infos(
 
   for (auto row_range : row_ranges) {
     if (row_range > rows_in_file) {
-      return arrow::Status::Invalid("Vortex row range exceeds the file row count");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Vortex row range exceeds the file row count");
     }
     uint64_t memory_size = 0;
     if (memory_size_estimate) {
@@ -282,7 +289,8 @@ static arrow::Result<std::shared_ptr<arrow::Schema>> projected_file_schema(
     const std::vector<std::string>& projected_columns,
     const std::string& path) {
   if (!file_schema) {
-    return arrow::Status::Invalid(fmt::format("Vortex file schema is not initialized. [path={}]", path));
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Vortex file schema is not initialized. [path=", path, "]");
   }
   if (projected_columns.empty()) {
     return file_schema;
@@ -363,37 +371,30 @@ static arrow::Result<uint64_t> compute_total_mem_usage(const std::vector<uint64_
   uint64_t total_size = 0;
   for (auto size : file_column_uncompressed_sizes) {
     if (size > std::numeric_limits<uint64_t>::max() - total_size) {
-      return arrow::Status::Invalid("Vortex column memory estimates exceed the uint64_t range");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                "Vortex column memory estimates exceed the uint64_t range");
     }
     total_size += size;
   }
   return total_size;
 }
 
-static std::optional<MemorySizeEstimate> estimate_memory_sizes(const VortexFile& vxfile,
-                                                               size_t column_count,
-                                                               const std::string& path) {
+static arrow::Result<std::optional<MemorySizeEstimate>> estimate_memory_sizes(const VortexFile& vxfile,
+                                                                              size_t column_count) {
   auto column_sizes_result = get_column_uncompressed_sizes(vxfile, column_count);
   if (!column_sizes_result.ok()) {
-    // Memory statistics are optional. Do not retain the underlying failure in
-    // row-group metadata: estimate APIs return a generic NotImplemented status
-    // instead. Keep the detailed reason in the debug log for diagnostics only.
-    LOG_STORAGE_DEBUG_ << "Vortex memory estimation is unavailable"
-                       << ", path=" << path << ", status=" << column_sizes_result.status().ToString();
-    return std::nullopt;
+    if (column_sizes_result.status().IsNotImplemented()) {
+      return std::optional<MemorySizeEstimate>{};
+    }
+    return column_sizes_result.status();
   }
 
   auto column_sizes = std::move(column_sizes_result).ValueOrDie();
-  auto total_size_result = compute_total_mem_usage(column_sizes);
-  if (!total_size_result.ok()) {
-    LOG_STORAGE_DEBUG_ << "Vortex memory estimation is unavailable"
-                       << ", path=" << path << ", status=" << total_size_result.status().ToString();
-    return std::nullopt;
-  }
-  return MemorySizeEstimate{
-      .total_size = total_size_result.ValueOrDie(),
+  ARROW_ASSIGN_OR_RAISE(auto total_size, compute_total_mem_usage(column_sizes));
+  return std::optional<MemorySizeEstimate>(MemorySizeEstimate{
+      .total_size = total_size,
       .column_sizes = std::move(column_sizes),
-  };
+  });
 }
 
 struct VortexOpenAsyncContext {
@@ -402,17 +403,25 @@ struct VortexOpenAsyncContext {
 };
 
 template <typename T>
-static void set_vortex_callback_exception(folly::Promise<T>& promise,
-                                          const char* operation,
-                                          const char* message) noexcept {
+static void set_vortex_callback_exception(folly::Promise<T>& promise) noexcept {
   try {
-    promise.setValue(T(arrow::Status::IOError(fmt::format("{}: {}", operation, message))));
+    promise.setValue(T(arrow::Status::UnknownError("Vortex async callback failed unexpectedly")));
   } catch (...) {
-    // No further error reporting is safe from a callback crossing the C ABI.
   }
 }
 
-static void vortex_open_async_callback(void* ctx_raw, uintptr_t handle, const char* error_msg) noexcept {
+template <typename T>
+static void set_vortex_callback_out_of_memory(folly::Promise<T>& promise) noexcept {
+  try {
+    promise.setValue(T(arrow::Status::OutOfMemory("Vortex async callback allocation failed")));
+  } catch (...) {
+  }
+}
+
+static void vortex_open_async_callback(void* ctx_raw,
+                                       uintptr_t handle,
+                                       int error_code,
+                                       const char* error_msg) noexcept {
   // The FFI contract invokes this callback exactly once; reclaim the context
   // ownership transferred before vortex_open_file_async().
   std::unique_ptr<VortexOpenAsyncContext> ctx(static_cast<VortexOpenAsyncContext*>(ctx_raw));
@@ -421,20 +430,19 @@ static void vortex_open_async_callback(void* ctx_raw, uintptr_t handle, const ch
 
   try {
     if (error) {
-      ctx->promise.setValue(MakeVortexErrorStatus("Failed to open vortex file", error.get()));
+      ctx->promise.setValue(MakeVortexErrorStatus("Failed to open vortex file", error_code, error.get()));
       return;
     }
 
     if (handle == 0) {
-      ctx->promise.setValue(arrow::Status::IOError("Vortex async open returned a null file handle"));
+      ctx->promise.setValue(MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                               "Vortex async open returned a null file handle"));
       return;
     }
 
     ctx->promise.setValue(ctx->initialize(handle));
-  } catch (const std::exception& e) {
-    set_vortex_callback_exception(ctx->promise, "Failed to import opened vortex file", e.what());
   } catch (...) {
-    set_vortex_callback_exception(ctx->promise, "Failed to import opened vortex file", "unknown exception");
+    set_vortex_callback_exception(ctx->promise);
   }
 }
 
@@ -454,7 +462,8 @@ std::string VortexFormatReader::MetaTrait::cache_key(const api::ColumnGroupFile&
 arrow::Result<VortexFormatReader::MetaTrait::MetadataPtr> VortexFormatReader::MetaTrait::create_metadata_from_reader(
     const std::shared_ptr<VortexFormatReader>& reader, const api::ColumnGroupFile& file) {
   if (!reader || !reader->vxfile_ || !reader->fs_holder_ || !reader->file_schema_) {
-    return arrow::Status::Invalid("Cannot create vortex metadata from an unopened reader");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Cannot create vortex metadata from an unopened reader");
   }
 
   auto metadata = std::make_shared<Metadata>(Metadata{
@@ -574,7 +583,7 @@ arrow::Result<std::optional<bool>> VortexFormatReader::parse_split_row_indices_o
   if (mode == "false") {
     return false;
   }
-  return arrow::Status::Invalid(fmt::format("Invalid Vortex split row indices mode: {}", mode));
+  return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "Invalid Vortex split row indices mode: ", mode);
 }
 
 VortexFormatReader::VortexFormatReader(MetaTrait::MetadataPtr metadata,
@@ -609,13 +618,18 @@ arrow::Status VortexFormatReader::open() {
   if (read_schema_ && read_schema_->num_fields() == 0) {
     read_schema_ = nullptr;
   }
-  ARROW_ASSIGN_OR_RAISE(vxfile_, open_shared_vortex_file(fs_holder_, path_, file_size_, footer_size_));
+  auto vxfile_res = open_shared_vortex_file(fs_holder_, path_, file_size_, footer_size_);
+  if (!vxfile_res.ok()) {
+    return std::move(vxfile_res).status();
+  }
+  vxfile_ = std::move(vxfile_res).ValueOrDie();
 
   // Always derive full file schema from file metadata
   ARROW_ASSIGN_OR_RAISE(file_schema_, import_vortex_file_schema(*vxfile_));
 
   ARROW_ASSIGN_OR_RAISE(auto row_ranges, get_vortex_splits(*vxfile_));
-  auto memory_size_estimate = estimate_memory_sizes(*vxfile_, static_cast<size_t>(file_schema_->num_fields()), path_);
+  ARROW_ASSIGN_OR_RAISE(auto memory_size_estimate,
+                        estimate_memory_sizes(*vxfile_, static_cast<size_t>(file_schema_->num_fields())));
   ARROW_ASSIGN_OR_RAISE(row_group_infos_,
                         create_row_group_infos(vxfile_->RowCount(), recalc_row_ranges(row_ranges, logical_chunk_rows_),
                                                memory_size_estimate));
@@ -665,8 +679,8 @@ folly::SemiFuture<arrow::Status> VortexFormatReader::open_async() {
     auto vxfile = std::shared_ptr<VortexFile>(std::move(vxfile_unique));
     ARROW_ASSIGN_OR_RAISE(auto file_schema, import_vortex_file_schema(*vxfile));
     ARROW_ASSIGN_OR_RAISE(auto row_ranges, get_vortex_splits(*vxfile));
-    auto memory_size_estimate =
-        estimate_memory_sizes(*vxfile, static_cast<size_t>(file_schema->num_fields()), self->path_);
+    ARROW_ASSIGN_OR_RAISE(auto memory_size_estimate,
+                          estimate_memory_sizes(*vxfile, static_cast<size_t>(file_schema->num_fields())));
     ARROW_ASSIGN_OR_RAISE(
         auto row_group_infos,
         create_row_group_infos(vxfile->RowCount(), recalc_row_ranges(row_ranges, self->logical_chunk_rows_),
@@ -697,7 +711,8 @@ arrow::Status VortexFormatReader::set_predicate(const std::string& predicate) {
     return arrow::Status::OK();
   }
   if (!file_schema_) {
-    return arrow::Status::Invalid("predicate set before file schema is available");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "predicate set before file schema is available");
   }
   ARROW_ASSIGN_OR_RAISE(auto maybe_expr, parse_predicate_for_schema(predicate, file_schema_));
   if (maybe_expr.has_value()) {
@@ -730,8 +745,8 @@ arrow::Result<std::vector<RowGroupInfo>> VortexFormatReader::get_row_group_infos
 
 arrow::Result<std::vector<uint64_t>> VortexFormatReader::get_rg_column_memsz(int64_t row_group_index) const {
   if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
-    return arrow::Status::Invalid(
-        fmt::format("Vortex row group index {} out of range {}", row_group_index, row_group_infos_.size()));
+    return arrow::Status::Invalid("Vortex row group index ", row_group_index, " out of range ",
+                                  row_group_infos_.size());
   }
   if (!row_group_infos_[row_group_index].memory_size_available || !column_memory_weights_) {
     return arrow::Status::NotImplemented("Vortex column memory size statistics are not available");
@@ -742,8 +757,8 @@ arrow::Result<std::vector<uint64_t>> VortexFormatReader::get_rg_column_memsz(int
 arrow::Result<std::shared_ptr<arrow::RecordBatch>> VortexFormatReader::get_chunk(const int& row_group_index) {
   assert(vxfile_);
   if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
-    return arrow::Status::Invalid(
-        fmt::format("Vortex row group index {} out of range {}", row_group_index, row_group_infos_.size()));
+    return arrow::Status::Invalid("Vortex row group index ", row_group_index, " out of range ",
+                                  row_group_infos_.size());
   }
   ARROW_ASSIGN_OR_RAISE(auto chunkedarray,
                         blocking_read(row_group_infos_[row_group_index].start_offset,
@@ -769,6 +784,13 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> VortexFormatRead
     return rbs;
   }
 
+  for (const auto row_group_index : rg_indices_in_file) {
+    if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
+      return arrow::Status::Invalid("Vortex row group index ", row_group_index, " out of range ",
+                                    row_group_infos_.size());
+    }
+  }
+
 #ifndef NDEBUG
   // verify rg_indices_in_file have been sorted
   for (size_t i = 1; i < rg_indices_in_file.size(); ++i) {
@@ -777,12 +799,6 @@ arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>> VortexFormatRead
 #endif
 
   std::vector<std::pair<uint64_t, uint64_t>> rg_idx_ranges;
-  for (const auto row_group_index : rg_indices_in_file) {
-    if (row_group_index < 0 || static_cast<size_t>(row_group_index) >= row_group_infos_.size()) {
-      return arrow::Status::Invalid(
-          fmt::format("Vortex row group index {} out of range {}", row_group_index, row_group_infos_.size()));
-    }
-  }
 
   // calc continuous ranges
   // ex. [1, 2, 3, 5] -> [(1, 3), (5, 5)]
@@ -822,7 +838,7 @@ arrow::Result<std::shared_ptr<FormatReader>> VortexFormatReader::clone_reader() 
 
 arrow::Result<ArrowArrayStream> VortexFormatReader::read_with_plan(const VortexReadPlan& plan) {
   if (!vxfile_) {
-    return arrow::Status::Invalid("VortexFormatReader is not opened");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "VortexFormatReader is not opened");
   }
 
   ARROW_ASSIGN_OR_RAISE(auto scan_builder, vxfile_->CreateScanBuilder(kSmallCoalescingWindow));
@@ -850,14 +866,16 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read_with_plan(const VortexR
 
   auto stream = std::move(scan_builder).IntoStream();
   if (!stream.ok()) {
-    return MakeVortexErrorStatus("Failed to read vortex file with plan", stream.status());
+    return TakeVortexErrorStatus("Failed to read vortex file with plan", stream.status());
   }
+  // Arrow C streams carry lazy failures as text. Keep Rust's trusted marker
+  // intact until the final C++ consumer can rebuild the typed StatusDetail.
   return std::move(stream).ValueOrDie();
 }
 
 arrow::Result<ArrowArrayStream> VortexFormatReader::read_row_ids_with_plan(const VortexReadPlan& plan) {
   if (!vxfile_) {
-    return arrow::Status::Invalid("VortexFormatReader is not opened");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "VortexFormatReader is not opened");
   }
 
   ARROW_ASSIGN_OR_RAISE(auto scan_builder, vxfile_->CreateScanBuilder(kSmallCoalescingWindow));
@@ -876,7 +894,7 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read_row_ids_with_plan(const
   ARROW_RETURN_NOT_OK(apply_read_plan_selection(&scan_builder, plan, vxfile_->RowCount(), path_));
   auto stream = std::move(scan_builder).IntoStream();
   if (!stream.ok()) {
-    return MakeVortexErrorStatus("Failed to read vortex row ids with plan", stream.status());
+    return TakeVortexErrorStatus("Failed to read vortex row ids with plan", stream.status());
   }
   return std::move(stream).ValueOrDie();
 }
@@ -902,7 +920,7 @@ arrow::Result<ArrowArrayStream> VortexFormatReader::read(uint64_t row_start,
   scan_builder.WithRowRange(row_start, row_end);
   auto stream = std::move(scan_builder).IntoStream();
   if (!stream.ok()) {
-    return MakeVortexErrorStatus("Failed to read vortex file", stream.status());
+    return TakeVortexErrorStatus("Failed to read vortex file", stream.status());
   }
   return std::move(stream).ValueOrDie();
 }
@@ -920,11 +938,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> VortexFormatReader::str
 arrow::Result<std::shared_ptr<arrow::ChunkedArray>> VortexFormatReader::blocking_read(
     uint64_t row_start, uint64_t row_end, const ffi::CoalescingWindow& coalescing_window) {
   ARROW_ASSIGN_OR_RAISE(auto array_stream, read(row_start, row_end, coalescing_window));
-  auto chunked_array_result = arrow::ImportChunkedArray(&array_stream);
-  if (!chunked_array_result.ok()) {
-    return MakeVortexErrorStatus("Failed to import vortex chunked array", chunked_array_result.status());
-  }
-  return chunked_array_result.ValueOrDie();
+  return milvus_storage::bridge::ImportBridgeChunkedArray(&array_stream, "Failed to import vortex chunked array");
 }
 
 arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std::vector<int64_t>& row_indices) {
@@ -945,14 +959,11 @@ arrow::Result<std::shared_ptr<arrow::Table>> VortexFormatReader::take(const std:
 
   auto array_stream = std::move(scan_builder).IntoStream();
   if (!array_stream.ok()) {
-    return MakeVortexErrorStatus("Failed to take from vortex file", array_stream.status());
+    return TakeVortexErrorStatus("Failed to take from vortex file", array_stream.status());
   }
   auto stream = std::move(array_stream).ValueOrDie();
-  auto chunkedarray_result = arrow::ImportChunkedArray(&stream);
-  if (!chunkedarray_result.ok()) {
-    return MakeVortexErrorStatus("Failed to import vortex take result", chunkedarray_result.status());
-  }
-  auto chunkedarray = chunkedarray_result.ValueOrDie();
+  ARROW_ASSIGN_OR_RAISE(auto chunkedarray, milvus_storage::bridge::ImportBridgeChunkedArray(
+                                               &stream, "Failed to import vortex take result"));
 
   // out of range
   if (chunkedarray->num_chunks() == 0) {
@@ -997,6 +1008,7 @@ struct VortexAsyncContext {
 
 static void vortex_take_async_callback(void* ctx_raw,
                                        ArrowArrayStream* /*out_stream*/,
+                                       int error_code,
                                        const char* error_msg) noexcept {
   // Reclaim the callback context exactly once after Rust finishes the scan.
   std::unique_ptr<VortexAsyncContext<std::shared_ptr<arrow::Table>>> ctx(
@@ -1006,7 +1018,7 @@ static void vortex_take_async_callback(void* ctx_raw,
 
   try {
     if (error) {
-      ctx->promise.setValue(MakeVortexErrorStatus("Failed to take from vortex file", error.get()));
+      ctx->promise.setValue(MakeVortexErrorStatus("Failed to take from vortex file", error_code, error.get()));
       return;
     }
 
@@ -1020,7 +1032,8 @@ static void vortex_take_async_callback(void* ctx_raw,
 
     auto chunked_array = result.ValueUnsafe();
     if (chunked_array->num_chunks() == 0) {
-      ctx->promise.setValue(arrow::Status::Invalid("take_async: empty result"));
+      ctx->promise.setValue(
+          MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "take_async: empty result"));
       return;
     }
 
@@ -1038,15 +1051,14 @@ static void vortex_take_async_callback(void* ctx_raw,
     }
 
     ctx->promise.setValue(arrow::Table::FromRecordBatches(rbs));
-  } catch (const std::exception& e) {
-    set_vortex_callback_exception(ctx->promise, "Failed to process vortex take result", e.what());
   } catch (...) {
-    set_vortex_callback_exception(ctx->promise, "Failed to process vortex take result", "unknown exception");
+    set_vortex_callback_exception(ctx->promise);
   }
 }
 
 static void vortex_read_range_async_callback(void* ctx_raw,
                                              ArrowArrayStream* /*out_stream*/,
+                                             int error_code,
                                              const char* error_msg) noexcept {
   // Reclaim the callback context exactly once after Rust publishes the stream.
   std::unique_ptr<VortexAsyncContext<std::shared_ptr<arrow::RecordBatchReader>>> ctx(
@@ -1056,7 +1068,7 @@ static void vortex_read_range_async_callback(void* ctx_raw,
 
   try {
     if (error) {
-      ctx->promise.setValue(MakeVortexErrorStatus("Failed to read vortex file", error.get()));
+      ctx->promise.setValue(MakeVortexErrorStatus("Failed to read vortex file", error_code, error.get()));
       return;
     }
 
@@ -1069,10 +1081,8 @@ static void vortex_read_range_async_callback(void* ctx_raw,
       return;
     }
     ctx->promise.setValue(internal::WrapVortexRecordBatchReader(reader_result.ValueOrDie()));
-  } catch (const std::exception& e) {
-    set_vortex_callback_exception(ctx->promise, "Failed to process vortex range-read result", e.what());
   } catch (...) {
-    set_vortex_callback_exception(ctx->promise, "Failed to process vortex range-read result", "unknown exception");
+    set_vortex_callback_exception(ctx->promise);
   }
 }
 

--- a/cpp/src/format/vortex/vortex_planner.cpp
+++ b/cpp/src/format/vortex/vortex_planner.cpp
@@ -26,6 +26,7 @@
 #include "milvus-storage/format/vortex/vortex_field_layout_internal.h"
 #include "milvus-storage/format/vortex/vortex_footer_reader.h"
 #include "milvus-storage/format/vortex/vortex_types.h"
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::vortex {
 
@@ -33,7 +34,8 @@ namespace {
 
 static arrow::Status CheckedAdd(uint64_t* total, uint64_t value, const std::string& key) {
   if (*total > std::numeric_limits<uint64_t>::max() - value) {
-    return arrow::Status::Invalid(fmt::format("Vortex field {} byte size overflows", key));
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              fmt::format("Vortex field {} byte size overflows", key));
   }
   *total += value;
   return arrow::Status::OK();
@@ -218,7 +220,8 @@ static arrow::Status ValidateSortedUniqueOffsets(const std::vector<int64_t>& off
 arrow::Result<VortexCellMetasPtr> BuildVortexCellMetas(const std::shared_ptr<VortexFooterReader>& footer_reader,
                                                        const std::string& field_name) {
   if (!footer_reader) {
-    return arrow::Status::Invalid("BuildVortexCellMetas requires a non-null footer reader");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "BuildVortexCellMetas requires a non-null footer reader");
   }
   const auto key = fmt::format("{}:{}", footer_reader->path(), field_name);
   ARROW_ASSIGN_OR_RAISE(auto layout, footer_reader->GetFieldLayout(field_name));
@@ -238,7 +241,8 @@ arrow::Result<VortexCellMetasPtr> BuildVortexCellMetas(const std::shared_ptr<Vor
 arrow::Result<VortexCellMetasPtr> BuildVortexGroupCellMetas(const std::shared_ptr<VortexFooterReader>& footer_reader,
                                                             const std::vector<std::string>& field_names) {
   if (!footer_reader) {
-    return arrow::Status::Invalid("BuildVortexGroupCellMetas requires a non-null footer reader");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "BuildVortexGroupCellMetas requires a non-null footer reader");
   }
   if (field_names.empty()) {
     return arrow::Status::Invalid("Vortex group cell meta builder requires at least one field");
@@ -258,7 +262,8 @@ arrow::Result<VortexCellMetasPtr> BuildVortexGroupCellMetas(const std::shared_pt
 arrow::Result<std::shared_ptr<VortexPlanner>> VortexPlanner::Make(
     const std::shared_ptr<VortexFooterReader>& footer_reader, std::string field_name, VortexCellMetasPtr cell_metas) {
   if (!footer_reader) {
-    return arrow::Status::Invalid("VortexPlanner requires a non-null footer reader");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexPlanner requires a non-null footer reader");
   }
   const auto key = fmt::format("{}:{}", footer_reader->path(), field_name);
   ARROW_RETURN_NOT_OK(ValidateCellMetasReady(cell_metas, footer_reader->rows(), key));
@@ -270,7 +275,8 @@ arrow::Result<std::shared_ptr<VortexPlanner>> VortexPlanner::Make(
 arrow::Result<std::shared_ptr<VortexPlanner>> VortexPlanner::MakeGroup(
     const std::shared_ptr<VortexFooterReader>& footer_reader, VortexCellMetasPtr cell_metas) {
   if (!footer_reader) {
-    return arrow::Status::Invalid("VortexPlanner requires a non-null footer reader");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexPlanner requires a non-null footer reader");
   }
   const auto key = fmt::format("{}:<column_group>", footer_reader->path());
   ARROW_RETURN_NOT_OK(ValidateCellMetasReady(cell_metas, footer_reader->rows(), key));
@@ -386,7 +392,8 @@ arrow::Result<std::vector<RowRange>> VortexPlanner::BuildReadRangesForCells(cons
   const auto& metas = cell_metas();
   for (auto cell_id : cell_ids) {
     if (cell_id >= metas.size()) {
-      return arrow::Status::Invalid(fmt::format("Vortex cell id {} out of range {}", cell_id, metas.size()));
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                fmt::format("Vortex cell id {} out of range {}", cell_id, metas.size()));
     }
     const auto& meta = metas[cell_id];
     const auto cell_start = meta.row_offset;
@@ -415,7 +422,8 @@ arrow::Result<std::vector<uint64_t>> VortexPlanner::PruneCellsByPredicate(const 
   const auto& metas = cell_metas();
   for (auto cell_id : cell_ids) {
     if (cell_id >= metas.size()) {
-      return arrow::Status::Invalid(fmt::format("Vortex cell id {} out of range {}", cell_id, metas.size()));
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                                fmt::format("Vortex cell id {} out of range {}", cell_id, metas.size()));
     }
     const auto& meta = metas[cell_id];
     if (meta.granularity != VortexPhysicalGranularity::kRowGroup) {

--- a/cpp/src/format/vortex/vortex_translater.cpp
+++ b/cpp/src/format/vortex/vortex_translater.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "milvus-storage/format/vortex/vortex_translater.h"
+#include "milvus-storage/common/extend_status.h"
 
 #include <algorithm>
 #include <limits>
@@ -94,17 +95,20 @@ arrow::Result<std::unique_ptr<VortexTranslater>> VortexTranslater::Make(
     std::string sparse_path,
     CacheWarmupPolicy cache_warmup_policy) {
   if (!source_fs) {
-    return arrow::Status::Invalid("VortexTranslater requires a non-null source filesystem");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexTranslater requires a non-null source filesystem");
   }
   if (!sparse_fs) {
-    return arrow::Status::Invalid("VortexTranslater requires a non-null range filesystem");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexTranslater requires a non-null range filesystem");
   }
   if (!cell_metas) {
     return arrow::Status::Invalid("VortexTranslater requires non-null cell metas");
   }
   ARROW_ASSIGN_OR_RAISE(auto range_file, GetVortexRangeFile(sparse_fs, sparse_path));
   if (!range_file) {
-    return arrow::Status::Invalid("VortexTranslater requires a non-null range file");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "VortexTranslater requires a non-null range file");
   }
 
   ARROW_ASSIGN_OR_RAISE(auto input_file, source_fs->OpenInputFile(source_path));

--- a/cpp/test/format/async_tasks_test.cpp
+++ b/cpp/test/format/async_tasks_test.cpp
@@ -20,7 +20,10 @@
 #include <string>
 #include <vector>
 
+#include <folly/futures/Promise.h>
+
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/format/async_tasks.h"
 #include "milvus-storage/format/column_group_reader.h"
 
@@ -68,6 +71,75 @@ TEST(AsyncTasksTest, FollyArrowAssignOrRaiseExposesAssignedValueOnSuccess) {
 
   ASSERT_TRUE(result.ok()) << result.status().ToString();
   EXPECT_EQ(result.ValueUnsafe(), 42);
+}
+
+TEST(AsyncTasksTest, FailFastCollectorAcceptsEmptyInput) {
+  std::vector<folly::SemiFuture<arrow::Result<int>>> futures;
+
+  auto result = std::move(CollectAllResultsFailFast(std::move(futures))).get();
+
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+  EXPECT_TRUE(result.ValueUnsafe().empty());
+}
+
+TEST(AsyncTasksTest, FailFastCollectorPreservesInputOrderOnSuccess) {
+  folly::Promise<arrow::Result<int>> first;
+  folly::Promise<arrow::Result<int>> second;
+  folly::Promise<arrow::Result<int>> third;
+  std::vector<folly::SemiFuture<arrow::Result<int>>> futures;
+  futures.push_back(first.getSemiFuture());
+  futures.push_back(second.getSemiFuture());
+  futures.push_back(third.getSemiFuture());
+  auto collected = std::move(CollectAllResultsFailFast(std::move(futures))).toUnsafeFuture();
+
+  third.setValue(30);
+  first.setValue(10);
+  EXPECT_FALSE(collected.isReady());
+  second.setValue(20);
+
+  ASSERT_TRUE(collected.isReady());
+  auto result = std::move(collected).get();
+  ASSERT_TRUE(result.ok()) << result.status().ToString();
+  EXPECT_EQ(result.ValueUnsafe(), (std::vector<int>{10, 20, 30}));
+}
+
+TEST(AsyncTasksTest, FailFastCollectorReturnsTypedErrorBeforeBlockedSibling) {
+  folly::Promise<arrow::Result<int>> blocked;
+  auto lifetime = std::make_shared<int>(42);
+  std::weak_ptr<int> weak_lifetime = lifetime;
+  auto blocked_future = blocked.getSemiFuture().deferEnsure([lifetime] {});
+  lifetime.reset();
+
+  auto expected = MakeExtendErrorMsg(ExtendStatusCode::StorageTransientTimeout, "first reader failed");
+  std::vector<folly::SemiFuture<arrow::Result<int>>> futures;
+  futures.push_back(std::move(blocked_future));
+  futures.push_back(folly::makeSemiFuture(arrow::Result<int>(expected)));
+  auto collected = std::move(CollectAllResultsFailFast(std::move(futures))).toUnsafeFuture();
+
+  ASSERT_TRUE(collected.isReady());
+  auto result = std::move(collected).get();
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(result.status().ToString(), expected.ToString());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientTimeout);
+  EXPECT_FALSE(weak_lifetime.expired());
+
+  blocked.setValue(7);
+  EXPECT_TRUE(weak_lifetime.expired());
+}
+
+TEST(AsyncTasksTest, FailFastCollectorAllReadySuccessCannotLoseToBrokenFailurePromise) {
+  for (int iteration = 0; iteration < 100; ++iteration) {
+    std::vector<folly::SemiFuture<arrow::Result<int>>> futures;
+    futures.push_back(folly::makeSemiFuture(arrow::Result<int>(iteration)));
+    futures.push_back(folly::makeSemiFuture(arrow::Result<int>(iteration + 1)));
+
+    auto result = std::move(CollectAllResultsFailFast(std::move(futures))).get();
+
+    ASSERT_TRUE(result.ok()) << "iteration=" << iteration << ": " << result.status().ToString();
+    EXPECT_EQ(result.ValueUnsafe(), (std::vector<int>{iteration, iteration + 1}));
+  }
 }
 
 TEST(AsyncTasksTest, ChunkTaskBuildGroupsByFileAndMergesContiguousRanges) {

--- a/cpp/test/format/external_table_arn_test.cpp
+++ b/cpp/test/format/external_table_arn_test.cpp
@@ -223,8 +223,9 @@ class ExternalTableArnTest : public ::testing::TestWithParam<std::string> {
     ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
     auto storage_options = iceberg::ToStorageOptions(write_config);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info, iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.empty()) {
       return arrow::Status::Invalid("PlanFiles returned no files");
     }
@@ -563,7 +564,8 @@ class ExternalTableGcpImpersonationTest : public ::testing::TestWithParam<std::s
     ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
     auto storage_options = iceberg::ToStorageOptions(write_config);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options, "gs");
+    ARROW_ASSIGN_OR_RAISE(auto table_info,
+                          iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options, "gs"));
 
     auto explore_dir = iceberg::ToMilvusUri(table_info.metadata_location, address_);
     auto milvus_path = iceberg::ToMilvusUri(table_info.data_file_uri, address_);
@@ -956,8 +958,9 @@ class ExternalTableAzureArnTest : public ::testing::TestWithParam<std::string> {
     ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
     auto storage_options = iceberg::ToStorageOptions(write_config);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info, iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.empty()) {
       return arrow::Status::Invalid("PlanFiles returned no files");
     }
@@ -1309,8 +1312,9 @@ class ExternalTableAliyunArnTest : public ::testing::Test {
     ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
     auto storage_options = iceberg::ToStorageOptions(write_config);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info, iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.empty()) {
       return arrow::Status::Invalid("PlanFiles returned no files");
     }
@@ -1963,8 +1967,9 @@ class ExternalTableAliyunOIDCArnTest : public ::testing::Test {
     ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(write_props_, write_config));
     auto storage_options = iceberg::ToStorageOptions(write_config);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info, iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.empty()) {
       return arrow::Status::Invalid("PlanFiles returned no files");
     }

--- a/cpp/test/format/external_table_test.cpp
+++ b/cpp/test/format/external_table_test.cpp
@@ -277,7 +277,7 @@ class ExternalTableTest : public ::testing::TestWithParam<std::string> {
     ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
     auto storage_options = lance::ToStorageOptions(fs_config);
 
-    auto dataset = lance::BlockingDataset::Open(lance_uri, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto dataset, lance::BlockingDataset::Open(lance_uri, storage_options));
 
     // Build predicate like "id in (3, 10, 25)"
     std::string predicate = "id in (";
@@ -287,7 +287,7 @@ class ExternalTableTest : public ::testing::TestWithParam<std::string> {
       predicate += std::to_string(deleted_ids[i]);
     }
     predicate += ")";
-    dataset->DeleteRows(predicate);
+    ARROW_RETURN_NOT_OK(dataset->DeleteRows(predicate));
 
     return WriteResult{std::move(result.cgfile), result.schema, num_rows};
   }
@@ -301,8 +301,9 @@ class ExternalTableTest : public ::testing::TestWithParam<std::string> {
     auto table_uri = MakeTableUri(bucket, path);
     auto storage_options = iceberg::ToStorageOptions(fs_config_);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info, iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.empty()) {
       return arrow::Status::Invalid("PlanFiles returned no files");
     }
@@ -321,8 +322,10 @@ class ExternalTableTest : public ::testing::TestWithParam<std::string> {
     auto table_uri = MakeTableUri(bucket, path);
     auto storage_options = iceberg::ToStorageOptions(fs_config_);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, num_rows, true, deleted_ids, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info,
+                          iceberg::CreateTestTable(table_uri, num_rows, true, deleted_ids, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.empty()) {
       return arrow::Status::Invalid("PlanFiles returned no files");
     }
@@ -519,8 +522,10 @@ class ExternalSplitColumnGroupTest : public ::testing::TestWithParam<std::string
     ARROW_ASSIGN_OR_RAISE(auto table_uri, MakeIcebergTableUri(test_base_ + "/iceberg"));
     auto storage_options = iceberg::ToStorageOptions(fs_config_);
 
-    auto table_info = iceberg::CreateTestTable(table_uri, kSplitExternalTotalRows, false, {}, storage_options);
-    auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+    ARROW_ASSIGN_OR_RAISE(auto table_info,
+                          iceberg::CreateTestTable(table_uri, kSplitExternalTotalRows, false, {}, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto file_infos,
+                          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options));
     if (file_infos.size() != 1) {
       return arrow::Status::Invalid("Expected exactly one Iceberg data file, got ", file_infos.size());
     }
@@ -1390,9 +1395,10 @@ TEST_F(GcpS3CompatWriteTest, IcebergWriteAndPlanFiles) {
   ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(props_, config));
   auto storage_options = iceberg::ToStorageOptions(config);
 
-  auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options);
+  auto table_info = iceberg::CreateTestTable(table_uri, num_rows, false, {}, storage_options).ValueOrDie();
 
-  auto file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos =
+      iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
   ASSERT_FALSE(file_infos.empty()) << "PlanFiles returned no files";
   ASSERT_EQ(file_infos[0].record_count, num_rows);
   std::cout << "[GCP S3-compat] iceberg-table write+PlanFiles OK: " << file_infos[0].data_file_path << " ("

--- a/cpp/test/format/format_reader_cache_test.cpp
+++ b/cpp/test/format/format_reader_cache_test.cpp
@@ -675,8 +675,9 @@ class FormatReaderMetadataCacheStressTest : public ::testing::TestWithParam<std:
     std::vector<iceberg::IcebergFileInfo> file_infos;
     try {
       auto storage_options = iceberg::ToStorageOptions(fs_config_);
-      table_info = iceberg::CreateTestTable(table_uri, kExpectedRows, false, {}, storage_options);
-      file_infos = iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+      table_info = iceberg::CreateTestTable(table_uri, kExpectedRows, false, {}, storage_options).ValueOrDie();
+      file_infos =
+          iceberg::PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
     } catch (const std::exception& e) {
       return arrow::Status::IOError("Failed to create Iceberg stress table: ", e.what());
     }

--- a/cpp/test/format/iceberg/iceberg_bridge_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_bridge_test.cpp
@@ -22,35 +22,31 @@ namespace milvus_storage::iceberg {
 
 class IcebergBridgeTest : public ::testing::Test {};
 
-// PlanFiles should throw IcebergException for a nonexistent local metadata file
+// PlanFiles should return an error status for a nonexistent local metadata file
 TEST_F(IcebergBridgeTest, PlanFilesNonexistentLocalMetadata) {
   std::unordered_map<std::string, std::string> opts;
-  EXPECT_THROW(PlanFiles("/nonexistent/path/v1.metadata.json", 1, opts), IcebergException);
+  EXPECT_FALSE(PlanFiles("/nonexistent/path/v1.metadata.json", 1, opts).ok());
 }
 
-// PlanFiles should throw IcebergException for an empty metadata location
+// PlanFiles should return an error status for an empty metadata location
 TEST_F(IcebergBridgeTest, PlanFilesEmptyMetadataLocation) {
   std::unordered_map<std::string, std::string> opts;
-  EXPECT_THROW(PlanFiles("", 1, opts), IcebergException);
+  EXPECT_FALSE(PlanFiles("", 1, opts).ok());
 }
 
-// PlanFiles should throw IcebergException with an invalid snapshot id
+// PlanFiles should return an error status with an invalid snapshot id
 // even if the metadata file does not exist
 TEST_F(IcebergBridgeTest, PlanFilesInvalidSnapshotId) {
   std::unordered_map<std::string, std::string> opts;
-  EXPECT_THROW(PlanFiles("file:///nonexistent/metadata.json", -999, opts), IcebergException);
+  EXPECT_FALSE(PlanFiles("file:///nonexistent/metadata.json", -999, opts).ok());
 }
 
-// Verify IcebergException carries a descriptive message
-TEST_F(IcebergBridgeTest, ExceptionMessageIsDescriptive) {
+// Verify the returned error status carries a descriptive message
+TEST_F(IcebergBridgeTest, ErrorStatusMessageIsDescriptive) {
   std::unordered_map<std::string, std::string> opts;
-  try {
-    PlanFiles("/nonexistent/v1.metadata.json", 1, opts);
-    FAIL() << "Expected IcebergException";
-  } catch (const IcebergException& e) {
-    std::string msg = e.what();
-    EXPECT_FALSE(msg.empty()) << "Exception message should not be empty";
-  }
+  auto result = PlanFiles("/nonexistent/v1.metadata.json", 1, opts);
+  ASSERT_FALSE(result.ok());
+  EXPECT_FALSE(result.status().message().empty()) << "Error message should not be empty";
 }
 
 // IcebergFileInfo default construction

--- a/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_format_reader_test.cpp
@@ -24,6 +24,7 @@
 #include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/extend_status.h"
 #include "test_env.h"
 
 namespace milvus_storage::iceberg {
@@ -90,9 +91,16 @@ class IcebergFormatReaderTest : public ::testing::Test {
     ASSERT_STATUS_OK(path_builder.Finish(&path_array));
     ASSERT_STATUS_OK(pos_builder.Finish(&pos_array));
 
-    auto batch = arrow::RecordBatch::Make(schema, deleted_positions.size(), {path_array, pos_array});
+    WriteParquetFile(delete_file_path_, schema, {path_array, pos_array}, deleted_positions.size());
+  }
 
-    ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(delete_file_path_));
+  void WriteParquetFile(const std::string& path,
+                        const std::shared_ptr<arrow::Schema>& schema,
+                        const std::vector<std::shared_ptr<arrow::Array>>& columns,
+                        int64_t num_rows) {
+    auto batch = arrow::RecordBatch::Make(schema, num_rows, columns);
+
+    ASSERT_AND_ASSIGN(auto sink, fs_->OpenOutputStream(path));
     ASSERT_AND_ASSIGN(auto writer, ::parquet::arrow::FileWriter::Open(*schema, arrow::default_memory_pool(), sink));
     ASSERT_STATUS_OK(writer->WriteRecordBatch(*batch));
     ASSERT_STATUS_OK(writer->Close());
@@ -426,6 +434,104 @@ TEST_F(IcebergFormatReaderTest, EqualityDeleteRejected) {
       << "Error should mention equality deletes: " << result.status().ToString();
 }
 
+TEST_F(IcebergFormatReaderTest, PositionalDeleteMissingRequiredColumnIsDataFormat) {
+  WriteDataFile(5);
+
+  auto schema = arrow::schema({arrow::field("pos", arrow::int64())});
+  arrow::Int64Builder pos_builder;
+  ASSERT_STATUS_OK(pos_builder.Append(1));
+  std::shared_ptr<arrow::Array> pos_array;
+  ASSERT_STATUS_OK(pos_builder.Finish(&pos_array));
+  WriteParquetFile(delete_file_path_, schema, {pos_array}, 1);
+
+  ColumnGroupFile file{data_file_path_, 0, data_num_rows_, MakeDeleteMetadataJson(delete_file_path_)};
+  auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_, {"id"}, nullptr);
+  ASSERT_FALSE(result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::DataCorrupted);
+}
+
+TEST_F(IcebergFormatReaderTest, PositionalDeleteWrongColumnTypesAreDataFormat) {
+  WriteDataFile(5);
+
+  auto schema = arrow::schema({arrow::field("file_path", arrow::int64()), arrow::field("pos", arrow::int32())});
+  arrow::Int64Builder path_builder;
+  arrow::Int32Builder pos_builder;
+  ASSERT_STATUS_OK(path_builder.Append(1));
+  ASSERT_STATUS_OK(pos_builder.Append(1));
+  std::shared_ptr<arrow::Array> path_array, pos_array;
+  ASSERT_STATUS_OK(path_builder.Finish(&path_array));
+  ASSERT_STATUS_OK(pos_builder.Finish(&pos_array));
+  WriteParquetFile(delete_file_path_, schema, {path_array, pos_array}, 1);
+
+  ColumnGroupFile file{data_file_path_, 0, data_num_rows_, MakeDeleteMetadataJson(delete_file_path_)};
+  auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_, {"id"}, nullptr);
+  ASSERT_FALSE(result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::DataCorrupted);
+}
+
+TEST_F(IcebergFormatReaderTest, PositionalDeleteNullValuesAreDataFormat) {
+  WriteDataFile(5);
+
+  auto schema = arrow::schema({arrow::field("file_path", arrow::utf8()), arrow::field("pos", arrow::int64())});
+  arrow::StringBuilder path_builder;
+  arrow::Int64Builder pos_builder;
+  ASSERT_STATUS_OK(path_builder.AppendNull());
+  ASSERT_STATUS_OK(pos_builder.Append(1));
+  std::shared_ptr<arrow::Array> path_array, pos_array;
+  ASSERT_STATUS_OK(path_builder.Finish(&path_array));
+  ASSERT_STATUS_OK(pos_builder.Finish(&pos_array));
+  WriteParquetFile(delete_file_path_, schema, {path_array, pos_array}, 1);
+
+  ColumnGroupFile file{data_file_path_, 0, data_num_rows_, MakeDeleteMetadataJson(delete_file_path_)};
+  auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_, {"id"}, nullptr);
+  ASSERT_FALSE(result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::DataCorrupted);
+}
+
+// A repeated (file_path, pos) is legal: the Iceberg spec only orders rows
+// within one delete file, and several delete files in a snapshot may name the
+// same position. Deletes are applied as a set, so the row is dropped once and
+// the table stays readable — engines like Spark/Trino read it fine too.
+TEST_F(IcebergFormatReaderTest, PositionalDeleteDuplicatePositionIsDeduplicated) {
+  WriteDataFile(5);
+  WritePositionalDeleteFile(data_file_path_, {1, 1});
+
+  ColumnGroupFile file{data_file_path_, 0, data_num_rows_, MakeDeleteMetadataJson(delete_file_path_)};
+  ASSERT_AND_ASSIGN(auto reader,
+                    FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_, {"id"}, nullptr));
+  ASSERT_AND_ASSIGN(auto row_group_infos, reader->get_row_group_infos());
+  ASSERT_EQ(row_group_infos.size(), 1);
+  // 5 rows, one distinct deleted position -> 4 logical rows, not 3.
+  EXPECT_EQ(row_group_infos[0].end_offset, 4);
+
+  ASSERT_AND_ASSIGN(auto batch, reader->get_chunk(0));
+  ASSERT_EQ(batch->num_rows(), 4);
+  auto id_array = std::dynamic_pointer_cast<arrow::Int64Array>(batch->column(0));
+  ASSERT_NE(id_array, nullptr);
+  std::vector<int64_t> expected_ids = {0, 2, 3, 4};
+  for (size_t i = 0; i < expected_ids.size(); ++i) {
+    EXPECT_EQ(id_array->Value(i), expected_ids[i]) << "Mismatch at index " << i;
+  }
+}
+
+TEST_F(IcebergFormatReaderTest, PositionalDeleteOutOfRangeIsDataFormat) {
+  WriteDataFile(5);
+  WritePositionalDeleteFile(data_file_path_, {-1});
+
+  ColumnGroupFile file{data_file_path_, 0, data_num_rows_, MakeDeleteMetadataJson(delete_file_path_)};
+  auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_, {"id"}, nullptr);
+  ASSERT_FALSE(result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::DataCorrupted);
+}
+
 // Invalid JSON metadata should cause an error
 TEST_F(IcebergFormatReaderTest, InvalidJsonMetadata) {
   WriteDataFile(5);
@@ -438,6 +544,27 @@ TEST_F(IcebergFormatReaderTest, InvalidJsonMetadata) {
                                      std::vector<std::string>{"id"}, nullptr);
 
   ASSERT_FALSE(result.ok());
+}
+
+TEST_F(IcebergFormatReaderTest, MalformedDeleteMetadataStructureIsDataCorrupted) {
+  WriteDataFile(5);
+
+  const std::vector<std::string> malformed_metadata = {
+      R"([1])",
+      R"([{"file_type":1}])",
+      R"([{"file_type":"unknown","path":1}])",
+  };
+
+  for (const auto& json : malformed_metadata) {
+    SCOPED_TRACE(json);
+    ColumnGroupFile file{data_file_path_, 0, data_num_rows_, {{kPropertyMetadata, json}}};
+    auto result = FormatReader::create(nullptr, LOON_FORMAT_ICEBERG_TABLE, file, properties_, {"id"}, nullptr);
+
+    ASSERT_FALSE(result.ok());
+    auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+    ASSERT_NE(detail, nullptr) << result.status().ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::DataCorrupted);
+  }
 }
 
 }  // namespace

--- a/cpp/test/format/iceberg/iceberg_integration_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_integration_test.cpp
@@ -18,6 +18,7 @@
 
 #include "milvus-storage/format/format_reader.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/extend_status.h"
 #include "iceberg_bridge.h"
 #include "test_env.h"
 
@@ -80,11 +81,11 @@ TEST_F(IcebergIntegrationTest, ExploreAndReadBasic) {
   const uint64_t num_rows = 50;
 
   // 1. Create a standard Iceberg table via Rust bridge
-  auto table_info = CreateTestTable(abs_table_dir_, num_rows, false, {});
+  auto table_info = CreateTestTable(abs_table_dir_, num_rows, false, {}).ValueOrDie();
 
   // 2. Explore: plan files from the Iceberg metadata
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
 
   ASSERT_EQ(file_infos.size(), 1);
   ASSERT_EQ(file_infos[0].record_count, num_rows);
@@ -133,17 +134,29 @@ TEST_F(IcebergIntegrationTest, ExploreAndReadBasic) {
   }
 }
 
+TEST_F(IcebergIntegrationTest, MissingSnapshotIsNotFoundRatherThanDataCorruption) {
+  auto table_info = CreateTestTable(abs_table_dir_, 10, false, {}).ValueOrDie();
+
+  std::unordered_map<std::string, std::string> storage_options;
+  auto result = PlanFiles(table_info.metadata_location, table_info.snapshot_id + 1, storage_options);
+  ASSERT_FALSE(result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound);
+  EXPECT_NE(CategoryForExtendStatusCode(detail->code()), ErrorCategory::DataFormat);
+}
+
 // End-to-end: create Iceberg table with positional deletes → explore → read with filtering
 TEST_F(IcebergIntegrationTest, ExploreAndReadWithPositionalDeletes) {
   const uint64_t num_rows = 20;
   std::vector<int64_t> deleted_positions = {3, 7, 15};
 
   // 1. Create Iceberg table with positional deletes
-  auto table_info = CreateTestTable(abs_table_dir_, num_rows, true, deleted_positions);
+  auto table_info = CreateTestTable(abs_table_dir_, num_rows, true, deleted_positions).ValueOrDie();
 
   // 2. Explore
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
 
   ASSERT_EQ(file_infos.size(), 1);
   ASSERT_EQ(file_infos[0].record_count, num_rows);
@@ -201,10 +214,10 @@ TEST_F(IcebergIntegrationTest, TakeWithPositionalDeletes) {
   const uint64_t num_rows = 30;
   std::vector<int64_t> deleted_positions = {5, 10, 20};
 
-  auto table_info = CreateTestTable(abs_table_dir_, num_rows, true, deleted_positions);
+  auto table_info = CreateTestTable(abs_table_dir_, num_rows, true, deleted_positions).ValueOrDie();
 
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
   ASSERT_EQ(file_infos.size(), 1);
 
   auto cg_file = MakeCgFile(file_infos[0]);
@@ -238,10 +251,10 @@ TEST_F(IcebergIntegrationTest, TakeWithPositionalDeletes) {
 TEST_F(IcebergIntegrationTest, ColumnProjection) {
   const uint64_t num_rows = 10;
 
-  auto table_info = CreateTestTable(abs_table_dir_, num_rows, false, {});
+  auto table_info = CreateTestTable(abs_table_dir_, num_rows, false, {}).ValueOrDie();
 
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
   ASSERT_EQ(file_infos.size(), 1);
 
   auto cg_file = MakeCgFile(file_infos[0]);
@@ -266,10 +279,10 @@ TEST_F(IcebergIntegrationTest, CloneReaderSharesDeletes) {
   const uint64_t num_rows = 10;
   std::vector<int64_t> deleted_positions = {2, 8};
 
-  auto table_info = CreateTestTable(abs_table_dir_, num_rows, true, deleted_positions);
+  auto table_info = CreateTestTable(abs_table_dir_, num_rows, true, deleted_positions).ValueOrDie();
 
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
 
   auto cg_file = MakeCgFile(file_infos[0]);
 

--- a/cpp/test/format/lance/lance_bridge_error_test.cpp
+++ b/cpp/test/format/lance/lance_bridge_error_test.cpp
@@ -1,0 +1,228 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression tests for the classified error channel of the Rust bridges:
+// the Rust side embeds a marker code into the (string-only) cxx error, the
+// shared decoder rebuilds a structured arrow::Status, and the segcore mapping
+// turns it into the right ErrorCode. These tests pin both the decoder table
+// and the end-to-end not-found path through a real lance open.
+
+#include <cerrno>
+#include <string>
+
+#include <arrow/status.h>
+#include <arrow/util/io_util.h>
+#include <gtest/gtest.h>
+
+#include "bridge_error.h"
+#include "lance_bridge.h"
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/ffi_internal/ffi_error_code.h"
+#include "milvus-storage/ffi_internal/result.h"
+
+namespace milvus_storage::bridge {
+namespace {
+
+constexpr const char* kMarker = "__LOON_RUST_BRIDGE_ERRCODE__=";
+
+// Code 12 is still decoded -- the vortex fork and the filesystem layer speak
+// the errno channel -- even though no bridge here emits it any more.
+TEST(BridgeErrorTest, NotFoundCodeBecomesEnoentDetail) {
+  auto status = MakeBridgeErrorStatus(std::string(kMarker) + "12; dataset was not found");
+  ASSERT_TRUE(status.IsIOError());
+  EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
+  // Marker must be stripped from the user-visible message.
+  EXPECT_EQ(status.message().find("__LOON_"), std::string::npos);
+  // End of the chain: fine-grained ObjectNotExist, never a transient code.
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist);
+}
+
+TEST(BridgeErrorTest, TransientCodeBecomesRetryableExtendDetail) {
+  auto status = MakeBridgeErrorStatus(std::string(kMarker) + "109; throttled by the object store");
+  ASSERT_TRUE(status.IsIOError());
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
+  EXPECT_TRUE(detail->retryable());
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageTransientError);
+}
+
+TEST(BridgeErrorTest, AccessDeniedKeepsItsTypedStorageCode) {
+  auto status = MakeBridgeErrorStatus(std::string(kMarker) + "105; external source rejected credentials");
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageAccessDenied);
+  EXPECT_EQ(FFIErrorCodeFromExtendStatus(status, LOON_ARROW_ERROR), LOON_STORAGE_ACCESS_DENIED);
+}
+
+TEST(BridgeErrorTest, IoFramePreservesPostIoTransportForConfigFailure) {
+  auto pre_io = MakeBridgeErrorStatus(std::string(kMarker) + "115; invalid credential configuration");
+  auto post_io =
+      MakeBridgeErrorStatus(std::string("Io error: ") + kMarker + "115; credential endpoint rejected request");
+
+  EXPECT_TRUE(pre_io.IsInvalid()) << pre_io.ToString();
+  EXPECT_TRUE(post_io.IsIOError()) << post_io.ToString();
+  auto detail = ExtendStatusDetail::UnwrapStatus(post_io);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageConfigInvalid);
+}
+
+TEST(BridgeErrorTest, BridgePrivateCodesMapToArrowStatusCodes) {
+  auto corrupt = MakeBridgeErrorStatus(std::string(kMarker) + "1001; corrupt file");
+  auto corrupt_detail = ExtendStatusDetail::UnwrapStatus(corrupt);
+  ASSERT_NE(corrupt_detail, nullptr);
+  EXPECT_EQ(corrupt_detail->code(), ExtendStatusCode::DataCorrupted);
+  EXPECT_EQ(ToSegcoreError(corrupt).get_error_code(), milvus::DataFormatBroken);
+
+  auto not_supported = MakeBridgeErrorStatus(std::string(kMarker) + "1002; unsupported feature");
+  EXPECT_TRUE(not_supported.IsNotImplemented());
+}
+
+TEST(BridgeErrorTest, UnmarkedMessageStaysConservativeIOError) {
+  auto status = MakeBridgeErrorStatus("some opaque failure");
+  ASSERT_TRUE(status.IsIOError());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  // Untagged -> conservative non-retriable StorageError, never invented
+  // retriability.
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+}
+
+TEST(BridgeErrorTest, UnknownMarkerCodeFallsBackToIOError) {
+  auto status = MakeBridgeErrorStatus(std::string(kMarker) + "424242; from a future version");
+  ASSERT_TRUE(status.IsIOError());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+}
+
+TEST(BridgeErrorTest, TranslatePreservesClassificationAndAddsContext) {
+  auto tagged = MakeBridgeErrorStatus(std::string(kMarker) + "109; throttled");
+  auto translated = TranslateBridgeStatus("reading chunk", tagged);
+  auto detail = ExtendStatusDetail::UnwrapStatus(translated);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
+  EXPECT_NE(translated.message().find("reading chunk"), std::string::npos);
+
+  // A status whose *message* still carries the marker (arrow FFI stream
+  // stringification, the mid-scan case) is decoded too.
+  auto raw = arrow::Status::IOError(std::string(kMarker) + "12; object vanished mid-scan");
+  auto decoded = TranslateBridgeStatus("stream", raw);
+  EXPECT_EQ(arrow::internal::ErrnoFromStatus(decoded), ENOENT);
+  EXPECT_EQ(decoded.message().find("__LOON_"), std::string::npos);
+
+  auto post_io_config =
+      TranslateBridgeStatus("stream", arrow::Status::IOError(std::string(kMarker) + "115; invalid endpoint reply"));
+  EXPECT_TRUE(post_io_config.IsIOError()) << post_io_config.ToString();
+  auto config_detail = ExtendStatusDetail::UnwrapStatus(post_io_config);
+  ASSERT_NE(config_detail, nullptr);
+  EXPECT_EQ(config_detail->code(), ExtendStatusCode::StorageConfigInvalid);
+}
+
+// A failure that did not come from a Rust bridge keeps whatever classification
+// its own producer gave it. Arrow's C-stream importer raises Invalid /
+// NotImplemented on its own, and rewriting those into a blanket IOError would
+// throw away a fact nobody can recover downstream.
+TEST(BridgeErrorTest, TranslateKeepsNonBridgeClassification) {
+  auto invalid = TranslateBridgeStatus("reading chunk", arrow::Status::Invalid("stream schema is not importable"));
+  EXPECT_TRUE(invalid.IsInvalid()) << invalid.ToString();
+  EXPECT_NE(invalid.message().find("reading chunk"), std::string::npos);
+
+  auto not_implemented =
+      TranslateBridgeStatus("reading chunk", arrow::Status::NotImplemented("importing this type is unsupported"));
+  EXPECT_TRUE(not_implemented.IsNotImplemented()) << not_implemented.ToString();
+
+  // Translating twice must be a no-op on the classification, not a slow slide
+  // down to IOError.
+  auto decoded = TranslateBridgeStatus("stream", MakeBridgeErrorStatus(std::string(kMarker) + "1002; unsupported"));
+  EXPECT_TRUE(TranslateBridgeStatus("outer", decoded).IsNotImplemented());
+}
+
+TEST(BridgeErrorTest, DecodeOnlyFiresOnTheMarker) {
+  EXPECT_FALSE(DecodeBridgeErrorStatus("plain arrow failure").has_value());
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string("caller path/") + kMarker + "109").has_value());
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string(kMarker) + "109 missing-semicolon").has_value());
+  auto decoded = DecodeBridgeErrorStatus(std::string(kMarker) + "12; gone");
+  ASSERT_TRUE(decoded.has_value());
+  EXPECT_EQ(arrow::internal::ErrnoFromStatus(*decoded), ENOENT);
+  EXPECT_EQ(StripBridgeErrorMarker(std::string(kMarker) + "12; gone"), "gone");
+
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string("External error: ") + kMarker + "109; throttled").has_value());
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string("Io: ") + kMarker + "109; throttled").has_value());
+
+  auto arrow_io_wrapped = DecodeBridgeErrorStatus(std::string("Io error: ") + kMarker + "104; missing");
+  ASSERT_TRUE(arrow_io_wrapped.has_value());
+  auto detail = ExtendStatusDetail::UnwrapStatus(*arrow_io_wrapped);
+  ASSERT_NE(detail, nullptr);
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound);
+
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string("External error: caller path/") + kMarker + "109").has_value());
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string("Io: caller path/") + kMarker + "109").has_value());
+  EXPECT_FALSE(DecodeBridgeErrorStatus(std::string("Io error: caller path/") + kMarker + "109").has_value());
+}
+
+TEST(BridgeErrorTest, EmbeddedCallerMarkerCannotForgeClassification) {
+  auto status =
+      BridgeErrorStatusFromException((std::string("failed to open s3://bucket/") + kMarker + "109; object").c_str());
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+}
+
+// The marker in the message IS the channel: `BridgeErrorStatusFromException`
+// decodes the code out of `what()` and strips the marker; a `what()` without
+// a marker is the conservative fallback. There is no shared state between
+// calls, so a classification can never attach itself to a later failure --
+// the property the retired thread-local side channel needed an explicit
+// clearing rule to approximate.
+TEST(BridgeErrorTest, MarkerInExceptionTextDrivesClassification) {
+  auto from_message =
+      milvus_storage::bridge::BridgeErrorStatusFromException((std::string(kMarker) + "109; throttled").c_str());
+  auto message_detail = ExtendStatusDetail::UnwrapStatus(from_message);
+  ASSERT_NE(message_detail, nullptr) << from_message.ToString();
+  EXPECT_EQ(message_detail->code(), ExtendStatusCode::StorageTransientThrottling);
+
+  // No marker: the conservative bucket, never an invented classification.
+  auto plain = milvus_storage::bridge::BridgeErrorStatusFromException("plain failure");
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(plain), nullptr) << plain.ToString();
+  EXPECT_TRUE(plain.IsIOError());
+
+  // The verdict lives in the text of ITS error: an unrelated failure cannot
+  // inherit it, and a second classified failure brings its own code.
+  auto second = milvus_storage::bridge::BridgeErrorStatusFromException(
+      (std::string(kMarker) + "105; credentials rejected").c_str());
+  auto second_detail = ExtendStatusDetail::UnwrapStatus(second);
+  ASSERT_NE(second_detail, nullptr) << second.ToString();
+  EXPECT_EQ(second_detail->code(), ExtendStatusCode::StorageAccessDenied);
+  EXPECT_FALSE(second_detail->retryable());
+}
+
+// End-to-end: a real lance open against a nonexistent local dataset must come
+// back as a classified not-found (ENOENT detail -> ObjectNotExist), not as an
+// exception and not as an opaque IOError.
+TEST(LanceBridgeErrorTest, OpenNonexistentDatasetClassifiesNotFound) {
+  auto result = milvus_storage::lance::BlockingDataset::Open("/nonexistent-milvus-storage-test/lance-dataset");
+  ASSERT_FALSE(result.ok());
+  const auto& status = result.status();
+  // Bridges report a missing object through the taxonomy channel, so that a
+  // consumer has one place to look regardless of which bridge answered.
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound) << status.ToString();
+  EXPECT_FALSE(detail->retryable()) << status.ToString();
+  EXPECT_EQ(status.message().find("__LOON_"), std::string::npos) << status.ToString();
+  // Same landing as the errno channel: the split must be invisible downstream.
+  EXPECT_EQ(milvus_storage::ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist) << status.ToString();
+}
+
+}  // namespace
+}  // namespace milvus_storage::bridge

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -46,6 +46,7 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "milvus-storage/common/arrow_util.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/constants.h"
@@ -321,8 +322,8 @@ TEST_F(LanceBasicTest, TestBasic) {
   }
 
   auto verify_reader = [&]() {
-    auto read_dataset = BlockingDataset::Open(lance_uri, storage_options);
-    const std::vector<uint64_t> fragment_ids = read_dataset->GetAllFragmentIds();
+    auto read_dataset = BlockingDataset::Open(lance_uri, storage_options).ValueOrDie();
+    const std::vector<uint64_t> fragment_ids = read_dataset->GetAllFragmentIds().ValueOrDie();
 
     uint64_t total_rows = 0;
     for (const auto& fragment_id : fragment_ids) {
@@ -385,7 +386,7 @@ TEST_F(LanceBasicTest, TestReaderHandlesFragmentMissingNullableDatasetColumn) {
   ASSERT_AND_ASSIGN(auto parsed_uri, ParseLanceUri(appended_file.path));
   ArrowFileSystemConfig fs_config;
   ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
-  auto dataset = BlockingDataset::Open(ToStandardLanceUri(parsed_uri.first), ToStorageOptions(fs_config));
+  auto dataset = BlockingDataset::Open(ToStandardLanceUri(parsed_uri.first), ToStorageOptions(fs_config)).ValueOrDie();
 
   LanceTableReader reader(dataset, parsed_uri.second, nullptr, properties_);
   ASSERT_STATUS_OK(reader.open());
@@ -422,9 +423,9 @@ TEST_F(LanceBasicTest, TestRead) {
   ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
   ASSERT_EQ(cgfile.end_index, large_batch->num_rows());
 
-  auto read_dataset = BlockingDataset::Open(lance_uri, storage_options);
+  auto read_dataset = BlockingDataset::Open(lance_uri, storage_options).ValueOrDie();
 
-  const std::vector<uint64_t> fragment_ids = read_dataset->GetAllFragmentIds();
+  const std::vector<uint64_t> fragment_ids = read_dataset->GetAllFragmentIds().ValueOrDie();
   // The splitting conditions(`WriteParams`) in lance are very strict.
   // So the default setting will only generate one fragment.
   ASSERT_EQ(fragment_ids.size(), 1);
@@ -433,12 +434,24 @@ TEST_F(LanceBasicTest, TestRead) {
   ASSERT_AND_ASSIGN(auto rgs, reader.get_row_group_infos());
   ASSERT_FALSE(rgs.empty());
   ASSERT_EQ(rgs.back().end_offset, large_batch->num_rows());
+
+  auto expect_plain_invalid = [](const arrow::Status& status) {
+    EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  };
+  for (const int bad_index : {-1, static_cast<int>(rgs.size())}) {
+    expect_plain_invalid(reader.get_rg_column_memsz(bad_index).status());
+    expect_plain_invalid(reader.get_chunk(bad_index).status());
+    expect_plain_invalid(reader.get_chunks({bad_index}).status());
+  }
+
   ASSERT_AND_ASSIGN(auto fragment_column_memory_sizes, read_dataset->EstimateFragmentColumnMemory(fragment_ids[0]));
   ASSERT_EQ(fragment_column_memory_sizes.size(), schema_->num_fields());
   auto estimated_memory_size =
       std::accumulate(rgs.begin(), rgs.end(), uint64_t{0},
                       [](uint64_t total, const RowGroupInfo& rg) { return total + rg.memory_size; });
-  ASSERT_EQ(estimated_memory_size, read_dataset->EstimateFragmentMemory(fragment_ids[0]));
+  ASSERT_AND_ASSIGN(auto fragment_memory_size, read_dataset->EstimateFragmentMemory(fragment_ids[0]));
+  ASSERT_EQ(estimated_memory_size, fragment_memory_size);
   ASSERT_EQ(std::accumulate(fragment_column_memory_sizes.begin(), fragment_column_memory_sizes.end(), uint64_t{0}),
             estimated_memory_size);
   for (size_t row_group_index = 0; row_group_index < rgs.size(); ++row_group_index) {
@@ -528,10 +541,10 @@ TEST_F(LanceBasicTest, EstimatedMemoryAccountsForDeletions) {
   ASSERT_STATUS_OK(writer.Write(batch));
   ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
   ASSERT_EQ(cgfile.end_index, kRows);
-  auto dataset = BlockingDataset::Open(lance_uri, storage_options);
-  dataset->DeleteRows("id < 2000");
+  auto dataset = BlockingDataset::Open(lance_uri, storage_options).ValueOrDie();
+  ASSERT_STATUS_OK(dataset->DeleteRows("id < 2000"));
 
-  auto fragment_ids = dataset->GetAllFragmentIds();
+  auto fragment_ids = dataset->GetAllFragmentIds().ValueOrDie();
   ASSERT_EQ(fragment_ids.size(), 1);
   LanceTableReader reader(dataset, fragment_ids[0], id_schema, properties_);
   ASSERT_STATUS_OK(reader.open());
@@ -625,7 +638,7 @@ TEST_F(LanceBasicTest, MemorySizeEstimationFailureDoesNotBlockOpen) {
 }
 #endif
 
-TEST_F(LanceBasicTest, LegacyFormatReadsWhenMemoryEstimateIsUnavailable) {
+TEST_F(LanceBasicTest, LegacyFormatMemoryEstimateFailureIsNotReclassified) {
   if (IsCloudEnv()) {
     GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
   }
@@ -644,26 +657,22 @@ TEST_F(LanceBasicTest, LegacyFormatReadsWhenMemoryEstimateIsUnavailable) {
   ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
   ASSERT_EQ(cgfile.end_index, kRows);
 
-  auto dataset = BlockingDataset::Open(lance_uri, storage_options);
-  auto fragment_ids = dataset->GetAllFragmentIds();
+  auto dataset = BlockingDataset::Open(lance_uri, storage_options).ValueOrDie();
+  auto fragment_ids = dataset->GetAllFragmentIds().ValueOrDie();
   ASSERT_EQ(fragment_ids.size(), 1);
 
   auto estimate_result = dataset->EstimateFragmentColumnMemory(fragment_ids[0]);
-  ASSERT_TRUE(estimate_result.status().IsNotImplemented()) << estimate_result.status().ToString();
+  ASSERT_FALSE(estimate_result.ok());
+  EXPECT_TRUE(estimate_result.status().IsIOError()) << estimate_result.status().ToString();
+  EXPECT_FALSE(estimate_result.status().IsNotImplemented());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(estimate_result.status()), nullptr);
 
   LanceTableReader reader(dataset, fragment_ids[0], vector_schema, properties_);
-  ASSERT_STATUS_OK(reader.open());
-  ASSERT_AND_ASSIGN(auto row_group_infos, reader.get_row_group_infos());
-  ASSERT_FALSE(row_group_infos.empty());
-  for (size_t row_group_index = 0; row_group_index < row_group_infos.size(); ++row_group_index) {
-    EXPECT_FALSE(row_group_infos[row_group_index].memory_size_available);
-    EXPECT_EQ(row_group_infos[row_group_index].memory_size, 0);
-    EXPECT_TRUE(reader.get_rg_column_memsz(row_group_index).status().IsNotImplemented());
-  }
-
-  ASSERT_AND_ASSIGN(auto rb_reader, reader.read_with_range(0, kRows));
-  ASSERT_AND_ASSIGN(auto table, arrow::Table::FromRecordBatchReader(rb_reader.get()));
-  ASSERT_EQ(table->num_rows(), kRows);
+  auto open_status = reader.open();
+  ASSERT_FALSE(open_status.ok());
+  EXPECT_TRUE(open_status.IsIOError()) << open_status.ToString();
+  EXPECT_FALSE(open_status.IsNotImplemented());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(open_status), nullptr);
 
   auto column_group = std::make_shared<api::ColumnGroup>();
   column_group->columns = {"vector"};
@@ -674,15 +683,11 @@ TEST_F(LanceBasicTest, LegacyFormatReadsWhenMemoryEstimateIsUnavailable) {
 
   auto api_reader = api::Reader::create(column_groups, vector_schema, nullptr, properties_);
   ASSERT_NE(api_reader, nullptr);
-  ASSERT_AND_ASSIGN(auto chunk_reader, api_reader->get_chunk_reader(0));
-  EXPECT_TRUE(chunk_reader->get_chunk_estimated_size().status().IsNotImplemented());
-  EXPECT_TRUE(chunk_reader->get_chunk_column_estimated_size().status().IsNotImplemented());
-  ASSERT_AND_ASSIGN(auto chunk, chunk_reader->get_chunk(0));
-  ASSERT_GT(chunk->num_rows(), 0);
-
-  ASSERT_AND_ASSIGN(auto packed_reader, api_reader->get_record_batch_reader());
-  ASSERT_AND_ASSIGN(auto packed_table, packed_reader->ToTable());
-  ASSERT_EQ(packed_table->num_rows(), kRows);
+  auto chunk_reader_result = api_reader->get_chunk_reader(0);
+  ASSERT_FALSE(chunk_reader_result.ok());
+  EXPECT_TRUE(chunk_reader_result.status().IsIOError()) << chunk_reader_result.status().ToString();
+  EXPECT_FALSE(chunk_reader_result.status().IsNotImplemented());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(chunk_reader_result.status()), nullptr);
 }
 
 TEST_F(LanceBasicTest, TestCachedOpenRejectsMissingNeededColumnWithoutReadSchema) {
@@ -812,10 +817,10 @@ void LanceBasicTest::RunCloudWideTableDuplicatedFragmentTake(int64_t column_coun
   // The shared scheduler retains the ObjectStore from its first dataset, so keep
   // that owner alive while later Reader datasets generate the measured I/O.
   std::shared_ptr<BlockingDataset> io_stats_owner_dataset;
-  ASSERT_NO_THROW(io_stats_owner_dataset = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config)));
+  ASSERT_AND_ASSIGN(io_stats_owner_dataset, BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config)));
   ASSERT_NE(io_stats_owner_dataset, nullptr);
   std::shared_ptr<BlockingDataset> non_owner_dataset;
-  ASSERT_NO_THROW(non_owner_dataset = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config)));
+  ASSERT_AND_ASSIGN(non_owner_dataset, BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config)));
   ASSERT_NE(non_owner_dataset, nullptr);
   ASSERT_NE(io_stats_owner_dataset.get(), non_owner_dataset.get());
 

--- a/cpp/test/format/paimon/paimon_integration_test.cpp
+++ b/cpp/test/format/paimon/paimon_integration_test.cpp
@@ -26,6 +26,7 @@
 #include <parquet/arrow/writer.h>
 
 #include "milvus-storage/common/config.h"
+#include "bridge_error.h"
 #include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/column_group_reader.h"
@@ -40,6 +41,18 @@
 
 namespace milvus_storage::test {
 namespace {
+
+// What matters about "these persisted bytes do not decode" is the
+// classification the caller branches on, not the arrow StatusCode that happens
+// to carry it -- the code is a second axis (what kind of operation failed) and
+// pinning it made these tests fail when the construction was unified.
+void ExpectDataFormat(const arrow::Status& status) {
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::DataCorrupted) << status.ToString();
+  EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::DataFormat);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::DataFormatBroken) << status.ToString();
+}
 
 class PaimonIntegrationTest : public ::testing::Test {
   protected:
@@ -379,7 +392,7 @@ TEST_F(PaimonIntegrationTest, MalformedMetadataTypesFailClosed) {
   files.front().Set(api::kPropertyMetadata, folly::toJson(descriptor));
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
-  EXPECT_TRUE(reader.status().IsInvalid());
+  ExpectDataFormat(reader.status());
   EXPECT_NE(reader.status().ToString().find("field types"), std::string::npos);
 }
 
@@ -393,7 +406,7 @@ TEST_F(PaimonIntegrationTest, MalformedDeletionMetadataTypesFailClosed) {
   files.front().Set(api::kPropertyMetadata, folly::toJson(descriptor));
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
-  EXPECT_TRUE(reader.status().IsInvalid());
+  ExpectDataFormat(reader.status());
   EXPECT_NE(reader.status().ToString().find("deletion_file has invalid field types"), std::string::npos);
 }
 
@@ -477,10 +490,13 @@ TEST_F(PaimonIntegrationTest, AutoUsesDirectFileAndAppliesDeletionVector) {
   tampered.Set(api::kPropertyMetadata, folly::toJson(descriptor));
   auto invalid = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, tampered, properties_, {"id"}, nullptr);
   ASSERT_FALSE(invalid.ok());
-  EXPECT_TRUE(invalid.status().IsInvalid()) << invalid.status().ToString();
+  // The descriptor and the deletion-vector file disagree about cardinality:
+  // persisted bytes that cannot be used together, so the verdict is
+  // DataCorrupted, not a conservative IOError.
+  ExpectDataFormat(invalid.status());
 }
 
-TEST_F(PaimonIntegrationTest, CorruptDeletionVectorCrcFailsAsInvalid) {
+TEST_F(PaimonIntegrationTest, CorruptDeletionVectorCrcFailsAsDataCorrupt) {
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "deletion-vector", {1, 5, 9}).status());
   ASSERT_AND_ASSIGN(auto files, Explore("auto"));
   ASSERT_EQ(files.size(), 1);
@@ -504,7 +520,10 @@ TEST_F(PaimonIntegrationTest, CorruptDeletionVectorCrcFailsAsInvalid) {
 
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
-  EXPECT_TRUE(reader.status().IsInvalid()) << reader.status().ToString();
+  // Flipping a bit in the persisted deletion-vector bytes fails the CRC
+  // check: corrupted storage content, so the verdict is DataCorrupted, not a
+  // conservative IOError.
+  ExpectDataFormat(reader.status());
   EXPECT_NE(reader.status().ToString().find("CRC mismatch"), std::string::npos);
 }
 
@@ -520,7 +539,12 @@ TEST_F(PaimonIntegrationTest, MissingDeletionVectorFileRemainsIOError) {
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
   EXPECT_TRUE(reader.status().IsIOError()) << reader.status().ToString();
-  EXPECT_EQ(arrow::internal::ErrnoFromStatus(reader.status()), ENOENT);
+  // A bridge reports a missing object through the taxonomy channel, not errno.
+  // Same landing either way -- that equivalence is pinned in the taxonomy test.
+  auto detail = ExtendStatusDetail::UnwrapStatus(reader.status());
+  ASSERT_NE(detail, nullptr) << reader.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound);
+  EXPECT_EQ(ToSegcoreError(reader.status()).get_error_code(), milvus::ObjectNotExist);
 }
 
 TEST_F(PaimonIntegrationTest, DirectFileFragmentRangeUsesPostDeletionLogicalRows) {
@@ -824,7 +848,7 @@ TEST_F(PaimonIntegrationTest, AsyncDataSplitChunksSpanSourceBatches) {
   }
 }
 
-TEST_F(PaimonIntegrationTest, MalformedDataSplitDescriptorFailsAsInvalid) {
+TEST_F(PaimonIntegrationTest, MalformedDataSplitDescriptorFailsAsDataCorrupted) {
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "append").status());
   ASSERT_AND_ASSIGN(auto files, Explore("auto"));
   ASSERT_EQ(files.size(), 1);
@@ -834,10 +858,25 @@ TEST_F(PaimonIntegrationTest, MalformedDataSplitDescriptorFailsAsInvalid) {
   files.front().Set(api::kPropertyMetadata, folly::toJson(descriptor));
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
-  EXPECT_TRUE(reader.status().IsInvalid()) << reader.status().ToString();
+  ExpectDataFormat(reader.status());
 }
 
-TEST_F(PaimonIntegrationTest, ZeroRowDataSplitDescriptorFailsAsInvalid) {
+TEST_F(PaimonIntegrationTest, MissingAndOversizedMetadataAreDataCorrupted) {
+  api::ColumnGroupFile missing{.path = table_dir_ + "/missing-metadata"};
+  auto missing_result =
+      paimon::PaimonFormatReader::MetaTrait::load_metadata(missing, properties_, /*key_retriever=*/nullptr);
+  ASSERT_FALSE(missing_result.ok());
+  ExpectDataFormat(missing_result.status());
+
+  api::ColumnGroupFile oversized{.path = table_dir_ + "/oversized-metadata"};
+  oversized.Set(api::kPropertyMetadata, std::string(12 * 1024 * 1024 + 1, 'x'));
+  auto oversized_result =
+      paimon::PaimonFormatReader::MetaTrait::load_metadata(oversized, properties_, /*key_retriever=*/nullptr);
+  ASSERT_FALSE(oversized_result.ok());
+  ExpectDataFormat(oversized_result.status());
+}
+
+TEST_F(PaimonIntegrationTest, ZeroRowDataSplitDescriptorFailsAsDataCorrupted) {
   ASSERT_STATUS_OK(paimon::CreateTestTable(table_dir_, 10, "append").status());
   ASSERT_AND_ASSIGN(auto files, Explore("data-split"));
   ASSERT_EQ(files.size(), 1);
@@ -847,7 +886,9 @@ TEST_F(PaimonIntegrationTest, ZeroRowDataSplitDescriptorFailsAsInvalid) {
   files.front().Set(api::kPropertyMetadata, folly::toJson(descriptor));
   auto reader = FormatReader::create(nullptr, LOON_FORMAT_PAIMON_TABLE, files.front(), properties_, {"id"}, nullptr);
   ASSERT_FALSE(reader.ok());
-  EXPECT_TRUE(reader.status().IsInvalid()) << reader.status().ToString();
+  // The descriptor is persisted metadata, so a contradiction in it is a
+  // data-format verdict -- same as the negative record_count check next to it.
+  ExpectDataFormat(reader.status());
   EXPECT_NE(reader.status().ToString().find("zero record_count"), std::string::npos);
 }
 
@@ -896,43 +937,58 @@ TEST_F(PaimonIntegrationTest, MissingTableFailsAndWriterIsReadOnly) {
 }
 
 TEST(PaimonBridgeErrorClassification, MarkersMapToArrowStatuses) {
-  EXPECT_TRUE(paimon::MakePaimonBridgeErrorStatus("[paimon:error=invalid] invalid metadata").IsInvalid());
-  EXPECT_TRUE(paimon::MakePaimonBridgeErrorStatus("[paimon:error=not-implemented] direct-file does not support orc")
+  auto config_invalid =
+      milvus_storage::bridge::MakeBridgeErrorStatus("__LOON_RUST_BRIDGE_ERRCODE__=115; invalid metadata");
+  EXPECT_TRUE(config_invalid.IsInvalid());
+  auto config_detail = ExtendStatusDetail::UnwrapStatus(config_invalid);
+  ASSERT_NE(config_detail, nullptr) << config_invalid.ToString();
+  EXPECT_EQ(config_detail->code(), ExtendStatusCode::StorageConfigInvalid);
+  EXPECT_TRUE(milvus_storage::bridge::MakeBridgeErrorStatus(
+                  "__LOON_RUST_BRIDGE_ERRCODE__=1002; direct-file does not support orc")
                   .IsNotImplemented());
 
-  auto not_found = paimon::MakePaimonBridgeErrorStatus("[paimon:error=not-found] missing object");
+  auto not_found = milvus_storage::bridge::MakeBridgeErrorStatus("__LOON_RUST_BRIDGE_ERRCODE__=104; missing object");
   EXPECT_TRUE(not_found.IsIOError());
-  EXPECT_EQ(arrow::internal::ErrnoFromStatus(not_found), ENOENT);
+  auto not_found_detail = ExtendStatusDetail::UnwrapStatus(not_found);
+  ASSERT_NE(not_found_detail, nullptr) << not_found.ToString();
+  EXPECT_EQ(not_found_detail->code(), ExtendStatusCode::StorageNotFound);
+  EXPECT_EQ(ToSegcoreError(not_found).get_error_code(), milvus::ObjectNotExist);
 
-  auto transient = paimon::MakePaimonBridgeErrorStatus("[paimon:error=transient-throttling] object store rate limit");
+  auto transient =
+      milvus_storage::bridge::MakeBridgeErrorStatus("__LOON_RUST_BRIDGE_ERRCODE__=109; object store rate limit");
   auto detail = ExtendStatusDetail::UnwrapStatus(transient);
   ASSERT_NE(detail, nullptr);
   EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
 
-  transient = paimon::MakePaimonBridgeErrorStatus("[paimon:error=transient-service] object store unavailable");
+  transient =
+      milvus_storage::bridge::MakeBridgeErrorStatus("__LOON_RUST_BRIDGE_ERRCODE__=110; object store unavailable");
   detail = ExtendStatusDetail::UnwrapStatus(transient);
   ASSERT_NE(detail, nullptr);
   EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientService);
 
-  EXPECT_TRUE(paimon::MakePaimonBridgeErrorStatus("unclassified storage failure").IsIOError());
+  EXPECT_TRUE(milvus_storage::bridge::MakeBridgeErrorStatus("unclassified storage failure").IsIOError());
 }
 
 TEST(PaimonBridgeErrorClassification, StreamReaderTranslatesReadNextNotFound) {
-  auto inner =
-      std::make_shared<FailingRecordBatchReader>(arrow::Status::IOError("[paimon:error=not-found] missing object"));
+  auto inner = std::make_shared<FailingRecordBatchReader>(
+      arrow::Status::IOError("__LOON_RUST_BRIDGE_ERRCODE__=104; missing object"));
   auto reader = paimon::internal::WrapPaimonRecordBatchReader(std::move(inner), arrow::schema({}));
 
   std::shared_ptr<arrow::RecordBatch> batch;
   auto status = reader->ReadNext(&batch);
 
   EXPECT_TRUE(status.IsIOError()) << status.ToString();
-  EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
-  EXPECT_EQ(status.ToString().find("[paimon:error="), std::string::npos);
+  // A bridge reports a missing object through the taxonomy channel, not errno.
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist) << status.ToString();
+  EXPECT_EQ(status.ToString().find("__LOON_RUST_BRIDGE_ERRCODE__="), std::string::npos);
 }
 
 TEST(PaimonBridgeErrorClassification, StreamReaderTranslatesReadNextThrottling) {
   auto inner = std::make_shared<FailingRecordBatchReader>(
-      arrow::Status::IOError("[paimon:error=transient-throttling] object store rate limit"));
+      arrow::Status::IOError("__LOON_RUST_BRIDGE_ERRCODE__=109; object store rate limit"));
   auto reader = paimon::internal::WrapPaimonRecordBatchReader(std::move(inner), arrow::schema({}));
 
   std::shared_ptr<arrow::RecordBatch> batch;
@@ -942,7 +998,7 @@ TEST(PaimonBridgeErrorClassification, StreamReaderTranslatesReadNextThrottling) 
   ASSERT_NE(detail, nullptr) << status.ToString();
   EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientThrottling);
   EXPECT_TRUE(detail->retryable());
-  EXPECT_EQ(status.ToString().find("[paimon:error="), std::string::npos);
+  EXPECT_EQ(status.ToString().find("__LOON_RUST_BRIDGE_ERRCODE__="), std::string::npos);
 }
 
 TEST_F(PaimonIntegrationTest, DataSplitMissingObjectPreservesErrno) {
@@ -979,18 +1035,27 @@ TEST_F(PaimonIntegrationTest, DataSplitMissingObjectPreservesErrno) {
 
   ASSERT_FALSE(status.ok());
   EXPECT_TRUE(status.IsIOError()) << status.ToString();
-  EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
-  EXPECT_EQ(status.ToString().find("[paimon:error="), std::string::npos);
+  // Same as the direct-file path: the missing object arrives through the
+  // taxonomy channel, and both landings agree on milvus::ObjectNotExist.
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound) << status.ToString();
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::ObjectNotExist) << status.ToString();
+  EXPECT_EQ(status.ToString().find("__LOON_RUST_BRIDGE_ERRCODE__="), std::string::npos);
 }
 
-TEST_F(PaimonIntegrationTest, MissingPinnedSnapshotFailsPlanAsInvalidWithRefresh) {
+TEST_F(PaimonIntegrationTest, MissingPinnedSnapshotFailsPlanAsNotFoundWithRefresh) {
   ASSERT_AND_ASSIGN(auto snapshot_id, paimon::CreateTestTable(table_dir_, 10, "append"));
   ASSERT_EQ(api::SetValue(properties_, PROPERTY_PAIMON_SNAPSHOT_ID, std::to_string(snapshot_id + 1000).c_str()),
             std::nullopt);
 
   auto files = Explore("auto");
   ASSERT_FALSE(files.ok());
-  EXPECT_TRUE(files.status().IsInvalid()) << files.status().ToString();
+  // Paimon itself reports the snapshot as NotFound; the bridge follows that
+  // classification instead of re-tagging it as an invalid configuration.
+  auto detail = ExtendStatusDetail::UnwrapStatus(files.status());
+  ASSERT_NE(detail, nullptr) << files.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageNotFound) << files.status().ToString();
   const auto message = files.status().ToString();
   EXPECT_NE(message.find("required metadata"), std::string::npos) << message;
   EXPECT_NE(message.find("was not found"), std::string::npos) << message;

--- a/cpp/test/format/parquet/folly_arrow_executor_test.cpp
+++ b/cpp/test/format/parquet/folly_arrow_executor_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <functional>
+#include <new>
 #include <string>
 #include <thread>
 
@@ -30,6 +31,11 @@ namespace milvus_storage::parquet::test {
 namespace {
 
 size_t CurrentThreadId() { return std::hash<std::thread::id>{}(std::this_thread::get_id()); }
+
+class BadAllocExecutor final : public folly::Executor {
+  public:
+  void add(folly::Func) override { throw std::bad_alloc(); }
+};
 
 TEST(FollyArrowExecutorTest, RoutesSubmittedTaskToFollyExecutor) {
   folly::CPUThreadPoolExecutor folly_executor(1);
@@ -110,6 +116,16 @@ TEST(FollyArrowExecutorTest, RejectsInlineLikeExecutors) {
 
   expect_rejected(folly::InlineExecutor::instance());
   expect_rejected(folly::QueuedImmediateExecutor::instance());
+}
+
+TEST(FollyArrowExecutorTest, SubmissionAllocationFailureIsReported) {
+  BadAllocExecutor folly_executor;
+  auto arrow_executor = MakeFollyArrowExecutor(folly::getKeepAliveToken(folly_executor), 1);
+
+  auto maybe_future = arrow_executor.ValueOrDie()->Submit([] { return 42; });
+
+  ASSERT_FALSE(maybe_future.ok());
+  EXPECT_TRUE(maybe_future.status().IsUnknownError()) << maybe_future.status().ToString();
 }
 
 }  // namespace

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -21,6 +21,7 @@
 #include <future>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -29,6 +30,7 @@
 #include <arrow/array.h>
 #include <arrow/array/array_dict.h>
 #include <arrow/array/concatenate.h>
+#include <arrow/c/bridge.h>
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/record_batch.h>
 #include <arrow/table.h>
@@ -38,11 +40,13 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/ffi_internal/result.h"
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 #include "milvus-storage/format/vortex/vortex_writer.h"
+#include "bridge_error.h"
 #include "test_env.h"
 #include "vortex_bridge.h"
 
@@ -136,15 +140,24 @@ INSTANTIATE_TEST_SUITE_P(V1V2,
 namespace {
 
 constexpr int kDictionaryValueGroup = 3;
+constexpr const char* kMarker = "__LOON_RUST_BRIDGE_ERRCODE__=";
 
 class FailingRecordBatchReader : public arrow::RecordBatchReader {
   public:
-  explicit FailingRecordBatchReader(arrow::Status status) : status_(std::move(status)) {}
+  explicit FailingRecordBatchReader(arrow::Status status,
+                                    std::optional<int> typed_code = std::nullopt,
+                                    std::string typed_message = {})
+      : status_(std::move(status)), typed_code_(typed_code), typed_message_(std::move(typed_message)) {}
 
   std::shared_ptr<arrow::Schema> schema() const override { return arrow::schema({}); }
 
   arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
     *batch = nullptr;
+    if (typed_code_.has_value()) {
+      // Mid-scan errors arrive as text through the Arrow C ABI; the Rust side
+      // embeds the universal transport marker in that text. Simulate it.
+      return arrow::Status::IOError(fmt::format("{}{}; {}", kMarker, *typed_code_, typed_message_));
+    }
     return status_;
   }
 
@@ -152,15 +165,53 @@ class FailingRecordBatchReader : public arrow::RecordBatchReader {
 
   private:
   arrow::Status status_;
+  std::optional<int> typed_code_;
+  std::string typed_message_;
 };
+
+struct FailingArrowArrayStreamState {
+  std::string message;
+
+  static int GetSchema(ArrowArrayStream*, ArrowSchema* out) {
+    auto status = arrow::ExportSchema(*arrow::schema({}), out);
+    return status.ok() ? 0 : EINVAL;
+  }
+
+  static int GetNext(ArrowArrayStream*, ArrowArray* out) {
+    std::memset(out, 0, sizeof(*out));
+    return EIO;
+  }
+
+  static const char* GetLastError(ArrowArrayStream* stream) {
+    return static_cast<FailingArrowArrayStreamState*>(stream->private_data)->message.c_str();
+  }
+
+  static void Release(ArrowArrayStream* stream) {
+    delete static_cast<FailingArrowArrayStreamState*>(stream->private_data);
+    stream->release = nullptr;
+    stream->private_data = nullptr;
+  }
+};
+
+ArrowArrayStream MakeFailingRustArrowStream(int code, std::string message) {
+  ArrowArrayStream stream{};
+  stream.get_schema = &FailingArrowArrayStreamState::GetSchema;
+  stream.get_next = &FailingArrowArrayStreamState::GetNext;
+  stream.get_last_error = &FailingArrowArrayStreamState::GetLastError;
+  stream.release = &FailingArrowArrayStreamState::Release;
+  stream.private_data =
+      new FailingArrowArrayStreamState{fmt::format("Io error: {}{}; {}", kMarker, code, std::move(message))};
+  return stream;
+}
 
 struct AsyncScanTestContext {
   ArrowArrayStream stream{};
   std::promise<std::string> completion;
+  std::promise<int> error_code;
   std::shared_ptr<FileSystemWrapper> fs_holder;
 };
 
-void AsyncScanTestCallback(void* raw_ctx, ArrowArrayStream* out_stream, const char* error_msg) {
+void AsyncScanTestCallback(void* raw_ctx, ArrowArrayStream* out_stream, int error_code, const char* error_msg) {
   std::unique_ptr<AsyncScanTestContext> ctx(static_cast<AsyncScanTestContext*>(raw_ctx));
 
   std::string error;
@@ -172,11 +223,34 @@ void AsyncScanTestCallback(void* raw_ctx, ArrowArrayStream* out_stream, const ch
     out_stream->release(out_stream);
   }
   ctx->completion.set_value(std::move(error));
+  ctx->error_code.set_value(error_code);
 }
 
-TEST(VortexErrorTest, StreamingReaderTranslatesReadNextBridgeError) {
+// Only the producer-owned prefix is framing. Marker text later in an ordinary
+// error can come from a caller-controlled URI/path and must stay inert.
+TEST(VortexErrorTest, EmbeddedMarkerTextInStreamErrorDoesNotDriveClassification) {
   auto inner = std::make_shared<FailingRecordBatchReader>(
-      arrow::Status::IOError(fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; readat failed", LOON_TRANSIENT_NETWORK)));
+      arrow::Status::IOError(fmt::format("field {}{} is invalid", kMarker, LOON_TRANSIENT_NETWORK)));
+  auto reader = vortex::internal::WrapVortexRecordBatchReader(std::move(inner));
+
+  std::shared_ptr<arrow::RecordBatch> batch;
+  auto status = reader->ReadNext(&batch);
+
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+
+  // No marker: arrow's own classification survives the translation.
+  auto plain = std::make_shared<FailingRecordBatchReader>(arrow::Status::Invalid("stream schema is not importable"));
+  auto plain_reader = vortex::internal::WrapVortexRecordBatchReader(std::move(plain));
+  auto plain_status = plain_reader->ReadNext(&batch);
+  EXPECT_TRUE(plain_status.IsInvalid()) << plain_status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(plain_status), nullptr);
+}
+
+TEST(VortexErrorTest, StreamingReaderDecodesMarkerFromStreamError) {
+  auto inner =
+      std::make_shared<FailingRecordBatchReader>(arrow::Status::Invalid("Arrow C stream flattened the error"),
+                                                 LOON_TRANSIENT_NETWORK, "Failed to read object: connection reset");
   auto reader = vortex::internal::WrapVortexRecordBatchReader(std::move(inner));
 
   std::shared_ptr<arrow::RecordBatch> batch;
@@ -185,84 +259,86 @@ TEST(VortexErrorTest, StreamingReaderTranslatesReadNextBridgeError) {
   auto detail = ExtendStatusDetail::UnwrapStatus(status);
   ASSERT_NE(detail, nullptr) << status.ToString();
   EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientNetwork);
-  EXPECT_TRUE(detail->retryable());
-  EXPECT_EQ(status.ToString().find("__LOON_VORTEX_FFI_ERRCODE__"), std::string::npos);
+  EXPECT_NE(status.ToString().find("connection reset"), std::string::npos);
+  EXPECT_EQ(status.ToString().find("__LOON_"), std::string::npos) << status.ToString();
+
+  auto config_inner =
+      std::make_shared<FailingRecordBatchReader>(arrow::Status::Invalid("Arrow C stream flattened the error"),
+                                                 LOON_STORAGE_CONFIG_INVALID, "credential endpoint rejected request");
+  auto config_reader = vortex::internal::WrapVortexRecordBatchReader(std::move(config_inner));
+  auto config_status = config_reader->ReadNext(&batch);
+  EXPECT_TRUE(config_status.IsIOError()) << config_status.ToString();
+  auto config_detail = ExtendStatusDetail::UnwrapStatus(config_status);
+  ASSERT_NE(config_detail, nullptr) << config_status.ToString();
+  EXPECT_EQ(config_detail->code(), ExtendStatusCode::StorageConfigInvalid);
 }
 
-TEST(VortexErrorTest, StreamingReaderTranslatesReadNextFileNotFound) {
-  auto inner = std::make_shared<FailingRecordBatchReader>(
-      arrow::Status::IOError(fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; file not found", LOON_FILE_NOT_FOUND)));
-  auto reader = vortex::internal::WrapVortexRecordBatchReader(std::move(inner));
+TEST(VortexErrorTest, RawRustStreamKeepsClassificationUntilFinalImport) {
+  {
+    auto stream = MakeFailingRustArrowStream(LOON_TRANSIENT_NETWORK, "connection reset");
+    auto result = milvus_storage::bridge::ImportBridgeChunkedArray(&stream, "reading Vortex data");
+    ASSERT_FALSE(result.ok());
+    auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+    ASSERT_NE(detail, nullptr) << result.status().ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientNetwork);
+    EXPECT_TRUE(detail->retryable());
+  }
 
-  std::shared_ptr<arrow::RecordBatch> batch;
-  auto status = reader->ReadNext(&batch);
-
-  EXPECT_TRUE(status.IsIOError());
-  EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
-  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
-  EXPECT_EQ(status.ToString().find("__LOON_VORTEX_FFI_ERRCODE__"), std::string::npos);
-}
-
-TEST(VortexErrorTest, StreamingReaderTranslatesCloseBridgeError) {
-  auto inner = std::make_shared<FailingRecordBatchReader>(
-      arrow::Status::IOError(fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; close failed", LOON_TRANSIENT_TIMEOUT)));
-  auto reader = vortex::internal::WrapVortexRecordBatchReader(std::move(inner));
-
-  auto status = reader->Close();
-
-  auto detail = ExtendStatusDetail::UnwrapStatus(status);
-  ASSERT_NE(detail, nullptr) << status.ToString();
-  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientTimeout);
-  EXPECT_TRUE(detail->retryable());
-  EXPECT_EQ(status.ToString().find("__LOON_VORTEX_FFI_ERRCODE__"), std::string::npos);
+  {
+    auto stream = MakeFailingRustArrowStream(LOON_VORTEX_DATA_FORMAT, "invalid encoded page");
+    ASSERT_AND_ASSIGN(auto reader, arrow::ImportRecordBatchReader(&stream));
+    auto translating_reader = vortex::internal::WrapVortexRecordBatchReader(std::move(reader));
+    std::shared_ptr<arrow::RecordBatch> batch;
+    auto status = translating_reader->ReadNext(&batch);
+    ASSERT_FALSE(status.ok());
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::VortexDataFormat);
+    EXPECT_FALSE(detail->retryable());
+  }
 }
 
 TEST(VortexErrorTest, MapsBridgeErrorCodesToStatusDetails) {
-  auto file_not_found_status = MakeVortexErrorStatus(
-      "Failed to read vortex file", fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; file not found", LOON_FILE_NOT_FOUND));
+  auto file_not_found_status =
+      MakeVortexErrorStatus("Failed to read vortex file", LOON_FILE_NOT_FOUND, "file not found");
   EXPECT_TRUE(file_not_found_status.IsIOError());
   EXPECT_EQ(arrow::internal::ErrnoFromStatus(file_not_found_status), ENOENT);
   EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(file_not_found_status), nullptr);
-  EXPECT_EQ(file_not_found_status.ToString().find("__LOON_VORTEX_FFI_ERRCODE__"), std::string::npos);
 
   auto aws_not_found_status =
-      MakeVortexErrorStatus("Failed to read vortex file",
-                            fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; object not found", LOON_AWS_ERROR_NOT_FOUND));
+      MakeVortexErrorStatus("Failed to read vortex file", LOON_STORAGE_NOT_FOUND, "object not found");
   auto aws_not_found_detail = ExtendStatusDetail::UnwrapStatus(aws_not_found_status);
   ASSERT_NE(aws_not_found_detail, nullptr);
-  EXPECT_EQ(aws_not_found_detail->code(), ExtendStatusCode::AwsErrorNotFound);
+  EXPECT_EQ(aws_not_found_detail->code(), ExtendStatusCode::StorageNotFound);
   EXPECT_FALSE(aws_not_found_detail->retryable());
 
-  auto timeout_status = MakeVortexErrorStatus(
-      "Failed to read vortex file", fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; read failed", LOON_TRANSIENT_TIMEOUT));
+  auto timeout_status = MakeVortexErrorStatus("Failed to read vortex file", LOON_TRANSIENT_TIMEOUT, "read failed");
   auto timeout_detail = ExtendStatusDetail::UnwrapStatus(timeout_status);
   ASSERT_NE(timeout_detail, nullptr);
   EXPECT_EQ(timeout_detail->code(), ExtendStatusCode::StorageTransientTimeout);
   EXPECT_TRUE(timeout_detail->retryable());
   EXPECT_NE(timeout_status.ToString().find("Failed to read vortex file: read failed"), std::string::npos);
 
-  auto upload_status =
-      MakeVortexErrorStatus("Failed to close Vortex file",
-                            fmt::format("outer __LOON_VORTEX_FFI_ERRCODE__={}; Failed to close ObjectStoreWriterCpp",
-                                        LOON_AWS_ERROR_NO_SUCH_UPLOAD));
+  auto upload_status = MakeVortexErrorStatus("Failed to close Vortex file", LOON_STORAGE_NO_SUCH_UPLOAD,
+                                             "Failed to close ObjectStoreWriterCpp");
   auto upload_detail = ExtendStatusDetail::UnwrapStatus(upload_status);
   ASSERT_NE(upload_detail, nullptr);
-  EXPECT_EQ(upload_detail->code(), ExtendStatusCode::AwsErrorNoSuchUpload);
+  EXPECT_EQ(upload_detail->code(), ExtendStatusCode::StorageNoSuchUpload);
+  // Retry recreates the failed writer and upload; it never reuses the dead id.
   EXPECT_TRUE(upload_detail->retryable());
-  EXPECT_EQ(upload_status.ToString().find("__LOON_VORTEX_FFI_ERRCODE__"), std::string::npos);
-
-  auto network_status = MakeVortexErrorStatus(
-      "Failed to import vortex chunked array",
-      arrow::Status::IOError(fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; readat failed", LOON_TRANSIENT_NETWORK)));
+  auto network_status =
+      MakeVortexErrorStatus("Failed to import vortex chunked array", LOON_TRANSIENT_NETWORK, "readat failed");
   auto network_detail = ExtendStatusDetail::UnwrapStatus(network_status);
   ASSERT_NE(network_detail, nullptr);
   EXPECT_EQ(network_detail->code(), ExtendStatusCode::StorageTransientNetwork);
   EXPECT_TRUE(network_detail->retryable());
-  EXPECT_EQ(network_status.ToString().find("__LOON_VORTEX_FFI_ERRCODE__"), std::string::npos);
-
-  auto txn_status =
-      MakeVortexErrorStatus("Failed to write Vortex file",
-                            fmt::format("__LOON_VORTEX_FFI_ERRCODE__={}; commit failed", LOON_TXN_EXHAUSTED_RETRY));
+  auto config_status = MakeVortexErrorStatus("Failed to read Vortex file", LOON_STORAGE_CONFIG_INVALID,
+                                             "credential endpoint rejected request");
+  EXPECT_TRUE(config_status.IsIOError()) << config_status.ToString();
+  auto config_detail = ExtendStatusDetail::UnwrapStatus(config_status);
+  ASSERT_NE(config_detail, nullptr);
+  EXPECT_EQ(config_detail->code(), ExtendStatusCode::StorageConfigInvalid);
+  auto txn_status = MakeVortexErrorStatus("Failed to write Vortex file", LOON_TXN_EXHAUSTED_RETRY, "commit failed");
   auto txn_detail = ExtendStatusDetail::UnwrapStatus(txn_status);
   ASSERT_NE(txn_detail, nullptr);
   EXPECT_EQ(txn_detail->code(), ExtendStatusCode::TxnExhaustedRetry);
@@ -675,19 +751,20 @@ TEST_P(VortexBasicTest, S3FlushFailureCloseReturnsErrorAndLeavesNoObject) {
     ScopedFiuFault fault(FIUKEY_S3FS_WRITER_FLUSH_FAIL, /*one_time=*/false);
     ASSERT_EQ(0, fault.enable_result());
 
-    for (int i = 10; i < 20; ++i) {
-      ASSERT_AND_ASSIGN(auto rb, MakeTestData(i * rows_per_batch, rows_per_batch));
-      write_status = vx_writer->Write(rb);
-      if (!write_status.ok()) {
-        EXPECT_NE(write_status.ToString().find(FIUKEY_S3FS_WRITER_FLUSH_FAIL), std::string::npos)
-            << write_status.ToString();
-        break;
-      }
-    }
-
+    // Exercise the operation named by the fault directly. Relying on a later
+    // Write() to happen to flush an internal Vortex buffer is data-size and
+    // build-mode dependent, so it can remain OK even though the fault is live.
+    write_status = vx_writer->Flush();
+    ASSERT_FALSE(write_status.ok());
+    EXPECT_NE(write_status.ToString().find(FIUKEY_S3FS_WRITER_FLUSH_FAIL), std::string::npos)
+        << write_status.ToString();
     auto close_result = vx_writer->Close();
     ASSERT_FALSE(close_result.ok());
+    EXPECT_TRUE(close_result.status().Equals(write_status));
   }
+
+  // Destroy releases the failed output stream without finalizing partial data.
+  vx_writer.reset();
 
   ASSERT_AND_ASSIGN(auto file_info, file_system_->GetFileInfo(test_path));
   EXPECT_EQ(arrow::fs::FileType::NotFound, file_info.type()) << file_info.ToString();
@@ -1375,8 +1452,11 @@ TEST_P(VortexBasicTest, AsyncScanFailureCompletesCallbackWithError) {
                                                   file_size, footer_size));
   ASSERT_AND_ASSIGN(auto scan_builder, vxfile.CreateScanBuilder(kSmallCoalescingWindow));
 
-  // Bypass VortexFormatReader::take_async validation to exercise async scan failure handling.
-  // Older Vortex versions panic for an out-of-range index, while newer versions return an error.
+  // Bypass VortexFormatReader::take_async validation to exercise async scan
+  // failure handling. An out-of-range index is caller-owned input, so a
+  // returned OutOfBounds error must not be classified as persisted data
+  // corruption. Older Vortex versions panic for this input; that path carries
+  // the explicit unexpected/internal code instead.
   const uint64_t out_of_range_index = vxfile.RowCount();
   scan_builder.WithSplitRowIndices(false);
   scan_builder.WithIncludeByIndex(&out_of_range_index, 1);
@@ -1384,6 +1464,7 @@ TEST_P(VortexBasicTest, AsyncScanFailureCompletesCallbackWithError) {
   auto ctx = std::make_unique<AsyncScanTestContext>();
   ctx->fs_holder = fs_holder;
   auto completion = ctx->completion.get_future();
+  auto error_code = ctx->error_code.get_future();
   auto* raw_ctx = ctx.release();
   const auto handle = std::move(scan_builder).IntoRawHandle();
   vortex_scan_collect_async(handle, &raw_ctx->stream, AsyncScanTestCallback, raw_ctx);
@@ -1393,10 +1474,26 @@ TEST_P(VortexBasicTest, AsyncScanFailureCompletesCallbackWithError) {
       << "Tokio scan task failure dropped the callback";
 
   const auto error = completion.get();
+  const auto code = error_code.get();
   ASSERT_FALSE(error.empty());
-  EXPECT_TRUE(error.find("vortex async scan panicked") != std::string::npos ||
-              error.find("OutOfBounds") != std::string::npos)
-      << error;
+  EXPECT_NE(code, LOON_VORTEX_DATA_FORMAT) << error;
+  EXPECT_TRUE(code == 0 || code == LOON_INTERNAL_INVARIANT)
+      << "unexpected structured async Vortex error code " << code << ": " << error;
+}
+
+TEST_P(VortexBasicTest, SegmentBytesOutOfRangeIsNotDataFormat) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile(test_file_name_));
+
+  const auto file_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  const auto footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  auto fs_holder = std::make_shared<FileSystemWrapper>(file_system_);
+  ASSERT_AND_ASSIGN(auto vxfile, VortexFile::Open(reinterpret_cast<uint8_t*>(fs_holder.get()), test_file_name_,
+                                                  file_size, footer_size));
+
+  auto result = vxfile.SegmentBytes(UINT64_MAX);
+  ASSERT_FALSE(result.ok());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  EXPECT_TRUE(detail == nullptr || detail->code() != ExtendStatusCode::VortexDataFormat) << result.status().ToString();
 }
 
 TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
@@ -1446,7 +1543,7 @@ TEST_P(VortexBasicTest, FooterSizeMatchesActualFile) {
       << "cached footer_size should match the actual Vortex footer body; normal open adds EOF_SIZE";
 }
 
-TEST_P(VortexBasicTest, FooterSizeNotMatch) {
+TEST_P(VortexBasicTest, DependencyAcceptsFooterSizeHint) {
   // Write a vortex file
   ASSERT_AND_ASSIGN(auto vx_writer,
                     vortex::VortexFileWriter::Open(file_system_, schema_, test_file_name_, properties_));
@@ -1480,6 +1577,9 @@ TEST_P(VortexBasicTest, FooterSizeNotMatch) {
     }
   };
 
+  // This path delegates the hint directly to Vortex. Vortex accepts an
+  // understated hint without reporting a failure, so there is no lower-layer
+  // error for this layer to reinterpret or recover from.
   verify_read(1);
 
   // Case 2: footer_size too large (= file_size, reads entire file as initial read).

--- a/cpp/test/format/vortex/vortex_local_format_test.cpp
+++ b/cpp/test/format/vortex/vortex_local_format_test.cpp
@@ -18,6 +18,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -39,7 +40,10 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/vortex/vortex_footer_internal.h"
+#include "milvus-storage/format/vortex/vortex_field_layout_internal.h"
 #include "milvus-storage/format/vortex/vortex_footer_reader.h"
 #include "milvus-storage/format/vortex/vortex_format_reader.h"
 #include "milvus-storage/format/vortex/vortex_planner.h"
@@ -296,56 +300,32 @@ class VortexLocalFormatTest : public ::testing::Test {
   const int64_t batch_count_ = 4;
 };
 
-TEST_F(VortexLocalFormatTest, TestFooterReaderOpensZeroRowVortexFile) {
+TEST_F(VortexLocalFormatTest, TestFooterReaderOpensZeroRowVortexFileWithoutFooterFallback) {
   ASSERT_AND_ASSIGN(auto cgfile, WriteEmptyVortexFile());
   ASSERT_EQ(0, cgfile.end_index);
   ASSERT_GT(cgfile.Get<uint64_t>(api::kPropertyFileSize), 0);
-  ASSERT_GT(cgfile.Get<uint64_t>(api::kPropertyFooterSize), 0);
+  const auto actual_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  ASSERT_GT(actual_footer_size, 1);
 
-  auto too_small_footer_file = cgfile;
-  too_small_footer_file.Set(api::kPropertyFooterSize, cgfile.Get<uint64_t>(api::kPropertyFooterSize) - 1);
-  auto too_small_footer_reader =
-      MakeFooterReader(too_small_footer_file, std::make_shared<InMemoryVortexRangeFileSystem>());
-  ASSERT_STATUS_OK(too_small_footer_reader->Open(file_system_));
-  ASSERT_TRUE(too_small_footer_reader->opened());
-  ASSERT_EQ(too_small_footer_reader->rows(), 0);
-  ASSERT_EQ(too_small_footer_reader->footer_size(), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
+  for (const uint64_t supplied_footer_size : {actual_footer_size - 1, uint64_t{1}}) {
+    auto understated_footer_file = cgfile;
+    understated_footer_file.Set(api::kPropertyFooterSize, supplied_footer_size);
+    auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+    auto reader = MakeFooterReader(understated_footer_file, sparse_fs);
 
-  auto tiny_footer_file = cgfile;
-  tiny_footer_file.Set(api::kPropertyFooterSize, static_cast<uint64_t>(1));
-  auto tiny_footer_reader = MakeFooterReader(tiny_footer_file, std::make_shared<InMemoryVortexRangeFileSystem>());
-  ASSERT_STATUS_OK(tiny_footer_reader->Open(file_system_));
-  ASSERT_TRUE(tiny_footer_reader->opened());
-  ASSERT_EQ(tiny_footer_reader->rows(), 0);
-  ASSERT_EQ(tiny_footer_reader->footer_size(), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
+    const auto status = reader->Open(file_system_);
+    ASSERT_FALSE(status.ok()) << "understated footer size " << supplied_footer_size;
+    EXPECT_FALSE(reader->opened());
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+    ASSERT_AND_ASSIGN(auto sparse_file, sparse_fs->GetInMemoryFile("test-file.vx.sparse"));
+    EXPECT_EQ(sparse_file->WriteRanges().size(), 1u) << "footer failure must not trigger another range read";
+  }
 
   auto footer_reader = MakeFooterReader(cgfile, std::make_shared<InMemoryVortexRangeFileSystem>());
   ASSERT_STATUS_OK(footer_reader->Open(file_system_));
   ASSERT_TRUE(footer_reader->opened());
   ASSERT_EQ(footer_reader->rows(), 0);
   ASSERT_EQ(footer_reader->footer_size(), cgfile.Get<uint64_t>(api::kPropertyFooterSize));
-  ASSERT_NE(footer_reader->file_schema(), nullptr);
-
-  ASSERT_AND_ASSIGN(auto cell_metas, BuildVortexCellMetas(footer_reader, "id"));
-  AssertLoadableEmptyCellMetas(cell_metas);
-  ASSERT_AND_ASSIGN(auto group_cell_metas, BuildVortexGroupCellMetas(footer_reader, data_columns()));
-  AssertLoadableEmptyCellMetas(group_cell_metas);
-}
-
-TEST_F(VortexLocalFormatTest, TestFooterReaderOpenAfterWriterCloseWithoutWriteIfFileExists) {
-  ASSERT_AND_ASSIGN(auto vx_writer,
-                    vortex::VortexFileWriter::Open(file_system_, schema_, test_file_name_, properties_));
-  ASSERT_AND_ASSIGN(auto cgfile, vx_writer->Close());
-  ASSERT_EQ(0, cgfile.end_index);
-
-  ASSERT_AND_ASSIGN(auto file_info, file_system_->GetFileInfo(test_file_name_));
-  ASSERT_TRUE(file_info.IsFile());
-  ASSERT_GT(file_info.size(), 0);
-
-  auto footer_reader = MakeFooterReader(cgfile, std::make_shared<InMemoryVortexRangeFileSystem>());
-  ASSERT_STATUS_OK(footer_reader->Open(file_system_));
-  ASSERT_TRUE(footer_reader->opened());
-  ASSERT_EQ(footer_reader->rows(), 0);
   ASSERT_NE(footer_reader->file_schema(), nullptr);
 
   ASSERT_AND_ASSIGN(auto cell_metas, BuildVortexCellMetas(footer_reader, "id"));
@@ -365,6 +345,19 @@ TEST_F(VortexLocalFormatTest, TestFooterReaderMissingFilePreservesEnoent) {
   ASSERT_FALSE(status.ok());
   EXPECT_TRUE(status.IsIOError());
   EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
+}
+
+TEST_F(VortexLocalFormatTest, TestFooterReaderMissingFieldIsCallerErrorNotDataFormat) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+  auto footer_reader = MakeFooterReader(cgfile, std::make_shared<InMemoryVortexRangeFileSystem>());
+  ASSERT_STATUS_OK(footer_reader->Open(file_system_));
+
+  auto result = footer_reader->GetFieldLayout("missing-field");
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsKeyError()) << result.status().ToString();
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  EXPECT_TRUE(detail == nullptr || detail->code() != ExtendStatusCode::VortexDataFormat) << result.status().ToString();
 }
 
 TEST_F(VortexLocalFormatTest, TestFooterReaderDoesNotPrefetchHeaderRangeWhenFooterSizeKnown) {
@@ -554,6 +547,47 @@ TEST_F(VortexLocalFormatTest, TestReadByPlanEmptyRangeReturnsEmptyStream) {
   ASSERT_EQ(chunked_array->length(), 0);
 }
 
+TEST_F(VortexLocalFormatTest, PublicArgumentValidationReturnsPlainInvalid) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+
+  auto expect_plain_invalid = [](const arrow::Status& status) {
+    EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  };
+
+  auto incomplete_metadata =
+      vortex::VortexFormatReader::MetaTrait::create_from_metadata(nullptr, cgfile, schema_, data_columns(), "");
+  ASSERT_FALSE(incomplete_metadata.ok());
+  expect_plain_invalid(incomplete_metadata.status());
+
+  auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
+                                              cgfile.Get<uint64_t>(api::kPropertyFileSize),
+                                              cgfile.Get<uint64_t>(api::kPropertyFooterSize));
+  ASSERT_STATUS_OK(vx_reader.open());
+
+  auto unsorted_ranges = vx_reader.read_with_plan(VortexReadPlan{
+      .op =
+          VortexReadPlan::RangeScan{
+              .ranges = {RowRange{.start = 100, .end = 200}, RowRange{.start = 50, .end = 75}},
+          },
+      .apply_predicate = false,
+  });
+  ASSERT_FALSE(unsorted_ranges.ok());
+  expect_plain_invalid(unsorted_ranges.status());
+
+  auto column_sizes = vx_reader.get_rg_column_memsz(-1);
+  ASSERT_FALSE(column_sizes.ok());
+  expect_plain_invalid(column_sizes.status());
+
+  auto chunk = vx_reader.get_chunk(-1);
+  ASSERT_FALSE(chunk.ok());
+  expect_plain_invalid(chunk.status());
+
+  auto chunks = vx_reader.get_chunks({0, -1});
+  ASSERT_FALSE(chunks.ok());
+  expect_plain_invalid(chunks.status());
+}
+
 TEST_F(VortexLocalFormatTest, TestTranslaterLoadsAndReleasesCellRanges) {
   api::SetValue(properties_, PROPERTY_WRITER_VORTEX_ENABLE_STATISTICS, "true");
   api::SetValue(properties_, PROPERTY_WRITER_VORTEX_V2_ROW_GROUP_MAX_SIZE, std::to_string(128 * 1024).c_str());
@@ -627,6 +661,340 @@ TEST_F(VortexLocalFormatTest, TestTranslaterRejectsInvalidInputs) {
   auto local_fs = std::make_shared<arrow::fs::LocalFileSystem>();
   ASSERT_STATUS_NOT_OK(
       VortexTranslater::Make(cell_metas, file_system_, test_file_name_, local_fs, "test-file.vx.sparse").status());
+}
+
+// The footer descriptor claims a byte range; this checks it against the file it
+// came from. This is a data-format error, not a bad caller argument: the
+// persisted layout was parsed and found to contradict the file.
+//
+// Tests the rule, not the path to it. The guard sits behind
+// VortexFile::OpenUnique, which is handed the same file_size the check later
+// uses, so no amount of tampering with file_size reaches it -- inflate and the
+// tail read runs past EOF into sparse zeroes, deflate and it lands mid-file;
+// either way the EOF trailer fails to parse and OpenUnique rejects the file
+// first. An end-to-end case needs a hand-built vortex file whose trailer parses
+// but whose descriptor lies, and no such fixture exists in this tree. Saying so
+// here rather than leaving a green test to imply coverage it does not have.
+TEST(VortexFooterRangeTest, InvalidRangeIsDataFormat) {
+  constexpr uint64_t kFileSize = 1000;
+
+  struct Case {
+    std::vector<uint64_t> range;
+    const char* what;
+  };
+  const Case bad[] = {
+      {{}, "empty -- not a pair"},
+      {{100}, "one element -- not a pair"},
+      {{100, 200, 300}, "three elements -- not a pair"},
+      {{kFileSize + 1, 0}, "offset past the end"},
+      {{0, kFileSize + 1}, "length past the end from offset 0"},
+      {{900, 200}, "offset in range, but offset+length past the end"},
+      // The check is written as `length > file_size - offset` precisely so this
+      // does not wrap to a pass.
+      {{1, std::numeric_limits<uint64_t>::max()}, "length that would overflow offset+length"},
+  };
+
+  for (const auto& c : bad) {
+    auto status = vortex::internal::CheckVortexFooterRange(c.range, kFileSize, "some.vortex");
+    ASSERT_FALSE(status.ok()) << c.what;
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << c.what << ": " << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::VortexDataFormat) << c.what;
+    EXPECT_EQ(CategoryForExtendStatusCode(detail->code()), ErrorCategory::DataFormat) << c.what;
+    EXPECT_FALSE(RetryableForExtendStatusCode(detail->code())) << c.what;
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::DataFormatBroken) << c.what;
+    EXPECT_NE(status.ToString().find("some.vortex"), std::string::npos) << c.what;
+  }
+
+  const Case good[] = {
+      {{0, 0}, "empty range at the start"},
+      {{0, kFileSize}, "the whole file"},
+      {{kFileSize, 0}, "empty range exactly at the end"},
+      {{900, 100}, "ends exactly at the end"},
+  };
+  for (const auto& c : good) {
+    EXPECT_TRUE(vortex::internal::CheckVortexFooterRange(c.range, kFileSize, "some.vortex").ok()) << c.what;
+  }
+}
+
+TEST(VortexFooterRangeTest, ZeroLengthFlatSegmentIsLegal) {
+  auto range = vortex::internal::FlatSegmentByteRangeFromBytes({4096, 0}, 7);
+  ASSERT_TRUE(range.ok()) << range.status().ToString();
+  EXPECT_EQ(range->offset, 4096u);
+  EXPECT_EQ(range->length, 0u);
+}
+
+TEST(VortexFooterRangeTest, WrongSizedBridgeResultIsInternal) {
+  for (const std::vector<uint64_t>& bytes :
+       {std::vector<uint64_t>{}, std::vector<uint64_t>{4096}, std::vector<uint64_t>{4096, 128, 9}}) {
+    auto range = vortex::internal::FlatSegmentByteRangeFromBytes(bytes, 7);
+    ASSERT_FALSE(range.ok()) << "size " << bytes.size();
+    EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(range.status()), nullptr)
+        << "size " << bytes.size() << ": " << range.status().ToString();
+    EXPECT_EQ(ToSegcoreError(range.status()).get_error_code(), milvus::StorageError)
+        << "size " << bytes.size() << ": " << range.status().ToString();
+  }
+}
+
+TEST(VortexFooterRangeTest, SegmentLookupPreservesCaughtPanicAsUnexpected) {
+  auto status =
+      vortex::internal::ClassifyVortexLayoutSegmentLookupFailure(arrow::Status::UnknownError("decoder panicked"), 7);
+
+  EXPECT_TRUE(status.IsUnknownError()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError);
+}
+
+TEST(VortexFooterRangeTest, OrdinaryPersistedSegmentLookupFailureIsDataFormat) {
+  auto status = vortex::internal::ClassifyVortexLayoutSegmentLookupFailure(
+      arrow::Status::Invalid("segment index is out of bounds"), 7);
+
+  auto detail = ExtendStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(detail, nullptr) << status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::VortexDataFormat);
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::DataFormatBroken);
+}
+
+TEST(VortexFieldLayoutEncodingTest, InvalidEncodingIsDataFormat) {
+  struct Case {
+    std::vector<uint64_t> encoded;
+    uint64_t rows;
+    const char* what;
+  };
+  const Case bad[] = {
+      {{}, 1, "missing header"},
+      {{1}, 1, "missing unit count"},
+      {{99, 0}, 0, "unknown granularity"},
+      {{1, 0}, 3, "non-empty file without units"},
+      {{1, std::numeric_limits<uint64_t>::max()}, 3, "impossible unit count"},
+      {{1, 1, 0, 0, 3}, 3, "truncated unit"},
+      {{1, 1, 0, 0, 3, 2, 7}, 3, "truncated segment list"},
+      {{1, 1, 0, 0, 3, 0, 42}, 3, "trailing word"},
+      {{1, 1, 0, 4, 0, 0}, 3, "row offset past file rows"},
+      {{1, 1, 0, 2, 2, 0}, 3, "row range past file rows"},
+      {{1, 1, 0, std::numeric_limits<uint64_t>::max(), 2, 0},
+       std::numeric_limits<uint64_t>::max(),
+       "row range addition would overflow"},
+  };
+
+  for (const auto& c : bad) {
+    auto status = vortex::internal::ValidateVortexFieldLayoutEncoding(c.encoded, c.rows, "id");
+    ASSERT_FALSE(status.ok()) << c.what;
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << c.what << ": " << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::VortexDataFormat) << c.what;
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::DataFormatBroken) << c.what;
+    EXPECT_NE(status.message().find("id"), std::string::npos) << c.what;
+  }
+}
+
+TEST(VortexFieldLayoutEncodingTest, HealthyEncodingsAreAccepted) {
+  ASSERT_STATUS_OK(vortex::internal::ValidateVortexFieldLayoutEncoding({1, 0}, 0, "id"));
+  ASSERT_STATUS_OK(vortex::internal::ValidateVortexFieldLayoutEncoding({1, 1, 0, 0, 3, 2, 7, 8}, 3, "id"));
+  ASSERT_STATUS_OK(vortex::internal::ValidateVortexFieldLayoutEncoding({2, 1, 4, 0, 3, 0}, 3, "id"));
+}
+
+TEST_F(VortexLocalFormatTest, StaleFooterSizeFailsAfterOneTailRead) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+  const auto full_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  const auto real_footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  ASSERT_GT(real_footer_size, 1u);
+
+  for (uint64_t understated : {uint64_t{1}, real_footer_size / 2}) {
+    auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+    auto reader =
+        std::make_shared<VortexFooterReader>(sparse_fs, "test-file.vx.sparse", test_file_name_, full_size, understated);
+
+    auto status = reader->Open(file_system_);
+    ASSERT_FALSE(status.ok()) << "understated footer size " << understated;
+    ASSERT_AND_ASSIGN(auto sparse_file, sparse_fs->GetInMemoryFile("test-file.vx.sparse"));
+    EXPECT_EQ(sparse_file->WriteRanges().size(), 1u) << "footer failure must not trigger another range read";
+  }
+
+  // The same file opens when its recorded footer size is correct.
+  auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+  auto reader = MakeFooterReader(cgfile, sparse_fs);
+  ASSERT_STATUS_OK(reader->Open(file_system_));
+}
+
+// An invalid trailer is a Vortex data-format failure. Classification is
+// attached only after the complete persisted object has been loaded and the
+// final decoder attempt still fails, without matching producer text.
+TEST_F(VortexLocalFormatTest, VortexInvalidTrailerFailsClosedWithoutClaimingCorruption) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+  const auto full_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(full_size, 64u);
+
+  // Keep the length unchanged so the decoder, rather than a short-read guard,
+  // rejects the trailer.
+  ASSERT_AND_ASSIGN(auto input, file_system_->OpenInputFile(test_file_name_));
+  ASSERT_AND_ASSIGN(auto whole, input->ReadAt(0, static_cast<int64_t>(full_size)));
+  ASSERT_STATUS_OK(input->Close());
+  {
+    std::vector<uint8_t> smashed(whole->data(), whole->data() + full_size);
+    for (size_t i = smashed.size() - 32; i < smashed.size(); ++i) {
+      smashed[i] ^= 0xff;
+    }
+    ASSERT_AND_ASSIGN(auto out, file_system_->OpenOutputStream(test_file_name_));
+    ASSERT_STATUS_OK(out->Write(smashed.data(), static_cast<int64_t>(smashed.size())));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+  auto footer_reader = MakeFooterReader(cgfile, sparse_fs);
+  auto status = footer_reader->Open(file_system_);
+
+  ASSERT_FALSE(status.ok()) << "a vortex file with a smashed trailer opened successfully";
+  // Deliberately NOT DataFormatBroken. Vortex reports footer-deserialization
+  // failures through its catch-all `Other` variant, so nothing below us
+  // positively identifies corruption, and neither this layer nor the bridge
+  // infers it: an unclassified failure stays in the conservative non-retriable
+  // bucket rather than claiming a verdict nobody established. What is pinned
+  // here is that it fails closed, carries no invented classification, and does
+  // not leak the internal marker.
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr) << status.ToString();
+  EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::StorageError) << status.ToString();
+  EXPECT_EQ(status.ToString().find("__LOON_RUST_BRIDGE_ERRCODE__"), std::string::npos) << status.ToString();
+}
+
+// A corrupt file must not be able to kill the process.
+//
+// These are extern "Rust" entry points: cxx turns a returned Err into a C++
+// exception, but a PANIC unwinding across that boundary aborts. Three altered
+// bytes inside a healthy file's footer were enough to reach one -- so a single
+// bad object could take the node down, and no error code helps after that.
+//
+// The assertion is deliberately weak on WHICH error comes back: different
+// mutations reach different failure modes, and pinning one would make this
+// test about vortex's internals. What must hold is that the process survives
+// and the caller is told something -- if the guard regresses, this test does
+// not fail, it aborts the whole binary with 134.
+TEST_F(VortexLocalFormatTest, CorruptFooterCannotAbortTheProcess) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+  const auto full_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  ASSERT_GT(full_size, 512u);
+
+  ASSERT_AND_ASSIGN(auto input, file_system_->OpenInputFile(test_file_name_));
+  ASSERT_AND_ASSIGN(auto whole, input->ReadAt(0, static_cast<int64_t>(full_size)));
+  ASSERT_STATUS_OK(input->Close());
+  const std::vector<uint8_t> pristine(whole->data(), whole->data() + full_size);
+
+  // Walk the footer region a few bytes at a time. Any one of these may or may
+  // not provoke a panic; the point is that none of them may end the process.
+  for (uint64_t back : {uint64_t{16}, uint64_t{24}, uint64_t{40}, uint64_t{64}, uint64_t{128}}) {
+    auto smashed = pristine;
+    for (uint64_t i = 0; i < 3; ++i) {
+      smashed[smashed.size() - back + i] ^= 0x5a;
+    }
+    {
+      ASSERT_AND_ASSIGN(auto out, file_system_->OpenOutputStream(test_file_name_));
+      ASSERT_STATUS_OK(out->Write(smashed.data(), static_cast<int64_t>(smashed.size())));
+      ASSERT_STATUS_OK(out->Close());
+    }
+
+    auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+    auto reader =
+        std::make_shared<VortexFooterReader>(sparse_fs, "test-file.vx.sparse", test_file_name_, full_size, uint64_t{0});
+    auto status = reader->Open(file_system_);
+    // Surviving the call IS the assertion. A verdict either way is fine.
+    SUCCEED() << "back=" << back << " -> " << (status.ok() ? std::string("opened") : status.ToString());
+  }
+
+  // Restore, so a later test in this fixture is not reading smashed bytes.
+  ASSERT_AND_ASSIGN(auto out, file_system_->OpenOutputStream(test_file_name_));
+  ASSERT_STATUS_OK(out->Write(pristine.data(), static_cast<int64_t>(pristine.size())));
+  ASSERT_STATUS_OK(out->Close());
+}
+
+// Corruption in the DATA region: opens cleanly, dies while streaming.
+//
+// A different boundary from CorruptFooterCannotAbortTheProcess. Decoding is
+// lazy, so the panic fires inside iter.next() -- called per batch from the
+// Arrow C stream callback -- long after every entry-point guard has returned.
+// Smashing bytes well before the footer leaves the file openable and defers the
+// failure to exactly there.
+//
+// As with the footer test, the assertion is survival, not a specific verdict:
+// where the decoder dies depends on which byte moved. If the guard regresses
+// this does not fail, it takes the whole binary down with 134.
+TEST_F(VortexLocalFormatTest, CorruptDataRegionCannotAbortTheStream) {
+  ASSERT_AND_ASSIGN(auto cgfile, WriteVortexFile());
+  const auto full_size = cgfile.Get<uint64_t>(api::kPropertyFileSize);
+  const auto footer_size = cgfile.Get<uint64_t>(api::kPropertyFooterSize);
+  ASSERT_GT(full_size, footer_size + 4096);
+
+  ASSERT_AND_ASSIGN(auto input, file_system_->OpenInputFile(test_file_name_));
+  ASSERT_AND_ASSIGN(auto whole, input->ReadAt(0, static_cast<int64_t>(full_size)));
+  ASSERT_STATUS_OK(input->Close());
+  const std::vector<uint8_t> pristine(whole->data(), whole->data() + full_size);
+
+  // Swept rather than pinned to a few offsets. Which byte provokes a panic
+  // depends on how the writer laid the file out, and a first version that
+  // guessed three positions hit none of them -- it passed, and passed just as
+  // happily with the guard removed. Sweeping costs about a second and does not
+  // rot when the layout changes.
+  const uint64_t stride = (full_size / 64) + 1;
+  for (uint64_t offset = 64; offset + 64 < full_size - footer_size; offset += stride) {
+    auto smashed = pristine;
+    for (uint64_t i = 0; i < 8; ++i) {
+      smashed[offset + i] ^= 0xa5;
+    }
+    {
+      ASSERT_AND_ASSIGN(auto out, file_system_->OpenOutputStream(test_file_name_));
+      ASSERT_STATUS_OK(out->Write(smashed.data(), static_cast<int64_t>(smashed.size())));
+      ASSERT_STATUS_OK(out->Close());
+    }
+
+    auto vx_reader = vortex::VortexFormatReader(file_system_, schema_, test_file_name_, properties_, data_columns(),
+                                                full_size, footer_size);
+    auto open_status = vx_reader.open();
+    if (!open_status.ok()) {
+      continue;  // died at open -- the other test's territory, still no abort
+    }
+
+    auto stream_result = vx_reader.read_with_plan(VortexReadPlan{
+        .op = VortexReadPlan::RangeScan{.ranges = {RowRange{.start = 0, .end = 4096}}},
+    });
+    if (!stream_result.ok()) {
+      continue;
+    }
+    auto array_stream = std::move(stream_result).ValueOrDie();
+    // Draining is where the lazy decode -- and the panic -- actually happens.
+    auto chunked = arrow::ImportChunkedArray(&array_stream);
+    SUCCEED() << "offset=" << offset << " -> " << (chunked.ok() ? std::string("read") : chunked.status().ToString());
+  }
+
+  ASSERT_AND_ASSIGN(auto out, file_system_->OpenOutputStream(test_file_name_));
+  ASSERT_STATUS_OK(out->Write(pristine.data(), static_cast<int64_t>(pristine.size())));
+  ASSERT_STATUS_OK(out->Close());
+}
+
+TEST_F(VortexLocalFormatTest, ShortFileIsDataFormatEvenWhenTheSizeWasHandedToUs) {
+  const std::string short_path = "truly-short.vx";
+  const std::vector<uint8_t> stub(VortexEofSize() - 1, 0x00);
+  {
+    ASSERT_AND_ASSIGN(auto out, file_system_->OpenOutputStream(short_path));
+    ASSERT_STATUS_OK(out->Write(stub.data(), static_cast<int64_t>(stub.size())));
+    ASSERT_STATUS_OK(out->Close());
+  }
+
+  // Supplied size (matching reality) and stat'd size (0 sentinel) must reach the
+  // same verdict.
+  for (uint64_t supplied : {static_cast<uint64_t>(stub.size()), uint64_t{0}}) {
+    auto sparse_fs = std::make_shared<InMemoryVortexRangeFileSystem>();
+    auto reader = std::make_shared<VortexFooterReader>(sparse_fs, "short.vx.sparse", short_path, supplied, uint64_t{0});
+
+    auto status = reader->Open(file_system_);
+    ASSERT_FALSE(status.ok()) << "supplied " << supplied;
+
+    auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr) << "supplied " << supplied << " arrived unclassified: " << status.ToString();
+    EXPECT_EQ(detail->code(), ExtendStatusCode::VortexDataFormat) << supplied;
+    EXPECT_EQ(ToSegcoreError(status).get_error_code(), milvus::DataFormatBroken) << supplied;
+  }
+
+  ASSERT_STATUS_OK(file_system_->DeleteFile(short_path));
 }
 
 }  // namespace milvus_storage

--- a/cpp/test/tools/loon_test.cpp
+++ b/cpp/test/tools/loon_test.cpp
@@ -160,11 +160,11 @@ TEST_F(LoonTest, CreateAndReadIceberg) {
   const uint64_t num_rows = 30;
 
   // 1. Create Iceberg test table
-  auto table_info = CreateTestTable(table_dir_, num_rows, false, {});
+  auto table_info = CreateTestTable(table_dir_, num_rows, false, {}).ValueOrDie();
 
   // 2. Explore via PlanFiles
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
   ASSERT_EQ(file_infos.size(), 1);
 
   // 3. Build ColumnGroup and commit manifest via Transaction
@@ -226,10 +226,10 @@ TEST_F(LoonTest, CreateAndTakeWithDeletes) {
   const uint64_t num_rows = 20;
   std::vector<int64_t> deleted_positions = {3, 7, 15};
 
-  auto table_info = CreateTestTable(table_dir_, num_rows, true, deleted_positions);
+  auto table_info = CreateTestTable(table_dir_, num_rows, true, deleted_positions).ValueOrDie();
 
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
   ASSERT_EQ(file_infos.size(), 1);
   ASSERT_FALSE(file_infos[0].delete_metadata_json.empty());
 
@@ -280,10 +280,10 @@ TEST_F(LoonTest, SequentialReadFiltersDeletes) {
   const uint64_t num_rows = 15;
   std::vector<int64_t> deleted_positions = {0, 5, 14};
 
-  auto table_info = CreateTestTable(table_dir_, num_rows, true, deleted_positions);
+  auto table_info = CreateTestTable(table_dir_, num_rows, true, deleted_positions).ValueOrDie();
 
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
 
   std::vector<ColumnGroupFile> files;
   {
@@ -342,10 +342,10 @@ TEST_F(LoonTest, ManifestPreservesDeleteMetadata) {
   const uint64_t num_rows = 10;
   std::vector<int64_t> deleted_positions = {2, 8};
 
-  auto table_info = CreateTestTable(table_dir_, num_rows, true, deleted_positions);
+  auto table_info = CreateTestTable(table_dir_, num_rows, true, deleted_positions).ValueOrDie();
 
   std::unordered_map<std::string, std::string> storage_options;
-  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options);
+  auto file_infos = PlanFiles(table_info.metadata_location, table_info.snapshot_id, storage_options).ValueOrDie();
 
   // Commit manifest with delete metadata
   std::vector<ColumnGroupFile> files;

--- a/cpp/tools/loon.cpp
+++ b/cpp/tools/loon.cpp
@@ -285,7 +285,13 @@ static int DoDemoTable(int argc, char** argv) {
     }
 
     bool with_deletes = !deletes.empty();
-    auto info = milvus_storage::iceberg::CreateTestTable(table_path, rows, with_deletes, deletes, storage_options);
+    auto info_result =
+        milvus_storage::iceberg::CreateTestTable(table_path, rows, with_deletes, deletes, storage_options);
+    if (!info_result.ok()) {
+      std::cerr << "Failed to create iceberg table: " << info_result.status().ToString() << std::endl;
+      return 1;
+    }
+    auto info = std::move(*info_result);
 
     std::cout << "Created iceberg table:" << std::endl;
     std::cout << "  path:              " << table_path << std::endl;
@@ -376,12 +382,12 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreLance(const std::strin
   ARROW_ASSIGN_OR_RAISE(auto lance_base_uri, milvus_storage::lance::BuildLanceBaseUri(fs_config, resolved_dir));
   auto storage_options = milvus_storage::lance::ToStorageOptions(fs_config);
 
-  auto dataset = milvus_storage::lance::BlockingDataset::Open(lance_base_uri, storage_options);
-  auto fragment_ids = dataset->GetAllFragmentIds();
+  ARROW_ASSIGN_OR_RAISE(auto dataset, milvus_storage::lance::BlockingDataset::Open(lance_base_uri, storage_options));
+  ARROW_ASSIGN_OR_RAISE(auto fragment_ids, dataset->GetAllFragmentIds());
 
   std::vector<ColumnGroupFile> files;
   for (auto frag_id : fragment_ids) {
-    auto row_count = dataset->GetFragmentRowCount(frag_id);
+    ARROW_ASSIGN_OR_RAISE(auto row_count, dataset->GetFragmentRowCount(frag_id));
     files.emplace_back(
         ColumnGroupFile{milvus_storage::lance::MakeLanceUri(
                             milvus_storage::lance::ToMilvusLanceUri(lance_base_uri, fs_config.address), frag_id),
@@ -404,7 +410,7 @@ static arrow::Result<std::vector<ColumnGroupFile>> ExploreIceberg(const std::str
   ARROW_ASSIGN_OR_RAISE(auto parsed_uri, StorageUri::Parse(source));
   ARROW_ASSIGN_OR_RAISE(auto iceberg_uri, StorageUri::Make(parsed_uri, false));
 
-  auto file_infos = milvus_storage::iceberg::PlanFiles(iceberg_uri, snapshot_id, storage_options);
+  ARROW_ASSIGN_OR_RAISE(auto file_infos, milvus_storage::iceberg::PlanFiles(iceberg_uri, snapshot_id, storage_options));
 
   std::vector<ColumnGroupFile> files;
   files.reserve(file_infos.size());


### PR DESCRIPTION
## Summary

Part 3 of the six-PR split of #603.

- Use one trusted Rust-owned error frame and decode it once at the final C++ consumer.
- Preserve typed status through Lance, Vortex, Paimon, Iceberg, and Arrow C-stream boundaries.
- Keep caller-controlled marker text inert and preserve producer-selected Arrow StatusCode.
- Avoid typed C++ status -> Arrow C stream re-export paths that discard detail.
- Preserve typed connect, timeout, throttling, service, and decoder-confirmed data-format causes where the producer has evidence.

Refs #642.
Depends on the cloud slice immediately below it and on #603.

## Review scope

This PR contains format bridge and format reader propagation only. Stateful writer rollback starts in the next stack entry.

## Validation

- WITH_CRT=True full C++ build.
- Rust bridge: 173 passed, 1 ignored.
- Focused C++ bridge/format set: 341 passed, 20 environment skips.
- Rust fmt passed.

## Stack

Review and merge in order:

1. #603 — taxonomy foundation
2. #647 — cloud filesystems, credentials, and lifecycle
3. #648 — Rust format error envelope
4. #649 — writer failure and output ownership
5. #650 — Packed metadata and missing-field projections
6. #651 — public API lifetime and consumer migration

Each PR is based on the preceding stack branch. After one PR merges, rebase the remaining stack onto the updated `main` (required for squash merges), update the synthetic branches with force-with-lease, and then retarget the next PR to `main`.
