### PR TITLE
fix: make writer failure cleanup transactional

### DIFF
--- a/cpp/include/milvus-storage/common/arrow_util.h
+++ b/cpp/include/milvus-storage/common/arrow_util.h
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #pragma once
-#include <memory>
+#include <charconv>
 #include <cstdint>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -51,8 +53,47 @@ class FollyArrowErrorFuture {
 
 }  // namespace detail
 
+// Validation-safe field-id parsing. Authoritative PARQUET:field_id metadata is
+// parsed strictly and returned as a status instead of throwing. When metadata
+// is absent, keep the legacy field-name fallback unchanged for compatibility.
+inline arrow::Result<int64_t> TryGetFieldId(const std::shared_ptr<arrow::Field>& field) {
+  if (!field) {
+    return arrow::Status::Invalid("Arrow field must not be null");
+  }
+
+  auto metadata = field->metadata();
+  if (metadata && metadata->Contains(ARROW_FIELD_ID_KEY)) {
+    ARROW_ASSIGN_OR_RAISE(auto value, metadata->Get(ARROW_FIELD_ID_KEY));
+    int64_t field_id = 0;
+    const auto* begin = value.data();
+    const auto* end = begin + value.size();
+    const auto [ptr, ec] = std::from_chars(begin, end, field_id);
+    if (ec != std::errc{} || ptr != end || field_id < 0) {
+      return arrow::Status::Invalid("Invalid ", ARROW_FIELD_ID_KEY, " value '", value, "' for field '", field->name(),
+                                    "': expected a non-negative int64");
+    }
+    return field_id;
+  }
+
+  // A missing field-id is a valid schema shape for non-packed callers. Keep
+  // the historical sentinel, but do not accept numeric prefixes: only a
+  // complete, non-negative decimal name is an id.
+  const auto& name = field->name();
+  int64_t field_id = 0;
+  const auto* begin = name.data();
+  const auto* end = begin + name.size();
+  const auto [ptr, ec] = std::from_chars(begin, end, field_id);
+  if (ec != std::errc{} || ptr != end || field_id < 0) {
+    return -1;
+  }
+  return field_id;
+}
+
 // Extract field_id from Arrow field.
-// Tries PARQUET:field_id metadata first, falls back to parsing field name as integer.
+//
+// Keep the original return type and parsing behavior because this helper is in
+// an installed public header. New validation-sensitive code should use
+// TryGetFieldId instead.
 inline int64_t GetFieldId(const std::shared_ptr<arrow::Field>& field) {
   auto metadata = field->metadata();
   if (metadata && metadata->Contains(ARROW_FIELD_ID_KEY)) {
@@ -60,9 +101,22 @@ inline int64_t GetFieldId(const std::shared_ptr<arrow::Field>& field) {
   }
   try {
     return std::stoll(field->name());
-  } catch (...) {
+  } catch (const std::invalid_argument&) {
+    return -1;
+  } catch (const std::out_of_range&) {
     return -1;
   }
+}
+
+inline arrow::Status ValidateFieldIds(const std::shared_ptr<arrow::Schema>& schema) {
+  if (!schema) {
+    return arrow::Status::Invalid("Arrow schema must not be null");
+  }
+  for (const auto& field : schema->fields()) {
+    auto field_id = TryGetFieldId(field);
+    ARROW_RETURN_NOT_OK(field_id.status());
+  }
+  return arrow::Status::OK();
 }
 
 arrow::Result<std::unique_ptr<::parquet::arrow::FileReader>> MakeArrowFileReader(

--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -476,10 +476,10 @@ FFI_EXPORT LoonFFIResult loon_writer_flush(LoonWriterHandle handle);
 /**
  * @brief Closes the writer and returns the column groups for a successfully written dataset.
  *
- * If a previous operation on this writer has already failed, close may still be called to
- * release/finalize resources owned by the writer. In that case, even if close succeeds,
- * the returned column groups are not a valid dataset manifest and must be discarded by
- * the caller.
+ * If an earlier write or flush reached the writer and failed, close abandons
+ * pending outputs, releases writer-owned resources, and returns the first
+ * recorded failure instead of publishing column groups. Call close after a
+ * writer operation fails so resources such as multipart uploads are released.
  *
  * @param handle Writer handle
  * @param out_columngroups Output LoonColumnGroups structure (function allocates and returns pointer)

--- a/cpp/include/milvus-storage/filesystem/ffi/filesystem_internal.h
+++ b/cpp/include/milvus-storage/filesystem/ffi/filesystem_internal.h
@@ -15,7 +15,11 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 #include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+
+#include "milvus-storage/common/writer_status.h"
 
 template <template <typename> class P, typename T>
 class PolymorphicWrapper {
@@ -28,5 +32,51 @@ class PolymorphicWrapper {
 };
 
 using FileSystemWrapper = PolymorphicWrapper<std::shared_ptr, arrow::fs::FileSystem>;
-using OutputStreamWrapper = PolymorphicWrapper<std::shared_ptr, arrow::io::OutputStream>;
 using RandomAccessFileWrapper = PolymorphicWrapper<std::shared_ptr, arrow::io::RandomAccessFile>;
+
+class OutputStreamWrapper {
+  public:
+  explicit OutputStreamWrapper(std::shared_ptr<arrow::io::OutputStream> stream) : stream_(std::move(stream)) {}
+
+  ~OutputStreamWrapper() = default;
+
+  arrow::Status Write(const void* data, int64_t nbytes) {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(stream_->Write(data, nbytes));
+  }
+
+  arrow::Status Flush() {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(stream_->Flush());
+  }
+
+  arrow::Status Close() {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(stream_->Close());
+  }
+
+  /// Give up on the stream and release what it allocated in the store.
+  ///
+  /// Deliberately no writer_status_.Check(): this is the one verb that has to
+  /// work after the writer has failed. Best effort -- the stream's own cleanup
+  /// failure is not reported, because whoever calls this is already handling a
+  /// failure of their own.
+  ///
+  /// The Rust bridge reaches this through loon_filesystem_writer_destroy, which
+  /// it already calls on every terminal path -- failed write, failed flush,
+  /// close, and Drop of an open writer (filesystem_c.rs). So a vortex file
+  /// abandoned mid-write does get its upload cancelled; the release rides the C
+  /// ABI the bridge already uses rather than a new cxx verb.
+  ///
+  /// Lance drives its own Rust object_store and never this wrapper, so nothing
+  /// here can reach its uncommitted fragments -- which costs nothing, because
+  /// the lance writer only exists in test builds.
+  arrow::Status Abort() {
+    (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+    return stream_->Abort();
+  }
+
+  private:
+  std::shared_ptr<arrow::io::OutputStream> stream_;
+  milvus_storage::WriterStatus writer_status_;
+};

--- a/cpp/include/milvus-storage/format/column_group_writer.h
+++ b/cpp/include/milvus-storage/format/column_group_writer.h
@@ -40,6 +40,19 @@ class ColumnGroupWriter {
   [[nodiscard]] virtual arrow::Status Flush() = 0;
   [[nodiscard]] virtual arrow::Result<std::vector<ColumnGroupFile>> Close() = 0;
 
+  /// Abandon this column group and release what it allocated in the store:
+  /// the format writer's in-progress file AND the files Flush() already
+  /// rolled -- those were finalized but never handed over (only Close()
+  /// transfers them), so this abort is their only release point. See
+  /// FormatWriter::Abort() for the contract: safe on a failed writer,
+  /// idempotent, and never reports its own cleanup failure.
+  virtual void Abort() noexcept = 0;
+
+  /// Delete files returned by a successful Close when an owning parent later
+  /// fails. Uses the same filesystem instance that created the files and is
+  /// idempotent. A successful outer close never calls this method.
+  virtual void RollbackClosedFiles() noexcept = 0;
+
   /**
    * @brief Create a column group writer for a column group
    *

--- a/cpp/include/milvus-storage/format/format_writer.h
+++ b/cpp/include/milvus-storage/format/format_writer.h
@@ -15,19 +15,25 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include <arrow/status.h>
 #include <arrow/result.h>
 #include <arrow/record_batch.h>
 
+#include <string_view>
+
 #include "milvus-storage/column_groups.h"
+#include "milvus-storage/common/log.h"
 
 namespace milvus_storage {
 
 class FormatWriter {
   public:
   virtual ~FormatWriter() = default;
+  // Every non-OK operation is terminal. Retry by destroying this writer and
+  // opening another writer on a new file path.
   /**
    * @brief Write a record batch to the file
    *
@@ -44,11 +50,98 @@ class FormatWriter {
   [[nodiscard]] virtual arrow::Status Flush() = 0;
 
   /**
-   * @brief Close the writer
-   *        After call this function, the writer should be closed and cannot be used again
-   * @return arrow::Status
+   * @brief Finish with this writer
+   *
+   * "I am done", not "finish the file". A healthy writer is finalized and its
+   * file published; a writer that has ALREADY FAILED is abandoned instead --
+   * releasing whatever it allocated in the store -- and the first failure comes
+   * back unchanged. Either way the writer is spent and cannot be used again.
+   *
+   * Abandoning on failure is not the same as finalizing on failure: nothing is
+   * published, so this does not contradict "a failed writer must not be
+   * finished". It exists because Close() is the only verb some callers can
+   * reach for. An FFI, Go, Java or Python caller has no destructor to fall
+   * back on,
+   * and every failure path that returned without releasing used to leave an S3
+   * multipart upload behind holding parts that no bucket listing can name.
+   *
+   * What Close() cannot express is abandoning a HEALTHY writer -- publishing a
+   * file nobody wants is worse than leaking an upload, because the file is not
+   * in the manifest and the manifest is what a GC walks. That is Abort()'s job.
    */
   [[nodiscard]] virtual arrow::Result<api::ColumnGroupFile> Close() = 0;
+
+  /**
+   * @brief Give up on this file and release what it already allocated
+   *
+   * The counterpart of Close(): Close() finishes the file, Abort() abandons it.
+   * A writer that has failed cannot be closed -- the format may have written
+   * half a footer, and finishing it would publish a file nobody should read --
+   * but abandoning it is not free either. An S3 multipart upload holds every
+   * part already sent, and those parts are invisible to a bucket listing, so
+   * only the writer that created the upload can ever release them.
+   *
+   * Implementations must be safe to call on an already-failed writer, must not
+   * report their own cleanup failures (the caller is already handling one --
+   * log and drop), and must be idempotent. In particular Abort() after a
+   * SUCCESSFUL Close() is a no-op in every respect, including the recorded
+   * status: that is what lets a caller abandon unconditionally without first
+   * working out which of the two verbs it owes.
+   *
+   * It returns void on purpose. A verb whose contract is "always succeeds"
+   * has nothing to report, and an arrow::Status return invited two mistakes at
+   * once: callers checking a value that never carries information, and
+   * implementations smuggling a real failure through it.
+   *
+   * noexcept for the same reason. Anything that escapes here would escape into
+   * a destructor; an allocation failure while abandoning a writer takes the
+   * process down rather than leaving a caller to guess what was released.
+   *
+   * The WRITER'S OWN destructor still must not do storage I/O -- it can run at
+   * shutdown, after the executor and client are gone. Its owner calls Abort()
+   * explicitly from its own failure path (R2.7b).
+   */
+  virtual void Abort() noexcept = 0;
 };  // class FormatWriter
+
+/// Run one abandonment step, absorbing anything it throws.
+///
+/// Abort() is noexcept so that abandonment can run on an owner's failure
+/// path -- including during stack unwinding, where anything that escaped
+/// would terminate the process -- and void so that a caller already handling
+/// their own failure is never handed a second one. But "does not report" is
+/// not "cannot happen":
+/// abandonment reaches into arrow streams and, below them, filesystem
+/// implementations we do not own. An arrow::io::OutputStream::Abort() may throw
+/// for reasons that have nothing to do with us -- this repository's own tests
+/// contain one that does.
+/// Steps returning arrow::Status are logged when non-OK; void-returning steps
+/// retain the same exception-only handling.
+///
+/// Without this the noexcept would turn that into std::terminate, which is the
+/// opposite of what a best-effort cleanup verb should do, and would kill the
+/// process before the FFI boundary could convert the failure into an error
+/// code. Log it and carry on; that IS the contract.
+///
+/// An allocation failure inside the logging still ends the process, which is
+/// deliberate and consistent with the rest of this library: OOM is not handled
+/// anywhere, it just ends things.
+template <typename Step>
+void AbandonQuietly(std::string_view what, Step&& step) noexcept {
+  try {
+    if constexpr (std::is_same_v<std::decay_t<decltype(step())>, arrow::Status>) {
+      auto status = step();
+      if (!status.ok()) {
+        LOG_STORAGE_WARNING_ << "Failed to abandon " << what << ": " << status.ToString();
+      }
+    } else {
+      step();
+    }
+  } catch (const std::exception& e) {
+    LOG_STORAGE_WARNING_ << "Failed to abandon " << what << ": " << e.what();
+  } catch (...) {
+    LOG_STORAGE_WARNING_ << "Failed to abandon " << what << " due to a non-standard exception";
+  }
+}
 
 }  // namespace milvus_storage

--- a/cpp/include/milvus-storage/format/lance/lance_table_writer.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_writer.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/format/format_writer.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/ffi/filesystem_internal.h"
@@ -47,7 +48,13 @@ class LanceTableWriter final : public FormatWriter {
 
   arrow::Result<api::ColumnGroupFile> Close() override;
 
+  void Abort() noexcept override;
+
   private:
+  arrow::Status WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record);
+  arrow::Status FlushImpl();
+  arrow::Result<api::ColumnGroupFile> CloseImpl();
+
   bool closed_;
   std::string base_path_;
   std::shared_ptr<arrow::Schema> schema_;
@@ -61,6 +68,7 @@ class LanceTableWriter final : public FormatWriter {
   /// missing. Only used to explain the failure if that verdict turns out to
   /// have been wrong.
   bool created_dataset_ = false;
+  WriterStatus writer_status_;
   int64_t written_rows_ = 0;
 };
 }  // namespace milvus_storage::lance

--- a/cpp/include/milvus-storage/format/parquet/parquet_writer.h
+++ b/cpp/include/milvus-storage/format/parquet/parquet_writer.h
@@ -24,11 +24,14 @@
 
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/metadata.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/format/format_writer.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/column_groups.h"
 
 namespace milvus_storage::parquet {
+
+class FailClosedOutputStream;
 
 class ParquetFileWriter : public FormatWriter {
   public:
@@ -55,13 +58,15 @@ class ParquetFileWriter : public FormatWriter {
   arrow::Status init();
 
   public:
-  ~ParquetFileWriter() override = default;
+  ~ParquetFileWriter() override;
 
   arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) override;
 
   arrow::Status Flush() override;
 
   arrow::Result<api::ColumnGroupFile> Close() override;
+
+  void Abort() noexcept override;
 
   arrow::Result<size_t> Tell() const;
 
@@ -70,14 +75,21 @@ class ParquetFileWriter : public FormatWriter {
   arrow::Status AddUserMetadata(const std::vector<std::pair<std::string, std::string>>& metadata);
 
   private:
+  arrow::Status WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record);
+  arrow::Status FlushImpl();
+  arrow::Result<api::ColumnGroupFile> CloseImpl();
+  arrow::Result<size_t> TellImpl() const;
+  arrow::Status AppendKVMetadataImpl(const std::string& key, const std::string& value);
+  arrow::Status AddUserMetadataImpl(const std::vector<std::pair<std::string, std::string>>& metadata);
   arrow::Status write_row_group(const std::vector<std::shared_ptr<arrow::RecordBatch>>& batch, size_t group_size);
+  arrow::Status Fail(arrow::Status status) const;
 
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::shared_ptr<arrow::Schema> schema_;
   const std::string file_path_;
   milvus_storage::StorageConfig storage_config_;
 
-  std::shared_ptr<arrow::io::OutputStream> sink_;
+  std::shared_ptr<FailClosedOutputStream> sink_;
   std::unique_ptr<::parquet::arrow::FileWriter> writer_;
   std::shared_ptr<arrow::KeyValueMetadata> kv_metadata_;
 
@@ -90,6 +102,7 @@ class ParquetFileWriter : public FormatWriter {
   std::vector<size_t> cached_batch_sizes_;
   bool closed_ = false;
   size_t cached_tell_ = 0;
+  mutable WriterStatus writer_status_;
 
   int64_t written_rows_ = 0;
 };

--- a/cpp/include/milvus-storage/format/vortex/vortex_writer.h
+++ b/cpp/include/milvus-storage/format/vortex/vortex_writer.h
@@ -14,9 +14,12 @@
 
 #pragma once
 
+#include <optional>
+
 #include <memory>
 
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/format/format_writer.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/filesystem/ffi/filesystem_internal.h"
@@ -47,7 +50,23 @@ class VortexFileWriter final : public FormatWriter {
 
   [[nodiscard]] arrow::Result<api::ColumnGroupFile> Close() override;
 
+  void Abort() noexcept override;
+
+#ifdef BUILD_GTEST
+  bool HasBridgeWriterForTest() const { return vx_writer_.has_value(); }
+#endif
+
   private:
+  arrow::Status WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record);
+  arrow::Status FlushImpl();
+  arrow::Result<api::ColumnGroupFile> CloseImpl();
+  arrow::Status RecordFirstFailure(arrow::Status status) {
+    if (!status.ok() && status_.ok()) {
+      status_ = std::move(status);
+    }
+    return status_.ok() ? status : status_;
+  }
+
   VortexFileWriter(std::unique_ptr<FileSystemWrapper> fs_holder,
                    VortexWriter vx_writer,
                    std::shared_ptr<arrow::Schema> schema,
@@ -57,10 +76,17 @@ class VortexFileWriter final : public FormatWriter {
   bool closed_;
   std::string file_path_;
   std::unique_ptr<FileSystemWrapper> fs_holder_;
-  VortexWriter vx_writer_;
+  // optional so Abort() can release the bridge writer immediately. Dropping it
+  // drops the Rust ObjectStoreWriterInner, whose Drop calls
+  // loon_filesystem_writer_destroy -- which aborts the C++ output stream and
+  // therefore the multipart upload. Holding it until this object is destroyed
+  // would still release it, just later than the caller asked.
+  std::optional<VortexWriter> vx_writer_;
   std::shared_ptr<arrow::Schema> schema_;
   api::Properties properties_;
+  arrow::Status status_ = arrow::Status::OK();
 
+  bool wrote_batch_ = false;
   int64_t written_rows_ = 0;
 };
 }  // namespace milvus_storage::vortex

--- a/cpp/include/milvus-storage/lob_column/lob_column_writer.h
+++ b/cpp/include/milvus-storage/lob_column/lob_column_writer.h
@@ -59,6 +59,8 @@ struct LobFileResult {
 //   5. use the returned references to write reference binlog
 //
 // thread safety: not thread-safe, use one writer per thread
+// failure semantics: any failed operation is terminal; Abort/destroy it and
+// create a new writer, which generates a new UUID-backed file path.
 class LobColumnWriter {
   public:
   virtual ~LobColumnWriter() = default;
@@ -108,7 +110,7 @@ class LobColumnWriter {
 
   // abort the writer and discard all written data
   // this will delete any LOB files that were created
-  virtual arrow::Status Abort() = 0;
+  virtual void Abort() noexcept = 0;
 
   // get the number of rows written so far
   virtual int64_t WrittenRows() const = 0;

--- a/cpp/include/milvus-storage/packed/writer.h
+++ b/cpp/include/milvus-storage/packed/writer.h
@@ -19,6 +19,7 @@
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/writer_status.h"
 
 namespace milvus_storage {
 
@@ -34,6 +35,8 @@ class PackedRecordBatchWriter {
       std::priority_queue<std::pair<GroupId, size_t>, std::vector<std::pair<GroupId, size_t>>, MemoryComparator>;
 
   public:
+  // Every non-OK operation is terminal. A retry must create a new packed
+  // writer with a new set of output paths.
   static arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> Make(
       std::shared_ptr<arrow::fs::FileSystem> fs,
       std::vector<std::string>& paths,
@@ -78,12 +81,24 @@ class PackedRecordBatchWriter {
    */
   arrow::Status Close();
 
+  /**
+   * @brief Abandon the packed files instead of finalizing them.
+   *
+   * See FormatWriter::Abort(): safe on a failed writer, idempotent, best
+   * effort, and it never reports a cleanup failure of its own.
+   */
+  void Abort() noexcept;
+
   arrow::Result<std::vector<size_t>> Tell() const;
 
   arrow::Status AddUserMetadata(const std::string& key, const std::string& value);
 
   private:
   arrow::Status init();
+  arrow::Status WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record);
+  arrow::Status CloseImpl();
+  arrow::Result<std::vector<size_t>> TellImpl() const;
+  arrow::Status AddUserMetadataImpl(const std::string& key, const std::string& value);
 
   // split first buffer into column groups based on column size
   // and init column group writer and put column groups into max heap
@@ -104,9 +119,13 @@ class PackedRecordBatchWriter {
   const std::vector<std::vector<int>> group_indices_;
   size_t current_memory_usage_;
   bool closed_ = false;
+  mutable WriterStatus writer_status_;
 
   std::vector<std::shared_ptr<arrow::RecordBatch>> buffered_batches_;
   std::vector<std::unique_ptr<milvus_storage::parquet::ParquetFileWriter>> group_writers_;
+  // Paths whose child Close succeeded but whose outer Close has not yet
+  // transferred ownership to the caller.
+  std::vector<std::string> pending_closed_paths_;
 
   IndicesBasedSplitter splitter_;
   MemoryMaxHeap max_heap_;

--- a/cpp/include/milvus-storage/segment/segment_writer.h
+++ b/cpp/include/milvus-storage/segment/segment_writer.h
@@ -68,23 +68,9 @@ struct SegmentWriteOutput {
   int64_t rows_written = 0;
 };
 
-// legacy result (kept for backward compatibility with callers that manage Transaction externally)
-struct SegmentWriterResult {
-  // full path to the committed manifest file
-  // format: {segment_path}/_metadata/manifest-{version}.avro
-  std::string manifest_path;
-
-  // committed version number
-  int64_t committed_version = 0;
-
-  // total number of rows written
-  int64_t rows_written = 0;
-};
-
 // statistics for segment writer
 struct SegmentWriterStats {
   int64_t total_rows = 0;             // total number of rows written
-  int64_t total_bytes = 0;            // total bytes written (approximate)
   int64_t parquet_files_created = 0;  // number of parquet files created
   int64_t lob_files_created = 0;      // number of LOB files created
 };
@@ -119,6 +105,8 @@ struct SegmentWriterStats {
 //               └── {uuid}.vx                  <- LOB files for TEXT columns (partition level)
 //
 // Thread safety: not thread-safe, use one writer per thread
+// Failure semantics: any failed operation is terminal. Abort/destroy the
+// instance and create a new writer with a new segment/file path to retry.
 class SegmentWriter {
   public:
   virtual ~SegmentWriter() = default;
@@ -147,10 +135,13 @@ class SegmentWriter {
   // does NOT commit manifest — caller must use Transaction to commit
   virtual arrow::Result<SegmentWriteOutput> Close() = 0;
 
-  // abort the writer and clean up all created files
-  // this will delete any LOB files and Parquet files that were created
+  // abort the writer and best-effort release resources still owned by
+  // in-progress child writers, including outputs from children whose Close()
+  // succeeded but whose ownership has not yet been returned by this writer's
+  // Close(). After this writer closes successfully, Abort() is a no-op because
+  // ownership has transferred to the caller.
   // does NOT commit the transaction
-  virtual arrow::Status Abort() = 0;
+  virtual void Abort() noexcept = 0;
 
   // get the number of rows written so far
   virtual int64_t WrittenRows() const = 0;

--- a/cpp/include/milvus-storage/writer.h
+++ b/cpp/include/milvus-storage/writer.h
@@ -22,7 +22,6 @@
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/properties.h"
-#include "milvus-storage/common/config.h"
 
 namespace milvus_storage::api {
 /**
@@ -103,6 +102,9 @@ class ColumnGroupPolicy {
  * The writer coordinates multiple column group writers to achieve optimal
  * storage layout and query performance while maintaining data consistency
  * and integrity.
+ *
+ * Any failed writer operation is terminal for that instance. Callers must
+ * destroy it and create a new writer (and therefore new file paths) to retry.
  */
 class Writer {
   public:
@@ -148,8 +150,9 @@ class Writer {
   /**
    * @brief Virtual destructor
    *
-   * Ensures proper cleanup of column group writers and temporary resources.
-   * If close() hasn't been called, this will attempt to clean up gracefully.
+   * Releases in-memory ownership only. Callers must invoke close() or abort()
+   * first; destruction deliberately performs no storage I/O and therefore
+   * cannot release a remote multipart upload by itself.
    */
   virtual ~Writer() = default;
 
@@ -184,8 +187,8 @@ class Writer {
    *
    * @return Status indicating success or error condition
    *
-   * @note This does not close the writers; additional batches can still be written
-   *       after flushing.
+   * @note After a successful flush, additional batches can still be written.
+   *       A failed flush makes the writer terminal.
    */
   virtual arrow::Status flush() = 0;
 
@@ -204,6 +207,21 @@ class Writer {
   virtual arrow::Result<std::shared_ptr<ColumnGroups>> close(
       const std::vector<std::string_view>& config_keys = {},
       const std::vector<std::string_view>& config_values = {}) = 0;
+
+  /**
+   * @brief Abandons the dataset instead of finalizing it
+   *
+   * The counterpart of close(). A failed writer cannot be closed -- doing so
+   * would publish files that were never finished -- but the column group
+   * writers underneath it may already hold storage the store will keep billing
+   * for, most notably an S3 multipart upload whose parts a bucket listing
+   * cannot even see. abort() releases what it can, best effort.
+   *
+   * Safe after any failure, idempotent, and it never reports a cleanup failure
+   * of its own: the caller is already handling one. Nothing is committed, so
+   * whatever was written is unreferenced by design.
+   */
+  virtual void abort() noexcept = 0;
 };
 
 }  // namespace milvus_storage::api

--- a/cpp/src/ffi/filesystem_c.cpp
+++ b/cpp/src/ffi/filesystem_c.cpp
@@ -153,7 +153,7 @@ LoonFFIResult loon_filesystem_writer_write(FileSystemWriterHandle handle, const 
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle, data, and size must not be null");
     }
 
-    auto output_stream = reinterpret_cast<OutputStreamWrapper*>(handle)->get();
+    auto* output_stream = reinterpret_cast<OutputStreamWrapper*>(handle);
     auto write_status = output_stream->Write(data, size);
     RETURN_ARROW_ERROR_IF(write_status, LOON_ARROW_ERROR, write_status.ToString());
     RETURN_SUCCESS();
@@ -170,7 +170,7 @@ LoonFFIResult loon_filesystem_writer_flush(FileSystemWriterHandle handle) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
     }
 
-    auto output_stream = reinterpret_cast<OutputStreamWrapper*>(handle)->get();
+    auto* output_stream = reinterpret_cast<OutputStreamWrapper*>(handle);
     auto flush_result = output_stream->Flush();
     RETURN_ARROW_ERROR_IF(flush_result, LOON_ARROW_ERROR, flush_result.ToString());
 
@@ -187,7 +187,7 @@ LoonFFIResult loon_filesystem_writer_close(FileSystemWriterHandle handle) {
       RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments: handle must not be null");
     }
 
-    auto output_stream = reinterpret_cast<OutputStreamWrapper*>(handle)->get();
+    auto* output_stream = reinterpret_cast<OutputStreamWrapper*>(handle);
     auto close_result = output_stream->Close();
     RETURN_ARROW_ERROR_IF(close_result, LOON_ARROW_ERROR, close_result.ToString());
 
@@ -201,6 +201,11 @@ LoonFFIResult loon_filesystem_writer_close(FileSystemWriterHandle handle) {
 void loon_filesystem_writer_destroy(FileSystemWriterHandle handle) {
   if (handle) {
     auto* wrapper = reinterpret_cast<OutputStreamWrapper*>(handle);
+    try {
+      (void)wrapper->Abort();
+    } catch (...) {
+      // Destruction is best effort and must not throw across the C ABI.
+    }
     delete wrapper;
   }
 }

--- a/cpp/src/format/column_group_writer.cpp
+++ b/cpp/src/format/column_group_writer.cpp
@@ -24,7 +24,9 @@
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/layout.h"
+#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/path_util.h"  // for kSep
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/format.h"
 #include "milvus-storage/format/column_group_reader.h"
@@ -48,15 +50,82 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
         format_writer_(nullptr) {}
 
   [[nodiscard]] arrow::Status Write(const std::shared_ptr<arrow::RecordBatch> record) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(WriteImpl(record));
+  }
+
+  [[nodiscard]] arrow::Status Flush() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(FlushImpl());
+  }
+
+  [[nodiscard]] arrow::Result<std::vector<ColumnGroupFile>> Close() override {
+    // Abandon on both failure paths; see FormatWriter::Close in format_writer.h.
+    if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+      Abort();
+      return first_failure;
+    }
+    auto result = CloseImpl();
+    if (!result.ok()) {
+      auto status = writer_status_.RecordFirstFailure(result.status());
+      Abort();
+      return status;
+    }
+    closed_ = true;
+    return result;
+  }
+
+  [[nodiscard]] arrow::Status Open() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(OpenImpl());
+  }
+
+  // Deliberately no writer_status_.Check(): abort is the one verb that must
+  // still work after the writer has failed, which is the only time anyone calls
+  // it.
+  void Abort() noexcept override {
+    // closed_ first, before recording the discard: abort after a successful Close has
+    // to be a no-op in every respect, including the recorded status, so a
+    // caller can abandon unconditionally without working out which verb it
+    // owes. The format writer below has the same guard, but reaching it would
+    // already have flipped this writer to Cancelled.
+    if (closed_) {
+      return;
+    }
+    (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+    if (format_writer_ != nullptr) {
+      format_writer_->Abort();
+      format_writer_.reset();
+    }
+    // Rolled files were finalized into the store but never handed to the
+    // caller: only Close() transfers them, and it did not run. No manifest
+    // will ever reference them, so this abort is their only release point.
+    // Best effort like every abandonment step (R2.7a); the LOB writer's
+    // Abort() does the same for the files it created.
+    RollbackClosedFiles();
+  }
+
+  void RollbackClosedFiles() noexcept override {
+    for (const auto& file : written_files_) {
+      AbandonQuietly("a column group file", [&] { return fs_->DeleteFile(file.path); });
+    }
+    written_files_.clear();
+  }
+
+  private:
+  [[nodiscard]] arrow::Status WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record) {
     // Fault injection point for testing
     FIU_RETURN_ON(FIUKEY_COLUMN_GROUP_WRITE_FAIL,
                   arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_COLUMN_GROUP_WRITE_FAIL)));
 
-    written_bytes_ += GetRecordBatchMemorySize(record);
-    return format_writer_->Write(record);
+    const auto record_bytes = GetRecordBatchMemorySize(record);
+    ARROW_RETURN_NOT_OK(format_writer_->Write(record));
+    written_bytes_ += record_bytes;
+    written_rows_ += record->num_rows();
+    return arrow::Status::OK();
   }
 
-  [[nodiscard]] arrow::Status Flush() override {
+  [[nodiscard]] arrow::Status FlushImpl() {
     ARROW_RETURN_NOT_OK(format_writer_->Flush());
 
     if (written_bytes_ == 0 || written_bytes_ < max_bytes_limit_) {
@@ -67,39 +136,49 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
     ARROW_ASSIGN_OR_RAISE(auto column_group_file, format_writer_->Close());
     written_files_.emplace_back(std::move(column_group_file));
     written_bytes_ = 0;
+    written_rows_ = 0;
 
     ARROW_ASSIGN_OR_RAISE(format_writer_,
-                          create_format_writer(base_path_, column_group_id_, column_group_, schema_, properties_));
+                          create_format_writer(base_path_, column_group_id_, column_group_, schema_, properties_, fs_));
 
     return arrow::Status::OK();
   }
 
-  [[nodiscard]] arrow::Result<std::vector<ColumnGroupFile>> Close() override {
+  [[nodiscard]] arrow::Result<std::vector<ColumnGroupFile>> CloseImpl() {
     assert(format_writer_);
-    ARROW_ASSIGN_OR_RAISE(auto column_group_file, format_writer_->Close());
-    // If current column_group_file without any data, do not add it to written_files_
-    if (written_bytes_ != 0) {
-      written_files_.emplace_back(std::move(column_group_file));
+    // A fresh writer, including the successor opened after a roll, has no file
+    // to publish. Closing the format writer would finalize an empty object that
+    // is deliberately omitted from metadata and can therefore never be found
+    // by manifest-based cleanup.
+    if (written_rows_ == 0) {
+      format_writer_->Abort();
+      format_writer_.reset();
+      return written_files_;
     }
+    ARROW_ASSIGN_OR_RAISE(auto column_group_file, format_writer_->Close());
+    written_files_.emplace_back(std::move(column_group_file));
     return written_files_;
   }
 
-  [[nodiscard]] arrow::Status Open() override {
+  [[nodiscard]] arrow::Status OpenImpl() {
     assert(!format_writer_);
+    // Held for Abort(): the rolled files it deletes were written through this
+    // filesystem, fetched from the same cache the format writers use.
+    ARROW_ASSIGN_OR_RAISE(fs_, milvus_storage::FilesystemCache::getInstance().get(properties_, base_path_));
     ARROW_ASSIGN_OR_RAISE(format_writer_,
-                          create_format_writer(base_path_, column_group_id_, column_group_, schema_, properties_));
+                          create_format_writer(base_path_, column_group_id_, column_group_, schema_, properties_, fs_));
     ARROW_ASSIGN_OR_RAISE(max_bytes_limit_, api::GetValue<uint64_t>(properties_, PROPERTY_WRITER_FILE_ROLLING_SIZE));
     return arrow::Status::OK();
   }
 
-  private:
   static arrow::Result<std::unique_ptr<FormatWriter>> create_format_writer(
       const std::string& base_path,
       const size_t& column_group_id,
       const std::shared_ptr<milvus_storage::api::ColumnGroup>& column_group,
       const std::shared_ptr<arrow::Schema>& schema,
-      const milvus_storage::api::Properties& properties) {
-    assert(column_group && schema);
+      const milvus_storage::api::Properties& properties,
+      const std::shared_ptr<arrow::fs::FileSystem>& file_system) {
+    assert(column_group && schema && file_system);
     auto format = column_group->format;
 
     // Create schema with only the columns for this column group
@@ -113,8 +192,6 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
       fields.emplace_back(field);
     }
     auto column_group_schema = arrow::schema(fields);
-    ARROW_ASSIGN_OR_RAISE(auto file_system, milvus_storage::FilesystemCache::getInstance().get(properties, base_path));
-
     // If current file system is local, create the parent directory if not exist
     // If current file system is remote, putobject will auto
     // create the parent directory if not exist
@@ -135,11 +212,20 @@ class ColumnGroupWriterImpl final : public ColumnGroupWriter {
   Properties properties_;
 
   std::unique_ptr<FormatWriter> format_writer_;
+  // Filesystem the format writers write through; kept so Abort() can delete
+  // the files FlushImpl() rolled into the store. Null exactly until Open()
+  // succeeds, which is also the only way written_files_ can grow.
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
 
   uint64_t max_bytes_limit_{0};
   uint64_t written_bytes_{0};
+  int64_t written_rows_{0};
 
   std::vector<ColumnGroupFile> written_files_;
+  WriterStatus writer_status_;
+  // Set only by a Close() that finished cleanly, so it means exactly
+  // "already finalized" and never "gave up part way".
+  bool closed_{false};
 };
 
 arrow::Result<std::unique_ptr<ColumnGroupWriter>> ColumnGroupWriter::create(
@@ -151,7 +237,11 @@ arrow::Result<std::unique_ptr<ColumnGroupWriter>> ColumnGroupWriter::create(
   std::unique_ptr<ColumnGroupWriterImpl> writer;
   assert(column_group && schema);
   writer = std::make_unique<ColumnGroupWriterImpl>(base_path, column_group_id, column_group, schema, properties);
-  ARROW_RETURN_NOT_OK(writer->Open());
+  auto status = writer->Open();
+  if (!status.ok()) {
+    writer->Abort();
+    return status;
+  }
   return writer;
 }
 

--- a/cpp/src/format/lance/lance_table_writer.cpp
+++ b/cpp/src/format/lance/lance_table_writer.cpp
@@ -16,6 +16,7 @@
 
 #include "milvus-storage/format/lance/lance_table_writer.h"
 
+#include <new>
 #include <string>
 #include <iostream>
 #include <unordered_set>
@@ -74,6 +75,11 @@ class BatchIterator : public arrow::RecordBatchReader {
 };
 
 arrow::Status LanceTableWriter::Write(const std::shared_ptr<arrow::RecordBatch> batch) {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return writer_status_.RecordFirstFailure(WriteImpl(batch));
+}
+
+arrow::Status LanceTableWriter::WriteImpl(const std::shared_ptr<arrow::RecordBatch>& batch) {
   assert(!closed_);
   assert(batch->schema()->Equals(*schema_, false));
   written_rows_ += batch->num_rows();
@@ -82,7 +88,12 @@ arrow::Status LanceTableWriter::Write(const std::shared_ptr<arrow::RecordBatch> 
   return arrow::Status::OK();
 }
 
-arrow::Status LanceTableWriter::Flush() { return arrow::Status::OK(); }
+arrow::Status LanceTableWriter::Flush() {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return writer_status_.RecordFirstFailure(FlushImpl());
+}
+
+arrow::Status LanceTableWriter::FlushImpl() { return arrow::Status::OK(); }
 
 bool fids_contains(const std::vector<uint64_t>& origin, const std::vector<uint64_t>& current) {
   assert(current.size() > origin.size());
@@ -104,7 +115,7 @@ bool fids_contains(const std::vector<uint64_t>& origin, const std::vector<uint64
 /// tolerance was not a worse error message: taking this branch against a
 /// dataset that DOES exist makes the writer believe it started from zero
 /// fragments, and everything downstream is computed from that belief (see the
-/// guard in Close). A transient open failure would have been laundered
+/// guard in CloseImpl). A transient open failure would have been laundered
 /// into a manifest entry pointing at somebody else's fragment. Failing the
 /// first write is recoverable; that is not.
 bool IsMissingDatasetStatus(const arrow::Status& status) {
@@ -130,7 +141,45 @@ std::vector<uint64_t> fids_diff(const std::vector<uint64_t>& origin, const std::
   return diff;
 }
 
+void LanceTableWriter::Abort() noexcept {
+  // closed_ before recording the discard: abort after a successful Close must not
+  // leave a writer that finished cleanly reading as Cancelled.
+  if (closed_) {
+    return;
+  }
+  (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+  closed_ = true;
+  // Buffered batches never reached the store, so dropping them is the whole of
+  // the local cleanup. Fragments already written through the Rust dataset are
+  // left behind: lance publishes them by committing a manifest version, so an
+  // abandoned write leaves fragments no version references, and removing those
+  // needs a lance-side API this bridge does not expose.
+  //
+  // Accepted, because this writer does not exist outside test builds -- the
+  // whole class is behind #ifdef BUILD_GTEST and LanceFormat::create_writer
+  // returns NotImplemented("Lance writer is only available in test builds")
+  // otherwise. Production reads lance, it never writes it, so there is no
+  // deployment in which these fragments accumulate.
+  record_batches_.clear();
+  dataset_.reset();
+}
+
 arrow::Result<api::ColumnGroupFile> LanceTableWriter::Close() {
+  // Abandon on both failure paths; see FormatWriter::Close in format_writer.h.
+  if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+    Abort();
+    return first_failure;
+  }
+  auto result = CloseImpl();
+  if (!result.ok()) {
+    auto status = writer_status_.RecordFirstFailure(result.status());
+    Abort();
+    return status;
+  }
+  return result;
+}
+
+arrow::Result<api::ColumnGroupFile> LanceTableWriter::CloseImpl() {
   assert(!closed_);
   struct ArrowArrayStream array_stream;
 

--- a/cpp/src/format/parquet/parquet_writer.cpp
+++ b/cpp/src/format/parquet/parquet_writer.cpp
@@ -21,6 +21,7 @@
 #include <arrow/util/compression.h>
 #include <parquet/properties.h>
 #include <parquet/metadata.h>
+#include <parquet/arrow/schema.h>
 #include <boost/variant.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -30,6 +31,7 @@
 
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/log.h"
 #include "milvus-storage/common/macro.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/common/arrow_util.h"
@@ -37,6 +39,127 @@
 #include "milvus-storage/filesystem/upload_sizable.h"
 
 namespace milvus_storage::parquet {
+
+// Parquet closes itself from its destructor and may try to write a footer after
+// its caller has already observed a failure. This wrapper remembers the first
+// lower-layer status and blocks every later operation locally. It never closes
+// or aborts the delegate from its destructor.
+class FailClosedOutputStream final : public arrow::io::OutputStream {
+  public:
+  explicit FailClosedOutputStream(std::shared_ptr<arrow::io::OutputStream> delegate) : delegate_(std::move(delegate)) {}
+
+  ~FailClosedOutputStream() override = default;
+
+  void EnableClose() { close_enabled_ = true; }
+
+  void Discard(const arrow::Status& status = arrow::Status::OK()) const {
+    Record(status);
+    discarded_ = true;
+  }
+
+  arrow::Status Close() override {
+    if (closed_) {
+      return first_status_;
+    }
+    if (discarded_ || !close_enabled_) {
+      closed_ = true;
+      return TerminalStatus();
+    }
+    auto status = delegate_->Close();
+    Record(status);
+    if (status.ok()) {
+      closed_ = true;
+      delegate_finished_ = true;
+    }
+    return status;
+  }
+
+  arrow::Status Abort() override {
+    const bool should_abort_delegate = !delegate_finished_;
+    discarded_ = true;
+    closed_ = true;
+    // Forward it. Blocking the delegate is this wrapper's job for Write /
+    // Flush / Close -- parquet finalizes itself from its destructor and must
+    // not be allowed to write a footer over a failure. Abort is the opposite
+    // case: it is not parquet finishing its work, it is our caller giving up,
+    // and the delegate is the only object that can release what it allocated
+    // in the store (an S3 multipart upload). Swallowing it here meant an
+    // explicit abort stopped at this wrapper and never reached the filesystem.
+    //
+    // Best effort: the delegate's status is logged, never returned, so the
+    // caller still sees the original failure.
+    if (should_abort_delegate && delegate_ != nullptr) {
+      delegate_finished_ = true;
+      auto status = delegate_->Abort();
+      if (!status.ok()) {
+        LOG_STORAGE_WARNING_ << "Failed to abort the parquet output stream: " << status.ToString();
+      }
+    }
+    return TerminalStatus();
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    if (discarded_) {
+      return TerminalStatus();
+    }
+    auto result = delegate_->Tell();
+    if (!result.ok()) {
+      Record(result.status());
+    }
+    return result;
+  }
+
+  bool closed() const override { return closed_ || discarded_ || delegate_->closed(); }
+
+  arrow::Status Write(const void* data, int64_t nbytes) override {
+    if (discarded_) {
+      return TerminalStatus();
+    }
+    auto status = delegate_->Write(data, nbytes);
+    Record(status);
+    return status;
+  }
+
+  arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
+    if (discarded_) {
+      return TerminalStatus();
+    }
+    auto status = delegate_->Write(data);
+    Record(status);
+    return status;
+  }
+
+  arrow::Status Flush() override {
+    if (discarded_) {
+      return TerminalStatus();
+    }
+    auto status = delegate_->Flush();
+    Record(status);
+    return status;
+  }
+
+  private:
+  void Record(const arrow::Status& status) const {
+    if (!status.ok() && first_status_.ok()) {
+      first_status_ = status;
+      discarded_ = true;
+    }
+  }
+
+  arrow::Status TerminalStatus() const {
+    if (!first_status_.ok()) {
+      return first_status_;
+    }
+    return arrow::Status::Cancelled("Parquet output stream was discarded");
+  }
+
+  std::shared_ptr<arrow::io::OutputStream> delegate_;
+  mutable arrow::Status first_status_ = arrow::Status::OK();
+  mutable bool discarded_ = false;
+  bool close_enabled_ = false;
+  bool closed_ = false;
+  bool delegate_finished_ = false;
+};
 
 static ::parquet::Compression::type convert_compression_type(const std::string& compression) {
   if (compression == "uncompressed") {
@@ -189,8 +312,25 @@ arrow::Result<std::unique_ptr<ParquetFileWriter>> ParquetFileWriter::Make(
     const std::shared_ptr<::parquet::WriterProperties>& writer_props) {
   auto writer = std::unique_ptr<ParquetFileWriter>(
       new ParquetFileWriter(std::move(schema), std::move(fs), file_path, storage_config, writer_props));
-  ARROW_RETURN_NOT_OK(writer->init());
+  auto status = writer->init();
+  if (!status.ok()) {
+    writer->Abort();
+    return status;
+  }
   return writer;
+}
+
+ParquetFileWriter::~ParquetFileWriter() {
+  if (sink_) {
+    AbandonQuietly("the parquet sink", [&] { sink_->Discard(writer_status_.Check()); });
+  }
+}
+
+arrow::Status ParquetFileWriter::Fail(arrow::Status status) const {
+  if (!status.ok() && sink_) {
+    sink_->Discard(status);
+  }
+  return writer_status_.RecordFirstFailure(std::move(status));
 }
 
 arrow::Status ParquetFileWriter::init() {
@@ -206,9 +346,7 @@ arrow::Status ParquetFileWriter::init() {
     auto parent_dir_path = dir_path.parent_path();
     auto create_dir_result = fs_->CreateDir(parent_dir_path.string());
     if (!create_dir_result.ok()) {
-      return arrow::Status::IOError(fmt::format("Failed to create directory [path={}, details: {}]",
-                                                parent_dir_path.string(),  // NOLINT
-                                                create_dir_result.ToString()));
+      return create_dir_result;
     }
   }
 
@@ -227,21 +365,42 @@ arrow::Status ParquetFileWriter::init() {
   }
 
   if (!sink_result.ok()) {
-    return arrow::Status::IOError(fmt::format("Failed to open output stream: {}", sink_result.status().ToString()));
+    return sink_result.status();
   }
-  sink_ = std::move(sink_result).ValueOrDie();
+  sink_ = std::make_shared<FailClosedOutputStream>(std::move(sink_result).ValueOrDie());
+
+  // Do all fallible schema conversion before handing the sink to Parquet.
+  // ParquetFileWriter's destructor calls Close(), so if a later Arrow wrapper
+  // initialization failed after the sink was adopted, it could write a footer
+  // while this factory was returning an error.
+  std::shared_ptr<::parquet::SchemaDescriptor> parquet_schema;
+  auto schema_status = ::parquet::arrow::ToParquetSchema(schema_.get(), *writer_props_, &parquet_schema);
+  if (!schema_status.ok()) {
+    return schema_status;
+  }
+  ::parquet::arrow::SchemaManifest schema_manifest;
+  schema_status = ::parquet::arrow::SchemaManifest::Make(
+      parquet_schema.get(), /*metadata=*/nullptr, ::parquet::default_arrow_reader_properties(), &schema_manifest);
+  if (!schema_status.ok()) {
+    return schema_status;
+  }
 
   auto writer_result = ::parquet::arrow::FileWriter::Open(*schema_, arrow::default_memory_pool(), sink_, writer_props_);
   if (!writer_result.ok()) {
-    return arrow::Status::IOError(
-        fmt::format("Failed to create parquet writer: {}", writer_result.status().ToString()));
+    return writer_result.status();
   }
   writer_ = std::move(writer_result).ValueOrDie();
+  sink_->EnableClose();
   kv_metadata_ = std::make_shared<arrow::KeyValueMetadata>();
   return arrow::Status::OK();
 }
 
 arrow::Status ParquetFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> record) {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return Fail(WriteImpl(record));
+}
+
+arrow::Status ParquetFileWriter::WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record) {
   if (!record) {
     return arrow::Status::OK();
   }
@@ -253,6 +412,11 @@ arrow::Status ParquetFileWriter::Write(const std::shared_ptr<arrow::RecordBatch>
 }
 
 arrow::Status ParquetFileWriter::Flush() {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return Fail(FlushImpl());
+}
+
+arrow::Status ParquetFileWriter::FlushImpl() {
   std::vector<std::shared_ptr<arrow::RecordBatch>> row_group_batches;
   std::vector<size_t> row_group_batch_sizes;
   size_t rg_size = 0;
@@ -315,6 +479,15 @@ arrow::Status ParquetFileWriter::write_row_group(const std::vector<std::shared_p
 }
 
 arrow::Result<size_t> ParquetFileWriter::Tell() const {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  auto result = TellImpl();
+  if (!result.ok()) {
+    return Fail(result.status());
+  }
+  return result;
+}
+
+arrow::Result<size_t> ParquetFileWriter::TellImpl() const {
   if (closed_) {
     return cached_tell_;
   }
@@ -323,24 +496,100 @@ arrow::Result<size_t> ParquetFileWriter::Tell() const {
 }
 
 arrow::Status ParquetFileWriter::AppendKVMetadata(const std::string& key, const std::string& value) {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return Fail(AppendKVMetadataImpl(key, value));
+}
+
+arrow::Status ParquetFileWriter::AppendKVMetadataImpl(const std::string& key, const std::string& value) {
   kv_metadata_->Append(key, value);
   return arrow::Status::OK();
 }
 
 arrow::Status ParquetFileWriter::AddUserMetadata(const std::vector<std::pair<std::string, std::string>>& metadata) {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return Fail(AddUserMetadataImpl(metadata));
+}
+
+arrow::Status ParquetFileWriter::AddUserMetadataImpl(const std::vector<std::pair<std::string, std::string>>& metadata) {
   for (const auto& [key, value] : metadata) {
-    ARROW_RETURN_NOT_OK(AppendKVMetadata(key, value));
+    ARROW_RETURN_NOT_OK(AppendKVMetadataImpl(key, value));
   }
   return arrow::Status::OK();
 }
 
 arrow::Result<api::ColumnGroupFile> ParquetFileWriter::Close() {
+  // Close() means "I am done with this writer", not "finish the file". A writer
+  // that has already failed cannot be finished -- the format may have written
+  // half a footer -- but it still holds an upload that only this object can
+  // name, and returning the failure without releasing it is what made every
+  // failure path leak. Abandoning publishes nothing, so it does not contradict
+  // "a failed writer must not be finalized"; it just stops the parts from
+  // outliving the caller. This matters most for callers that cannot express
+  // RAII -- every FFI binding -- because Close() is the only verb they reach
+  // for.
+  if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+    Abort();
+    return first_failure;
+  }
+  auto result = CloseImpl();
+  if (!result.ok()) {
+    auto status = Fail(result.status());
+    Abort();
+    return status;
+  }
+  return result;
+}
+
+void ParquetFileWriter::Abort() noexcept {
+  // No writer_status_.Check(): abort has to work from the state the writer is
+  // usually in when someone gives up on it -- already failed.
+  if (closed_) {
+    // Already finalized, or already aborted. Abort after a successful Close is
+    // a no-op by design: it is what lets a caller destroy every writer
+    // unconditionally without first working out which of the two verbs it owes.
+    return;
+  }
+  (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+  // Drop parquet's own writer FIRST. Its destructor finalizes the file, and a
+  // finalize that runs after the sink has been aborted would try to write a
+  // footer into a stream whose upload no longer exists. Discard() makes the
+  // sink refuse those writes, so the destructor is a no-op by the time it runs.
+  if (sink_) {
+    AbandonQuietly("the parquet sink", [&] { sink_->Discard(writer_status_.Check()); });
+  }
+  writer_.reset();
+  cached_batches_.clear();
+  cached_batch_sizes_.clear();
+  cached_size_ = 0;
+  // Now release what the stream holds in the store. Best effort: FailClosedOutputStream::Abort
+  // logs and swallows the delegate's failure, because the caller is already
+  // handling one of their own.
+  if (sink_) {
+    // The sink is arrow-layer, so it still answers with a Status. Dropping it
+    // here is the boundary between the two contracts: the sink's terminal
+    // status is the caller's own failure coming back, and reporting it would
+    // make an abandonment look like a new error. It can also throw -- the
+    // delegate below it is a filesystem implementation we do not own.
+    AbandonQuietly("the parquet output stream", [&] { return sink_->Abort(); });
+  }
+  sink_.reset();
+  // The sink's Abort releases what the store allocated for the upload: on S3
+  // the aborted multipart upload never becomes an object. Arrow's local
+  // output stream is the exception -- its Abort finalizes nothing and deletes
+  // nothing -- so an abandoned in-progress file would linger with no manifest
+  // ever referencing it. Delete it here too, best effort: on stores where the
+  // abort already removed the path this is a silent not-found.
+  AbandonQuietly("the parquet file", [&] { return fs_->DeleteFile(file_path_); });
+  closed_ = true;
+}
+
+arrow::Result<api::ColumnGroupFile> ParquetFileWriter::CloseImpl() {
   if (closed_ || !writer_) {
     return arrow::Status::Invalid(
         fmt::format("Current writer is closed or writer is not initialized. [file_path={}]", file_path_));
   }
   // Flush any pending batches first
-  ARROW_RETURN_NOT_OK(Flush());
+  ARROW_RETURN_NOT_OK(FlushImpl());
 
   // Write any remaining cached batches that are smaller than DEFAULT_MAX_ROW_GROUP_SIZE
   if (!cached_batches_.empty()) {
@@ -350,8 +599,8 @@ arrow::Result<api::ColumnGroupFile> ParquetFileWriter::Close() {
     cached_size_ = 0;
   }
 
-  ARROW_RETURN_NOT_OK(AppendKVMetadata(milvus_storage::ROW_GROUP_META_KEY, row_group_metadata_.Serialize()));
-  ARROW_RETURN_NOT_OK(AppendKVMetadata(milvus_storage::STORAGE_VERSION_KEY, "1.0.0"));
+  ARROW_RETURN_NOT_OK(AppendKVMetadataImpl(milvus_storage::ROW_GROUP_META_KEY, row_group_metadata_.Serialize()));
+  ARROW_RETURN_NOT_OK(AppendKVMetadataImpl(milvus_storage::STORAGE_VERSION_KEY, "1.0.0"));
   ARROW_RETURN_NOT_OK(writer_->AddKeyValueMetadata(kv_metadata_));
 
   ARROW_RETURN_NOT_OK(writer_->Close());

--- a/cpp/src/format/vortex/vortex_writer.cpp
+++ b/cpp/src/format/vortex/vortex_writer.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -57,8 +58,14 @@ VortexFileWriter::VortexFileWriter(std::unique_ptr<FileSystemWrapper> fs_holder,
       properties_(std::move(properties)) {}
 
 arrow::Status VortexFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> batch) {
+  ARROW_RETURN_NOT_OK(status_);
+  return RecordFirstFailure(WriteImpl(batch));
+}
+
+arrow::Status VortexFileWriter::WriteImpl(const std::shared_ptr<arrow::RecordBatch>& batch) {
   if (closed_) {
-    return arrow::Status::Invalid("Vortex writer is closed. [file_path=", file_path_, "]");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Vortex writer is closed. [file_path=", file_path_, "]");
   }
 
   assert(!closed_);
@@ -69,22 +76,29 @@ arrow::Status VortexFileWriter::Write(const std::shared_ptr<arrow::RecordBatch> 
   ArrowArray exported_array;
   ArrowSchema exported_schema;
   ARROW_RETURN_NOT_OK(arrow::ExportArray(*arrow_struct_array, &exported_array, &exported_schema));
-  auto status = vx_writer_.Write(exported_schema, exported_array);
+  auto status = vx_writer_->Write(exported_schema, exported_array);
   if (!status.ok()) {
     closed_ = true;
     return MakeVortexErrorStatus("Failed to write Vortex file", status);
   }
+  wrote_batch_ = true;
   written_rows_ += batch->num_rows();
   return arrow::Status::OK();
 }
 
 arrow::Status VortexFileWriter::Flush() {
+  ARROW_RETURN_NOT_OK(status_);
+  return RecordFirstFailure(FlushImpl());
+}
+
+arrow::Status VortexFileWriter::FlushImpl() {
   if (closed_) {
-    return arrow::Status::Invalid("Vortex writer is closed. [file_path=", file_path_, "]");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Vortex writer is closed. [file_path=", file_path_, "]");
   }
 
   assert(!closed_);
-  auto status = vx_writer_.Flush();
+  auto status = vx_writer_->Flush();
   if (!status.ok()) {
     closed_ = true;
     return MakeVortexErrorStatus("Failed to flush Vortex file", status);
@@ -92,15 +106,67 @@ arrow::Status VortexFileWriter::Flush() {
   return arrow::Status::OK();
 }
 
+void VortexFileWriter::Abort() noexcept {
+  // NOT `if (closed_)`. Unlike the other writers, closed_ here means "no longer
+  // usable" -- WriteImpl, FlushImpl and CloseImpl all set it on their failure
+  // paths -- so it is true exactly when a failed Close has left the bridge
+  // writer still holding the upload, which is the case an abort exists for.
+  //
+  // What must not happen is the status flip on a writer that finished cleanly.
+  // A close that succeeded is the only way to be closed with nothing having
+  // failed, so that pair is the real "already finalized" test.
+  if (closed_ && status_.ok()) {
+    return;
+  }
+  (void)RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+  closed_ = true;
+  // Release the bridge writer here rather than at destruction. There IS a path
+  // from here to the stream's Abort(), it just does not look like one: dropping
+  // the Rust VortexWriter drops ObjectStoreWriterInner, whose Drop calls
+  // loon_filesystem_writer_destroy (filesystem_c.rs), and that entry point
+  // aborts the OutputStreamWrapper before releasing it. So the multipart upload
+  // is cancelled -- via the C ABI the bridge already uses for every other verb,
+  // not via a cxx method we would have had to add.
+  //
+  // Deliberately NOT vx_writer_->Close(): close would finalize a file that was
+  // abandoned on purpose.
+  AbandonQuietly("the vortex bridge writer", [&] { vx_writer_.reset(); });
+}
+
 arrow::Result<api::ColumnGroupFile> VortexFileWriter::Close() {
+  // Abandon on both failure paths; see FormatWriter::Close in format_writer.h.
+  if (auto first_failure = status_; !first_failure.ok()) {
+    Abort();
+    return first_failure;
+  }
+  auto result = CloseImpl();
+  if (!result.ok()) {
+    auto status = RecordFirstFailure(result.status());
+    Abort();
+    return status;
+  }
+  return result;
+}
+
+arrow::Result<api::ColumnGroupFile> VortexFileWriter::CloseImpl() {
   if (closed_) {
-    return arrow::Status::Invalid("Vortex writer is closed. [file_path=", file_path_, "]");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Vortex writer is closed. [file_path=", file_path_, "]");
   }
 
   assert(!closed_);
 
+  // The Rust bridge opens its output lazily on the first batch. Close must
+  // still publish a real zero-row Vortex file: otherwise a pre-existing object
+  // at the same path survives while the returned metadata describes an empty
+  // file, and readers silently consume the old rows.
+  if (!wrote_batch_) {
+    ARROW_ASSIGN_OR_RAISE(auto empty_batch, arrow::RecordBatch::MakeEmpty(schema_));
+    ARROW_RETURN_NOT_OK(WriteImpl(empty_batch));
+  }
+
   // Close returns the total file size and footer size from WriteSummary
-  auto summary_result = vx_writer_.Close();
+  auto summary_result = vx_writer_->Close();
   if (!summary_result.ok()) {
     closed_ = true;
     return MakeVortexErrorStatus("Failed to close Vortex file", summary_result.status());

--- a/cpp/src/lob_column/lob_column_writer.cpp
+++ b/cpp/src/lob_column/lob_column_writer.cpp
@@ -14,6 +14,8 @@
 
 #include "milvus-storage/lob_column/lob_column_writer.h"
 
+#include "milvus-storage/common/extend_status.h"
+
 #include <arrow/array/builder_binary.h>
 #include <arrow/type.h>
 #include <arrow/util/key_value_metadata.h>
@@ -21,6 +23,8 @@
 #include <numeric>
 
 #include "milvus-storage/lob_column/lob_reference.h"
+#include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/filesystem/fs.h"
 
 #include "milvus-storage/format/vortex/vortex_writer.h"
@@ -42,16 +46,96 @@ class LobColumnWriterImpl : public LobColumnWriter {
     GenerateUUIDBinary(current_file_id_);
   }
 
-  ~LobColumnWriterImpl() override {
-    if (!closed_) {
-      // best effort abort, ignore errors in destructor
-      (void)Abort();
-    }
-  }
+  ~LobColumnWriterImpl() override = default;
 
   arrow::Result<std::vector<uint8_t>> WriteData(const uint8_t* data, size_t data_size) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    auto result = WriteDataImpl(data, data_size);
+    if (!result.ok()) {
+      return writer_status_.RecordFirstFailure(result.status());
+    }
+    return result;
+  }
+
+  arrow::Result<std::vector<std::vector<uint8_t>>> WriteBatchData(
+      const std::vector<std::pair<const uint8_t*, size_t>>& items) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    auto result = WriteBatchDataImpl(items);
+    if (!result.ok()) {
+      return writer_status_.RecordFirstFailure(result.status());
+    }
+    return result;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::BinaryArray>> WriteArrowArray(
+      const std::shared_ptr<arrow::BinaryArray>& data_array) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    auto result = WriteArrowArrayImpl(data_array);
+    if (!result.ok()) {
+      return writer_status_.RecordFirstFailure(result.status());
+    }
+    return result;
+  }
+
+  arrow::Status Flush() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(FlushImpl());
+  }
+
+  arrow::Result<std::vector<LobFileResult>> Close() override {
+    if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+      Abort();
+      return first_failure;
+    }
+    auto result = CloseImpl();
+    if (!result.ok()) {
+      auto status = writer_status_.RecordFirstFailure(result.status());
+      Abort();
+      return status;
+    }
+    return result;
+  }
+
+  void Abort() noexcept override {
+    // closed_ before recording the discard: see SegmentWriter::Abort. Abort after a
+    // successful Close must not leave the writer reading as Cancelled.
     if (closed_) {
-      return arrow::Status::Invalid("writer is closed");
+      return;
+    }
+    (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+
+    // discard pending data
+    pending_builder_.Reset();
+
+    // abandon the vortex writer without committing. Abort() rather than a bare
+    // reset(): dropping it releases local ownership, aborting is what asks the
+    // layer below to release what it allocated in the store. The in-progress
+    // file is already in created_files_ (EnsureVortexWriter records it when the
+    // writer opens), so the DeleteFile loop below covers the object itself.
+    if (vortex_writer_) {
+      vortex_writer_->Abort();
+      vortex_writer_.reset();
+    }
+
+    // delete created files (best effort, ignore errors)
+    for (const auto& file_result : created_files_) {
+      AbandonQuietly("a LOB file", [&] { return fs_->DeleteFile(file_result.path); });
+    }
+
+    created_files_.clear();
+    closed_ = true;
+  }
+
+  int64_t WrittenRows() const override { return written_rows_; }
+
+  LobColumnWriterStats GetStats() const override { return stats_; }
+
+  bool IsClosed() const override { return closed_; }
+
+  private:
+  arrow::Result<std::vector<uint8_t>> WriteDataImpl(const uint8_t* data, size_t data_size) {
+    if (closed_) {
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is closed");
     }
 
     // check if data should be stored inline
@@ -90,10 +174,10 @@ class LobColumnWriterImpl : public LobColumnWriter {
     return ref;
   }
 
-  arrow::Result<std::vector<std::vector<uint8_t>>> WriteBatchData(
-      const std::vector<std::pair<const uint8_t*, size_t>>& items) override {
+  arrow::Result<std::vector<std::vector<uint8_t>>> WriteBatchDataImpl(
+      const std::vector<std::pair<const uint8_t*, size_t>>& items) {
     if (closed_) {
-      return arrow::Status::Invalid("writer is closed");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is closed");
     }
 
     std::vector<std::vector<uint8_t>> results;
@@ -128,10 +212,10 @@ class LobColumnWriterImpl : public LobColumnWriter {
     return results;
   }
 
-  arrow::Result<std::shared_ptr<arrow::BinaryArray>> WriteArrowArray(
-      const std::shared_ptr<arrow::BinaryArray>& data_array) override {
+  arrow::Result<std::shared_ptr<arrow::BinaryArray>> WriteArrowArrayImpl(
+      const std::shared_ptr<arrow::BinaryArray>& data_array) {
     if (closed_) {
-      return arrow::Status::Invalid("writer is closed");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is closed");
     }
 
     arrow::BinaryBuilder builder;
@@ -145,7 +229,7 @@ class LobColumnWriterImpl : public LobColumnWriter {
       } else {
         int32_t length;
         const uint8_t* value = data_array->GetValue(i, &length);
-        ARROW_ASSIGN_OR_RAISE(auto ref, WriteData(value, static_cast<size_t>(length)));
+        ARROW_ASSIGN_OR_RAISE(auto ref, WriteDataImpl(value, static_cast<size_t>(length)));
         ARROW_RETURN_NOT_OK(builder.Append(ref.data(), ref.size()));
       }
     }
@@ -155,9 +239,9 @@ class LobColumnWriterImpl : public LobColumnWriter {
     return result;
   }
 
-  arrow::Status Flush() override {
+  arrow::Status FlushImpl() {
     if (closed_) {
-      return arrow::Status::Invalid("writer is closed");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is closed");
     }
 
     ARROW_RETURN_NOT_OK(FlushPending());
@@ -165,9 +249,9 @@ class LobColumnWriterImpl : public LobColumnWriter {
     return arrow::Status::OK();
   }
 
-  arrow::Result<std::vector<LobFileResult>> Close() override {
+  arrow::Result<std::vector<LobFileResult>> CloseImpl() {
     if (closed_) {
-      return arrow::Status::Invalid("writer is already closed");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is already closed");
     }
 
     ARROW_RETURN_NOT_OK(FlushPending());
@@ -177,36 +261,6 @@ class LobColumnWriterImpl : public LobColumnWriter {
     return created_files_;
   }
 
-  arrow::Status Abort() override {
-    if (closed_) {
-      return arrow::Status::OK();
-    }
-
-    // discard pending data
-    pending_builder_.Reset();
-
-    // close vortex writer without committing
-    if (vortex_writer_) {
-      vortex_writer_.reset();
-    }
-
-    // delete created files (best effort, ignore errors)
-    for (const auto& file_result : created_files_) {
-      (void)fs_->DeleteFile(file_result.path);
-    }
-
-    created_files_.clear();
-    closed_ = true;
-    return arrow::Status::OK();
-  }
-
-  int64_t WrittenRows() const override { return written_rows_; }
-
-  LobColumnWriterStats GetStats() const override { return stats_; }
-
-  bool IsClosed() const override { return closed_; }
-
-  private:
   std::shared_ptr<arrow::DataType> ArrowType() const {
     return config_.data_type == LobDataType::kText ? arrow::utf8() : arrow::binary();
   }
@@ -251,6 +305,9 @@ class LobColumnWriterImpl : public LobColumnWriter {
 
     std::shared_ptr<arrow::Array> array;
     ARROW_RETURN_NOT_OK(pending_builder_.Finish(&array));
+
+    FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, arrow::Status::IOError("Injected fault after finalizing pending LOB data: ",
+                                                                   FIUKEY_WRITER_FLUSH_FAIL));
 
     auto schema = arrow::schema({
         arrow::field(FieldName(), ArrowType(), false),
@@ -317,6 +374,7 @@ class LobColumnWriterImpl : public LobColumnWriter {
   // BinaryBuilder works for both text (utf8 is binary-compatible) and binary data.
   arrow::BinaryBuilder pending_builder_;
   size_t pending_bytes_;
+  WriterStatus writer_status_;
 
   // created file results (for cleanup on abort and return on close)
   std::vector<LobFileResult> created_files_;

--- a/cpp/src/packed/writer.cpp
+++ b/cpp/src/packed/writer.cpp
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <exception>
+#include <new>
 #include <stdexcept>
 #include <utility>
 
@@ -32,6 +32,7 @@
 #include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/packed/column_group.h"
 #include "milvus-storage/format/parquet/parquet_writer.h"
+#include "milvus-storage/format/format_writer.h"
 #include "milvus-storage/packed/splitter/indices_based_splitter.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/arrow_util.h"
@@ -66,7 +67,11 @@ arrow::Result<std::shared_ptr<PackedRecordBatchWriter>> PackedRecordBatchWriter:
     std::shared_ptr<::parquet::WriterProperties> writer_props) {
   auto writer = std::shared_ptr<PackedRecordBatchWriter>(new PackedRecordBatchWriter(
       std::move(fs), paths, std::move(schema), storage_config, column_groups, buffer_size, std::move(writer_props)));
-  ARROW_RETURN_NOT_OK(writer->init());
+  auto status = writer->init();
+  if (!status.ok()) {
+    writer->Abort();
+    return status;
+  }
   return writer;
 }
 
@@ -108,14 +113,15 @@ arrow::Status PackedRecordBatchWriter::init() {
   group_field_id_list_ = GroupFieldIDList::Make(group_indices_, field_id_list.ValueOrDie());
 
   splitter_ = IndicesBasedSplitter(group_indices_);
+  // Allocate every ownership slot before opening the first child. Once a
+  // Parquet writer has opened its output, it must be reachable from Abort().
+  group_writers_.reserve(paths_.size());
   for (size_t i = 0; i < paths_.size(); ++i) {
     auto column_group_schema = getColumnGroupSchema(schema_, group_indices_[i]);
     auto writer_result = milvus_storage::parquet::ParquetFileWriter::Make(column_group_schema, fs_, paths_[i],
                                                                           storage_config_, writer_props_);
     if (!writer_result.ok()) {
-      return WrapExtendError(ExtendStatusCode::PackedStorageIO,
-                             fmt::format("Failed to create packed column group writer. [path={}]", paths_[i]),
-                             writer_result.status());
+      return writer_result.status();
     }
     auto writer = std::move(writer_result).ValueOrDie();
     group_writers_.emplace_back(std::move(writer));
@@ -124,11 +130,20 @@ arrow::Status PackedRecordBatchWriter::init() {
 }
 
 arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::RecordBatch>& record) {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return writer_status_.RecordFirstFailure(WriteImpl(record));
+}
+
+arrow::Status PackedRecordBatchWriter::WriteImpl(const std::shared_ptr<arrow::RecordBatch>& record) {
   try {
+    if (closed_) {
+      return arrow::Status::Invalid("Cannot write to closed packed writer");
+    }
+
     // Fault injection point for testing
-    FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
-                  MakeExtendError(ExtendStatusCode::PackedStorageIO,
-                                  fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
+    FIU_RETURN_ON(
+        FIUKEY_WRITER_WRITE_FAIL,
+        MakeExtendError(ExtendStatusCode::PackedIO, fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
 
     if (!record) {
       return arrow::Status::OK();
@@ -148,106 +163,170 @@ arrow::Status PackedRecordBatchWriter::Write(const std::shared_ptr<arrow::Record
 
     ARROW_ASSIGN_OR_RAISE(std::vector<ColumnGroup> column_groups, splitter_.Split(record));
 
-    // Flush column groups until there's enough room for the new column groups
+    // Stateful file writers cannot continue after any child failure. Flush one
+    // group at a time and only advance heap/memory bookkeeping after success.
     // to ensure that memory usage stays strictly below the limit
     while (current_memory_usage_ + next_batch_size >= buffer_size_ && !max_heap_.empty()) {
       LOG_STORAGE_DEBUG_ << "Current memory usage: " << current_memory_usage_ / 1024 / 1024 << " MB, "
                          << ", flushing column group: " << max_heap_.top().first;
       auto max_group = max_heap_.top();
-      max_heap_.pop();
-
-      assert(current_memory_usage_ >= max_group.second);
-      current_memory_usage_ -= max_group.second;
 
       milvus_storage::parquet::ParquetFileWriter* writer = group_writers_[max_group.first].get();
       auto flush_status = writer->Flush();
       if (!flush_status.ok()) {
-        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
-                               flush_status);
+        return flush_status;
       }
+
+      max_heap_.pop();
+      assert(current_memory_usage_ >= max_group.second);
+      current_memory_usage_ -= max_group.second;
     }
 
     // After flushing, add the new column groups if memory usage allows
     for (const ColumnGroup& group : column_groups) {
-      current_memory_usage_ += group.GetMemoryUsage();
-      max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
-
       assert(group.GrpId() < group_writers_.size());
       auto& grp_writer = group_writers_[group.GrpId()];
       auto write_status = grp_writer->Write(group.GetRecordBatch(0));
       if (!write_status.ok()) {
-        return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to write packed column group", write_status);
+        return write_status;
       }
+
+      current_memory_usage_ += group.GetMemoryUsage();
+      max_heap_.emplace(group.GrpId(), group.GetMemoryUsage());
     }
 
     ARROW_RETURN_NOT_OK(balanceMaxHeap());
     return arrow::Status::OK();
+  } catch (const std::bad_alloc&) {
+    return arrow::Status::OutOfMemory("Packed writer write ran out of memory");
   } catch (const std::exception& e) {
-    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+    return MakeExtendError(ExtendStatusCode::InternalInvariantViolated,
                            fmt::format("Packed writer write failed unexpectedly: {}", e.what()));
   } catch (...) {
-    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
-                           "Packed writer write with unknown exception failed unexpectedly");
+    return MakeExtendError(ExtendStatusCode::InternalInvariantViolated, "Packed writer write failed unexpectedly");
   }
 }
 
-arrow::Status PackedRecordBatchWriter::Close() {
-  try {
-    // Fault injection point for testing
-    FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
-                  MakeExtendError(ExtendStatusCode::PackedStorageIO,
-                                  fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
+void PackedRecordBatchWriter::Abort() noexcept {
+  // No writer_status_.Check(): abort is for the state where the writer has
+  // already failed.
+  if (closed_) {
+    // Already finalized, or already aborted: abort after a successful close is
+    // a no-op, so a caller can destroy unconditionally.
+    return;
+  }
+  closed_ = true;
+  (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+  buffered_batches_.clear();
+  // Each group writer owns its own output stream, so each one has to be asked
+  // separately; one refusing to release its upload is not a reason to skip the
+  // rest.
+  for (auto& writer : group_writers_) {
+    if (writer != nullptr) {
+      writer->Abort();
+    }
+  }
+  group_writers_.clear();
+  for (const auto& path : pending_closed_paths_) {
+    AbandonQuietly("a pending packed file", [&] { return fs_->DeleteFile(path); });
+  }
+  pending_closed_paths_.clear();
+}
 
+arrow::Status PackedRecordBatchWriter::Close() {
+  // Abandon on both failure paths; see FormatWriter::Close in format_writer.h.
+  if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+    Abort();
+    return first_failure;
+  }
+  auto status = writer_status_.RecordFirstFailure(CloseImpl());
+  if (!status.ok()) {
+    Abort();
+  }
+  return status;
+}
+
+arrow::Status PackedRecordBatchWriter::CloseImpl() {
+  try {
     // Check if already closed
     if (closed_) {
       return arrow::Status::OK();
     }
 
+    // Fault injection point for testing
+    FIU_RETURN_ON(
+        FIUKEY_WRITER_CLOSE_FAIL,
+        MakeExtendError(ExtendStatusCode::PackedIO, fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
+
+    // Reserve before any child publishes a file. Recording each successful
+    // Close below must not allocate after ownership has changed hands.
+    pending_closed_paths_.reserve(group_writers_.size());
+
     // flush all remaining column groups before closing
     auto status = flushRemainingBuffer();
-    if (status.ok()) {
-      closed_ = true;
+    if (!status.ok()) {
+      return status;
     }
-    return status;
+    // The complete set is now published at the caller-supplied paths.
+    pending_closed_paths_.clear();
+    closed_ = true;
+    return arrow::Status::OK();
+  } catch (const std::bad_alloc&) {
+    return arrow::Status::OutOfMemory("Packed writer close ran out of memory");
   } catch (const std::exception& e) {
-    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+    return MakeExtendError(ExtendStatusCode::InternalInvariantViolated,
                            fmt::format("Packed writer close failed unexpectedly: {}", e.what()));
   } catch (...) {
-    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
-                           "Packed writer close with unknown exception failed unexpectedly");
+    return MakeExtendError(ExtendStatusCode::InternalInvariantViolated, "Packed writer close failed unexpectedly");
   }
 }
 
 arrow::Result<std::vector<size_t>> PackedRecordBatchWriter::Tell() const {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  auto result = TellImpl();
+  if (!result.ok()) {
+    return writer_status_.RecordFirstFailure(result.status());
+  }
+  return result;
+}
+
+arrow::Result<std::vector<size_t>> PackedRecordBatchWriter::TellImpl() const {
   try {
     std::vector<size_t> positions(group_writers_.size());
     for (size_t writer_idx = 0; writer_idx < group_writers_.size(); ++writer_idx) {
       auto tell_result = group_writers_[writer_idx]->Tell();
       if (!tell_result.ok()) {
-        return WrapExtendError(ExtendStatusCode::PackedStorageIO,
-                               fmt::format("Failed to tell packed column group writer. [writer_index={}]", writer_idx),
-                               tell_result.status());
+        return tell_result.status();
       }
       positions[writer_idx] = tell_result.ValueOrDie();
     }
     return positions;
+  } catch (const std::bad_alloc&) {
+    return arrow::Status::OutOfMemory("Packed writer tell ran out of memory");
   } catch (const std::exception& e) {
-    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
+    return MakeExtendError(ExtendStatusCode::InternalInvariantViolated,
                            fmt::format("Packed writer tell failed unexpectedly: {}", e.what()));
   } catch (...) {
-    return MakeExtendError(ExtendStatusCode::PackedUnexpected,
-                           "Packed writer tell with unknown exception failed unexpectedly");
+    return MakeExtendError(ExtendStatusCode::InternalInvariantViolated, "Packed writer tell failed unexpectedly");
   }
 }
 
 arrow::Status PackedRecordBatchWriter::AddUserMetadata(const std::string& key, const std::string& value) {
+  ARROW_RETURN_NOT_OK(writer_status_.Check());
+  return writer_status_.RecordFirstFailure(AddUserMetadataImpl(key, value));
+}
+
+arrow::Status PackedRecordBatchWriter::AddUserMetadataImpl(const std::string& key, const std::string& value) {
+  if (closed_) {
+    return arrow::Status::Invalid("Cannot add metadata to closed packed writer");
+  }
   user_metadata_.emplace_back(key, value);
   return arrow::Status::OK();
 }
 
 arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
   // Fault injection point for testing
-  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, MakeExtendError(ExtendStatusCode::PackedStorageIO,
+  FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL, MakeExtendError(ExtendStatusCode::PackedIO,
                                                           fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
 
   if (closed_) {
@@ -256,35 +335,39 @@ arrow::Status PackedRecordBatchWriter::flushRemainingBuffer() {
 
   while (!max_heap_.empty()) {
     auto max_group = max_heap_.top();
-    max_heap_.pop();
     auto& grp_writer = group_writers_[max_group.first];
 
     LOG_STORAGE_DEBUG_ << "Flushing remaining column group: " << max_group.first;
-    current_memory_usage_ -= max_group.second;
     auto flush_status = grp_writer->Flush();
     if (!flush_status.ok()) {
-      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to flush packed column group writer",
-                             flush_status);
+      return flush_status;
     }
+
+    max_heap_.pop();
+    assert(current_memory_usage_ >= max_group.second);
+    current_memory_usage_ -= max_group.second;
   }
 
-  for (auto& grp_writer : group_writers_) {
+  for (size_t writer_idx = 0; writer_idx < group_writers_.size(); ++writer_idx) {
+    auto& grp_writer = group_writers_[writer_idx];
     auto append_status = grp_writer->AppendKVMetadata(GROUP_FIELD_ID_LIST_META_KEY, group_field_id_list_.Serialize());
     if (!append_status.ok()) {
-      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to append packed group field id metadata",
-                             append_status);
+      return append_status;
     }
 
     auto metadata_status = grp_writer->AddUserMetadata(user_metadata_);
     if (!metadata_status.ok()) {
-      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to add packed user metadata", metadata_status);
+      return metadata_status;
     }
 
     auto close_result = grp_writer->Close();
     if (!close_result.ok()) {
-      return WrapExtendError(ExtendStatusCode::PackedStorageIO, "Failed to close packed column group writer",
-                             close_result.status());
+      return close_result.status();
     }
+    // paths_ is only needed to open each child and to remember a successfully
+    // closed child for rollback. Moving it here is allocation-free after the
+    // reserve in CloseImpl(), and no successful path needs this string again.
+    pending_closed_paths_.push_back(std::move(paths_[writer_idx]));
   }
 
   return arrow::Status::OK();

--- a/cpp/src/segment/segment_writer.cpp
+++ b/cpp/src/segment/segment_writer.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "milvus-storage/format/format_writer.h"
 #include "milvus-storage/segment/segment_writer.h"
+
+#include "milvus-storage/common/extend_status.h"
 
 #include <arrow/array/builder_binary.h>
 #include <arrow/type.h>
@@ -25,6 +28,7 @@
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/layout.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/lob_column/lob_column_reader.h"
 #include "milvus-storage/lob_column/lob_column_writer.h"
 #include "milvus-storage/lob_column/lob_reference.h"
@@ -48,29 +52,27 @@ class SegmentWriterImpl : public SegmentWriter {
         closed_(false),
         written_rows_(0) {}
 
-  ~SegmentWriterImpl() override {
-    if (!closed_) {
-      // best effort abort, ignore errors in destructor
-      (void)Abort();
-    }
-  }
+  ~SegmentWriterImpl() override = default;
 
   arrow::Status Init() {
     // create LobColumnWriters for each LOB column (TEXT or BINARY)
     for (int col_idx : lob_column_indices_) {
       auto field = original_schema_->field(col_idx);
-      auto field_id = GetFieldId(field);
+      ARROW_ASSIGN_OR_RAISE(auto field_id, TryGetFieldId(field));
       if (field_id < 0) {
         return arrow::Status::Invalid("LOB column must have a valid field_id in metadata");
       }
 
       auto it = config_.lob_columns.find(field_id);
       if (it == config_.lob_columns.end()) {
-        return arrow::Status::Invalid("LOB column config not found for field_id: " + std::to_string(field_id));
+        return arrow::Status::Invalid("LOB column config not found for field_id: ", field_id);
       }
 
       ARROW_ASSIGN_OR_RAISE(auto writer, lob_column::CreateLobColumnWriter(fs_, it->second));
       lob_writers_[col_idx] = std::move(writer);
+      // Allocate the ownership slot before Close can publish a LOB file. Moving
+      // the returned vector into this existing slot is allocation-free.
+      lob_file_results_.try_emplace(col_idx);
 
       // if rewrite_mode, also create a reader to decode old LOB references
       if (it->second.rewrite_mode) {
@@ -90,8 +92,95 @@ class SegmentWriterImpl : public SegmentWriter {
   }
 
   arrow::Status Write(const std::shared_ptr<arrow::RecordBatch>& batch) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(WriteImpl(batch));
+  }
+
+  arrow::Status Flush() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(FlushImpl());
+  }
+
+  arrow::Result<SegmentWriteOutput> Close() override {
+    // Abandon on both failure paths; see FormatWriter::Close in format_writer.h.
+    if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+      Abort();
+      return first_failure;
+    }
+    auto result = CloseImpl();
+    if (!result.ok()) {
+      auto status = writer_status_.RecordFirstFailure(result.status());
+      Abort();
+      return status;
+    }
+    return result;
+  }
+
+  void Abort() noexcept override {
+    // The closed_ check comes FIRST, before recording the discard. Abort() after a
+    // successful Close() has to be a no-op in every respect -- that is what
+    // lets a caller (or a scope guard) abandon unconditionally without first
+    // working out which of the two verbs it owes. Discarding here would flip a
+    // writer that finished cleanly to Cancelled.
     if (closed_) {
-      return arrow::Status::Invalid("writer is closed");
+      return;
+    }
+    (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+
+    // abort the column group writers first: they are the ones holding storage
+    // the store keeps charging for (an S3 multipart upload's parts do not even
+    // appear in a bucket listing). LOB files are ordinary objects, so they can
+    // wait a line.
+    if (writer_ != nullptr) {
+      writer_->abort();
+    }
+
+    // A successfully closed api::Writer cannot delete its files on Abort().
+    // This segment still owns them until SegmentWriteOutput is returned.
+    if (pending_column_groups_ != nullptr) {
+      for (const auto& column_group : *pending_column_groups_) {
+        for (const auto& file : column_group->files) {
+          AbandonQuietly("a pending segment column group file", [&] { return fs_->DeleteFile(file.path); });
+        }
+      }
+      pending_column_groups_.reset();
+    }
+
+    // abort all TEXT column writers (they will delete their LOB files)
+    for (auto& [col_idx, writer] : lob_writers_) {
+      writer->Abort();
+    }
+    // The same ownership gap exists for a LOB writer whose Close() succeeded
+    // before a later child failed.
+    for (const auto& [col_idx, lob_files] : lob_file_results_) {
+      for (const auto& lob_file : lob_files) {
+        AbandonQuietly("a pending segment LOB file", [&] { return fs_->DeleteFile(lob_file.path); });
+      }
+    }
+    lob_file_results_.clear();
+
+    // close LOB readers (rewrite mode)
+    for (auto& reader_entry : lob_readers_) {
+      AbandonQuietly("a LOB reader", [&reader_entry] { return reader_entry.second->Close(); });
+    }
+
+    closed_ = true;
+  }
+
+  int64_t WrittenRows() const override { return written_rows_; }
+
+  SegmentWriterStats GetStats() const override { return stats_; }
+
+  std::shared_ptr<arrow::Schema> GetStorageSchema() const override { return storage_schema_; }
+
+  std::shared_ptr<arrow::Schema> GetOriginalSchema() const override { return original_schema_; }
+
+  bool IsClosed() const override { return closed_; }
+
+  private:
+  arrow::Status WriteImpl(const std::shared_ptr<arrow::RecordBatch>& batch) {
+    if (closed_) {
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is closed");
     }
 
     if (!batch || batch->num_rows() == 0) {
@@ -153,9 +242,9 @@ class SegmentWriterImpl : public SegmentWriter {
     return arrow::Status::OK();
   }
 
-  arrow::Status Flush() override {
+  arrow::Status FlushImpl() {
     if (closed_) {
-      return arrow::Status::Invalid("writer is closed");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is closed");
     }
 
     // flush all TEXT column writers
@@ -169,18 +258,18 @@ class SegmentWriterImpl : public SegmentWriter {
     return arrow::Status::OK();
   }
 
-  arrow::Result<SegmentWriteOutput> Close() override {
+  arrow::Result<SegmentWriteOutput> CloseImpl() {
     if (closed_) {
-      return arrow::Status::Invalid("writer is already closed");
+      return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated, "writer is already closed");
     }
 
     // flush pending data
-    ARROW_RETURN_NOT_OK(Flush());
+    ARROW_RETURN_NOT_OK(FlushImpl());
 
     // close all TEXT column writers and collect LOB file results
     for (auto& [col_idx, writer] : lob_writers_) {
       ARROW_ASSIGN_OR_RAISE(auto lob_files, writer->Close());
-      lob_file_results_[col_idx] = std::move(lob_files);
+      lob_file_results_.at(col_idx) = std::move(lob_files);
 
       auto text_stats = writer->GetStats();
       stats_.lob_files_created += text_stats.lob_files_created;
@@ -192,14 +281,14 @@ class SegmentWriterImpl : public SegmentWriter {
     }
 
     // close api::Writer and get ColumnGroups
-    ARROW_ASSIGN_OR_RAISE(auto column_groups, writer_->close());
-    stats_.parquet_files_created = column_groups->size();
+    ARROW_ASSIGN_OR_RAISE(pending_column_groups_, writer_->close());
+    stats_.parquet_files_created = pending_column_groups_->size();
 
     // build LOB file info list from results
     std::vector<api::LobFileInfo> lob_file_infos;
     for (const auto& [col_idx, lob_files] : lob_file_results_) {
       auto field = original_schema_->field(col_idx);
-      auto field_id = GetFieldId(field);
+      ARROW_ASSIGN_OR_RAISE(auto field_id, TryGetFieldId(field));
 
       for (const auto& lob_result : lob_files) {
         api::LobFileInfo lob_info;
@@ -215,44 +304,14 @@ class SegmentWriterImpl : public SegmentWriter {
     closed_ = true;
 
     SegmentWriteOutput output;
-    output.column_groups = column_groups;
+    output.column_groups = std::move(pending_column_groups_);
     output.lob_files = std::move(lob_file_infos);
     output.rows_written = written_rows_;
+    lob_file_results_.clear();
 
     return output;
   }
 
-  arrow::Status Abort() override {
-    if (closed_) {
-      return arrow::Status::OK();
-    }
-
-    // abort all TEXT column writers (they will delete their LOB files)
-    for (auto& [col_idx, writer] : lob_writers_) {
-      // best effort abort, continue on error
-      (void)writer->Abort();
-    }
-
-    // close LOB readers (rewrite mode)
-    for (auto& [col_idx, reader] : lob_readers_) {
-      (void)reader->Close();
-    }
-
-    closed_ = true;
-    return arrow::Status::OK();
-  }
-
-  int64_t WrittenRows() const override { return written_rows_; }
-
-  SegmentWriterStats GetStats() const override { return stats_; }
-
-  std::shared_ptr<arrow::Schema> GetStorageSchema() const override { return storage_schema_; }
-
-  std::shared_ptr<arrow::Schema> GetOriginalSchema() const override { return original_schema_; }
-
-  bool IsClosed() const override { return closed_; }
-
-  private:
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::shared_ptr<arrow::Schema> original_schema_;
   std::shared_ptr<arrow::Schema> storage_schema_;
@@ -261,6 +320,7 @@ class SegmentWriterImpl : public SegmentWriter {
 
   bool closed_;
   int64_t written_rows_;
+  WriterStatus writer_status_;
 
   // LOB column writers (TEXT or BINARY), keyed by column index
   std::unordered_map<int, std::unique_ptr<lob_column::LobColumnWriter>> lob_writers_;
@@ -277,6 +337,10 @@ class SegmentWriterImpl : public SegmentWriter {
   // LOB file results, keyed by column index
   std::unordered_map<int, std::vector<lob_column::LobFileResult>> lob_file_results_;
 
+  // Successfully closed regular files remain owned here until the complete
+  // SegmentWriteOutput is ready to return.
+  std::shared_ptr<api::ColumnGroups> pending_column_groups_;
+
   // statistics
   SegmentWriterStats stats_;
 };
@@ -286,6 +350,8 @@ arrow::Result<std::unique_ptr<SegmentWriter>> SegmentWriter::Create(std::shared_
                                                                     const std::shared_ptr<arrow::Schema>& schema,
                                                                     const SegmentWriterConfig& config) {
   if (!fs) {
+    // Caller-owned argument: a null filesystem is the caller's error, not an
+    // invariant of ours.
     return arrow::Status::Invalid("filesystem is null");
   }
 
@@ -299,7 +365,11 @@ arrow::Result<std::unique_ptr<SegmentWriter>> SegmentWriter::Create(std::shared_
 
   // validate required properties for ColumnGroupPolicy
   if (config.properties.find(PROPERTY_WRITER_POLICY) == config.properties.end()) {
-    return arrow::Status::Invalid("properties must contain " + std::string(PROPERTY_WRITER_POLICY));
+    // A missing property is deployment configuration, not a broken invariant:
+    // StorageConfigInvalid is the code an ownership-aware entry point can
+    // re-tag to the user when the properties came from an external table.
+    return MakeExtendErrorMsg(ExtendStatusCode::StorageConfigInvalid, "properties must contain ",
+                              PROPERTY_WRITER_POLICY);
   }
 
   // identify LOB columns (TEXT or BINARY) and build storage schema
@@ -308,11 +378,12 @@ arrow::Result<std::unique_ptr<SegmentWriter>> SegmentWriter::Create(std::shared_
 
   for (int i = 0; i < schema->num_fields(); i++) {
     auto field = schema->field(i);
+    ARROW_ASSIGN_OR_RAISE(auto field_id, TryGetFieldId(field));
 
-    if (config.lob_columns.count(GetFieldId(field)) > 0) {
+    if (config.lob_columns.count(field_id) > 0) {
       // LOB column: storage always uses binary for LOBReferences
       // (input may be utf8 for TEXT or binary for BINARY LOB)
-      auto storage_field = arrow::field(field->name(), arrow::binary(), field->nullable(), field->metadata()->Copy());
+      auto storage_field = arrow::field(field->name(), arrow::binary(), field->nullable(), field->metadata());
       storage_fields.push_back(storage_field);
       lob_column_indices.push_back(i);
     } else {

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -38,7 +38,9 @@
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/common/layout.h"
 #include "milvus-storage/common/log.h"
+#include "milvus-storage/common/writer_status.h"
 #include "milvus-storage/format/column_group_writer.h"
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::api {
 
@@ -216,10 +218,12 @@ std::vector<std::shared_ptr<ColumnGroup>> SchemaBasedColumnGroupPolicy::get_colu
 
 arrow::Status SizeBasedColumnGroupPolicy::sample(const std::shared_ptr<arrow::RecordBatch>& batch) {
   if (!batch) {
-    return arrow::Status::Invalid("Sample batch cannot be null for SizeBasedColumnGroupPolicy");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Sample batch cannot be null for SizeBasedColumnGroupPolicy");
   }
   if (batch->num_rows() == 0) {
-    return arrow::Status::Invalid("Sample batch cannot be empty (0 rows) for SizeBasedColumnGroupPolicy");
+    return MakeExtendErrorMsg(ExtendStatusCode::InternalInvariantViolated,
+                              "Sample batch cannot be empty (0 rows) for SizeBasedColumnGroupPolicy");
   }
 
   // Calculate average column sizes based on the sample
@@ -323,6 +327,11 @@ class WriterImpl : public Writer {
    *       All batches written to the same writer should have consistent schemas.
    */
   arrow::Status write(const std::shared_ptr<arrow::RecordBatch>& batch) override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(write_impl(batch));
+  }
+
+  arrow::Status write_impl(const std::shared_ptr<arrow::RecordBatch>& batch) {
     FIU_RETURN_ON(FIUKEY_WRITER_WRITE_FAIL,
                   arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_WRITE_FAIL)));
 
@@ -360,6 +369,11 @@ class WriterImpl : public Writer {
    *       after flushing.
    */
   arrow::Status flush() override {
+    ARROW_RETURN_NOT_OK(writer_status_.Check());
+    return writer_status_.RecordFirstFailure(flush_impl());
+  }
+
+  arrow::Status flush_impl() {
     FIU_RETURN_ON(FIUKEY_WRITER_FLUSH_FAIL,
                   arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_FLUSH_FAIL)));
 
@@ -397,6 +411,51 @@ class WriterImpl : public Writer {
    */
   arrow::Result<std::shared_ptr<ColumnGroups>> close(const std::vector<std::string_view>& config_keys = {},
                                                      const std::vector<std::string_view>& config_values = {}) override {
+    // Abandon on both failure paths; see FormatWriter::Close in format_writer.h.
+    if (auto first_failure = writer_status_.Check(); !first_failure.ok()) {
+      abort();
+      return first_failure;
+    }
+    auto result = close_impl(config_keys, config_values);
+    if (!result.ok()) {
+      auto status = writer_status_.RecordFirstFailure(result.status());
+      abort();
+      return status;
+    }
+    return result;
+  }
+
+  // No writer_status_.Check(): abort must work precisely when the writer is
+  // already terminal, which is the only state anyone calls it from.
+  void abort() noexcept override {
+    // closed_ before recording the discard: abort after a successful close must be a
+    // no-op in every respect, including the recorded status.
+    if (closed_) {
+      return;
+    }
+    (void)writer_status_.RecordFirstFailure(arrow::Status::Cancelled("Stateful writer was discarded"));
+    closed_ = true;
+    // Every column group gets its chance. One failing to release its storage is
+    // no reason to leave the others holding theirs, and none of them reports
+    // its cleanup failure upward -- ColumnGroupWriter::Abort logs and returns OK.
+    for (const auto& writer : column_group_writers_) {
+      if (writer != nullptr) {
+        writer->Abort();
+        // Abort is intentionally a no-op after a successful child Close. If a
+        // later child failed, the parent still owns those published files.
+        writer->RollbackClosedFiles();
+      }
+    }
+    column_group_writers_.clear();
+
+    for (const auto& column_group : column_groups_) {
+      column_group->files.clear();
+    }
+    cgs_->clear();
+  }
+
+  arrow::Result<std::shared_ptr<ColumnGroups>> close_impl(const std::vector<std::string_view>& config_keys = {},
+                                                          const std::vector<std::string_view>& config_values = {}) {
     FIU_RETURN_ON(FIUKEY_WRITER_CLOSE_FAIL,
                   arrow::Status::IOError(fmt::format("Injected fault: {}", FIUKEY_WRITER_CLOSE_FAIL)));
 
@@ -441,6 +500,7 @@ class WriterImpl : public Writer {
   // ==================== Internal Data Members ====================
   bool closed_{false};       ///< Whether the writer has been closed
   bool initialized_{false};  ///< Whether the writer has been initialized
+  WriterStatus writer_status_;
 
   std::string base_path_;                                   ///< Base directory for column group files
   std::shared_ptr<arrow::Schema> schema_;                   ///< Logical schema of the dataset

--- a/cpp/test/api_writer_reader_test.cpp
+++ b/cpp/test/api_writer_reader_test.cpp
@@ -413,7 +413,7 @@ TEST_P(APIWriterReaderTest, SizeBasedColumnGroupPolicy) {
 }
 
 #ifdef BUILD_WITH_FIU
-TEST_P(APIWriterReaderTest, WriterCloseAfterInitColumnGroupWritersFail) {
+TEST_P(APIWriterReaderTest, WriterInitFailureIsTerminal) {
   if (format != LOON_FORMAT_PARQUET) {
     GTEST_SKIP() << "This cleanup path is covered with parquet format only";
   }
@@ -428,11 +428,10 @@ TEST_P(APIWriterReaderTest, WriterCloseAfterInitColumnGroupWritersFail) {
   ASSERT_FALSE(status.ok());
   EXPECT_TRUE(status.ToString().find(FIUKEY_WRITER_INIT_COLUMN_GROUP_WRITERS_FAIL) != std::string::npos);
 
+  // close() returns the first failure without additional cleanup I/O.
   auto close_result = writer->close();
-  ASSERT_TRUE(close_result.ok()) << close_result.status().ToString();
-  auto cgs = std::move(close_result).ValueOrDie();
-  ASSERT_NE(cgs, nullptr);
-  EXPECT_TRUE(cgs->empty());
+  ASSERT_FALSE(close_result.ok());
+  EXPECT_TRUE(close_result.status().Equals(status));
 }
 #endif
 

--- a/cpp/test/format/column_groups_wr_test.cpp
+++ b/cpp/test/format/column_groups_wr_test.cpp
@@ -24,6 +24,7 @@
 #include <arrow/testing/gtest_util.h>
 
 #include "milvus-storage/common/fiu_local.h"
+#include "milvus-storage/common/layout.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/async_tasks.h"
 #include "milvus-storage/format/column_group_reader.h"
@@ -607,6 +608,99 @@ TEST_P(ColumnGroupsWRTest, GetChunksFailWithParallelism) {
   FIU_DISABLE_FAULT(FIUKEY_COLUMN_GROUP_READ_FAIL);
 }
 #endif  // BUILD_WITH_FIU
+
+// Rolling hands files to Abort(), not to the caller: only Close() transfers
+// them, so a writer abandoned mid-rolling must delete what it rolled -- no
+// manifest will ever reference those objects, and nothing else can name them.
+TEST_P(ColumnGroupsWRTest, AbortDeletesRolledFiles) {
+  // Roll on every flush so several finalized objects exist before the abort.
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_WRITER_FILE_ROLLING_SIZE, "1"), std::nullopt);
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(format, schema_));
+  auto writer = Writer::create(base_path_, schema_, std::move(policy), properties_);
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_STATUS_OK(writer->write(test_batch_));
+    ASSERT_STATUS_OK(writer->flush());
+  }
+
+  arrow::fs::FileSelector selector;
+  selector.base_dir = get_data_path(base_path_);
+  ASSERT_AND_ASSIGN(const auto before_abort, fs_->GetFileInfo(selector));
+  ASSERT_GT(before_abort.size(), 1) << "rolling should have produced several files";
+
+  writer->abort();
+
+  ASSERT_AND_ASSIGN(const auto after_abort, fs_->GetFileInfo(selector));
+  EXPECT_TRUE(after_abort.empty()) << [&] {
+    std::string names;
+    for (const auto& info : after_abort) {
+      names += " " + info.path();
+    }
+    return "files survived abort:" + names;
+  }();
+}
+
+TEST_P(ColumnGroupsWRTest, CloseWithoutWritesPublishesNoFile) {
+  auto column_group = std::make_shared<ColumnGroup>();
+  column_group->columns = schema_->field_names();
+  column_group->format = format;
+  ASSERT_AND_ASSIGN(auto writer, ColumnGroupWriter::create(base_path_, 0, column_group, schema_, properties_));
+
+  ASSERT_AND_ASSIGN(auto files, writer->Close());
+  EXPECT_TRUE(files.empty());
+
+  arrow::fs::FileSelector selector;
+  selector.base_dir = get_data_path(base_path_);
+  ASSERT_AND_ASSIGN(const auto physical_files, fs_->GetFileInfo(selector));
+  EXPECT_TRUE(physical_files.empty());
+}
+
+TEST_P(ColumnGroupsWRTest, NonEmptyZeroByteBatchIsNotDiscardedAsEmpty) {
+  auto null_schema = arrow::schema({arrow::field("only_null", arrow::null())});
+  auto null_batch = arrow::RecordBatch::Make(
+      null_schema, 7, {std::static_pointer_cast<arrow::Array>(std::make_shared<arrow::NullArray>(7))});
+  ASSERT_EQ(GetRecordBatchMemorySize(null_batch), 0u);
+
+  auto column_group = std::make_shared<ColumnGroup>();
+  column_group->columns = null_schema->field_names();
+  column_group->format = format;
+  ASSERT_AND_ASSIGN(auto writer, ColumnGroupWriter::create(base_path_, 0, column_group, null_schema, properties_));
+
+  ASSERT_STATUS_OK(writer->Write(null_batch));
+  ASSERT_AND_ASSIGN(auto files, writer->Close());
+
+  ASSERT_EQ(files.size(), 1u);
+  EXPECT_EQ(files.front().start_index, 0);
+  EXPECT_EQ(files.front().end_index, null_batch->num_rows());
+
+  arrow::fs::FileSelector selector;
+  selector.base_dir = get_data_path(base_path_);
+  ASSERT_AND_ASSIGN(const auto physical_files, fs_->GetFileInfo(selector));
+  EXPECT_EQ(physical_files.size(), 1u);
+}
+
+TEST_P(ColumnGroupsWRTest, CloseAfterRollDoesNotPublishEmptySuccessor) {
+  ASSERT_EQ(api::SetValue(properties_, PROPERTY_WRITER_FILE_ROLLING_SIZE, "1"), std::nullopt);
+  auto column_group = std::make_shared<ColumnGroup>();
+  column_group->columns = schema_->field_names();
+  column_group->format = format;
+  ASSERT_AND_ASSIGN(auto writer, ColumnGroupWriter::create(base_path_, 0, column_group, schema_, properties_));
+
+  ASSERT_STATUS_OK(writer->Write(test_batch_));
+  ASSERT_STATUS_OK(writer->Flush());
+  ASSERT_AND_ASSIGN(auto files, writer->Close());
+
+  ASSERT_EQ(files.size(), 1u);
+  EXPECT_EQ(files.front().start_index, 0);
+  EXPECT_EQ(files.front().end_index, test_batch_->num_rows());
+  EXPECT_GT(files.front().Get<uint64_t>(api::kPropertyFileSize), 0u);
+  EXPECT_GT(files.front().Get<uint64_t>(api::kPropertyFooterSize), 0u);
+
+  arrow::fs::FileSelector selector;
+  selector.base_dir = get_data_path(base_path_);
+  ASSERT_AND_ASSIGN(const auto physical_files, fs_->GetFileInfo(selector));
+  ASSERT_EQ(physical_files.size(), 1u);
+  EXPECT_EQ(physical_files.front().path(), files.front().path);
+}
 
 INSTANTIATE_TEST_SUITE_P(ColumnGroupsWRTestP,
                          ColumnGroupsWRTest,

--- a/cpp/test/format/parquet/file_writer_test.cpp
+++ b/cpp/test/format/parquet/file_writer_test.cpp
@@ -30,7 +30,6 @@
 #include <parquet/file_reader.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
-#include <parquet/file_reader.h>
 #include <parquet/metadata.h>
 #include <parquet/properties.h>
 
@@ -41,7 +40,9 @@
 #include "milvus-storage/common/arrow_util.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/layout.h"
+#include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/packed/writer.h"
 #include "milvus-storage/format/parquet/parquet_format_reader.h"
 
@@ -113,6 +114,245 @@ class TrackingMemoryPool final : public arrow::MemoryPool {
   std::vector<ResizeEvent> events_;
 };
 
+class FailingOpenOutputFileSystem final : public arrow::fs::SubTreeFileSystem {
+  public:
+  FailingOpenOutputFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs, arrow::Status failure)
+      : arrow::fs::SubTreeFileSystem("", std::move(base_fs)), failure_(std::move(failure)) {}
+
+  std::string type_name() const override { return "failing-open-output"; }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
+    opened_path_ = path;
+    return failure_;
+  }
+
+  const std::string& opened_path() const { return opened_path_; }
+
+  private:
+  arrow::Status failure_;
+  std::string opened_path_;
+};
+
+class AbortTrackingOutputStream final : public arrow::io::OutputStream {
+  public:
+  explicit AbortTrackingOutputStream(bool close_on_abort = true) : close_on_abort_(close_on_abort) {}
+
+  void ArmWriteFailure(arrow::Status failure) { write_failure_ = std::move(failure); }
+  void ArmCloseFailure(arrow::Status failure) { close_failure_ = std::move(failure); }
+
+  arrow::Status Close() override {
+    ++close_count_;
+    if (!close_failure_.ok()) {
+      return close_failure_;
+    }
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Abort() override {
+    ++abort_count_;
+    closed_ = close_on_abort_;
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    if (closed_) {
+      return arrow::Status::Invalid("stream is closed");
+    }
+    return position_;
+  }
+
+  bool closed() const override { return closed_; }
+
+  arrow::Status Write(const void*, int64_t nbytes) override {
+    if (closed_) {
+      return arrow::Status::Invalid("stream is closed");
+    }
+    ++write_count_;
+    if (!write_failure_.ok()) {
+      return write_failure_;
+    }
+    position_ += nbytes;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override {
+    if (closed_) {
+      return arrow::Status::Invalid("stream is closed");
+    }
+    return arrow::Status::OK();
+  }
+
+  int abort_count() const { return abort_count_; }
+  int close_count() const { return close_count_; }
+  int write_count() const { return write_count_; }
+
+  private:
+  bool closed_ = false;
+  bool close_on_abort_;
+  int64_t position_ = 0;
+  int abort_count_ = 0;
+  int close_count_ = 0;
+  int write_count_ = 0;
+  arrow::Status write_failure_ = arrow::Status::OK();
+  arrow::Status close_failure_ = arrow::Status::OK();
+};
+
+class FailingWriteOutputStream final : public arrow::io::OutputStream {
+  public:
+  explicit FailingWriteOutputStream(arrow::Status failure) : failure_(std::move(failure)) {}
+
+  arrow::Status Close() override {
+    ++close_count_;
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Abort() override {
+    ++abort_count_;
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    if (closed_) {
+      return arrow::Status::Invalid("stream is closed");
+    }
+    return 0;
+  }
+
+  bool closed() const override { return closed_; }
+
+  arrow::Status Write(const void*, int64_t) override {
+    ++write_count_;
+    return failure_;
+  }
+
+  int abort_count() const { return abort_count_; }
+  int close_count() const { return close_count_; }
+  int write_count() const { return write_count_; }
+
+  private:
+  arrow::Status failure_;
+  bool closed_ = false;
+  int abort_count_ = 0;
+  int close_count_ = 0;
+  int write_count_ = 0;
+};
+
+// A stream whose Abort() throws something that is not std::exception.
+//
+// arrow::io::OutputStream::Abort() is allowed to throw -- it is a filesystem
+// implementation we do not own -- and this repository already contains one that
+// does (see c_abi_exception_boundary_test). Writers, by contrast, abandon
+// through a void noexcept Abort(), so an escaping exception would call
+// std::terminate and take the process down before the FFI boundary could report
+// the caller's own failure.
+class ThrowingAbortOutputStream final : public arrow::io::OutputStream {
+  public:
+  arrow::Status Close() override {
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Abort() override {
+    ++abort_count_;
+    throw 42;
+  }
+
+  arrow::Result<int64_t> Tell() const override { return position_; }
+  bool closed() const override { return closed_; }
+
+  arrow::Status Write(const void*, int64_t nbytes) override {
+    position_ += nbytes;
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override { return arrow::Status::OK(); }
+
+  int abort_count() const { return abort_count_; }
+
+  private:
+  bool closed_ = false;
+  int64_t position_ = 0;
+  int abort_count_ = 0;
+};
+
+class TrackingOutputFileSystem final : public arrow::fs::SubTreeFileSystem {
+  public:
+  TrackingOutputFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs,
+                           std::shared_ptr<arrow::io::OutputStream> stream)
+      : arrow::fs::SubTreeFileSystem("", std::move(base_fs)), stream_(std::move(stream)) {}
+
+  std::string type_name() const override { return "tracking-output"; }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string&, const std::shared_ptr<const arrow::KeyValueMetadata>&) override {
+    return stream_;
+  }
+
+  private:
+  std::shared_ptr<arrow::io::OutputStream> stream_;
+};
+
+class FailSecondOpenOutputFileSystem final : public arrow::fs::SubTreeFileSystem {
+  public:
+  FailSecondOpenOutputFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs,
+                                 std::shared_ptr<arrow::io::OutputStream> first_stream,
+                                 arrow::Status second_failure)
+      : arrow::fs::SubTreeFileSystem("", std::move(base_fs)),
+        first_stream_(std::move(first_stream)),
+        second_failure_(std::move(second_failure)) {}
+
+  std::string type_name() const override { return "fail-second-open-output"; }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string&, const std::shared_ptr<const arrow::KeyValueMetadata>&) override {
+    ++open_count_;
+    if (open_count_ == 2) {
+      return second_failure_;
+    }
+    return first_stream_;
+  }
+
+  int open_count() const { return open_count_; }
+
+  private:
+  std::shared_ptr<arrow::io::OutputStream> first_stream_;
+  arrow::Status second_failure_;
+  int open_count_ = 0;
+};
+
+class SequencedOutputFileSystem final : public arrow::fs::SubTreeFileSystem {
+  public:
+  SequencedOutputFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs,
+                            std::vector<std::shared_ptr<arrow::io::OutputStream>> streams)
+      : arrow::fs::SubTreeFileSystem("", std::move(base_fs)), streams_(std::move(streams)) {}
+
+  std::string type_name() const override { return "sequenced-output"; }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string&, const std::shared_ptr<const arrow::KeyValueMetadata>&) override {
+    if (next_stream_ >= streams_.size()) {
+      return arrow::Status::Invalid("no test output stream available");
+    }
+    return streams_[next_stream_++];
+  }
+
+  arrow::Status DeleteFile(const std::string& path) override {
+    deleted_paths_.push_back(path);
+    return arrow::Status::OK();
+  }
+
+  const std::vector<std::string>& deleted_paths() const { return deleted_paths_; }
+
+  private:
+  std::vector<std::shared_ptr<arrow::io::OutputStream>> streams_;
+  size_t next_stream_ = 0;
+  std::vector<std::string> deleted_paths_;
+};
+
 }  // namespace
 
 class ParquetFileWriterTest : public ::testing::Test {
@@ -145,6 +385,205 @@ class ParquetFileWriterTest : public ::testing::Test {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::string base_path_;
 };
+
+TEST_F(ParquetFileWriterTest, OpenOutputStreamFailurePreservesExtendStatusDetail) {
+  auto original = MakeExtendError(ExtendStatusCode::StorageTransientTimeout, "Azure request timed out",
+                                  "operation=OpenOutputStream http_status=408");
+  auto failing_fs = std::make_shared<FailingOpenOutputFileSystem>(fs_, original);
+  const std::string file_path = "container/path/data.parquet";
+  StorageConfig config;
+
+  auto result = parquet::ParquetFileWriter::Make(schema_, failing_fs, file_path, config);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(failing_fs->opened_path(), file_path);
+  EXPECT_EQ(result.status().code(), original.code());
+  EXPECT_EQ(result.status().detail(), original.detail());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientTimeout);
+  EXPECT_EQ(detail->extra_info(), "operation=OpenOutputStream http_status=408");
+  EXPECT_TRUE(result.status().Equals(original));
+}
+
+TEST_F(ParquetFileWriterTest, HeaderWriteFailureAbortsWithoutFinalizingAndPreservesDetail) {
+  auto original = MakeExtendError(ExtendStatusCode::StorageTransientTimeout, "Parquet header write timed out",
+                                  "operation=WriteHeader http_status=408");
+  auto stream = std::make_shared<FailingWriteOutputStream>(original);
+  auto tracking_fs = std::make_shared<TrackingOutputFileSystem>(fs_, stream);
+  const std::string file_path = base_path_ + "/header-write-failure.parquet";
+  StorageConfig config;
+
+  auto result = parquet::ParquetFileWriter::Make(schema_, tracking_fs, file_path, config);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_GT(stream->write_count(), 0);
+  EXPECT_EQ(stream->abort_count(), 1);
+  EXPECT_EQ(stream->close_count(), 0);
+  EXPECT_TRUE(stream->closed());
+  EXPECT_EQ(result.status().code(), original.code());
+  auto detail = ExtendStatusDetail::UnwrapStatus(result.status());
+  ASSERT_NE(detail, nullptr) << result.status().ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientTimeout);
+  EXPECT_EQ(detail->extra_info(), "operation=WriteHeader http_status=408");
+  EXPECT_NE(result.status().message().find("Parquet header write timed out"), std::string::npos);
+}
+
+TEST_F(ParquetFileWriterTest, FlushFailureAbortStillReachesDelegateWithoutFinalizing) {
+  auto original = MakeExtendError(ExtendStatusCode::StorageTransientTimeout, "Parquet data write timed out",
+                                  "operation=WriteRowGroup http_status=408");
+  auto stream = std::make_shared<AbortTrackingOutputStream>();
+  auto tracking_fs = std::make_shared<TrackingOutputFileSystem>(fs_, stream);
+  ASSERT_AND_ASSIGN(auto test_schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(test_schema, 0, false, 512, 1024));
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(test_schema, tracking_fs,
+                                                                  base_path_ + "/flush-failure.parquet", config));
+  const int writes_after_init = stream->write_count();
+  stream->ArmWriteFailure(original);
+
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+  auto flush_status = writer->Flush();
+
+  ASSERT_FALSE(flush_status.ok());
+  EXPECT_GT(stream->write_count(), writes_after_init);
+  auto detail = ExtendStatusDetail::UnwrapStatus(flush_status);
+  ASSERT_NE(detail, nullptr) << flush_status.ToString();
+  EXPECT_EQ(detail->code(), ExtendStatusCode::StorageTransientTimeout);
+  EXPECT_EQ(detail->extra_info(), "operation=WriteRowGroup http_status=408");
+
+  writer->Abort();
+  EXPECT_EQ(stream->abort_count(), 1);
+  EXPECT_EQ(stream->close_count(), 0);
+  EXPECT_TRUE(writer->Flush().Equals(flush_status));
+}
+
+TEST_F(ParquetFileWriterTest, PackedMakeAbortsOpenedGroupsWhenLaterOpenFails) {
+  auto original = MakeExtendError(ExtendStatusCode::StorageTransientTimeout, "Second output open timed out",
+                                  "operation=OpenOutputStream group=1 http_status=408");
+  auto first_stream = std::make_shared<AbortTrackingOutputStream>();
+  auto failing_fs = std::make_shared<FailSecondOpenOutputFileSystem>(fs_, first_stream, original);
+  StorageConfig config;
+  std::vector<std::string> paths = {base_path_ + "/first.parquet", base_path_ + "/second.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0}, {1}};
+
+  auto result = PackedRecordBatchWriter::Make(failing_fs, paths, schema_, config, column_groups, 1024 * 1024);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(failing_fs->open_count(), 2);
+  EXPECT_EQ(first_stream->abort_count(), 1);
+  EXPECT_EQ(first_stream->close_count(), 0);
+  EXPECT_TRUE(first_stream->closed());
+  EXPECT_TRUE(result.status().Equals(original)) << result.status().ToString();
+}
+
+TEST_F(ParquetFileWriterTest, PackedCloseDeletesEarlierChildOutputWhenLaterChildFails) {
+  auto original = MakeExtendError(ExtendStatusCode::StorageTransientTimeout, "Second output close timed out",
+                                  "operation=Close group=1 http_status=408");
+  auto first_stream = std::make_shared<AbortTrackingOutputStream>();
+  auto second_stream = std::make_shared<AbortTrackingOutputStream>();
+  second_stream->ArmCloseFailure(original);
+  auto tracking_fs = std::make_shared<SequencedOutputFileSystem>(
+      fs_, std::vector<std::shared_ptr<arrow::io::OutputStream>>{first_stream, second_stream});
+  StorageConfig config;
+  std::vector<std::string> paths = {base_path_ + "/first.parquet", base_path_ + "/second.parquet"};
+  std::vector<std::vector<int>> column_groups = {{0}, {1}};
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(schema_, 0, false, 8, 8));
+  ASSERT_AND_ASSIGN(auto writer,
+                    PackedRecordBatchWriter::Make(tracking_fs, paths, schema_, config, column_groups, 1024 * 1024));
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+
+  auto close_status = writer->Close();
+
+  EXPECT_TRUE(close_status.Equals(original)) << close_status.ToString();
+  ASSERT_EQ(tracking_fs->deleted_paths().size(), 2u);
+  EXPECT_NE(std::find(tracking_fs->deleted_paths().begin(), tracking_fs->deleted_paths().end(), paths.front()),
+            tracking_fs->deleted_paths().end());
+  EXPECT_NE(std::find(tracking_fs->deleted_paths().begin(), tracking_fs->deleted_paths().end(), paths.back()),
+            tracking_fs->deleted_paths().end());
+  EXPECT_EQ(first_stream->close_count(), 1);
+  EXPECT_EQ(first_stream->abort_count(), 0) << "a successfully closed child no longer owns its file";
+  EXPECT_EQ(second_stream->close_count(), 1);
+  EXPECT_EQ(second_stream->abort_count(), 1);
+}
+
+TEST_F(ParquetFileWriterTest, DestroyDoesNotFinalizeOrAbort) {
+  ASSERT_AND_ASSIGN(auto test_schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(test_schema));
+  auto stream = std::make_shared<AbortTrackingOutputStream>(/*close_on_abort=*/false);
+  auto metrics_stream = std::make_shared<MetricsOutputStream>(stream, std::make_shared<FilesystemMetrics>());
+  auto tracking_fs = std::make_shared<TrackingOutputFileSystem>(fs_, metrics_stream);
+
+  int writes_before_destroy = 0;
+  {
+    StorageConfig config;
+    ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(test_schema, tracking_fs,
+                                                                    base_path_ + "/discarded.parquet", config));
+    ASSERT_STATUS_OK(writer->Write(record_batch));
+    writes_before_destroy = stream->write_count();
+  }
+
+  EXPECT_EQ(stream->write_count(), writes_before_destroy);
+  EXPECT_EQ(stream->abort_count(), 0);
+  EXPECT_EQ(stream->close_count(), 0);
+}
+
+// The assertion here is that the test finishes at all. Abandoning reaches a
+// stream that throws, and ParquetFileWriter::Abort() is noexcept, so without
+// AbandonQuietly absorbing it this would std::terminate and take the whole test
+// binary with it -- there would be no failure to report, just a dead process.
+// Everything after the Abort() call is therefore the real check.
+TEST_F(ParquetFileWriterTest, AbandonSurvivesAStreamThatThrows) {
+  ASSERT_AND_ASSIGN(auto test_schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(test_schema));
+  auto stream = std::make_shared<ThrowingAbortOutputStream>();
+  auto metrics_stream = std::make_shared<MetricsOutputStream>(stream, std::make_shared<FilesystemMetrics>());
+  auto tracking_fs = std::make_shared<TrackingOutputFileSystem>(fs_, metrics_stream);
+
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(auto writer, parquet::ParquetFileWriter::Make(test_schema, tracking_fs,
+                                                                  base_path_ + "/throwing_abort.parquet", config));
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+
+  writer->Abort();
+
+  EXPECT_EQ(stream->abort_count(), 1) << "the abandonment must still reach the stream";
+  // And the writer is spent, exactly as it would be after a clean abandonment.
+  EXPECT_FALSE(writer->Close().ok());
+  // Still idempotent: a second abandonment is a no-op and also must not throw.
+  writer->Abort();
+  EXPECT_EQ(stream->abort_count(), 1);
+}
+
+// Abort is the giving-up path, and it has to reach the stream: the stream is
+// the only object that can release what the write allocated in the store (an S3
+// multipart upload's parts, which no bucket listing can show). It must not
+// close -- closing finalizes a file that was abandoned on purpose -- and it has
+// to survive being called twice, because the caller is already handling a
+// failure and should not have to track whether it aborted yet.
+TEST_F(ParquetFileWriterTest, AbortReachesTheStreamWithoutFinalizing) {
+  ASSERT_AND_ASSIGN(auto test_schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto record_batch, CreateTestData(test_schema));
+  auto stream = std::make_shared<AbortTrackingOutputStream>(/*close_on_abort=*/true);
+  auto metrics_stream = std::make_shared<MetricsOutputStream>(stream, std::make_shared<FilesystemMetrics>());
+  auto tracking_fs = std::make_shared<TrackingOutputFileSystem>(fs_, metrics_stream);
+
+  StorageConfig config;
+  ASSERT_AND_ASSIGN(
+      auto writer, parquet::ParquetFileWriter::Make(test_schema, tracking_fs, base_path_ + "/aborted.parquet", config));
+  ASSERT_STATUS_OK(writer->Write(record_batch));
+
+  writer->Abort();
+  EXPECT_EQ(stream->abort_count(), 1);
+  EXPECT_EQ(stream->close_count(), 0);
+
+  writer->Abort();
+  EXPECT_EQ(stream->abort_count(), 1) << "abort must be idempotent";
+
+  // The file was abandoned, so finishing it is not on offer any more.
+  EXPECT_FALSE(writer->Close().ok());
+  EXPECT_EQ(stream->close_count(), 0);
+}
 
 TEST_F(ParquetFileWriterTest, LargeRecordBatchSplitting) {
   // Create a large record batch with mixed data sizes
@@ -857,7 +1296,7 @@ TEST_F(ParquetFileWriterTest, FooterSizeNotMatch) {
   };
 
   // Case 1: footer_size too small (1 byte).
-  // Pre-read can't cover the Thrift metadata → falls back to Arrow's normal 2-step footer read.
+  // Pre-read can't cover the Thrift metadata -> falls back to Arrow's normal 2-step footer read.
   verify_read(1);
 
   // Case 2: footer_size too large (= file_size).

--- a/cpp/test/format/vortex/vortex_basic_test.cpp
+++ b/cpp/test/format/vortex/vortex_basic_test.cpp
@@ -32,6 +32,7 @@
 #include <arrow/array/concatenate.h>
 #include <arrow/c/bridge.h>
 #include <arrow/filesystem/filesystem.h>
+#include <arrow/io/memory.h>
 #include <arrow/record_batch.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
@@ -203,6 +204,46 @@ ArrowArrayStream MakeFailingRustArrowStream(int code, std::string message) {
       new FailingArrowArrayStreamState{fmt::format("Io error: {}{}; {}", kMarker, code, std::move(message))};
   return stream;
 }
+
+class AbortTrackingOutputStream final : public arrow::io::MockOutputStream {
+  public:
+  explicit AbortTrackingOutputStream(bool fail_close = false) : fail_close_(fail_close) {}
+
+  arrow::Status Close() override {
+    if (fail_close_) {
+      return arrow::Status::IOError("injected close failure");
+    }
+    return arrow::io::MockOutputStream::Close();
+  }
+
+  arrow::Status Abort() override {
+    ++abort_count_;
+    return arrow::io::MockOutputStream::Close();
+  }
+
+  int abort_count() const { return abort_count_; }
+
+  private:
+  bool fail_close_;
+  int abort_count_ = 0;
+};
+
+class SingleOutputStreamFileSystem final : public arrow::fs::SubTreeFileSystem {
+  public:
+  SingleOutputStreamFileSystem(std::shared_ptr<arrow::fs::FileSystem> base_fs,
+                               std::shared_ptr<arrow::io::OutputStream> stream)
+      : arrow::fs::SubTreeFileSystem("", std::move(base_fs)), stream_(std::move(stream)) {}
+
+  std::string type_name() const override { return "single-output-stream"; }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string&, const std::shared_ptr<const arrow::KeyValueMetadata>&) override {
+    return stream_;
+  }
+
+  private:
+  std::shared_ptr<arrow::io::OutputStream> stream_;
+};
 
 struct AsyncScanTestContext {
   ArrowArrayStream stream{};
@@ -722,6 +763,46 @@ TEST_P(VortexBasicTest, FlushAllowsSubsequentWrites) {
   ASSERT_EQ(cgfile.end_index, rb->num_rows());
 }
 
+TEST_P(VortexBasicTest, CloseFailureReleasesBridgeWriterWithoutAnExplicitAbort) {
+  auto stream = std::make_shared<AbortTrackingOutputStream>(true);
+  auto fs = std::make_shared<SingleOutputStreamFileSystem>(file_system_, stream);
+  ASSERT_AND_ASSIGN(auto vx_writer, vortex::VortexFileWriter::Open(fs, schema_, test_file_name_, properties_));
+  ASSERT_STATUS_OK(vx_writer->Write(record_batches_.front()));
+
+  auto close_result = vx_writer->Close();
+  ASSERT_FALSE(close_result.ok());
+  // A failed Close abandons: the bridge writer, and with it the upload it
+  // holds, is released without the caller having to know to ask for it. This
+  // is what makes Close() sufficient for callers that cannot express RAII --
+  // every FFI binding -- because Close() is the only verb they reach for.
+  EXPECT_FALSE(vx_writer->HasBridgeWriterForTest());
+  EXPECT_EQ(stream->abort_count(), 1);
+
+  // The explicit verb stays available and stays idempotent.
+  vx_writer->Abort();
+  EXPECT_FALSE(vx_writer->HasBridgeWriterForTest());
+  EXPECT_EQ(stream->abort_count(), 1);
+
+  vx_writer->Abort();
+  EXPECT_FALSE(vx_writer->HasBridgeWriterForTest());
+  EXPECT_EQ(stream->abort_count(), 1);
+}
+
+TEST_P(VortexBasicTest, AbortAfterSuccessfulCloseIsIdempotent) {
+  auto stream = std::make_shared<AbortTrackingOutputStream>();
+  auto fs = std::make_shared<SingleOutputStreamFileSystem>(file_system_, stream);
+  ASSERT_AND_ASSIGN(auto vx_writer, vortex::VortexFileWriter::Open(fs, schema_, test_file_name_, properties_));
+  ASSERT_STATUS_OK(vx_writer->Write(record_batches_.front()));
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer->Close());
+  EXPECT_EQ(cgfile.end_index, record_batches_.front()->num_rows());
+  EXPECT_EQ(stream->abort_count(), 1);
+
+  vx_writer->Abort();
+  EXPECT_EQ(stream->abort_count(), 1);
+  vx_writer->Abort();
+  EXPECT_EQ(stream->abort_count(), 1);
+}
+
 #ifdef BUILD_WITH_FIU
 TEST_P(VortexBasicTest, S3FlushFailureCloseReturnsErrorAndLeavesNoObject) {
   ArrowFileSystemConfig fs_config;
@@ -1163,7 +1244,7 @@ TEST_P(VortexBasicTest, TestDictionaryOfFixedSizeBinaryWriteFails) {
 
   auto close_result = vx_writer->Close();
   ASSERT_FALSE(close_result.ok());
-  EXPECT_TRUE(close_result.status().IsInvalid()) << close_result.status().ToString();
+  EXPECT_TRUE(close_result.status().Equals(status)) << close_result.status().ToString();
 }
 
 TEST_P(VortexBasicTest, TestFixedSizeListWidthMismatchReadFails) {

--- a/cpp/test/format/vortex/vortex_local_format_test.cpp
+++ b/cpp/test/format/vortex/vortex_local_format_test.cpp
@@ -334,6 +334,31 @@ TEST_F(VortexLocalFormatTest, TestFooterReaderOpensZeroRowVortexFileWithoutFoote
   AssertLoadableEmptyCellMetas(group_cell_metas);
 }
 
+TEST_F(VortexLocalFormatTest, TestFooterReaderOpenAfterWriterCloseWithoutWriteIfFileExists) {
+  ASSERT_AND_ASSIGN(auto old_file, WriteVortexFile());
+  ASSERT_GT(old_file.end_index, 0);
+
+  ASSERT_AND_ASSIGN(auto vx_writer,
+                    vortex::VortexFileWriter::Open(file_system_, schema_, test_file_name_, properties_));
+  ASSERT_AND_ASSIGN(auto cgfile, vx_writer->Close());
+  ASSERT_EQ(0, cgfile.end_index);
+
+  ASSERT_AND_ASSIGN(auto file_info, file_system_->GetFileInfo(test_file_name_));
+  ASSERT_TRUE(file_info.IsFile());
+  ASSERT_GT(file_info.size(), 0);
+
+  auto footer_reader = MakeFooterReader(cgfile, std::make_shared<InMemoryVortexRangeFileSystem>());
+  ASSERT_STATUS_OK(footer_reader->Open(file_system_));
+  ASSERT_TRUE(footer_reader->opened());
+  ASSERT_EQ(footer_reader->rows(), 0);
+  ASSERT_NE(footer_reader->file_schema(), nullptr);
+
+  ASSERT_AND_ASSIGN(auto cell_metas, BuildVortexCellMetas(footer_reader, "id"));
+  AssertLoadableEmptyCellMetas(cell_metas);
+  ASSERT_AND_ASSIGN(auto group_cell_metas, BuildVortexGroupCellMetas(footer_reader, data_columns()));
+  AssertLoadableEmptyCellMetas(group_cell_metas);
+}
+
 TEST_F(VortexLocalFormatTest, TestFooterReaderMissingFilePreservesEnoent) {
   constexpr const char* kMissingPath = "missing-vortex-file-for-enoent-test.vx";
   boost::filesystem::remove(kMissingPath);

--- a/cpp/test/lob_column/lob_column_cloud_test.cpp
+++ b/cpp/test/lob_column/lob_column_cloud_test.cpp
@@ -368,7 +368,7 @@ TEST_F(LobColumnCloudTest, AbortCleansUpFiles) {
     }
 
     // abort
-    ASSERT_STATUS_OK(writer->Abort());
+    writer->Abort();
   }
 
   // verify LOB data directory is empty or doesn't exist

--- a/cpp/test/lob_column/lob_column_manager_test.cpp
+++ b/cpp/test/lob_column/lob_column_manager_test.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "test_env.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/lob_column/lob_column_manager.h"
 #include "milvus-storage/lob_column/lob_column_writer.h"
 #include "milvus-storage/lob_column/lob_column_reader.h"
@@ -94,18 +95,48 @@ TEST_F(LobColumnManagerTest, CreateManagerInvalidConfig) {
   // null filesystem
   auto result1 = LobColumnManager::Create(nullptr, config_);
   ASSERT_FALSE(result1.ok());
+  EXPECT_TRUE(result1.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result1.status()), nullptr);
 
   // empty lob_base_path
   LobColumnConfig invalid_config = config_;
   invalid_config.lob_base_path = "";
   auto result2 = LobColumnManager::Create(fs_, invalid_config);
   ASSERT_FALSE(result2.ok());
+  EXPECT_TRUE(result2.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result2.status()), nullptr);
 
   // zero inline threshold
   invalid_config = config_;
   invalid_config.inline_threshold = 0;
   auto result3 = LobColumnManager::Create(fs_, invalid_config);
   ASSERT_FALSE(result3.ok());
+  EXPECT_TRUE(result3.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result3.status()), nullptr);
+
+  // zero maximum file size
+  invalid_config = config_;
+  invalid_config.max_lob_file_bytes = 0;
+  auto result4 = LobColumnManager::Create(fs_, invalid_config);
+  ASSERT_FALSE(result4.ok());
+  EXPECT_TRUE(result4.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result4.status()), nullptr);
+
+  // zero flush threshold
+  invalid_config = config_;
+  invalid_config.flush_threshold_bytes = 0;
+  auto result5 = LobColumnManager::Create(fs_, invalid_config);
+  ASSERT_FALSE(result5.ok());
+  EXPECT_TRUE(result5.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result5.status()), nullptr);
+
+  // flush threshold cannot exceed the maximum file size
+  invalid_config = config_;
+  invalid_config.flush_threshold_bytes = invalid_config.max_lob_file_bytes + 1;
+  auto result6 = LobColumnManager::Create(fs_, invalid_config);
+  ASSERT_FALSE(result6.ok());
+  EXPECT_TRUE(result6.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result6.status()), nullptr);
 }
 
 // test writing inline text
@@ -366,8 +397,7 @@ TEST_F(LobColumnManagerTest, WriterAbort) {
   ASSERT_TRUE(refs_result.ok());
 
   // abort instead of close
-  auto abort_result = writer->Abort();
-  ASSERT_TRUE(abort_result.ok());
+  writer->Abort();
   ASSERT_TRUE(writer->IsClosed());
 
   // verify no files remain

--- a/cpp/test/lob_column/lob_column_writer_edge_test.cpp
+++ b/cpp/test/lob_column/lob_column_writer_edge_test.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "test_env.h"
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/lob_column/lob_column_manager.h"
 #include "milvus-storage/lob_column/lob_column_writer.h"
 #include "milvus-storage/lob_column/lob_column_reader.h"
@@ -77,6 +78,47 @@ class LobColumnWriterEdgeTest : public ::testing::Test {
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   LobColumnConfig config_;
 };
+
+#ifdef BUILD_WITH_FIU
+TEST_F(LobColumnWriterEdgeTest, FlushFailureIsTerminalAndRetryReplacesWriter) {
+  ASSERT_EQ(0, InitFiuOnce());
+  config_.flush_threshold_bytes = 1;
+
+  ASSERT_AND_ASSIGN(auto manager, LobColumnManager::Create(fs_, config_));
+  ASSERT_AND_ASSIGN(auto writer, manager->CreateWriter());
+
+  arrow::Status first_failure;
+  {
+    ScopedFiuFault fault(FIUKEY_WRITER_FLUSH_FAIL, /*one_time=*/true);
+    ASSERT_EQ(0, fault.enable_result());
+    auto result = writer->WriteText(GenerateRandomString(64));
+    ASSERT_FALSE(result.ok());
+    first_failure = result.status();
+    EXPECT_NE(first_failure.ToString().find(FIUKEY_WRITER_FLUSH_FAIL), std::string::npos);
+  }
+
+  EXPECT_TRUE(writer->Flush().Equals(first_failure));
+
+  // Close on a failed direct writer returns the first cause and performs the
+  // same cleanup as Abort; callers do not have to remember a second verb after
+  // they already tried to close it.
+  auto close_result = writer->Close();
+  ASSERT_FALSE(close_result.ok());
+  EXPECT_TRUE(close_result.status().Equals(first_failure));
+  EXPECT_TRUE(writer->IsClosed());
+  auto lob_data_dir = config_.lob_base_path + "/_data";
+  if (boost::filesystem::exists(lob_data_dir)) {
+    EXPECT_TRUE(boost::filesystem::is_empty(lob_data_dir));
+  }
+
+  // Retrying creates a fresh Vortex writer and a fresh UUID-backed file.
+  ASSERT_AND_ASSIGN(auto replacement, manager->CreateWriter());
+  ASSERT_AND_ASSIGN(auto ref, replacement->WriteText(GenerateRandomString(64)));
+  EXPECT_TRUE(IsLOBReference(ref.data()));
+  ASSERT_AND_ASSIGN(auto files, replacement->Close());
+  ASSERT_EQ(files.size(), 1);
+}
+#endif
 
 // ==================== Boundary Threshold Tests ====================
 
@@ -348,7 +390,7 @@ TEST_F(LobColumnWriterEdgeTest, AbortAfterWrite) {
   }
 
   // abort
-  ASSERT_STATUS_OK(writer->Abort());
+  writer->Abort();
   ASSERT_TRUE(writer->IsClosed());
 
   // verify no files remain
@@ -369,7 +411,7 @@ TEST_F(LobColumnWriterEdgeTest, AbortWithoutWrite) {
   auto writer = std::move(writer_result).ValueOrDie();
 
   // abort immediately
-  ASSERT_STATUS_OK(writer->Abort());
+  writer->Abort();
   ASSERT_TRUE(writer->IsClosed());
 }
 
@@ -386,8 +428,8 @@ TEST_F(LobColumnWriterEdgeTest, DoubleAbort) {
   auto ref = writer->WriteText(GenerateRandomString(100));
   ASSERT_TRUE(ref.ok());
 
-  ASSERT_STATUS_OK(writer->Abort());
-  ASSERT_STATUS_OK(writer->Abort());  // should be idempotent
+  writer->Abort();
+  writer->Abort();  // should be idempotent
 }
 
 // ==================== Write After Close/Abort Tests ====================
@@ -420,7 +462,7 @@ TEST_F(LobColumnWriterEdgeTest, WriteAfterAbort) {
   ASSERT_TRUE(writer_result.ok());
   auto writer = std::move(writer_result).ValueOrDie();
 
-  ASSERT_STATUS_OK(writer->Abort());
+  writer->Abort();
 
   // try to write after abort
   auto ref = writer->WriteText("test");

--- a/cpp/test/segment/segment_writer_test.cpp
+++ b/cpp/test/segment/segment_writer_test.cpp
@@ -26,6 +26,8 @@
 
 #include "test_env.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/segment/segment_writer.h"
 #include "milvus-storage/segment/segment_reader.h"
 #include "milvus-storage/transaction/transaction.h"
@@ -160,22 +162,45 @@ TEST_F(SegmentWriterTest, CreateWriterInvalidConfig) {
   // null filesystem
   auto result1 = SegmentWriter::Create(nullptr, schema_, config_);
   ASSERT_FALSE(result1.ok());
+  EXPECT_TRUE(result1.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result1.status()), nullptr);
 
   // null schema
   auto result2 = SegmentWriter::Create(fs_, nullptr, config_);
   ASSERT_FALSE(result2.ok());
+  EXPECT_TRUE(result2.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result2.status()), nullptr);
 
   // empty segment path
   SegmentWriterConfig invalid_config = config_;
   invalid_config.segment_path = "";
   auto result4 = SegmentWriter::Create(fs_, schema_, invalid_config);
   ASSERT_FALSE(result4.ok());
+  EXPECT_TRUE(result4.status().IsInvalid());
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(result4.status()), nullptr);
 
   // missing writer policy
   invalid_config = config_;
   invalid_config.properties.erase(PROPERTY_WRITER_POLICY);
   auto result5 = SegmentWriter::Create(fs_, schema_, invalid_config);
   ASSERT_FALSE(result5.ok());
+}
+
+TEST_F(SegmentWriterTest, BatchSchemaMismatchIsCallerInvalidWithoutInternalDetail) {
+  ASSERT_AND_ASSIGN(auto writer, SegmentWriter::Create(fs_, schema_, config_));
+  ASSERT_AND_ASSIGN(auto batch, CreateTestBatch(1));
+
+  auto mismatched_schema = arrow::schema({
+      arrow::field("different_id", arrow::int64(), false, arrow::key_value_metadata({ARROW_FIELD_ID_KEY}, {"100"})),
+      schema_->field(1),
+      schema_->field(2),
+  });
+  auto mismatched_batch = arrow::RecordBatch::Make(mismatched_schema, batch->num_rows(), batch->columns());
+
+  auto status = writer->Write(mismatched_batch);
+  EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+  EXPECT_EQ(ExtendStatusDetail::UnwrapStatus(status), nullptr);
+  writer->Abort();
 }
 
 // test writing single batch
@@ -450,13 +475,39 @@ TEST_F(SegmentWriterTest, WriterAbort) {
   ASSERT_STATUS_OK(writer->Write(batch));
 
   // abort instead of close
-  auto abort_status = writer->Abort();
-  ASSERT_TRUE(abort_status.ok());
+  writer->Abort();
   ASSERT_TRUE(writer->IsClosed());
 
   // verify no manifest was created (transaction was not committed)
   // manifest directory at segment level might exist but should be empty or not contain new version
 }
+
+#ifdef BUILD_WITH_FIU
+TEST_F(SegmentWriterTest, CloseFailureDeletesLobPublishedBeforeRegularWriterFails) {
+  ASSERT_EQ(InitFiuOnce(), 0);
+  ASSERT_AND_ASSIGN(auto writer, SegmentWriter::Create(fs_, schema_, config_));
+  ASSERT_AND_ASSIGN(auto batch, CreateTestBatch(20));
+  ASSERT_STATUS_OK(writer->Write(batch));
+
+  arrow::Status close_status;
+  {
+    ScopedFiuFault fault(FIUKEY_WRITER_CLOSE_FAIL);
+    auto result = writer->Close();
+    ASSERT_FALSE(result.ok());
+    close_status = result.status();
+  }
+  EXPECT_NE(close_status.ToString().find(FIUKEY_WRITER_CLOSE_FAIL), std::string::npos) << close_status.ToString();
+
+  arrow::fs::FileSelector selector;
+  selector.base_dir = test_dir_ + "/lobs";
+  selector.recursive = true;
+  selector.allow_not_found = true;
+  ASSERT_AND_ASSIGN(auto remaining, fs_->GetFileInfo(selector));
+  for (const auto& info : remaining) {
+    EXPECT_NE(info.type(), arrow::fs::FileType::File) << "orphaned LOB output: " << info.path();
+  }
+}
+#endif
 
 // test writing with null values in TEXT column
 TEST_F(SegmentWriterTest, WriteWithNullText) {


### PR DESCRIPTION
## Summary

Part 4 of the six-PR split of #603.

- Record the first writer failure and make failed writers terminal.
- Implement failed Close as: keep first error, best-effort abandon owned resources, return the first error.
- Keep successfully closed child outputs owned by the composite writer until outer Close succeeds; delete them on later failure.
- Apply the same ownership rule to API, Segment, Packed, column-group, LOB, Parquet, Vortex, and Lance writers.
- Log cleanup statuses that are intentionally ignored.

Refs #643.
Depends on the typed error propagation in the preceding stack entries.

## Review scope

No new global lifecycle framework is introduced. The shared pieces are the small first-failure recorder and the existing writer Abort contract.

## Validation

- WITH_CRT=True full C++ build.
- Focused writer/LOB/Segment/Vortex tests: 147 passed, 14 cloud-environment skips.

## Stack

Review and merge in order:

1. #603 — taxonomy foundation
2. #647 — cloud filesystems, credentials, and lifecycle
3. #648 — Rust format error envelope
4. #649 — writer failure and output ownership
5. #650 — Packed metadata and missing-field projections
6. #651 — public API lifetime and consumer migration

Each PR is based on the preceding stack branch. After one PR merges, rebase the remaining stack onto the updated `main` (required for squash merges), update the synthetic branches with force-with-lease, and then retarget the next PR to `main`.
