### PR TITLE
enhance: add FlatObjectStorage primitives for object-key-native filesystem ops

### DIFF
--- a/cpp/include/milvus-storage/filesystem/flat_object_storage.h
+++ b/cpp/include/milvus-storage/filesystem/flat_object_storage.h
@@ -1,0 +1,96 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+namespace milvus_storage {
+
+/// \brief Object-key-native operations for filesystems backed by a flat object
+/// store (AWS S3, S3-compatible services, and GCS via the S3 interoperability
+/// layer).
+///
+/// Arrow's FileSystem models a hierarchical namespace, which forces the S3
+/// backend to emulate directories:
+///   - GetFileInfo(FileSelector) enumerates a whole directory subtree;
+///   - DeleteFile is directory-aware (HeadObject, then DeleteObject, then a
+///     PutObject to recreate the parent "dir/" marker);
+///   - GetFileInfo(path) reports a key that only has descendants (or a "key/"
+///     marker) as a Directory rather than NotFound.
+///
+/// On a real object store those behaviours cost extra requests, mutate marker
+/// objects, and break exact-object semantics. A caller that treats the store as
+/// a flat key/value namespace (e.g. Milvus's ChunkManager) wants the raw
+/// equivalents. Filesystems that can serve them natively implement this
+/// interface; the free helpers below dispatch to it and otherwise fall back to
+/// Arrow's directory semantics, so callers stay backend-agnostic.
+class FlatObjectStorage {
+  public:
+  virtual ~FlatObjectStorage() = default;
+
+  /// \brief List every object whose key begins with @prefix.
+  ///
+  /// The match is a raw object-key prefix (it may end mid-segment) evaluated
+  /// server-side (S3 ListObjectsV2 with Prefix=). Unlike GetFileInfo(selector),
+  /// it does NOT enumerate the prefix's parent directory subtree, so cost is
+  /// proportional to the number of matching keys rather than to the parent's
+  /// size. Every returned FileInfo is FileType::File; paths are in this
+  /// filesystem's own namespace. Results are paginated internally.
+  [[nodiscard]] virtual arrow::Result<std::vector<arrow::fs::FileInfo>> ListObjectsByPrefix(
+      const std::string& prefix) = 0;
+
+  /// \brief Delete exactly one object by key.
+  ///
+  /// Idempotent: deleting a key that does not exist is success. Issues a single
+  /// DeleteObject with no preceding HeadObject and no parent directory-marker
+  /// maintenance, unlike DeleteFile.
+  [[nodiscard]] virtual arrow::Status DeleteObject(const std::string& path) = 0;
+
+  /// \brief Whether @path names an existing object (exact-key HeadObject
+  /// semantics).
+  ///
+  /// Only a real object stored at the exact key returns true. A key that merely
+  /// has descendants, or a zero-byte "key/" directory marker, is NOT an object
+  /// and returns false.
+  [[nodiscard]] virtual arrow::Result<bool> ObjectExists(const std::string& path) = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Free helpers: dispatch to FlatObjectStorage when the filesystem implements it
+// (AWS/S3-compatible/GCS), otherwise fall back to Arrow's directory semantics
+// (local, Azure). Callers use these and stay backend-agnostic.
+// ---------------------------------------------------------------------------
+
+/// See FlatObjectStorage::ListObjectsByPrefix. Fallback lists the prefix's
+/// parent directory recursively and filters file entries on the raw prefix.
+[[nodiscard]] arrow::Result<std::vector<arrow::fs::FileInfo>> ListObjectsByPrefix(
+    const std::shared_ptr<arrow::fs::FileSystem>& fs, const std::string& prefix);
+
+/// See FlatObjectStorage::DeleteObject. Fallback uses DeleteFile and swallows a
+/// not-found target so removal stays idempotent.
+[[nodiscard]] arrow::Status DeleteObject(const std::shared_ptr<arrow::fs::FileSystem>& fs, const std::string& path);
+
+/// See FlatObjectStorage::ObjectExists. Fallback uses GetFileInfo and treats
+/// only FileType::File as an existing object.
+[[nodiscard]] arrow::Result<bool> ObjectExists(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                               const std::string& path);
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -32,6 +32,7 @@
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/fiu_local.h"
 #include "milvus-storage/common/lrucache.h"
+#include "milvus-storage/filesystem/flat_object_storage.h"
 #include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/filesystem/upload_conditional.h"
 #include "milvus-storage/filesystem/upload_sizable.h"
@@ -53,7 +54,8 @@ using ArrowFileSystemPtr = std::shared_ptr<arrow::fs::FileSystem>;
 class FileSystemProxy : public arrow::fs::SubTreeFileSystem,
                         public UploadConditional,
                         public Observable,
-                        public UploadSizable {
+                        public UploadSizable,
+                        public FlatObjectStorage {
   public:
   FileSystemProxy(const std::string& base_path, std::shared_ptr<arrow::fs::FileSystem> base_fs)
       : arrow::fs::SubTreeFileSystem(base_path, std::move(base_fs)) {}
@@ -107,6 +109,39 @@ class FileSystemProxy : public arrow::fs::SubTreeFileSystem,
 
     ARROW_ASSIGN_OR_RAISE(auto full_path, PrependBase(path));
     return sizable->OpenOutputStreamWithUploadSize(full_path, metadata, part_size);
+  }
+
+  arrow::Result<std::vector<arrow::fs::FileInfo>> ListObjectsByPrefix(const std::string& prefix) override {
+    auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(base_fs());
+    if (!flat) {
+      return arrow::Status::NotImplemented("Filesystem does not implement FlatObjectStorage");
+    }
+    ARROW_ASSIGN_OR_RAISE(auto full_prefix, PrependBase(prefix));
+    ARROW_ASSIGN_OR_RAISE(auto infos, flat->ListObjectsByPrefix(full_prefix));
+    // Strip the subtree base from each listed path so results come back in the
+    // caller's namespace, matching GetFileInfo on this proxy.
+    for (auto& info : infos) {
+      ARROW_RETURN_NOT_OK(FixInfo(&info));
+    }
+    return infos;
+  }
+
+  arrow::Status DeleteObject(const std::string& path) override {
+    auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(base_fs());
+    if (!flat) {
+      return arrow::Status::NotImplemented("Filesystem does not implement FlatObjectStorage");
+    }
+    ARROW_ASSIGN_OR_RAISE(auto full_path, PrependBase(path));
+    return flat->DeleteObject(full_path);
+  }
+
+  arrow::Result<bool> ObjectExists(const std::string& path) override {
+    auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(base_fs());
+    if (!flat) {
+      return arrow::Status::NotImplemented("Filesystem does not implement FlatObjectStorage");
+    }
+    ARROW_ASSIGN_OR_RAISE(auto full_path, PrependBase(path));
+    return flat->ObjectExists(full_path);
   }
 };
 

--- a/cpp/include/milvus-storage/filesystem/s3/s3_filesystem.h
+++ b/cpp/include/milvus-storage/filesystem/s3/s3_filesystem.h
@@ -30,6 +30,7 @@
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/s3/s3_options.h"
 #include "milvus-storage/filesystem/s3/s3_client.h"
+#include "milvus-storage/filesystem/flat_object_storage.h"
 #include "milvus-storage/filesystem/observable.h"
 #include "milvus-storage/filesystem/upload_conditional.h"
 #include "milvus-storage/filesystem/upload_sizable.h"
@@ -39,7 +40,11 @@ using ::arrow::fs::FileInfoGenerator;
 
 namespace milvus_storage {
 
-class S3FileSystem : public arrow::fs::FileSystem, public UploadConditional, public Observable, public UploadSizable {
+class S3FileSystem : public arrow::fs::FileSystem,
+                     public UploadConditional,
+                     public Observable,
+                     public UploadSizable,
+                     public FlatObjectStorage {
   public:
   ~S3FileSystem() override;
 
@@ -96,6 +101,15 @@ class S3FileSystem : public arrow::fs::FileSystem, public UploadConditional, pub
 
   arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
       const std::string& s, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata, int64_t part_size) override;
+
+  /// \brief FlatObjectStorage: raw object-key prefix listing (ListObjectsV2).
+  arrow::Result<std::vector<arrow::fs::FileInfo>> ListObjectsByPrefix(const std::string& prefix) override;
+
+  /// \brief FlatObjectStorage: single idempotent object delete (DeleteObject).
+  arrow::Status DeleteObject(const std::string& path) override;
+
+  /// \brief FlatObjectStorage: exact-object existence (HeadObject).
+  arrow::Result<bool> ObjectExists(const std::string& path) override;
 
   protected:
   explicit S3FileSystem(const S3Options& options, const arrow::io::IOContext& io_context);

--- a/cpp/src/filesystem/flat_object_storage.cpp
+++ b/cpp/src/filesystem/flat_object_storage.cpp
@@ -1,0 +1,92 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/flat_object_storage.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <arrow/filesystem/filesystem.h>
+
+namespace milvus_storage {
+
+using ::arrow::fs::FileInfo;
+using ::arrow::fs::FileSelector;
+using ::arrow::fs::FileType;
+
+arrow::Result<std::vector<FileInfo>> ListObjectsByPrefix(const std::shared_ptr<arrow::fs::FileSystem>& fs,
+                                                         const std::string& prefix) {
+  if (auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(fs)) {
+    auto result = flat->ListObjectsByPrefix(prefix);
+    // NotImplemented is the proxy's "the backend has no native flat listing"
+    // signal; anything else (success or a real error) is authoritative.
+    if (!result.status().IsNotImplemented()) {
+      return result;
+    }
+  }
+
+  // Fallback for non-object-store backends (local, Azure): Arrow's FileSelector
+  // is directory-based, so list the prefix's parent directory recursively and
+  // filter file entries on the raw prefix. Bounded and cheap on these backends.
+  FileSelector selector;
+  auto slash_pos = prefix.find_last_of('/');
+  selector.base_dir = slash_pos == std::string::npos ? "" : prefix.substr(0, slash_pos);
+  selector.recursive = true;
+  selector.allow_not_found = true;
+
+  ARROW_ASSIGN_OR_RAISE(auto infos, fs->GetFileInfo(selector));
+  std::vector<FileInfo> result;
+  for (auto& info : infos) {
+    if (info.type() == FileType::File && info.path().rfind(prefix, 0) == 0) {
+      result.push_back(std::move(info));
+    }
+  }
+  return result;
+}
+
+arrow::Status DeleteObject(const std::shared_ptr<arrow::fs::FileSystem>& fs, const std::string& path) {
+  if (auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(fs)) {
+    auto status = flat->DeleteObject(path);
+    if (!status.IsNotImplemented()) {
+      return status;
+    }
+  }
+
+  // Fallback: DeleteFile, but swallow a positively-confirmed not-found target so
+  // removal stays idempotent. Any other DeleteFile error is returned as-is.
+  auto status = fs->DeleteFile(path);
+  if (status.ok()) {
+    return status;
+  }
+  auto info = fs->GetFileInfo(path);
+  if (info.ok() && info->type() == FileType::NotFound) {
+    return arrow::Status::OK();
+  }
+  return status;
+}
+
+arrow::Result<bool> ObjectExists(const std::shared_ptr<arrow::fs::FileSystem>& fs, const std::string& path) {
+  if (auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(fs)) {
+    auto result = flat->ObjectExists(path);
+    if (!result.status().IsNotImplemented()) {
+      return result;
+    }
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto info, fs->GetFileInfo(path));
+  return info.type() == FileType::File;
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
+++ b/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
@@ -229,8 +229,13 @@ arrow::Result<S3Options> GcpFileSystemProducer::CreateS3Options() {
     options.region = config_.region;
   }
 
+  // request_timeout is in fractional seconds (double). Divide by 1000.0, not
+  // 1000: integer division truncates sub-second timeouts (1500ms -> 1s) and
+  // zeroes any value below 1s, which the client builder then treats as "no
+  // timeout". s3_client_builder applies ceil(request_timeout * 1000) to recover
+  // the exact millisecond value.
   options.request_timeout = config_.request_timeout_ms <= 0 ? DEFAULT_ARROW_FILESYSTEM_S3_REQUEST_TIMEOUT_SEC
-                                                            : config_.request_timeout_ms / 1000;
+                                                            : config_.request_timeout_ms / 1000.0;
   options.max_connections = config_.max_connections;
   options.multi_part_upload_size = config_.multi_part_upload_size;
   options.cloud_provider = config_.cloud_provider;

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -2804,6 +2804,87 @@ arrow::Status S3FileSystem::DeleteFile(const std::string& s) {
   return impl_->EnsureParentExists(path);
 }
 
+arrow::Result<std::vector<FileInfo>> S3FileSystem::ListObjectsByPrefix(const std::string& s) {
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  if (path.bucket.empty()) {
+    return arrow::Status::Invalid("Cannot list objects with an empty bucket: '", s, "'");
+  }
+
+  // S3Path::FromString strips a trailing '/', but a raw object-key prefix must
+  // reach ListObjectsV2 verbatim: a boundary prefix ("dir/") must match only
+  // keys under dir/, not a sibling ("dir.txt"). Recover the exact key prefix
+  // (including any trailing '/') from the original input rather than path.key.
+  const std::string key_prefix = path.key.empty() ? std::string() : s.substr(path.bucket.size() + 1);
+
+  // Raw object-key prefix listing: set Prefix to the exact key (which may end
+  // mid-segment) and no delimiter, so S3 returns every matching object flat.
+  // This deliberately avoids GetFileInfo(selector), which lists the parent
+  // directory subtree.
+  std::vector<FileInfo> result;
+  S3Model::ListObjectsV2Request req;
+  req.SetBucket(ToAwsString(path.bucket));
+  if (!key_prefix.empty()) {
+    req.SetPrefix(ToAwsString(key_prefix));
+  }
+  req.SetMaxKeys(Impl::kListObjectsMaxKeys);
+
+  while (true) {
+    ARROW_ASSIGN_OR_RAISE(auto client_lock, impl_->holder_->Lock());
+    auto outcome = client_lock.Move()->ListObjectsV2(req);
+    if (!outcome.IsSuccess()) {
+      return ErrorToStatus(
+          std::forward_as_tuple("When listing objects under prefix '", path.key, "' in bucket '", path.bucket, "': "),
+          "ListObjectsV2", outcome.GetError());
+    }
+    const auto& list_result = outcome.GetResult();
+    for (const auto& obj : list_result.GetContents()) {
+      FileInfo info;
+      info.set_path(path.bucket + kSep + std::string(FromAwsString(obj.GetKey())));
+      FileObjectToInfo(obj, &info);
+      result.push_back(std::move(info));
+    }
+    if (!list_result.GetIsTruncated()) {
+      break;
+    }
+    req.SetContinuationToken(list_result.GetNextContinuationToken());
+  }
+  return result;
+}
+
+arrow::Status S3FileSystem::DeleteObject(const std::string& s) {
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  ARROW_RETURN_NOT_OK(ValidateFilePath(path));
+  // S3 DeleteObject is idempotent (a missing key returns success). Unlike
+  // DeleteFile, issue it directly with no preceding HeadObject and no parent
+  // directory-marker recreation.
+  return impl_->DeleteObject(path.bucket, path.key);
+}
+
+arrow::Result<bool> S3FileSystem::ObjectExists(const std::string& s) {
+  ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
+  if (path.bucket.empty() || path.key.empty()) {
+    // The root and buckets are not objects.
+    return false;
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto client_lock, impl_->holder_->Lock());
+  S3Model::HeadObjectRequest req;
+  req.SetBucket(ToAwsString(path.bucket));
+  req.SetKey(ToAwsString(path.key));
+
+  auto outcome = client_lock.Move()->HeadObject(req);
+  if (outcome.IsSuccess()) {
+    return true;
+  }
+  if (IsNotFound(outcome.GetError())) {
+    // Exact-object semantics: a key with only descendants or a "key/" marker
+    // is not the object itself, so HeadObject on the exact key is a miss.
+    return false;
+  }
+  const auto msg = "When getting information for key '" + path.key + "' in bucket '" + path.bucket + "': ";
+  return ErrorToStatus(msg, "HeadObject", outcome.GetError(), impl_->options().region);
+}
+
 arrow::Status S3FileSystem::Move(const std::string& src, const std::string& dest) {
   // XXX We don't implement moving directories as it would be too expensive:
   // one must copy all directory contents one by one (including object data),

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -169,8 +169,13 @@ arrow::Result<S3Options> S3FileSystemProducer::CreateS3Options() {
     options.region = config_.region;
   }
 
+  // request_timeout is in fractional seconds (double). Divide by 1000.0, not
+  // 1000: integer division truncates sub-second timeouts (1500ms -> 1s) and
+  // zeroes any value below 1s, which the client builder then treats as "no
+  // timeout". s3_client_builder applies ceil(request_timeout * 1000) to recover
+  // the exact millisecond value.
   options.request_timeout = config_.request_timeout_ms <= 0 ? DEFAULT_ARROW_FILESYSTEM_S3_REQUEST_TIMEOUT_SEC
-                                                            : config_.request_timeout_ms / 1000;
+                                                            : config_.request_timeout_ms / 1000.0;
   options.max_connections = config_.max_connections;
   options.multi_part_upload_size = config_.multi_part_upload_size;
   options.cloud_provider = config_.cloud_provider;

--- a/cpp/test/filesystem/flat_object_storage_test.cpp
+++ b/cpp/test/filesystem/flat_object_storage_test.cpp
@@ -1,0 +1,204 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <arrow/filesystem/localfs.h>
+#include <arrow/testing/gtest_util.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "milvus-storage/filesystem/flat_object_storage.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/properties.h"
+
+#include "test_env.h"
+
+namespace milvus_storage {
+
+namespace {
+
+arrow::Status WriteObject(const ArrowFileSystemPtr& fs, const std::string& path, const std::string& content) {
+  ARROW_ASSIGN_OR_RAISE(auto out, fs->OpenOutputStream(path));
+  ARROW_RETURN_NOT_OK(out->Write(content.data(), static_cast<int64_t>(content.size())));
+  return out->Close();
+}
+
+bool Contains(const std::vector<arrow::fs::FileInfo>& infos, const std::string& path) {
+  return std::any_of(infos.begin(), infos.end(), [&](const arrow::fs::FileInfo& info) { return info.path() == path; });
+}
+
+}  // namespace
+
+// ============================================================================
+// Local backend: exercises the free-helper fallback path and the
+// FileSystemProxy's NotImplemented delegation (the local base filesystem does
+// not implement FlatObjectStorage). Always runs.
+// ============================================================================
+class FlatObjectStorageLocalTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    api::SetValue(properties_, PROPERTY_FS_STORAGE_TYPE, "local");
+    api::SetValue(properties_, PROPERTY_FS_ROOT_PATH, "/tmp/milvus-storage-test");
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+    base_path_ = GetTestBasePath("flat-object-local-test");
+    ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_, /*allow_missing=*/true));
+    ASSERT_STATUS_OK(fs_->CreateDir(base_path_, true));
+  }
+
+  void TearDown() override { ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_, /*allow_missing=*/true)); }
+
+  api::Properties properties_;
+  ArrowFileSystemPtr fs_;
+  std::string base_path_;
+};
+
+TEST_F(FlatObjectStorageLocalTest, ProxyReportsNotImplementedForLocalBase) {
+  // FileSystemProxy implements FlatObjectStorage but delegates to its base
+  // filesystem. A local base does not implement FlatObjectStorage, so the proxy
+  // reports NotImplemented and the free helpers fall back to Arrow semantics.
+  // (GetFileSystem("local") returns a bare LocalFileSystemWrapper, not a proxy,
+  // so construct the proxy explicitly to exercise its delegation.)
+  auto base = std::make_shared<arrow::fs::LocalFileSystem>();
+  auto proxy = std::make_shared<FileSystemProxy>(base_path_, base);
+  auto flat = std::dynamic_pointer_cast<FlatObjectStorage>(proxy);
+  ASSERT_NE(flat, nullptr);
+  EXPECT_TRUE(flat->ListObjectsByPrefix("x").status().IsNotImplemented());
+  EXPECT_TRUE(flat->DeleteObject("x").IsNotImplemented());
+  EXPECT_TRUE(flat->ObjectExists("x").status().IsNotImplemented());
+}
+
+TEST_F(FlatObjectStorageLocalTest, ObjectExistsFallback) {
+  const std::string path = base_path_ + "/exists.txt";
+  ASSERT_STATUS_OK(WriteObject(fs_, path, "hello"));
+
+  ASSERT_AND_ASSIGN(auto exists, ObjectExists(fs_, path));
+  EXPECT_TRUE(exists);
+
+  ASSERT_AND_ASSIGN(auto missing, ObjectExists(fs_, base_path_ + "/nope.txt"));
+  EXPECT_FALSE(missing);
+
+  // A directory is not an object.
+  ASSERT_AND_ASSIGN(auto dir_is_obj, ObjectExists(fs_, base_path_));
+  EXPECT_FALSE(dir_is_obj);
+}
+
+TEST_F(FlatObjectStorageLocalTest, DeleteObjectFallbackIsIdempotent) {
+  const std::string path = base_path_ + "/to-delete.txt";
+  ASSERT_STATUS_OK(WriteObject(fs_, path, "data"));
+
+  ASSERT_STATUS_OK(DeleteObject(fs_, path));
+  ASSERT_AND_ASSIGN(auto exists, ObjectExists(fs_, path));
+  EXPECT_FALSE(exists);
+
+  // Deleting a missing object is success.
+  ASSERT_STATUS_OK(DeleteObject(fs_, path));
+}
+
+TEST_F(FlatObjectStorageLocalTest, ListObjectsByPrefixFallbackMatchesRawPrefix) {
+  ASSERT_STATUS_OK(WriteObject(fs_, base_path_ + "/list_a1.txt", "1"));
+  ASSERT_STATUS_OK(WriteObject(fs_, base_path_ + "/list_a2.txt", "2"));
+  ASSERT_STATUS_OK(WriteObject(fs_, base_path_ + "/list_b1.txt", "3"));
+
+  // Mid-segment prefix matches list_a* only.
+  ASSERT_AND_ASSIGN(auto a_infos, ListObjectsByPrefix(fs_, base_path_ + "/list_a"));
+  EXPECT_EQ(a_infos.size(), 2u);
+  EXPECT_TRUE(Contains(a_infos, base_path_ + "/list_a1.txt"));
+  EXPECT_TRUE(Contains(a_infos, base_path_ + "/list_a2.txt"));
+  EXPECT_FALSE(Contains(a_infos, base_path_ + "/list_b1.txt"));
+
+  // Broader prefix matches all three.
+  ASSERT_AND_ASSIGN(auto all_infos, ListObjectsByPrefix(fs_, base_path_ + "/list_"));
+  EXPECT_EQ(all_infos.size(), 3u);
+}
+
+// ============================================================================
+// Remote backend: exercises the native S3 FlatObjectStorage implementation.
+// Runs only against a cloud/minio environment (STORAGE_TYPE=remote), matching
+// the existing cloud filesystem tests.
+// ============================================================================
+class FlatObjectStorageRemoteTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    if (!IsCloudEnv()) {
+      GTEST_SKIP() << "remote FlatObjectStorage tests require a cloud/minio environment";
+    }
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+    prefix_ = "flat-object-remote-test";
+  }
+
+  api::Properties properties_;
+  ArrowFileSystemPtr fs_;
+  std::string prefix_;
+};
+
+TEST_F(FlatObjectStorageRemoteTest, ListObjectsByPrefixIsRawNotDirectory) {
+  ASSERT_STATUS_OK(WriteObject(fs_, prefix_ + "/seg/one.txt", "1"));
+  ASSERT_STATUS_OK(WriteObject(fs_, prefix_ + "/seg/two.txt", "2"));
+  // Sibling object that shares the "seg" mid-segment prefix but is not under seg/.
+  ASSERT_STATUS_OK(WriteObject(fs_, prefix_ + "/segment.txt", "3"));
+
+  // Raw object-key prefix "…/seg" matches the two seg/ objects AND segment.txt,
+  // which a directory-scoped listing could not do.
+  ASSERT_AND_ASSIGN(auto seg_infos, ListObjectsByPrefix(fs_, prefix_ + "/seg"));
+  EXPECT_TRUE(Contains(seg_infos, prefix_ + "/seg/one.txt"));
+  EXPECT_TRUE(Contains(seg_infos, prefix_ + "/seg/two.txt"));
+  EXPECT_TRUE(Contains(seg_infos, prefix_ + "/segment.txt"));
+
+  // Boundary prefix "…/seg/" matches only the objects under seg/.
+  ASSERT_AND_ASSIGN(auto boundary_infos, ListObjectsByPrefix(fs_, prefix_ + "/seg/"));
+  EXPECT_TRUE(Contains(boundary_infos, prefix_ + "/seg/one.txt"));
+  EXPECT_TRUE(Contains(boundary_infos, prefix_ + "/seg/two.txt"));
+  EXPECT_FALSE(Contains(boundary_infos, prefix_ + "/segment.txt"));
+
+  ASSERT_STATUS_OK(DeleteObject(fs_, prefix_ + "/seg/one.txt"));
+  ASSERT_STATUS_OK(DeleteObject(fs_, prefix_ + "/seg/two.txt"));
+  ASSERT_STATUS_OK(DeleteObject(fs_, prefix_ + "/segment.txt"));
+}
+
+TEST_F(FlatObjectStorageRemoteTest, ObjectExistsHasExactObjectSemantics) {
+  ASSERT_STATUS_OK(WriteObject(fs_, prefix_ + "/dir/child.txt", "x"));
+
+  ASSERT_AND_ASSIGN(auto child_exists, ObjectExists(fs_, prefix_ + "/dir/child.txt"));
+  EXPECT_TRUE(child_exists);
+
+  // "…/dir" has a descendant (and possibly a directory marker) but is not
+  // itself an object: exact-key HeadObject semantics report it as missing.
+  ASSERT_AND_ASSIGN(auto dir_is_obj, ObjectExists(fs_, prefix_ + "/dir"));
+  EXPECT_FALSE(dir_is_obj);
+
+  ASSERT_AND_ASSIGN(auto missing, ObjectExists(fs_, prefix_ + "/dir/absent.txt"));
+  EXPECT_FALSE(missing);
+
+  ASSERT_STATUS_OK(DeleteObject(fs_, prefix_ + "/dir/child.txt"));
+}
+
+TEST_F(FlatObjectStorageRemoteTest, DeleteObjectIsIdempotent) {
+  const std::string path = prefix_ + "/deletable.txt";
+  ASSERT_STATUS_OK(WriteObject(fs_, path, "y"));
+  ASSERT_AND_ASSIGN(auto exists, ObjectExists(fs_, path));
+  ASSERT_TRUE(exists);
+
+  ASSERT_STATUS_OK(DeleteObject(fs_, path));
+  ASSERT_AND_ASSIGN(auto gone, ObjectExists(fs_, path));
+  EXPECT_FALSE(gone);
+
+  // Deleting a missing object is success (no HeadObject, no error).
+  ASSERT_STATUS_OK(DeleteObject(fs_, path));
+}
+
+}  // namespace milvus_storage


### PR DESCRIPTION
## What

Adds a `FlatObjectStorage` extension interface to the filesystem layer, exposing three object-key-native primitives that bypass Arrow's directory emulation:

- **`ListObjectsByPrefix`** — raw object-key prefix listing (S3 `ListObjectsV2` with `Prefix=` and no delimiter, paginated). Cost is proportional to the number of matching keys, and it matches raw *mid-segment* prefixes that a directory-scoped `GetFileInfo(FileSelector)` cannot.
- **`DeleteObject`** — a single idempotent `DeleteObject`, with no preceding `HeadObject` and no parent directory-marker maintenance (unlike `DeleteFile`, which does `HeadObject` → `DeleteObject` → a `PutObject` that recreates the parent `dir/` marker).
- **`ObjectExists`** — exact-key `HeadObject` semantics: a key that only has descendants (or a zero-byte `key/` marker) is reported as **absent**, not present.

`S3FileSystem` implements the interface natively. `FileSystemProxy` delegates to its wrapped base filesystem (prepending/stripping the subtree base) and reports `NotImplemented` when the base cannot serve it. Free helpers dispatch to the native implementation when present and otherwise fall back to Arrow's directory semantics, so callers stay backend-agnostic on non-object-store filesystems (local, Azure).

A second, independent commit **fixes sub-second S3 request timeouts**: `CreateS3Options` derived `request_timeout` (a `double`, in seconds) from the int64 `request_timeout_ms` via integer division, truncating every sub-second component (1500ms → 1s; anything below 1000ms → 0, which the client builder then silently drops in favor of the SDK default). Dividing by `1000.0` preserves the fractional value; the consumer already applies `ceil(request_timeout * 1000)` to recover the exact millisecond value. Applied in both the S3 and GCP producers.

## Why

Callers that treat the store as a flat key/value namespace — notably Milvus's `ChunkManager` (`ListWithPrefix` / `Remove` / `Exist`) — get wrong or costly behavior from Arrow's directory emulation on a real object store: a directory-scoped listing misses raw mid-segment prefix matches, delete is non-idempotent and rewrites marker objects, and existence returns `true` for a path that only has descendants.

These primitives are the milvus-storage half of the fix for review feedback on the ArrowFileSystemChunkManager work in milvus-io/milvus#52805; the Milvus-side consumer changes will follow once this lands.

## Tests

- New `flat_object_storage_test.cpp`: **4 local** (free-helper fallback + `FileSystemProxy` `NotImplemented` delegation over a local base) + **3 remote/minio** (native S3 raw-prefix listing incl. the mid-segment vs. boundary-prefix distinction, exact-key existence, idempotent delete). All 7 pass against minio.
- Regression: full S3 + filesystem suites (`S3UnitTest`, `S3ClientTest`, `S3ProviderTest`, `ExternalFilesystemTest`, `LocalFsTest`, `CloudFsTest`) — **128 passed, 1 skipped** (`CloudFsTest.ConditionalWriteAzure`, no Azure endpoint), **0 failed**. `S3UnitTest.TestCreateS3Options` covers the timeout change.

DCO signed off on both commits.
