### PR TITLE
feat: integrate Talon read-through cache with a local test stack

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -248,3 +248,78 @@ jobs:
           fail_ci_if_error: true
           disable_safe_directory: true
           verbose: true
+
+  # Talon read-through cache end-to-end. Self-contained (does not touch the
+  # build/unittest artifact): builds with WITH_TALON=True so the Talon link path
+  # is compiled, then stands up a containerized single-node Talon stack
+  # (coordinator + worker + MinIO) via scripts/setup_talon.sh and runs the Talon
+  # integration test against it. The coordinator/worker images are built locally
+  # from the same pinned talon source the C SDK is fetched from, so nothing is
+  # pulled from a registry for the servers. The test client runs on the stack
+  # network in the milvus builder image (mandatory — see setup_talon.sh header),
+  # executing the runner-built binary as-is. That first image build is the
+  # dominant cost of this job.
+  talon:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: aminya/setup-cpp@v1
+        with:
+          conan: 2.25.1
+          cmake: true
+
+      # Conan 2.x CMakeDeps doesn't propagate system_libs through shared library targets,
+      # so libaio (required by folly) must be explicitly installed and linked.
+      - name: Install system libraries
+        run: sudo apt-get update && sudo apt-get install -y libaio-dev
+
+      - name: Setup Rust
+        id: rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore rust build cache
+        id: rust-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            cpp/build/Release/cargo/build
+          key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
+          restore-keys: |
+            storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
+
+      - name: Restore conan package cache
+        id: conan-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.conan2
+          key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
+          restore-keys: |
+            conan-cpp-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: setup conan
+        run: |
+          conan profile detect --force
+          # || true: Conan 2.x errors if the remote already exists (e.g. restored from cache)
+          conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
+          conan remote list
+
+      - name: Build with Talon
+        working-directory: ./cpp
+        run: |
+          make build WITH_TALON=True
+
+      - name: Bring up the Talon stack
+        working-directory: ./cpp
+        run: ./scripts/setup_talon.sh up
+
+      - name: Run the Talon integration test
+        working-directory: ./cpp
+        run: ./scripts/setup_talon.sh test
+
+      - name: Tear down the Talon stack
+        if: always()
+        working-directory: ./cpp
+        run: ./scripts/setup_talon.sh down

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,10 +13,15 @@ option(WITH_JNI "Build with JNI library." OFF)
 option(WITH_PYTHON_BINDING "Build for Python bindings with hidden symbols." OFF)
 option(WITH_FIU "Build with fault injection support (libfiu)." OFF)
 option(WITH_CRT "Build with AWS S3 CRT support." OFF)
+option(WITH_TALON "Build with Talon C SDK input-file support." OFF)
 option(ARROW_WITH_JEMALLOC "Build with jemalloc." OFF)
 
 if (WITH_CRT)
   add_compile_definitions(WITH_CRT)
+endif()
+
+if (WITH_TALON)
+  add_compile_definitions(WITH_TALON)
 endif()
 
 include(GNUInstallDirs)
@@ -57,6 +62,20 @@ else()
   set(AVRO_TARGET avro-cpp::avrocpp_s)
 endif()
 
+# When Talon is enabled, establish Corrosion at this top-level scope up front so
+# both the Rust bridge subdirectory (added below) and the Talon crate import
+# further down share a single Corrosion instance. Without Talon the bridge keeps
+# owning its own Corrosion, exactly as before.
+if (WITH_TALON)
+  include(FetchContent)
+  FetchContent_Declare(
+    Corrosion
+    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+    GIT_TAG v0.5
+  )
+  FetchContent_MakeAvailable(Corrosion)
+endif()
+
 # Rust bridge for Vortex and Lance formats (always built)
 set(RUST_BRIDGE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/format/bridge/rust)
 set(CORROSION_FEATURES "")
@@ -67,6 +86,38 @@ add_subdirectory(${RUST_BRIDGE_PATH})
 
 list(APPEND LINK_LIBS prsbridge)
 list(APPEND INCLUDE_PATHS ${RUST_BRIDGE_PATH}/include/)
+
+# Talon distributed object-cache client (optional upstream dependency).
+# Fetches the Talon repository at a pinned commit and builds its C SDK crate
+# (workspace member `talon-c` -> libtalon_c) from source with Corrosion, the
+# same mechanism used for the Rust bridge above. The C ABI header (talon.h) and
+# the static library both come from the fetched Talon source tree; milvus-storage
+# only owns the C++ wrapper in src/filesystem/talon that binds against them.
+if (WITH_TALON)
+  FetchContent_Declare(
+    talon
+    GIT_REPOSITORY https://github.com/milvus-io/talon.git
+    # PR #564 merge commit: C SDK optional version/size fast-path + concurrent block reads.
+    GIT_TAG dcfa3b833bd02c6b69dc98f8777f9eda4e4d631b
+  )
+  FetchContent_GetProperties(talon)
+  if(NOT talon_POPULATED)
+    FetchContent_Populate(talon)
+  endif()
+
+  # CRATES selects the Cargo package `talon-c`; Corrosion creates the imported
+  # library target from its lib name (`talon_c`), normalizing hyphens to
+  # underscores, so the link target below is `talon_c` (compare the Rust bridge,
+  # which links `rust_bridge`).
+  corrosion_import_crate(
+    MANIFEST_PATH ${talon_SOURCE_DIR}/Cargo.toml
+    CRATES talon-c
+  )
+
+  list(APPEND LINK_LIBS talon_c)
+  list(APPEND INCLUDE_PATHS ${talon_SOURCE_DIR}/clients/c/include)
+  message(STATUS "Talon C SDK enabled (source: ${talon_SOURCE_DIR})")
+endif()
 
 list(APPEND LINK_LIBS milvus-common::milvus-common)
 message(STATUS "milvus-common found; enabling Vortex cache translator")
@@ -85,6 +136,12 @@ file(GLOB_RECURSE ALL_SRC_FILES
 )
 list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/format/bridge/.*\\.(cpp|cc)$")
 list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/jni/.*\\.cpp$")
+
+# The Talon wrapper binds against the Talon C SDK, which is only fetched/linked
+# when WITH_TALON is set; keep it out of the default build.
+if (NOT WITH_TALON)
+  list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/filesystem/talon/.*\\.(cpp|cc)$")
+endif()
 
 add_library(milvus-storage SHARED ${ALL_SRC_FILES})
 

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test test-all test-cloud-storage \
+.PHONY: build clean test test-all test-cloud-storage test-talon benchmark-talon \
 	python-lib java-lib package \
 	fix-format check-format fix-tidy check-tidy \
 	check-error-ratchet update-error-ratchet \
@@ -14,6 +14,7 @@ use_asan := $(or $(USE_ASAN),True)
 with_ut := $(or $(WITH_UT),True)
 with_fiu := $(or $(WITH_FIU),True)
 with_crt := $(or $(WITH_CRT),False)
+with_talon := $(or $(WITH_TALON),False)
 with_benchmark := $(or $(WITH_BENCHMARK),True)
 build_type := $(or $(BUILD_TYPE),Release)
 use_jni := $(or $(USE_JNI),False)
@@ -43,16 +44,17 @@ build:
 	@echo "use_python_binding: ${use_python_binding}"
 	@echo "with_fiu: ${with_fiu}"
 	@echo "with_crt: ${with_crt}"
+	@echo "with_talon: ${with_talon}"
 
 	mkdir -p build && cd build && \
 	${CONAN_BASE} \
 	-o "&:with_ut=${with_ut}" -o "&:with_benchmark=${with_benchmark}" -o "&:with_asan=${use_asan}" \
 	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" \
-	-o "&:with_crt=${with_crt}" && \
+	-o "&:with_crt=${with_crt}" -o "&:with_talon=${with_talon}" && \
 	conan build .. ${CONAN_SETTINGS} \
 	-o "&:with_ut=${with_ut}" -o "&:with_benchmark=${with_benchmark}" -o "&:with_asan=${use_asan}" \
 	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" \
-	-o "&:with_crt=${with_crt}"
+	-o "&:with_crt=${with_crt}" -o "&:with_talon=${with_talon}"
 
 package: build
 	mkdir -p build && cd build && \
@@ -117,6 +119,47 @@ test-cloud-storage: build
 
 # Individual cloud provider targets
 aws gcp azure aliyun tencent huawei: test-cloud-storage
+
+# Talon read-through cache. These targets are "bare": they build with the Talon C
+# SDK and run the test / benchmark against a stack that is ALREADY up. The stack
+# (a containerized coordinator + worker backed by MinIO) is owned by
+# scripts/setup_talon.sh, which builds the server images from the same pinned
+# talon source the C SDK was fetched from. The canonical path is the orchestrator,
+# which runs the already-built binary on the stack network (the only place the
+# worker is reachable — see the setup_talon.sh header):
+#
+#   ./scripts/setup_talon.sh up      # bring the stack up (leave running)
+#   ./scripts/setup_talon.sh test    # run the Talon gtest against it
+#   ./scripts/setup_talon.sh down    # tear it down
+#
+# or in one self-cleaning shot:  ./scripts/setup_talon.sh e2e
+#
+# The targets below are the manual build+run equivalent, for a dev shell that is
+# itself joined to the stack network; set TALON_COORDINATOR_ADDR to the
+# coordinator's on-network address there (talon_env.sh's 127.0.0.1 default only
+# fits a host-published stack, which the containerized stack is not).
+test-talon:
+	$(MAKE) build WITH_TALON=True
+	export LD_LIBRARY_PATH="$$LD_LIBRARY_PATH:$(CURDIR)/build/${build_type}:$(CURDIR)/build/${build_type}/libs"; \
+	. ./scripts/talon_env.sh; \
+	./build/${build_type}/test/milvus_test --gtest_filter='Talon*'
+
+# Built for measurement, not debugging: USE_ASAN=False (ASan perturbs timing and
+# the default build turns it on) and WITH_UT=False (the unit-test build injects
+# -fprofile-arcs coverage flags that the benchmark would inherit, and drags in
+# Test_FFI, whose folly/libaio link is broken in non-ASan builds).
+#
+# The clean build is required, not just tidy: toggling these options on an existing
+# build dir does not reliably reconfigure (conan/CMake keep the previously cached
+# WITH_ASAN/WITH_UT, so a build left over from `test-talon` would still be ASan +
+# would still build the broken Test_FFI). A fresh configure applies the options from
+# scratch and also yields clean, reproducible throughput numbers.
+benchmark-talon:
+	$(MAKE) clean
+	$(MAKE) build WITH_TALON=True USE_ASAN=False WITH_UT=False
+	export LD_LIBRARY_PATH="$$LD_LIBRARY_PATH:$(CURDIR)/build/${build_type}:$(CURDIR)/build/${build_type}/libs"; \
+	. ./scripts/talon_env.sh; \
+	./build/${build_type}/benchmark/benchmark --benchmark_filter='TalonReaderBenchmark'
 
 # Source directories for formatting
 FORMAT_DIRS := ./src ./include ./test ./benchmark

--- a/cpp/benchmark/CMakeLists.txt
+++ b/cpp/benchmark/CMakeLists.txt
@@ -22,6 +22,13 @@ list(APPEND BENCHMARK_SOURCES
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_storage_layer.cpp
 )
 
+# Talon read-through cache benchmark (only when built with the Talon C SDK).
+if (WITH_TALON)
+  list(APPEND BENCHMARK_SOURCES
+    ${PROJECT_SOURCE_DIR}/benchmark/benchmark_talon_reader.cpp
+  )
+endif()
+
 # Data loader for configurable data sources (synthetic or Milvus segment)
 list(APPEND BENCHMARK_SOURCES
   ${PROJECT_SOURCE_DIR}/benchmark/benchmark_data_loader.cpp
@@ -38,6 +45,20 @@ add_executable(
 target_link_libraries(
   benchmark milvus-storage benchmark::benchmark
 )
+
+# Keep every transitive dependency (notably libmilvus-common.so) in the
+# benchmark's DT_NEEDED. The benchmark's own objects only reference
+# libmilvus-storage.so symbols, so under the default --as-needed the loader
+# reaches libmilvus-common.so only transitively and initializes it in an order
+# that crashes its prometheus metric registration during static init, before
+# main. milvus_test avoids this because its objects reference milvus-common
+# symbols directly, keeping it a direct dependency. --no-as-needed reproduces
+# that working DSO initialization order. (Adding the Talon C SDK to
+# libmilvus-storage.so's DT_NEEDED is what shifted the order enough to expose
+# the latent milvus-common static-init dependency.)
+if (NOT APPLE)
+  target_link_options(benchmark PRIVATE "LINKER:--no-as-needed")
+endif()
 
 # Include directories for benchmark headers and test helpers
 target_include_directories(benchmark PUBLIC

--- a/cpp/benchmark/benchmark_talon_reader.cpp
+++ b/cpp/benchmark/benchmark_talon_reader.cpp
@@ -1,0 +1,189 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Throughput benchmarks for the Talon-backed input file. They read a single
+// object served by a running Talon deployment (a local coordinator + worker in
+// dev, whatever CI points them at otherwise), so they only build with WITH_TALON
+// and only run when a coordinator + object URI are supplied via the environment;
+// otherwise each case reports itself skipped, mirroring the integration test.
+//
+//   TALON_COORDINATOR_ADDR - control address of a running coordinator (required)
+//   TALON_TEST_URI         - an object URI the deployment can serve (required)
+//   TALON_BENCH_BLOCK_SIZE - async block size in bytes (optional, default 4 MiB)
+#ifdef WITH_TALON
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/buffer.h>
+#include <arrow/util/future.h>
+
+#include "milvus-storage/filesystem/talon/talon_client.h"
+#include "milvus-storage/filesystem/talon/talon_input_file.h"
+
+namespace milvus_storage::talon {
+namespace {
+
+constexpr int64_t kDefaultBlockSize = 4 * 1024 * 1024;
+
+struct TalonBenchEnv {
+  std::string coordinator;
+  std::string uri;
+  int64_t block_size = kDefaultBlockSize;
+  bool available = false;
+};
+
+TalonBenchEnv ReadEnv() {
+  TalonBenchEnv env;
+  const char* addr = std::getenv("TALON_COORDINATOR_ADDR");
+  const char* uri = std::getenv("TALON_TEST_URI");
+  if (addr != nullptr && addr[0] != '\0' && uri != nullptr && uri[0] != '\0') {
+    env.coordinator = addr;
+    env.uri = uri;
+    env.available = true;
+  }
+  const char* block = std::getenv("TALON_BENCH_BLOCK_SIZE");
+  if (block != nullptr && block[0] != '\0') {
+    const int64_t parsed = std::atoll(block);
+    if (parsed > 0) {
+      env.block_size = parsed;
+    }
+  }
+  return env;
+}
+
+// Resolves a client and object once, then reads the object into the Talon cache
+// so the measured loop reports steady-state (cache-hit) throughput through the
+// worker rather than the one-off origin fetch.
+class TalonReaderBenchmark : public ::benchmark::Fixture {
+  protected:
+  void SetUp(::benchmark::State& state) override {
+    env_ = ReadEnv();
+    if (!env_.available) {
+      state.SkipWithError("set TALON_COORDINATOR_ADDR and TALON_TEST_URI to run Talon benchmarks");
+      return;
+    }
+
+    auto client = TalonClient::Make(env_.coordinator);
+    if (!client.ok()) {
+      state.SkipWithError(client.status().ToString().c_str());
+      return;
+    }
+    client_ = client.ValueOrDie();
+
+    file_ = std::make_shared<TalonInputFile>(client_, env_.uri);
+    auto size = file_->GetSize();
+    if (!size.ok()) {
+      state.SkipWithError(size.status().ToString().c_str());
+      return;
+    }
+    size_ = size.ValueOrDie();
+    if (size_ <= 0) {
+      state.SkipWithError("TALON_TEST_URI resolves to an empty object");
+      return;
+    }
+    scratch_.assign(static_cast<size_t>(size_), 0);
+
+    // Warm the cache so the first measured iteration is not the origin fetch.
+    auto warm = file_->ReadAt(0, size_);
+    if (!warm.ok()) {
+      state.SkipWithError(warm.status().ToString().c_str());
+      return;
+    }
+  }
+
+  void TearDown(::benchmark::State& /*state*/) override {
+    if (file_ != nullptr && !file_->closed()) {
+      auto status = file_->Close();
+      if (!status.ok()) {
+        // Best-effort cleanup; nothing actionable during benchmark teardown.
+      }
+    }
+    file_.reset();
+    client_.reset();
+    scratch_.clear();
+    scratch_.shrink_to_fit();
+  }
+
+  TalonBenchEnv env_;
+  std::shared_ptr<TalonClient> client_;
+  std::shared_ptr<TalonInputFile> file_;
+  int64_t size_ = 0;
+  std::vector<uint8_t> scratch_;
+};
+
+// Full-object read through the buffer-returning path (what a format reader that
+// pulls a whole footer/column chunk does).
+BENCHMARK_DEFINE_F(TalonReaderBenchmark, FullObjectReadAt)(::benchmark::State& state) {
+  if (file_ == nullptr) {
+    return;  // SetUp already flagged the skip.
+  }
+  for (auto _ : state) {
+    auto buffer = file_->ReadAt(0, size_);
+    if (!buffer.ok()) {
+      state.SkipWithError(buffer.status().ToString().c_str());
+      break;
+    }
+    ::benchmark::DoNotOptimize(buffer.ValueUnsafe()->data());
+  }
+  state.SetBytesProcessed(state.iterations() * size_);
+}
+
+// Whole object read as a fan-out of fixed-size async range reads into a
+// caller-owned buffer — the NonBlockingReadAtFile fast path the Parquet reader
+// uses. All reads for one iteration are issued before any is awaited, so this
+// measures Talon's concurrent block fetch, not serialized round trips.
+BENCHMARK_DEFINE_F(TalonReaderBenchmark, ConcurrentAsyncBlocks)(::benchmark::State& state) {
+  if (file_ == nullptr) {
+    return;  // SetUp already flagged the skip.
+  }
+  const int64_t block = env_.block_size;
+  std::vector<arrow::Future<int64_t>> futures;
+  futures.reserve(static_cast<size_t>((size_ + block - 1) / block));
+
+  for (auto _ : state) {
+    futures.clear();
+    for (int64_t offset = 0; offset < size_; offset += block) {
+      const int64_t nbytes = std::min(block, size_ - offset);
+      futures.push_back(file_->ReadAtAsyncInto(offset, nbytes, scratch_.data() + offset));
+    }
+    bool failed = false;
+    for (auto& future : futures) {
+      auto read = future.result();
+      if (!read.ok()) {
+        state.SkipWithError(read.status().ToString().c_str());
+        failed = true;
+        break;
+      }
+    }
+    if (failed) {
+      break;
+    }
+  }
+  state.SetBytesProcessed(state.iterations() * size_);
+}
+
+BENCHMARK_REGISTER_F(TalonReaderBenchmark, FullObjectReadAt)->Unit(::benchmark::kMillisecond)->UseRealTime();
+BENCHMARK_REGISTER_F(TalonReaderBenchmark, ConcurrentAsyncBlocks)->Unit(::benchmark::kMillisecond)->UseRealTime();
+
+}  // namespace
+}  // namespace milvus_storage::talon
+
+#endif  // WITH_TALON

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -32,6 +32,7 @@ class StorageConan(ConanFile):
         "with_python_binding": [True, False],
         "with_fiu": [True, False],
         "with_crt": [True, False],
+        "with_talon": [True, False],
     }
     default_options = {
         "shared": True,
@@ -45,6 +46,7 @@ class StorageConan(ConanFile):
         "with_python_binding": False,
         "with_fiu": False,
         "with_crt": False,
+        "with_talon": False,
         "folly/*:shared": True,
         "glog/*:with_gflags": True,
         "glog/*:shared": True,
@@ -243,6 +245,7 @@ class StorageConan(ConanFile):
         tc.variables["WITH_PYTHON_BINDING"] = self.options.with_python_binding
         tc.variables["WITH_FIU"] = self.options.with_fiu
         tc.variables["WITH_CRT"] = self.options.with_crt
+        tc.variables["WITH_TALON"] = self.options.with_talon
 
         # Set JAVA_HOME for JNI compilation
         if self.options.with_jni:

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -243,6 +243,14 @@ struct ArrowFileSystemConfig {
   // WITH_CRT is enabled. Ignored by non-S3 filesystems and non-CRT builds.
   bool s3_crt_async_read = true;
 
+  // Talon read-through cache. When enabled, OpenInputFile/OpenInputStream on a
+  // remote (S3-compatible) filesystem are served from the Talon distributed
+  // object cache instead of the origin; all other operations still go to the
+  // origin backend. Only effective in a WITH_TALON build; a true value in a
+  // non-Talon build is a configuration error, not a silent no-op.
+  bool talon_enabled = false;
+  std::string talon_coordinator = "";
+
   // Shared Lance scheduler capacity for local and remote reader fragment I/O.
   // Zero selects Lance's default of 64; it does not disable scheduler sharing.
   uint32_t lance_io_parallelism = 64;

--- a/cpp/include/milvus-storage/filesystem/talon/talon_client.h
+++ b/cpp/include/milvus-storage/filesystem/talon/talon_client.h
@@ -1,0 +1,105 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/util/future.h>
+
+// Upstream Talon C SDK ABI (milvus-io/talon, clients/c/include/talon.h). The
+// header and the linked libtalon_c static library are provided by the Talon
+// source tree fetched at configure time; see cpp/CMakeLists.txt (WITH_TALON).
+#include <talon.h>
+
+namespace milvus_storage::talon {
+
+/// Object identity + length as reported by a Talon StatObject.
+struct TalonStat {
+  int64_t size = 0;     // total object length in bytes
+  std::string version;  // opaque object generation token (may be empty)
+};
+
+/// Outcome of a single Talon read. `object_size` / `version` echo what Talon
+/// resolved for the object generation it served, so a caller that did not
+/// supply them up front can cache them and take the stat-skipping fast path on
+/// subsequent reads.
+struct TalonReadResult {
+  int64_t bytes_written = 0;
+  int64_t object_size = -1;  // arrow::fs::kNoSize when Talon did not report it
+  std::string version;
+};
+
+/// Translate a `talon_status` code (from a result or a submit call) into an
+/// arrow::Status. TALON_STATUS_INVALID_ARGUMENT maps to Invalid; every other
+/// non-OK code maps to IOError. `op` and `uri` are woven into the message.
+arrow::Status TalonStatusToStatus(int status, const char* error, std::string_view op, const std::string& uri);
+
+/// Thin RAII owner of a `talon_client`. Reads and stats are submitted through
+/// the C SDK's async API and completed via an arrow::Future; the client keeps
+/// itself alive across in-flight operations (each submission holds a
+/// shared_ptr) so callers may drop their reference without cancelling work.
+///
+/// Callbacks run inline on the SDK's runtime thread (no callback executor is
+/// installed), so the marshalling here only marks the future finished — exactly
+/// the convention the S3 CRT reader uses. Heavy or blocking continuation work
+/// must be moved off that thread by the caller, at the future's continuation
+/// boundary.
+class TalonClient : public std::enable_shared_from_this<TalonClient> {
+  public:
+  /// Connect a client to `coordinator_addr`. The client uses the SDK's default
+  /// block granularity, which is set to match the worker cache configuration.
+  static arrow::Result<std::shared_ptr<TalonClient>> Make(const std::string& coordinator_addr);
+
+  ~TalonClient();
+
+  TalonClient(const TalonClient&) = delete;
+  TalonClient& operator=(const TalonClient&) = delete;
+
+  /// Submit a read of [offset, offset + len) into the caller-owned buffer
+  /// [dst, dst + len). The buffer must stay valid and untouched until the
+  /// returned future completes (the SDK owns it meanwhile).
+  ///
+  /// When BOTH `version` and `object_size` are provided the read takes Talon's
+  /// fast path and skips the StatObject round trip; a lone value is dropped
+  /// (passing it would not skip the stat), matching the C ABI contract.
+  arrow::Future<TalonReadResult> ReadAsync(const std::string& uri,
+                                           int64_t offset,
+                                           uint8_t* dst,
+                                           int64_t len,
+                                           const std::optional<std::string>& version,
+                                           const std::optional<int64_t>& object_size);
+
+  /// Resolve object length + version via a StatObject.
+  arrow::Future<TalonStat> StatAsync(const std::string& uri);
+
+  /// Blocking convenience wrapper over StatAsync.
+  arrow::Result<TalonStat> Stat(const std::string& uri);
+
+  /// Raw handle, for tests and advanced callers. Never freed by the caller.
+  talon_client* raw() const { return client_; }
+
+  private:
+  explicit TalonClient(talon_client* client) : client_(client) {}
+
+  talon_client* client_ = nullptr;
+};
+
+}  // namespace milvus_storage::talon

--- a/cpp/include/milvus-storage/filesystem/talon/talon_file_system.h
+++ b/cpp/include/milvus-storage/filesystem/talon/talon_file_system.h
@@ -1,0 +1,73 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/result.h>
+
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/talon/talon_client.h"
+
+namespace milvus_storage::talon {
+
+/// A FileSystemProxy whose read openers serve from the Talon object cache while
+/// every other operation (writes, listing, deletes, metrics, conditional and
+/// sized uploads) is inherited unchanged and keeps going to the origin backend.
+///
+/// It subclasses FileSystemProxy rather than wrapping it so the milvus-storage
+/// interfaces the proxy already exposes — UploadConditional, Observable,
+/// UploadSizable, and the SubTree bucket rooting — continue to work with no
+/// forwarding boilerplate. Only OpenInputFile / OpenInputStream are overridden.
+///
+/// Paths reaching these overrides are bucket-relative (the SubTree contract), so
+/// the Talon object URI is `<scheme>://<bucket>/<path>`.
+class TalonFileSystemProxy : public FileSystemProxy {
+  public:
+  TalonFileSystemProxy(const std::string& base_path,
+                       std::shared_ptr<arrow::fs::FileSystem> base_fs,
+                       std::shared_ptr<TalonClient> client,
+                       std::string scheme,
+                       std::string bucket)
+      : FileSystemProxy(base_path, std::move(base_fs)),
+        client_(std::move(client)),
+        scheme_(std::move(scheme)),
+        bucket_(std::move(bucket)) {}
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override;
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override;
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override;
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const arrow::fs::FileInfo& info) override;
+
+  private:
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenTalon(const std::string& path, int64_t size) const;
+  std::string BuildUri(const std::string& path) const;
+
+  std::shared_ptr<TalonClient> client_;
+  std::string scheme_;
+  std::string bucket_;
+};
+
+/// Wrap a producer-built remote filesystem so its reads go through Talon. The
+/// input must be the FileSystemProxy a remote producer returns (bucket-rooted);
+/// returns an error for local or otherwise unsupported backends, or when the
+/// coordinator address is missing. Creates the Talon client bound to the
+/// filesystem's lifetime.
+arrow::Result<ArrowFileSystemPtr> WrapWithTalon(const ArrowFileSystemConfig& config, ArrowFileSystemPtr base_fs);
+
+}  // namespace milvus_storage::talon

--- a/cpp/include/milvus-storage/filesystem/talon/talon_input_file.h
+++ b/cpp/include/milvus-storage/filesystem/talon/talon_input_file.h
@@ -1,0 +1,120 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <arrow/io/interfaces.h>
+#include <arrow/memory_pool.h>
+#include <arrow/result.h>
+#include <arrow/util/future.h>
+
+#include "milvus-storage/filesystem/async_random_access_file.h"
+#include "milvus-storage/filesystem/talon/talon_client.h"
+
+namespace milvus_storage::talon {
+
+/// A random-access input file backed by the Talon C SDK.
+///
+/// It implements arrow::io::RandomAccessFile, which is the single interface
+/// every Arrow-based format reader consumes (Parquet, Lance, Arrow IPC, CSV,
+/// ...). Constructing one over a Talon URI therefore lets any of those formats
+/// be read straight out of the Talon cache with no per-format work. It also
+/// implements milvus_storage::NonBlockingReadAtFile, the async fast path the
+/// Parquet reader opportunistically `dynamic_cast`s to, so range reads issue
+/// through `talon_read_async` and complete without blocking a worker thread.
+///
+/// Object identity (length + version) is resolved lazily and cached: the first
+/// GetSize() or the first read learns both from Talon, and every read after
+/// that supplies them so Talon skips its StatObject round trip (the PR #564
+/// fast path). The buffer handed to a read must outlive the returned future —
+/// that is the NonBlockingReadAtFile contract, and Talon owns the buffer until
+/// completion.
+class TalonInputFile final : public arrow::io::RandomAccessFile, public NonBlockingReadAtFile {
+  public:
+  /// @param client Shared Talon client; kept alive for the file's lifetime.
+  /// @param uri    Object URI Talon resolves (e.g. "s3://bucket/key").
+  /// @param size   Known object length, or arrow::fs::kNoSize if unknown.
+  /// @param version Known object version, or "" if unknown. A size+version pair
+  ///        known up front lets the very first read take the fast path.
+  /// @param pool   Memory pool for buffer-returning reads.
+  TalonInputFile(std::shared_ptr<TalonClient> client,
+                 std::string uri,
+                 int64_t size = -1,
+                 std::string version = "",
+                 arrow::MemoryPool* pool = arrow::default_memory_pool());
+
+  ~TalonInputFile() override = default;
+
+  // arrow::io::RandomAccessFile
+  arrow::Result<int64_t> GetSize() override;
+  arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+  arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) override;
+  arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
+                                                          int64_t position,
+                                                          int64_t nbytes) override;
+
+  // arrow::io::Seekable / InputStream
+  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override;
+  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
+  arrow::Status Seek(int64_t position) override;
+  arrow::Result<int64_t> Tell() const override;
+  arrow::Status Close() override;
+  bool closed() const override;
+
+  // milvus_storage::NonBlockingReadAtFile
+  arrow::Future<int64_t> ReadAtAsyncInto(int64_t position, int64_t nbytes, uint8_t* out) override;
+
+  private:
+  /// Shared read identity, updated at most once from unknown -> known. The
+  /// content length is atomic (the hot read path only reads it); the version is
+  /// guarded because it is a string and coupled with `has_version`.
+  struct Identity {
+    explicit Identity(int64_t size) : content_length(size) {}
+    std::atomic<int64_t> content_length;  // arrow::fs::kNoSize until resolved
+    mutable std::mutex version_mutex;
+    std::string version;
+    bool has_version = false;
+  };
+
+  arrow::Status CheckClosed() const;
+  /// Resolve and cache the object length (and version) if not already known.
+  arrow::Status EnsureSize();
+  /// Clamp a requested read to [0, size - position] when the size is known;
+  /// pass it through unchanged (letting Talon bound it at EOF) when it is not.
+  arrow::Result<int64_t> ClampReadSize(int64_t position, int64_t nbytes) const;
+
+  std::shared_ptr<TalonClient> client_;
+  std::string uri_;
+  std::shared_ptr<Identity> identity_;
+  arrow::MemoryPool* pool_;
+  int64_t pos_ = 0;
+  bool closed_ = false;
+};
+
+/// Open a Talon-backed random-access file. The returned handle plugs directly
+/// into any Arrow format reader that takes an arrow::io::RandomAccessFile.
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenTalonInputFile(
+    std::shared_ptr<TalonClient> client,
+    std::string uri,
+    int64_t size = -1,
+    std::string version = "",
+    arrow::MemoryPool* pool = arrow::default_memory_pool());
+
+}  // namespace milvus_storage::talon

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -100,6 +100,11 @@ struct PropertyInfo {
 #define PROPERTY_FS_IOPS_INITIAL_RATE "fs.iops_initial_rate"
 #define PROPERTY_FS_IOPS_MAX_RATE "fs.iops_max_rate"
 
+// Talon read-through cache. Route OpenInputFile/OpenInputStream through the
+// Talon distributed object cache. Only effective when built with WITH_TALON.
+#define PROPERTY_FS_TALON_ENABLED "fs.talon.enabled"
+#define PROPERTY_FS_TALON_COORDINATOR "fs.talon.coordinator"
+
 // Cross-tenant access properties
 #define PROPERTY_FS_GCP_TARGET_SERVICE_ACCOUNT "fs.gcp_target_service_account"
 #define PROPERTY_FS_AZURE_CLIENT_ID "fs.azure_client_id"

--- a/cpp/scripts/s3_seed.py
+++ b/cpp/scripts/s3_seed.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Seed a MinIO/S3 object for the Talon integration test using only the Python
+standard library. The milvus builder image ships no s3cmd/mc/aws/boto3, so
+scripts/setup_talon.sh calls this instead to guarantee the test object exists.
+
+Path-style requests, AWS Signature V4. Idempotent: it HEADs the object and
+uploads --size-mb MiB of deterministic bytes only when the object is missing,
+creating the bucket first if needed. This is a test fixture, not a general S3
+client (single unsigned-streaming PUT, no multipart, minimal error handling).
+
+Usage:
+  s3_seed.py --endpoint http://minio:9000 --bucket B --key path/to/obj \
+             --access KEY --secret SECRET [--size-mb 64] [--region us-east-1]
+Exit 0 when the object is present (already there or freshly uploaded).
+"""
+import argparse
+import datetime
+import hashlib
+import hmac
+import sys
+import urllib.error
+import urllib.request
+
+_SERVICE = "s3"
+_ALGO = "AWS4-HMAC-SHA256"
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hmac(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _signing_key(secret: str, datestamp: str, region: str) -> bytes:
+    k = _hmac(("AWS4" + secret).encode("utf-8"), datestamp)
+    k = _hmac(k, region)
+    k = _hmac(k, _SERVICE)
+    return _hmac(k, "aws4_request")
+
+
+def _signed_request(method, endpoint, canonical_uri, access, secret, region, body):
+    """Build a SigV4-signed urllib Request for a path-style S3 call."""
+    host = endpoint.split("://", 1)[1]
+    payload_hash = _sha256_hex(body)
+    now = datetime.datetime.utcnow()
+    amzdate = now.strftime("%Y%m%dT%H%M%SZ")
+    datestamp = now.strftime("%Y%m%d")
+
+    canonical_headers = (
+        f"host:{host}\n"
+        f"x-amz-content-sha256:{payload_hash}\n"
+        f"x-amz-date:{amzdate}\n"
+    )
+    signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    canonical_request = (
+        f"{method}\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+    )
+    scope = f"{datestamp}/{region}/{_SERVICE}/aws4_request"
+    string_to_sign = f"{_ALGO}\n{amzdate}\n{scope}\n{_sha256_hex(canonical_request.encode('utf-8'))}"
+    signature = hmac.new(
+        _signing_key(secret, datestamp, region), string_to_sign.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    authorization = (
+        f"{_ALGO} Credential={access}/{scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+    req = urllib.request.Request(endpoint + canonical_uri, data=body, method=method)
+    req.add_header("Host", host)
+    req.add_header("x-amz-content-sha256", payload_hash)
+    req.add_header("x-amz-date", amzdate)
+    req.add_header("Authorization", authorization)
+    return req
+
+
+def _call(method, endpoint, canonical_uri, access, secret, region, body=b""):
+    req = _signed_request(method, endpoint, canonical_uri, access, secret, region, body)
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--endpoint", required=True)
+    ap.add_argument("--bucket", required=True)
+    ap.add_argument("--key", required=True)
+    ap.add_argument("--access", required=True)
+    ap.add_argument("--secret", required=True)
+    ap.add_argument("--region", default="us-east-1")
+    ap.add_argument("--size-mb", type=int, default=64)
+    args = ap.parse_args()
+
+    obj_uri = f"/{args.bucket}/{args.key}"
+
+    # Already present? HEAD returns 200 when the object exists.
+    status, _ = _call("HEAD", args.endpoint, obj_uri, args.access, args.secret, args.region)
+    if status == 200:
+        print(f"Test object s3://{args.bucket}/{args.key} already present")
+        return 0
+
+    # Ensure the bucket exists (200 fresh, 409 already-owned are both fine).
+    status, body = _call("PUT", args.endpoint, f"/{args.bucket}/", args.access, args.secret, args.region)
+    if status not in (200, 409):
+        sys.stderr.write(f"bucket create failed: HTTP {status}: {body[:200]!r}\n")
+        return 1
+
+    # Upload deterministic bytes so repeated seeds are byte-identical.
+    nbytes = args.size_mb * 1024 * 1024
+    data = (hashlib.sha256(b"talon-seed").digest() * ((nbytes // 32) + 1))[:nbytes]
+    print(f"Seeding s3://{args.bucket}/{args.key} ({args.size_mb} MiB)")
+    status, body = _call("PUT", args.endpoint, obj_uri, args.access, args.secret, args.region, data)
+    if status not in (200, 201):
+        sys.stderr.write(f"object PUT failed: HTTP {status}: {body[:200]!r}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cpp/scripts/setup_talon.sh
+++ b/cpp/scripts/setup_talon.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Host-side orchestrator for a local, containerized Talon stack — one coordinator
+# and one S3/MinIO-backed worker — so the Talon integration test
+# (test/filesystem/talon) and benchmark (benchmark_talon_reader) have a real
+# deployment to run against.
+#
+# It mirrors talon's own e2e harness (talon's test/stack/deploy.sh): one script
+# with up/down/status/test subcommands, and the coordinator and worker IMAGES are
+# built locally from the SAME pinned talon source milvus-storage fetched for the C
+# SDK (build/<type>/_deps/talon-src) — so the servers never drift from the linked
+# client and nothing is pulled from a registry. MinIO is brought up in a container
+# the same way scripts/setup_minio.sh does for the object-store tests.
+#
+# talon reaches its in-cluster C SDK test via `kubectl exec`; with a plain docker
+# network we reach ours the analogous way. The test/benchmark client ALWAYS runs
+# inside the stack network — in a milvus builder container joined to $NET — and
+# reaches services by container name. This is not a convenience: the worker
+# advertises its own container name and the coordinator relays every object
+# request (StatObject/read) to the worker at that advertised address, so a client
+# off the network (e.g. on the host via a published port) is never served —
+# the on-network coordinator cannot dial a host-only address. Running the client
+# on $NET makes the single advertised address reachable by both coordinator and
+# client. We run the PRE-BUILT binary (no rebuild) in the builder image, which is
+# ABI-compatible with it: locally the binary was built in this image; in CI it was
+# built on the ubuntu-22.04 runner, whose libstdc++ the (also ubuntu-22.04-based)
+# builder image is backward-compatible with.
+#
+# Subcommands:
+#   up      build images (if missing) + bring the stack up, seed the origin
+#           object, wait for the worker to register, then leave it running
+#   test    run the Talon gtest suite against the running stack
+#   bench   run the Talon benchmark against the running stack
+#   down    stop and remove the stack (containers + network)
+#   e2e     up + test + down as one self-cleaning shot (local convenience)
+#   status  show stack state
+#
+# Requires a WITH_TALON build first (make build WITH_TALON=True) so both talon-src
+# (the image build context) and the milvus_test/benchmark binaries exist.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CPP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CPP_DIR/.." && pwd)"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+
+# talon source: the copy milvus-storage fetched for WITH_TALON (same pinned commit
+# as the linked C SDK). The images are built from here, so they can never drift
+# from the client. Override with TALON_SRC for an out-of-tree checkout.
+TALON_SRC="${TALON_SRC:-$CPP_DIR/build/$BUILD_TYPE/_deps/talon-src}"
+
+# --- topology -----------------------------------------------------------------
+NET="${TALON_NET:-talon-net}"
+MINIO_CT="${TALON_MINIO_CONTAINER:-talon-minio}"
+COORD_CT="${TALON_COORDINATOR_CONTAINER:-talon-coordinator}"
+WORKER_CT="${TALON_WORKER_CONTAINER:-talon-worker}"
+COORD_PORT=7000
+COORD_ADMIN=8000
+WORKER_PORT=7001
+WORKER_ADMIN=8001
+
+# --- images -------------------------------------------------------------------
+# The coordinator/worker images are tagged with the pinned talon short SHA for
+# traceability; the no-drift guarantee comes from the build context (TALON_SRC),
+# not the tag. Infra images match the object-store tests' choices where they overlap.
+IMG_TAG="$(git -C "$TALON_SRC" rev-parse --short HEAD 2>/dev/null || echo pinned)"
+COORD_IMG="${TALON_COORDINATOR_IMAGE:-talon-local/coordinator:$IMG_TAG}"
+WORKER_IMG="${TALON_WORKER_IMAGE:-talon-local/worker:$IMG_TAG}"
+MINIO_IMG="${TALON_MINIO_IMAGE:-quay.io/minio/minio}"
+SEED_IMG="${TALON_SEED_IMAGE:-python:3-slim}"
+BUILDER_IMG="${TALON_BUILDER_IMAGE:-milvusdb/milvus-env:ubuntu22.04-20260714-c135601}"
+
+# Own back any files the container run touches (e.g. coverage .gcda written next
+# to the instrumented binary) to the invoking user after the root-in-container run.
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+
+# --- origin object store (MinIO / S3-compatible) ------------------------------
+MINIO_USER="${TALON_MINIO_ACCESS_KEY:-minioadmin}"
+MINIO_PASS="${TALON_MINIO_SECRET_KEY:-minioadmin}"
+BUCKET="${TALON_TEST_BUCKET:-test-bucket}"
+OBJECT_KEY="${TALON_TEST_OBJECT_KEY:-talon-test/obj}"
+OBJECT_MB="${TALON_TEST_OBJECT_MB:-64}"
+REGION="${TALON_TEST_REGION:-us-east-1}"
+BLOCK_SIZE="${TALON_WORKER_BLOCK_SIZE:-8388608}"
+CLUSTER_ID="${TALON_CLUSTER_ID:-milvus-storage-dev}"
+TEST_URI="s3://$BUCKET/$OBJECT_KEY"
+
+log() { printf '\033[1;34m[talon]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[talon] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+require_talon_src() {
+  [[ -f "$TALON_SRC/deploy/docker/coordinator.Dockerfile" ]] || fail \
+    "talon source not found at $TALON_SRC. Build once with 'make build WITH_TALON=True' (in the builder container) so talon-src and the test binaries exist, or set TALON_SRC to a talon checkout."
+}
+
+build_images() {
+  # Build from the pinned Dockerfiles with talon-src as context. Cached across
+  # runs (cargo-chef layers survive source-only changes); force a rebuild with
+  # TALON_REBUILD_IMAGES=1. The first build is expensive (compiles talon's Rust
+  # deps) — that is the cost of the local-build approach talon itself uses.
+  local img df
+  for pair in "$COORD_IMG:coordinator" "$WORKER_IMG:worker"; do
+    img="${pair%:*}"; df="${pair##*:}"
+    if [[ "${TALON_REBUILD_IMAGES:-0}" != "1" ]] && docker image inspect "$img" >/dev/null 2>&1; then
+      log "image $img present (set TALON_REBUILD_IMAGES=1 to rebuild)"
+      continue
+    fi
+    log "building $img from $TALON_SRC/deploy/docker/$df.Dockerfile"
+    docker build -f "$TALON_SRC/deploy/docker/$df.Dockerfile" -t "$img" "$TALON_SRC"
+  done
+}
+
+remove_container() { docker rm -f "$1" >/dev/null 2>&1 || true; }
+
+cmd_down() {
+  log "tearing down the talon stack"
+  remove_container "$WORKER_CT"
+  remove_container "$COORD_CT"
+  remove_container "$MINIO_CT"
+  docker network rm "$NET" >/dev/null 2>&1 || true
+}
+
+seed_object() {
+  # The milvus builder image ships no S3 CLI (s3cmd/mc/aws) and no boto3, so seed
+  # through the stdlib-only SigV4 helper, running it in a throwaway python
+  # container joined to the stack network — MinIO is never published to the host.
+  # Idempotent (HEAD then PUT) and retried while MinIO finishes starting.
+  local i
+  for i in $(seq 1 15); do
+    if docker run --rm --network "$NET" -v "$SCRIPT_DIR/s3_seed.py:/s3_seed.py:ro" "$SEED_IMG" \
+        python3 /s3_seed.py --endpoint "http://$MINIO_CT:9000" \
+        --bucket "$BUCKET" --key "$OBJECT_KEY" \
+        --access "$MINIO_USER" --secret "$MINIO_PASS" \
+        --region "$REGION" --size-mb "$OBJECT_MB" 2>/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+  fail "could not seed s3://$BUCKET/$OBJECT_KEY (MinIO not reachable at $MINIO_CT:9000?)"
+}
+
+wait_registered() {
+  # Gate on the worker actually joining placement. The coordinator's admin API
+  # (/api/v1/cluster) reports healthy_worker_count and is unauthenticated by
+  # default; curl ships in the coordinator image, so query it via `docker exec`
+  # (no admin port need be published, and it works identically in both modes).
+  local i n
+  printf '[talon] waiting for the worker to register'
+  for i in $(seq 1 60); do
+    if ! docker ps --format '{{.Names}}' | grep -qx "$COORD_CT"; then
+      printf '\n'; docker logs --tail 40 "$COORD_CT" 2>&1 || true
+      fail "coordinator container exited"
+    fi
+    n="$(docker exec "$COORD_CT" curl -fsS "http://127.0.0.1:$COORD_ADMIN/api/v1/cluster" 2>/dev/null \
+         | grep -oE '"healthy_worker_count"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' || true)"
+    if [[ -n "$n" && "$n" -ge 1 ]]; then printf ' ready\n'; return 0; fi
+    printf '.'; sleep 1
+  done
+  printf ' FAILED\n' >&2
+  docker logs --tail 40 "$WORKER_CT" 2>&1 || true
+  fail "worker did not register within 60s"
+}
+
+cmd_up() {
+  require_talon_src
+  build_images
+  cmd_down # clean slate: remove any stale stack from a previous run
+  log "creating network $NET"
+  docker network create "$NET" >/dev/null
+
+  log "starting MinIO ($MINIO_CT) on $NET"
+  docker run -d --name "$MINIO_CT" --network "$NET" \
+    -e "MINIO_ROOT_USER=$MINIO_USER" -e "MINIO_ROOT_PASSWORD=$MINIO_PASS" \
+    "$MINIO_IMG" server /data --console-address ":9001" >/dev/null
+  seed_object
+  log "seeded $TEST_URI ($OBJECT_MB MiB)"
+
+  # No host port publishing: every client runs on $NET (see the header), so the
+  # worker advertises its own container name for the coordinator to relay to.
+  local worker_advertise="$WORKER_CT:$WORKER_PORT"
+
+  log "starting coordinator ($COORD_CT)"
+  docker run -d --name "$COORD_CT" --network "$NET" \
+    "$COORD_IMG" \
+    --listen "0.0.0.0:$COORD_PORT" --admin-listen "0.0.0.0:$COORD_ADMIN" \
+    --cluster-id "$CLUSTER_ID" --node-id coord-0 >/dev/null
+
+  # Backend/S3/cache settings are env-only in talon (the secret key intentionally
+  # so); only topology goes on the CLI. The worker reaches MinIO by name on $NET.
+  log "starting worker ($WORKER_CT), advertising $worker_advertise"
+  docker run -d --name "$WORKER_CT" --network "$NET" \
+    -e TALON_WORKER_BACKEND=s3 \
+    -e "TALON_WORKER_S3_REGION=$REGION" \
+    -e "TALON_WORKER_S3_ENDPOINT=http://$MINIO_CT:9000" \
+    -e "TALON_WORKER_S3_ACCESS_KEY_ID=$MINIO_USER" \
+    -e "TALON_WORKER_S3_SECRET_ACCESS_KEY=$MINIO_PASS" \
+    -e TALON_WORKER_S3_PATH_STYLE=true \
+    -e TALON_WORKER_FORCE_TOKIO_DATA_PLANE=1 \
+    "$WORKER_IMG" \
+    --coordinator "$COORD_CT:$COORD_PORT" \
+    --listen "0.0.0.0:$WORKER_PORT" --advertise-addr "$worker_advertise" \
+    --admin-listen "0.0.0.0:$WORKER_ADMIN" \
+    --cluster-id "$CLUSTER_ID" --node-id worker-0 \
+    --block-size "$BLOCK_SIZE" >/dev/null
+
+  wait_registered
+  cat <<EOF
+
+[talon] stack is up
+  coordinator : $COORD_CT:$COORD_PORT   (image $COORD_IMG)
+  worker      : advertises $worker_advertise   (image $WORKER_IMG)
+  origin      : $TEST_URI   (MinIO $MINIO_CT, in-network only)
+
+  run:   $0 test        # Talon gtest suite
+         $0 bench       # Talon benchmark
+  stop:  $0 down
+EOF
+}
+
+# Run the PRE-BUILT Talon client (test or benchmark) against the running stack,
+# in a builder container joined to $NET (see the header for why on-network is
+# mandatory). No rebuild: the binary from `make build WITH_TALON=True` is executed
+# as-is, so this needs no conan cache and never drifts from the CI build. The tree
+# is chown'd back afterwards in case the instrumented binary drops root-owned
+# coverage files. LD_LIBRARY_PATH is set to the container-side build paths so the
+# loader finds the bundled deps regardless of the binary's baked rpath.
+run_client() {
+  local kind="$1" relbin filter
+  case "$kind" in
+    test) relbin="test/milvus_test"; filter="--gtest_filter=Talon*" ;;
+    bench) relbin="benchmark/benchmark"; filter="--benchmark_filter=TalonReaderBenchmark" ;;
+    *) fail "unknown client kind: $kind" ;;
+  esac
+  [[ -x "$CPP_DIR/build/$BUILD_TYPE/$relbin" ]] || fail \
+    "build/$BUILD_TYPE/$relbin not found — build first with 'make build WITH_TALON=True'."
+
+  log "running the Talon $kind client on $NET ($BUILDER_IMG)"
+  docker run --rm --network "$NET" \
+    --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+    -v "$REPO_ROOT:/workspace/milvus-storage" \
+    -e "TALON_COORDINATOR_ADDR=$COORD_CT:$COORD_PORT" \
+    -e "TALON_TEST_URI=$TEST_URI" \
+    -e "TALON_BENCH_BLOCK_SIZE=$BLOCK_SIZE" \
+    -w /workspace/milvus-storage/cpp \
+    "$BUILDER_IMG" \
+    bash -lc "export LD_LIBRARY_PATH=/workspace/milvus-storage/cpp/build/$BUILD_TYPE:/workspace/milvus-storage/cpp/build/$BUILD_TYPE/libs:\${LD_LIBRARY_PATH:-}; ./build/$BUILD_TYPE/$relbin $filter; rc=\$?; chown -R $HOST_UID:$HOST_GID build 2>/dev/null || true; exit \$rc"
+}
+
+cmd_status() {
+  echo "network: $NET"
+  docker ps -a --filter "name=$MINIO_CT" --filter "name=$COORD_CT" --filter "name=$WORKER_CT" \
+    --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null || echo "(docker unavailable)"
+}
+
+case "${1:-status}" in
+  up) trap 'cmd_down' EXIT; cmd_up; trap - EXIT ;;
+  test) run_client test ;;
+  bench) run_client bench ;;
+  down | stop) cmd_down ;;
+  status) cmd_status ;;
+  e2e)
+    trap 'cmd_down' EXIT
+    cmd_up
+    rc=0; run_client test || rc=$?
+    cmd_down; trap - EXIT
+    exit $rc
+    ;;
+  *) echo "usage: $0 [up|test|bench|down|e2e|status]" >&2; exit 2 ;;
+esac

--- a/cpp/scripts/talon_env.sh
+++ b/cpp/scripts/talon_env.sh
@@ -1,0 +1,10 @@
+# Environment for the Talon integration test and benchmark. Source this after
+# scripts/setup_talon.sh has brought up the local stack:
+#
+#   source ./scripts/talon_env.sh
+#   ./build/Release/test/milvus_test --gtest_filter='Talon*'
+#
+# The values match setup_talon.sh's defaults; already-exported values win, so a
+# custom topology (different coordinator address or object URI) is honored.
+export TALON_COORDINATOR_ADDR="${TALON_COORDINATOR_ADDR:-127.0.0.1:7000}"
+export TALON_TEST_URI="${TALON_TEST_URI:-s3://test-bucket/talon-test/obj}"

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -29,6 +29,10 @@
 
 #include "milvus-storage/filesystem/azure/azure_fs_producer.h"
 
+#ifdef WITH_TALON
+#include "milvus-storage/filesystem/talon/talon_file_system.h"
+#endif
+
 namespace milvus_storage {
 
 enum class StorageType : int8_t {
@@ -94,6 +98,13 @@ std::string ArrowFileSystemConfig::GetCacheKey() const {
   hash_combine(s3_crt_async_read);
   hash_combine(load_frequency);
 
+  // Talon routing changes which filesystem instance a config maps to, so two
+  // configs differing only in Talon settings must not share one cached instance.
+  hash_combine(talon_enabled);
+  if (talon_enabled) {
+    hash_combine(talon_coordinator);
+  }
+
   if (IsAzureCredentialBrokerEnabled()) {
     hash_combine(access_key_id);
     hash_combine(azure_client_id);
@@ -143,7 +154,7 @@ std::string ArrowFileSystemConfig::ToString() const {
   return ss.str();
 }
 
-arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemConfig& config) {
+static arrow::Result<ArrowFileSystemPtr> CreateBackendFileSystem(const ArrowFileSystemConfig& config) {
   auto storage_type = StorageType_Map[config.storage_type];
   switch (storage_type) {
     case StorageType::Local: {
@@ -173,6 +184,27 @@ arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemCon
       return arrow::Status::Invalid("Unsupported storage type: " + config.storage_type);
     }
   }
+}
+
+arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemConfig& config) {
+#ifndef WITH_TALON
+  // Fail fast on a misconfiguration before building any backend.
+  if (config.talon_enabled) {
+    return arrow::Status::Invalid(
+        "fs.talon.enabled=true but milvus-storage was built without Talon support (rebuild with -DWITH_TALON=ON)");
+  }
+#endif
+
+  ARROW_ASSIGN_OR_RAISE(auto fs, CreateBackendFileSystem(config));
+
+#ifdef WITH_TALON
+  if (config.talon_enabled) {
+    // Serve reads for this filesystem from the Talon cache; writes and metadata
+    // still flow to the backend built above.
+    return talon::WrapWithTalon(config, std::move(fs));
+  }
+#endif
+  return fs;
 }
 
 bool IsLocalFileSystem(const ArrowFileSystemPtr& fs) {
@@ -252,6 +284,9 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
   ARROW_ASSIGN_OR_RAISE(result.use_crc32c_checksum,
                         api::GetValue<bool>(properties_map, PROPERTY_FS_USE_CRC32C_CHECKSUM));
   ARROW_ASSIGN_OR_RAISE(result.s3_crt_async_read, api::GetValue<bool>(properties_map, PROPERTY_FS_S3_CRT_ASYNC_READ));
+  ARROW_ASSIGN_OR_RAISE(result.talon_enabled, api::GetValue<bool>(properties_map, PROPERTY_FS_TALON_ENABLED));
+  ARROW_ASSIGN_OR_RAISE(result.talon_coordinator,
+                        api::GetValue<std::string>(properties_map, PROPERTY_FS_TALON_COORDINATOR));
   ARROW_ASSIGN_OR_RAISE(result.lance_io_parallelism,
                         api::GetValue<uint32_t>(properties_map, PROPERTY_FS_LANCE_IO_PARALLELISM));
   ARROW_ASSIGN_OR_RAISE(result.iops_initial_rate,

--- a/cpp/src/filesystem/talon/talon_client.cpp
+++ b/cpp/src/filesystem/talon/talon_client.cpp
@@ -1,0 +1,193 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/talon/talon_client.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace milvus_storage::talon {
+
+namespace {
+
+/// RAII owner for a `talon_result`. Every callback receives ownership of the
+/// result and must free it exactly once; this guarantees that even on an early
+/// return path.
+class TalonResultHandle {
+  public:
+  explicit TalonResultHandle(talon_result* result) : result_(result) {}
+  ~TalonResultHandle() {
+    if (result_ != nullptr) {
+      talon_result_free(result_);
+    }
+  }
+  TalonResultHandle(const TalonResultHandle&) = delete;
+  TalonResultHandle& operator=(const TalonResultHandle&) = delete;
+
+  private:
+  talon_result* result_;
+};
+
+/// Heap state that outlives the ReadAsync call and is reclaimed by the
+/// callback. It backs the C-string / size pointers handed to the SDK and holds
+/// a shared_ptr to the client so it cannot be freed mid-flight.
+struct ReadContext {
+  arrow::Future<TalonReadResult> future;
+  std::shared_ptr<TalonClient> client;
+  std::string uri;           // backs the `uri` pointer
+  std::string version;       // backs the `version` pointer (fast path only)
+  uint64_t object_size = 0;  // backs the `object_size` pointer (fast path only)
+};
+
+struct StatContext {
+  arrow::Future<TalonStat> future;
+  std::shared_ptr<TalonClient> client;
+  std::string uri;
+};
+
+void ReadCallback(talon_result* result, void* user_data) {
+  std::unique_ptr<ReadContext> ctx(static_cast<ReadContext*>(user_data));
+  TalonResultHandle handle(result);
+
+  const int status = talon_result_status(result);
+  if (status != TALON_STATUS_OK) {
+    ctx->future.MarkFinished(
+        arrow::Result<TalonReadResult>(TalonStatusToStatus(status, talon_result_error(result), "read", ctx->uri)));
+    return;
+  }
+
+  TalonReadResult out;
+  out.bytes_written = static_cast<int64_t>(talon_result_bytes_written(result));
+  out.object_size = static_cast<int64_t>(talon_result_object_size(result));
+  if (const char* version = talon_result_version(result); version != nullptr) {
+    out.version = version;
+  }
+  ctx->future.MarkFinished(std::move(out));
+}
+
+void StatCallback(talon_result* result, void* user_data) {
+  std::unique_ptr<StatContext> ctx(static_cast<StatContext*>(user_data));
+  TalonResultHandle handle(result);
+
+  const int status = talon_result_status(result);
+  if (status != TALON_STATUS_OK) {
+    ctx->future.MarkFinished(
+        arrow::Result<TalonStat>(TalonStatusToStatus(status, talon_result_error(result), "stat", ctx->uri)));
+    return;
+  }
+
+  TalonStat out;
+  out.size = static_cast<int64_t>(talon_result_object_size(result));
+  if (const char* version = talon_result_version(result); version != nullptr) {
+    out.version = version;
+  }
+  ctx->future.MarkFinished(std::move(out));
+}
+
+}  // namespace
+
+arrow::Status TalonStatusToStatus(int status, const char* error, std::string_view op, const std::string& uri) {
+  std::string detail = error != nullptr && error[0] != '\0' ? error : "no error detail";
+  std::string message = "Talon " + std::string(op) + " failed for '" + uri + "': " + detail +
+                        " (talon_status=" + std::to_string(status) + ")";
+  switch (status) {
+    case TALON_STATUS_INVALID_ARGUMENT:
+      return arrow::Status::Invalid(std::move(message));
+    default:
+      return arrow::Status::IOError(std::move(message));
+  }
+}
+
+arrow::Result<std::shared_ptr<TalonClient>> TalonClient::Make(const std::string& coordinator_addr) {
+  talon_client_options options;
+  talon_client_options_init(&options);
+  // Complete callbacks inline on the SDK runtime thread; continuations are
+  // rescheduled by the caller at the future boundary, as the S3 CRT reader does.
+  options.callback_executor = nullptr;
+
+  talon_client* client = nullptr;
+  const int rc = talon_client_new(coordinator_addr.c_str(), &options, &client);
+  if (rc != TALON_STATUS_OK || client == nullptr) {
+    return TalonStatusToStatus(rc, talon_last_error(), "client_new", coordinator_addr);
+  }
+  return std::shared_ptr<TalonClient>(new TalonClient(client));
+}
+
+TalonClient::~TalonClient() {
+  if (client_ != nullptr) {
+    talon_client_free(client_);
+    client_ = nullptr;
+  }
+}
+
+arrow::Future<TalonReadResult> TalonClient::ReadAsync(const std::string& uri,
+                                                      int64_t offset,
+                                                      uint8_t* dst,
+                                                      int64_t len,
+                                                      const std::optional<std::string>& version,
+                                                      const std::optional<int64_t>& object_size) {
+  auto ctx = std::make_unique<ReadContext>();
+  ctx->future = arrow::Future<TalonReadResult>::Make();
+  ctx->client = shared_from_this();
+  ctx->uri = uri;
+
+  const char* version_ptr = nullptr;
+  const uint64_t* size_ptr = nullptr;
+  // Fast path requires BOTH; a lone value is ignored by the SDK, so do not send
+  // it (avoids implying a capability the read cannot actually use).
+  if (version.has_value() && object_size.has_value()) {
+    ctx->version = *version;
+    ctx->object_size = static_cast<uint64_t>(*object_size);
+    version_ptr = ctx->version.c_str();
+    size_ptr = &ctx->object_size;
+  }
+
+  auto future = ctx->future;
+  uint64_t request_id = 0;
+  const int rc =
+      talon_read_async(client_, ctx->uri.c_str(), static_cast<uint64_t>(offset), dst, static_cast<size_t>(len),
+                       version_ptr, size_ptr, &ReadCallback, ctx.get(), &request_id);
+  if (rc != TALON_STATUS_OK) {
+    // Submission failed: the callback will not run, so this unique_ptr reclaims
+    // the context as it goes out of scope.
+    future.MarkFinished(arrow::Result<TalonReadResult>(TalonStatusToStatus(rc, talon_last_error(), "read", uri)));
+    return future;
+  }
+  // Submission succeeded: the callback now owns the context.
+  ctx.release();
+  return future;
+}
+
+arrow::Future<TalonStat> TalonClient::StatAsync(const std::string& uri) {
+  auto ctx = std::make_unique<StatContext>();
+  ctx->future = arrow::Future<TalonStat>::Make();
+  ctx->client = shared_from_this();
+  ctx->uri = uri;
+
+  auto future = ctx->future;
+  uint64_t request_id = 0;
+  const int rc = talon_stat_async(client_, ctx->uri.c_str(), &StatCallback, ctx.get(), &request_id);
+  if (rc != TALON_STATUS_OK) {
+    future.MarkFinished(arrow::Result<TalonStat>(TalonStatusToStatus(rc, talon_last_error(), "stat", uri)));
+    return future;
+  }
+  ctx.release();
+  return future;
+}
+
+arrow::Result<TalonStat> TalonClient::Stat(const std::string& uri) { return StatAsync(uri).result(); }
+
+}  // namespace milvus_storage::talon

--- a/cpp/src/filesystem/talon/talon_file_system.cpp
+++ b/cpp/src/filesystem/talon/talon_file_system.cpp
@@ -1,0 +1,98 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/talon/talon_file_system.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "milvus-storage/common/log.h"
+#include "milvus-storage/filesystem/talon/talon_input_file.h"
+
+namespace milvus_storage::talon {
+
+namespace {
+
+// Talon addresses objects by origin URI. Only S3-compatible backends are
+// supported today; they all share the `s3` scheme (the endpoint/region a
+// non-AWS backend needs is Talon worker configuration, not part of the URI).
+arrow::Result<std::string> TalonSchemeForProvider(const std::string& cloud_provider) {
+  if (cloud_provider == kCloudProviderAWS || cloud_provider == kCloudProviderAliyun ||
+      cloud_provider == kCloudProviderTencent || cloud_provider == kCloudProviderHuawei) {
+    return std::string("s3");
+  }
+  return arrow::Status::NotImplemented("Talon read caching does not support cloud provider '", cloud_provider,
+                                       "' yet (only S3-compatible backends)");
+}
+
+}  // namespace
+
+std::string TalonFileSystemProxy::BuildUri(const std::string& path) const {
+  std::string key = path;
+  while (!key.empty() && key.front() == '/') {
+    key.erase(key.begin());
+  }
+  return scheme_ + "://" + bucket_ + "/" + key;
+}
+
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> TalonFileSystemProxy::OpenTalon(const std::string& path,
+                                                                                            int64_t size) const {
+  return OpenTalonInputFile(client_, BuildUri(path), size);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> TalonFileSystemProxy::OpenInputFile(
+    const std::string& path) {
+  return OpenTalon(path, arrow::fs::kNoSize);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> TalonFileSystemProxy::OpenInputFile(
+    const arrow::fs::FileInfo& info) {
+  // A listing already knows the length; hand it to the reader so GetSize()
+  // needs no Talon stat.
+  return OpenTalon(info.path(), info.size());
+}
+
+arrow::Result<std::shared_ptr<arrow::io::InputStream>> TalonFileSystemProxy::OpenInputStream(const std::string& path) {
+  ARROW_ASSIGN_OR_RAISE(auto file, OpenTalon(path, arrow::fs::kNoSize));
+  return std::static_pointer_cast<arrow::io::InputStream>(file);
+}
+
+arrow::Result<std::shared_ptr<arrow::io::InputStream>> TalonFileSystemProxy::OpenInputStream(
+    const arrow::fs::FileInfo& info) {
+  ARROW_ASSIGN_OR_RAISE(auto file, OpenTalon(info.path(), info.size()));
+  return std::static_pointer_cast<arrow::io::InputStream>(file);
+}
+
+arrow::Result<ArrowFileSystemPtr> WrapWithTalon(const ArrowFileSystemConfig& config, ArrowFileSystemPtr base_fs) {
+  if (config.talon_coordinator.empty()) {
+    return arrow::Status::Invalid("fs.talon.enabled=true requires fs.talon.coordinator to be set");
+  }
+  ARROW_ASSIGN_OR_RAISE(auto scheme, TalonSchemeForProvider(config.cloud_provider));
+
+  // Producers return a bucket-rooted FileSystemProxy; reuse its base path and
+  // origin backend so non-read operations are unchanged.
+  auto proxy = std::dynamic_pointer_cast<FileSystemProxy>(base_fs);
+  if (proxy == nullptr) {
+    return arrow::Status::Invalid("Talon read caching requires a remote filesystem backend");
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto client, TalonClient::Make(config.talon_coordinator));
+  LOG_STORAGE_INFO_ << "Talon read caching enabled for bucket '" << config.bucket_name << "' via coordinator '"
+                    << config.talon_coordinator << "'";
+  return std::make_shared<TalonFileSystemProxy>(proxy->base_path(), proxy->base_fs(), std::move(client),
+                                                std::move(scheme), config.bucket_name);
+}
+
+}  // namespace milvus_storage::talon

--- a/cpp/src/filesystem/talon/talon_input_file.cpp
+++ b/cpp/src/filesystem/talon/talon_input_file.cpp
@@ -1,0 +1,232 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/talon/talon_input_file.h"
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include <arrow/buffer.h>
+#include <arrow/filesystem/filesystem.h>  // arrow::fs::kNoSize
+
+namespace milvus_storage::talon {
+
+namespace {
+using ::arrow::fs::kNoSize;
+
+arrow::Future<int64_t> FailedReadFuture(arrow::Status status) {
+  return arrow::Future<int64_t>::MakeFinished(arrow::Result<int64_t>(std::move(status)));
+}
+}  // namespace
+
+TalonInputFile::TalonInputFile(
+    std::shared_ptr<TalonClient> client, std::string uri, int64_t size, std::string version, arrow::MemoryPool* pool)
+    : client_(std::move(client)), uri_(std::move(uri)), identity_(std::make_shared<Identity>(size)), pool_(pool) {
+  if (!version.empty()) {
+    identity_->version = std::move(version);
+    identity_->has_version = true;
+  }
+}
+
+arrow::Status TalonInputFile::CheckClosed() const {
+  if (closed_) {
+    return arrow::Status::Invalid("Operation on closed Talon input file");
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Status TalonInputFile::EnsureSize() {
+  if (identity_->content_length.load(std::memory_order_acquire) != kNoSize) {
+    return arrow::Status::OK();
+  }
+  ARROW_ASSIGN_OR_RAISE(auto stat, client_->Stat(uri_));
+  int64_t expected = kNoSize;
+  identity_->content_length.compare_exchange_strong(expected, stat.size, std::memory_order_acq_rel,
+                                                    std::memory_order_acquire);
+  if (!stat.version.empty()) {
+    std::lock_guard<std::mutex> lock(identity_->version_mutex);
+    if (!identity_->has_version) {
+      identity_->version = std::move(stat.version);
+      identity_->has_version = true;
+    }
+  }
+  return arrow::Status::OK();
+}
+
+arrow::Result<int64_t> TalonInputFile::ClampReadSize(int64_t position, int64_t nbytes) const {
+  if (position < 0) {
+    return arrow::Status::Invalid("Cannot read from negative position");
+  }
+  if (nbytes < 0) {
+    return arrow::Status::Invalid("Cannot read a negative number of bytes");
+  }
+  const int64_t size = identity_->content_length.load(std::memory_order_acquire);
+  if (size != kNoSize) {
+    if (position > size) {
+      return arrow::Status::IOError("Cannot read past end of Talon object '", uri_, "'");
+    }
+    nbytes = std::min(nbytes, size - position);
+  }
+  return nbytes;
+}
+
+arrow::Future<int64_t> TalonInputFile::ReadAtAsyncInto(int64_t position, int64_t nbytes, uint8_t* out) {
+  if (auto status = CheckClosed(); !status.ok()) {
+    return FailedReadFuture(std::move(status));
+  }
+  auto clamped = ClampReadSize(position, nbytes);
+  if (!clamped.ok()) {
+    return FailedReadFuture(clamped.status());
+  }
+  nbytes = clamped.ValueOrDie();
+  if (nbytes == 0) {
+    return arrow::Future<int64_t>::MakeFinished(0);
+  }
+
+  // Take the stat-skipping fast path only when both halves of the identity are
+  // known; otherwise let Talon resolve them and learn the result below.
+  std::optional<std::string> version;
+  std::optional<int64_t> object_size;
+  const int64_t size = identity_->content_length.load(std::memory_order_acquire);
+  if (size != kNoSize) {
+    std::lock_guard<std::mutex> lock(identity_->version_mutex);
+    if (identity_->has_version) {
+      version = identity_->version;
+      object_size = size;
+    }
+  }
+
+  auto identity = identity_;
+  return client_->ReadAsync(uri_, position, out, nbytes, version, object_size)
+      .Then([identity, nbytes, uri = uri_](const TalonReadResult& result) -> arrow::Result<int64_t> {
+        // Cache identity learned from a non-fast-path read so later reads skip
+        // the stat. compare_exchange keeps the first resolved value.
+        if (result.object_size != kNoSize) {
+          int64_t expected = kNoSize;
+          identity->content_length.compare_exchange_strong(expected, result.object_size, std::memory_order_acq_rel,
+                                                           std::memory_order_acquire);
+        }
+        if (!result.version.empty()) {
+          std::lock_guard<std::mutex> lock(identity->version_mutex);
+          if (!identity->has_version) {
+            identity->version = result.version;
+            identity->has_version = true;
+          }
+        }
+        if (result.bytes_written > nbytes) {
+          return arrow::Status::IOError("Talon read for '", uri, "' returned ", result.bytes_written, " bytes for a ",
+                                        nbytes, "-byte request");
+        }
+        return result.bytes_written;
+      });
+}
+
+arrow::Result<int64_t> TalonInputFile::ReadAt(int64_t position, int64_t nbytes, void* out) {
+  return ReadAtAsyncInto(position, nbytes, reinterpret_cast<uint8_t*>(out)).result();
+}
+
+arrow::Result<std::shared_ptr<arrow::Buffer>> TalonInputFile::ReadAt(int64_t position, int64_t nbytes) {
+  ARROW_RETURN_NOT_OK(CheckClosed());
+  ARROW_ASSIGN_OR_RAISE(nbytes, ClampReadSize(position, nbytes));
+
+  ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, pool_));
+  if (nbytes > 0) {
+    ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(position, nbytes, buffer->mutable_data()));
+    ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read));
+  }
+  return std::shared_ptr<arrow::Buffer>(std::move(buffer));
+}
+
+arrow::Future<std::shared_ptr<arrow::Buffer>> TalonInputFile::ReadAsync(const arrow::io::IOContext& io_context,
+                                                                        int64_t position,
+                                                                        int64_t nbytes) {
+  if (auto status = CheckClosed(); !status.ok()) {
+    return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(std::move(status));
+  }
+  auto clamped = ClampReadSize(position, nbytes);
+  if (!clamped.ok()) {
+    return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(clamped.status());
+  }
+  nbytes = clamped.ValueOrDie();
+
+  auto maybe_buffer = arrow::AllocateResizableBuffer(nbytes, io_context.pool());
+  if (!maybe_buffer.ok()) {
+    return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(maybe_buffer.status());
+  }
+  auto buffer = std::move(maybe_buffer).ValueOrDie();
+  auto* out = buffer->mutable_data();
+
+  return ReadAtAsyncInto(position, nbytes, out)
+      .Then([buffer = std::move(buffer)](int64_t bytes_read) mutable -> arrow::Result<std::shared_ptr<arrow::Buffer>> {
+        ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read));
+        return std::shared_ptr<arrow::Buffer>(std::move(buffer));
+      });
+}
+
+arrow::Result<int64_t> TalonInputFile::Read(int64_t nbytes, void* out) {
+  ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(pos_, nbytes, out));
+  pos_ += bytes_read;
+  return bytes_read;
+}
+
+arrow::Result<std::shared_ptr<arrow::Buffer>> TalonInputFile::Read(int64_t nbytes) {
+  ARROW_ASSIGN_OR_RAISE(auto buffer, ReadAt(pos_, nbytes));
+  pos_ += buffer->size();
+  return buffer;
+}
+
+arrow::Result<int64_t> TalonInputFile::GetSize() {
+  ARROW_RETURN_NOT_OK(CheckClosed());
+  ARROW_RETURN_NOT_OK(EnsureSize());
+  return identity_->content_length.load(std::memory_order_acquire);
+}
+
+arrow::Status TalonInputFile::Seek(int64_t position) {
+  ARROW_RETURN_NOT_OK(CheckClosed());
+  if (position < 0) {
+    return arrow::Status::Invalid("Cannot seek to a negative position");
+  }
+  const int64_t size = identity_->content_length.load(std::memory_order_acquire);
+  if (size != kNoSize && position > size) {
+    return arrow::Status::IOError("Cannot seek past end of Talon object '", uri_, "'");
+  }
+  pos_ = position;
+  return arrow::Status::OK();
+}
+
+arrow::Result<int64_t> TalonInputFile::Tell() const {
+  ARROW_RETURN_NOT_OK(CheckClosed());
+  return pos_;
+}
+
+arrow::Status TalonInputFile::Close() {
+  closed_ = true;
+  client_.reset();
+  return arrow::Status::OK();
+}
+
+bool TalonInputFile::closed() const { return closed_; }
+
+arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenTalonInputFile(
+    std::shared_ptr<TalonClient> client, std::string uri, int64_t size, std::string version, arrow::MemoryPool* pool) {
+  if (client == nullptr) {
+    return arrow::Status::Invalid("OpenTalonInputFile requires a non-null Talon client");
+  }
+  return std::static_pointer_cast<arrow::io::RandomAccessFile>(
+      std::make_shared<TalonInputFile>(std::move(client), std::move(uri), size, std::move(version), pool));
+}
+
+}  // namespace milvus_storage::talon

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -445,6 +445,17 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "Whether S3 OpenInputFile should use AWS CRT-backed async random reads when built with CRT.",
                       true,
                       ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_TALON_ENABLED,
+                      PropertyType::BOOL,
+                      "Route OpenInputFile/OpenInputStream through the Talon distributed object cache. "
+                      "Requires a build with WITH_TALON and a reachable fs.talon.coordinator.",
+                      false,
+                      ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_TALON_COORDINATOR,
+                      PropertyType::STRING,
+                      "Control address of the Talon coordinator (used when fs.talon.enabled is true).",
+                      "",
+                      ValidatePropertyType()),
     REGISTER_PROPERTY(
         PROPERTY_FS_LANCE_IO_PARALLELISM,
         PropertyType::UINT32,

--- a/cpp/test/filesystem/talon/talon_config_test.cpp
+++ b/cpp/test/filesystem/talon/talon_config_test.cpp
@@ -1,0 +1,86 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Talon config-plumbing and factory-gating tests. These are pure configuration
+// logic (no Talon SDK, no coordinator, no cloud), so they run in the default
+// build regardless of WITH_TALON.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/properties.h"
+
+namespace milvus_storage::test {
+
+TEST(TalonConfigTest, PropertiesParseIntoConfig) {
+  api::Properties properties;
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_ENABLED, "true"), std::nullopt);
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_COORDINATOR, "talon-coord:7000"), std::nullopt);
+
+  ArrowFileSystemConfig config;
+  ASSERT_TRUE(ArrowFileSystemConfig::create_file_system_config(properties, config).ok());
+  EXPECT_TRUE(config.talon_enabled);
+  EXPECT_EQ(config.talon_coordinator, "talon-coord:7000");
+}
+
+TEST(TalonConfigTest, TalonDefaultsAreOff) {
+  api::Properties properties;
+  ArrowFileSystemConfig config;
+  ASSERT_TRUE(ArrowFileSystemConfig::create_file_system_config(properties, config).ok());
+  EXPECT_FALSE(config.talon_enabled);
+  EXPECT_EQ(config.talon_coordinator, "");
+}
+
+TEST(TalonConfigTest, CacheKeyDistinguishesTalonRouting) {
+  ArrowFileSystemConfig base;
+  base.storage_type = "remote";
+  base.cloud_provider = kCloudProviderAWS;
+  base.address = "s3.amazonaws.com";
+  base.bucket_name = "b";
+
+  ArrowFileSystemConfig talon = base;
+  talon.talon_enabled = true;
+  talon.talon_coordinator = "coord-a:7000";
+
+  // Talon vs no-Talon must not collide.
+  EXPECT_NE(base.GetCacheKey(), talon.GetCacheKey());
+
+  // Different coordinators must not share an instance.
+  ArrowFileSystemConfig talon_other = talon;
+  talon_other.talon_coordinator = "coord-b:7000";
+  EXPECT_NE(talon.GetCacheKey(), talon_other.GetCacheKey());
+
+  // Identical Talon routing is stable.
+  ArrowFileSystemConfig talon_same = talon;
+  EXPECT_EQ(talon.GetCacheKey(), talon_same.GetCacheKey());
+}
+
+// Enabling Talon in a build without WITH_TALON must fail loudly rather than
+// silently ignore the request. The rejection happens before any backend is
+// built, so storage_type is irrelevant here.
+#ifndef WITH_TALON
+TEST(TalonConfigTest, EnabledWithoutTalonBuildIsRejected) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "local";
+  config.talon_enabled = true;
+
+  auto result = CreateArrowFileSystem(config);
+  ASSERT_FALSE(result.ok());
+  EXPECT_NE(result.status().ToString().find("Talon"), std::string::npos) << result.status().ToString();
+}
+#endif  // WITH_TALON
+
+}  // namespace milvus_storage::test

--- a/cpp/test/filesystem/talon/talon_input_file_test.cpp
+++ b/cpp/test/filesystem/talon/talon_input_file_test.cpp
@@ -1,0 +1,188 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integration coverage for the Talon-backed input file. It exercises the real
+// Talon C SDK, so it only compiles when WITH_TALON is set and only runs when a
+// coordinator is provided; otherwise it skips, matching how the other
+// remote-storage tests behave without their backing service. There is no fake
+// Talon here on purpose — the SDK is an upstream dependency, not something
+// milvus-storage reimplements.
+#ifdef WITH_TALON
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <arrow/buffer.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/testing/gtest_util.h>
+
+#include "milvus-storage/filesystem/async_random_access_file.h"
+#include "milvus-storage/filesystem/talon/talon_client.h"
+#include "milvus-storage/filesystem/talon/talon_input_file.h"
+
+namespace milvus_storage::talon {
+namespace {
+
+// Configuration comes from the environment so the test binds to whatever Talon
+// deployment CI (or a developer) points it at:
+//   TALON_COORDINATOR_ADDR - control address of a running coordinator (required)
+//   TALON_TEST_URI         - an object URI the deployment can serve (required)
+struct TalonEnv {
+  std::string coordinator;
+  std::string uri;
+  bool available = false;
+};
+
+TalonEnv ReadEnv() {
+  TalonEnv env;
+  const char* addr = std::getenv("TALON_COORDINATOR_ADDR");
+  const char* uri = std::getenv("TALON_TEST_URI");
+  if (addr != nullptr && addr[0] != '\0' && uri != nullptr && uri[0] != '\0') {
+    env.coordinator = addr;
+    env.uri = uri;
+    env.available = true;
+  }
+  return env;
+}
+
+std::shared_ptr<TalonClient> MakeClientOrSkip(const TalonEnv& env) {
+  auto result = TalonClient::Make(env.coordinator);
+  if (!result.ok()) {
+    ADD_FAILURE() << "failed to create Talon client: " << result.status().ToString();
+    return nullptr;
+  }
+  return result.ValueOrDie();
+}
+
+class TalonInputFileTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    env_ = ReadEnv();
+    if (!env_.available) {
+      GTEST_SKIP() << "set TALON_COORDINATOR_ADDR and TALON_TEST_URI to run Talon integration tests";
+    }
+  }
+
+  TalonEnv env_;
+};
+
+TEST_F(TalonInputFileTest, GetSizeResolvesObjectLength) {
+  auto client = MakeClientOrSkip(env_);
+  ASSERT_NE(client, nullptr);
+
+  TalonInputFile file(client, env_.uri);
+  ASSERT_OK_AND_ASSIGN(int64_t size, file.GetSize());
+  EXPECT_GE(size, 0);
+}
+
+TEST_F(TalonInputFileTest, ReadAtMatchesSequentialRead) {
+  auto client = MakeClientOrSkip(env_);
+  ASSERT_NE(client, nullptr);
+
+  TalonInputFile file(client, env_.uri);
+  ASSERT_OK_AND_ASSIGN(int64_t size, file.GetSize());
+  if (size == 0) {
+    GTEST_SKIP() << "TALON_TEST_URI is empty; nothing to read";
+  }
+
+  const int64_t want = std::min<int64_t>(size, 4096);
+  ASSERT_OK_AND_ASSIGN(auto via_read_at, file.ReadAt(0, want));
+  EXPECT_EQ(via_read_at->size(), want);
+
+  ASSERT_OK(file.Seek(0));
+  ASSERT_OK_AND_ASSIGN(int64_t pos, file.Tell());
+  EXPECT_EQ(pos, 0);
+  ASSERT_OK_AND_ASSIGN(auto via_read, file.Read(want));
+  EXPECT_EQ(via_read->size(), want);
+  EXPECT_TRUE(via_read_at->Equals(*via_read));
+
+  ASSERT_OK_AND_ASSIGN(pos, file.Tell());
+  EXPECT_EQ(pos, want);
+}
+
+TEST_F(TalonInputFileTest, AsyncReadIntoFillsCallerBuffer) {
+  auto client = MakeClientOrSkip(env_);
+  ASSERT_NE(client, nullptr);
+
+  auto file = std::make_shared<TalonInputFile>(client, env_.uri);
+  ASSERT_OK_AND_ASSIGN(int64_t size, file->GetSize());
+  if (size == 0) {
+    GTEST_SKIP() << "TALON_TEST_URI is empty; nothing to read";
+  }
+
+  const int64_t want = std::min<int64_t>(size, 1024);
+  std::vector<uint8_t> buffer(static_cast<size_t>(want), 0);
+  // Hold the Future in a named local: Future::result() returns a reference into
+  // the future's shared state, so the future must outlive every use of that
+  // reference. Calling .result() on a temporary (…AsyncInto(...).result()) frees
+  // the state at the end of the statement while ASSERT_OK_AND_ASSIGN still reads
+  // it on the next line — a use-after-free.
+  auto read_future = file->ReadAtAsyncInto(0, want, buffer.data());
+  ASSERT_OK_AND_ASSIGN(int64_t read, read_future.result());
+  EXPECT_EQ(read, want);
+
+  ASSERT_OK_AND_ASSIGN(auto expected, file->ReadAt(0, want));
+  EXPECT_EQ(0, std::memcmp(buffer.data(), expected->data(), static_cast<size_t>(want)));
+}
+
+TEST_F(TalonInputFileTest, ShortReadPastEofReturnsAvailableBytes) {
+  auto client = MakeClientOrSkip(env_);
+  ASSERT_NE(client, nullptr);
+
+  TalonInputFile file(client, env_.uri);
+  ASSERT_OK_AND_ASSIGN(int64_t size, file.GetSize());
+
+  ASSERT_OK_AND_ASSIGN(auto buffer, file.ReadAt(size, 1024));
+  EXPECT_EQ(buffer->size(), 0);
+}
+
+// The whole point of implementing arrow::io::RandomAccessFile plus
+// NonBlockingReadAtFile: any Arrow-based format reader (Parquet, Lance, IPC, ...)
+// can consume this handle, and the ones that special-case async reads can
+// recover the fast path via a dynamic_cast.
+TEST_F(TalonInputFileTest, ExposesArrowAndAsyncInterfaces) {
+  auto client = MakeClientOrSkip(env_);
+  ASSERT_NE(client, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(auto opened, OpenTalonInputFile(client, env_.uri));
+  std::shared_ptr<arrow::io::RandomAccessFile> as_arrow = opened;
+  EXPECT_NE(as_arrow, nullptr);
+  EXPECT_NE(dynamic_cast<NonBlockingReadAtFile*>(opened.get()), nullptr);
+
+  ASSERT_OK(opened->Close());
+  EXPECT_TRUE(opened->closed());
+}
+
+TEST_F(TalonInputFileTest, ReadOnClosedFileFails) {
+  auto client = MakeClientOrSkip(env_);
+  ASSERT_NE(client, nullptr);
+
+  TalonInputFile file(client, env_.uri);
+  ASSERT_OK(file.Close());
+
+  uint8_t byte = 0;
+  auto status = file.ReadAtAsyncInto(0, 1, &byte).result().status();
+  EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+}
+
+}  // namespace
+}  // namespace milvus_storage::talon
+
+#endif  // WITH_TALON


### PR DESCRIPTION
## What

Integrate the [Talon](https://github.com/milvus-io/talon) read-through cache into milvus-storage. milvus-storage wraps the Talon C SDK to expose cache-backed objects as Arrow random-access files, so **any** Arrow format (Parquet/Lance/IPC/…) reads through the cache with no per-format work.

- New `cpp/src/filesystem/talon/` + headers: `TalonClient` (RAII over `talon_client`, async `ReadAsync`/`StatAsync` → `arrow::Future`) and `TalonInputFile` (an `arrow::io::RandomAccessFile` that also implements the non-blocking async fast path the Parquet reader `dynamic_cast`s to). Wired into `CreateArrowFileSystem` via a `TalonFileSystem` read decorator over the base backend.
- Depends on the **real upstream SDK**, not a vendored copy: `milvus-io/talon` is fetched via FetchContent + Corrosion in `cpp/CMakeLists.txt`, pinned to `dcfa3b8`. Gated by `-DWITH_TALON=ON` (off by default; sources are excluded from the glob and unlinked when off).
- Fast path: `TalonInputFile` caches `(size, version)` from the first stat/read and passes both on every read, so Talon skips its `StatObject`.

## Local stack & tests

`cpp/scripts/setup_talon.sh` is a host-side Docker orchestrator (mirrors talon's own `test/stack/deploy.sh`: one script, subcommands `up`/`test`/`bench`/`down`/`e2e`/`status`). It **builds the coordinator/worker images locally from the same pinned talon source** the C SDK is fetched from (no registry pull, so the servers can't drift from the linked client), brings up coordinator + worker + MinIO on a private docker network, seeds the origin object in-network, and gates on worker registration via the coordinator's `/api/v1/cluster`.

- The test/benchmark client runs the **pre-built** binary in a milvus builder container joined to the stack network. This is mandatory, not cosmetic: the coordinator relays every object request to the worker at the worker's *advertised* address, and since the coordinator is itself a container, that address (and therefore the client using it) must live on the stack network. A host-published stack advertising `127.0.0.1` fails — the coordinator dials its own empty localhost.
- `make test-talon` / `make benchmark-talon` are "bare" (build + run against an already-up stack); the orchestrator owns bring-up/teardown.

## CI

Adds an **isolated `talon` job** to `cpp-ci.yml` that builds `WITH_TALON=True` (compiling the Talon link path) and runs the integration test against the containerized stack (`up` → `test` → `down`, teardown `if: always()`). The runner-built binary is executed in the builder image on the stack network; the builder is ubuntu-22.04-based, so its libstdc++ is backward-compatible with the runner's. The existing `build`/`unittest`/`lint` jobs are untouched.

## Test plan

Validated locally against the containerized stack:

- Integration test: **9/9 pass** (`TalonConfigTest` ×3 + `TalonInputFileTest` ×6; the input-file reads exercise the real worker→MinIO path).
- Benchmark: `FullObjectReadAt` 525 MiB/s (sync full-object) vs `ConcurrentAsyncBlocks` 14.5 GiB/s (async 4 MiB fan-out).
- The exact CI path (`up` → `test` → `down`, running the pre-built binary in the builder container on the stack network) re-run end-to-end after this change: worker registers (`healthy_worker_count:1`), test passes, clean teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
