### PR TITLE
chore: add nightly Python E2E workflow

### DIFF
--- a/.github/actions/setup-python-test/action.yml
+++ b/.github/actions/setup-python-test/action.yml
@@ -1,0 +1,146 @@
+name: Setup Python test environment
+description: Build the native library and install the Python package for tests
+
+inputs:
+  python-version:
+    description: Python version used by the test environment
+    required: false
+    default: '3.11'
+  conan-version:
+    description: Conan version used to build the native library
+    required: false
+    default: '2.25.1'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v4
+
+    # libaio-dev: Conan 2.x CMakeDeps doesn't propagate system_libs through shared
+    # library targets, so libaio (required by folly) must be explicitly installed.
+    - name: Install C++ dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libaio-dev
+        pip install conan==${{ inputs.conan-version }}
+
+    - name: Restore Conan packages
+      id: conan-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.conan2
+        key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
+        restore-keys: |
+          conan-cpp-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Setup Conan remote
+      shell: bash
+      run: |
+        conan profile detect --force
+        # Conan 2.x errors if the remote already exists, for example after restoring the cache.
+        conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
+        conan remote list
+
+    - name: Setup Rust
+      id: rust-toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Restore Rust build cache
+      id: rust-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: cpp/build/Release/cargo/build
+        key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
+        restore-keys: |
+          storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
+
+    - name: Build C++ library for Python
+      shell: bash
+      working-directory: ./cpp
+      run: make python-lib
+
+    - name: Save Conan packages
+      if: github.ref == 'refs/heads/main' && steps.conan-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      continue-on-error: true
+      with:
+        path: ~/.conan2
+        key: ${{ steps.conan-cache.outputs.cache-primary-key }}
+
+    - name: Save Rust build cache
+      if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      continue-on-error: true
+      with:
+        path: cpp/build/Release/cargo/build
+        key: ${{ steps.rust-cache.outputs.cache-primary-key }}
+
+    - name: Set library path
+      shell: bash
+      run: |
+        BUILD_DIR="$GITHUB_WORKSPACE/cpp/build/Release"
+        BUILD_LIB_DIR="$BUILD_DIR/libs"
+
+        # Use the dependency libraries copied for this build. Scanning the
+        # whole Conan cache can put stale/incompatible libraries before the
+        # ones that match libmilvus-storage.so.
+        echo "LD_LIBRARY_PATH=$BUILD_LIB_DIR:$BUILD_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
+        # Preload the liblzma copied for this build to override system liblzma.
+        BUILD_LZMA=$(find "$BUILD_LIB_DIR" -name "liblzma.so*" -type f 2>/dev/null | sort | head -n 1)
+        PRELOAD_LIBS=""
+
+        if [ -n "$BUILD_LZMA" ]; then
+          echo "Found build liblzma at: $BUILD_LZMA"
+          echo "Checking symbol in $BUILD_LZMA:"
+          nm -D "$BUILD_LZMA" | grep lzma_index_uncompressed_size || echo "Symbol NOT FOUND in build lib"
+          PRELOAD_LIBS="$BUILD_LZMA"
+        else
+          echo "WARNING: build liblzma.so* not found! Verify xz_utils:shared=True"
+        fi
+
+        echo "Checking system liblzma symbol:"
+        nm -D /usr/lib/x86_64-linux-gnu/liblzma.so.5 2>/dev/null | grep lzma_index_uncompressed_size || echo "Symbol NOT FOUND in system lib"
+
+        # Preload libaio: folly (shared) uses io_submit but doesn't have libaio in DT_NEEDED.
+        LIBAIO=$(find /usr/lib -name "libaio.so*" 2>/dev/null | head -n 1)
+        if [ -n "$LIBAIO" ]; then
+          echo "Found libaio at: $LIBAIO"
+          PRELOAD_LIBS="${PRELOAD_LIBS:+$PRELOAD_LIBS:}$LIBAIO"
+        else
+          echo "WARNING: libaio.so not found!"
+        fi
+
+        if [ -n "$PRELOAD_LIBS" ]; then
+          echo "LD_PRELOAD=$PRELOAD_LIBS" >> "$GITHUB_ENV"
+        fi
+
+        echo "Configured LD_LIBRARY_PATH and LD_PRELOAD for runtime"
+
+    - name: Install Python package
+      shell: bash
+      working-directory: ./python
+      run: make install
+
+    - name: Verify library dependencies
+      shell: bash
+      run: |
+        set -o pipefail
+
+        echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+        echo "libmilvus-storage dependency resolution:"
+        ldd -r cpp/build/Release/libmilvus-storage.so 2>&1 | tee /tmp/libmilvus-storage.ldd
+        if grep -q "not found\|undefined symbol" /tmp/libmilvus-storage.ldd; then
+          echo "Runtime dependency resolution failed"
+          exit 1
+        fi
+        ldconfig -p | grep lzma || echo "liblzma not in ldconfig, checking file system..."
+        ls -la /usr/lib/x86_64-linux-gnu/liblzma* || true
+        find cpp/build/Release/libs -name "libglog.so*" -exec ldd {} \; 2>/dev/null | head -20 || true

--- a/.github/workflows/nightly-python-e2e.yml
+++ b/.github/workflows/nightly-python-e2e.yml
@@ -1,0 +1,42 @@
+name: Python Nightly E2E
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+      timezone: Asia/Shanghai
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/nightly-python-e2e.yml'
+      - '.github/actions/setup-python-test/**'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python test environment
+        uses: ./.github/actions/setup-python-test
+        with:
+          python-version: '3.11'
+
+      - name: Install integration and stress test dependencies
+        id: test-dependencies
+        run: uv pip install --python ./python/.venv/bin/python -r ./tests/requirements.txt
+
+      - name: Run integration tests
+        run: ./python/.venv/bin/python -m pytest -c tests/pytest.ini tests/integration/ -v --tb=short
+
+      - name: Run stress tests at 1% scale
+        if: ${{ !cancelled() && steps.test-dependencies.outcome == 'success' }}
+        run: ./python/.venv/bin/python -m pytest -c tests/pytest.ini tests/stress/ -v --tb=short --stress-scale=0.01
+
+      - name: Run stress tests at 10% scale
+        if: ${{ !cancelled() && steps.test-dependencies.outcome == 'success' }}
+        run: ./python/.venv/bin/python -m pytest -c tests/pytest.ini tests/stress/ -v --tb=short --stress-scale=0.1
+
+      - name: Run stress tests at 100% scale
+        if: ${{ !cancelled() && steps.test-dependencies.outcome == 'success' }}
+        run: ./python/.venv/bin/python -m pytest -c tests/pytest.ini tests/stress/ -v --tb=short --stress-scale=1.0

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,15 +5,14 @@ on:
     paths:
       - 'python/**'
       - 'cpp/**'
+      - '.github/actions/setup-python-test/**'
       - '.github/workflows/python-ci.yml'
   pull_request:
     paths:
       - 'python/**'
       - 'cpp/**'
+      - '.github/actions/setup-python-test/**'
       - '.github/workflows/python-ci.yml'
-
-env:
-  CONAN_VERSION: "2.25.1"
 
 jobs:
   lint:
@@ -46,137 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Set up Python test environment
+        uses: ./.github/actions/setup-python-test
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-
-      # libaio-dev: Conan 2.x CMakeDeps doesn't propagate system_libs through shared
-      # library targets, so libaio (required by folly) must be explicitly installed.
-      - name: Install C++ dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake libaio-dev
-          pip install conan==${{ env.CONAN_VERSION }}
-
-      - name: Restore Conan packages
-        id: conan-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.conan2
-          key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
-          restore-keys: |
-            conan-cpp-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Setup Conan remote
-        run: |
-          conan profile detect --force
-          # || true: Conan 2.x errors if the remote already exists (e.g. restored from cache)
-          conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
-          conan remote list
-
-      - name: Setup Rust
-        id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Restore rust build cache
-        id: rust-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            cpp/build/Release/cargo/build
-          key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
-          restore-keys: |
-            storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-
-      - name: Build C++ library for Python
-        working-directory: ./cpp
-        run: |
-          make python-lib
-
-      - name: Save Conan packages
-        if: github.ref == 'refs/heads/main' && steps.conan-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: ~/.conan2
-          key: ${{ steps.conan-cache.outputs.cache-primary-key }}
-
-      - name: Save rust build cache
-        if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: |
-            cpp/build/Release/cargo/build
-          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
-
-      - name: Set library path
-        run: |
-          BUILD_DIR="$GITHUB_WORKSPACE/cpp/build/Release"
-          BUILD_LIB_DIR="$BUILD_DIR/libs"
-
-          # Use the dependency libraries copied for this build. Scanning the
-          # whole Conan cache can put stale/incompatible libraries before the
-          # ones that match libmilvus-storage.so.
-          echo "LD_LIBRARY_PATH=$BUILD_LIB_DIR:$BUILD_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> $GITHUB_ENV
-
-          # Preload the liblzma copied for this build to override system liblzma.
-          BUILD_LZMA=$(find "$BUILD_LIB_DIR" -name "liblzma.so*" -type f 2>/dev/null | sort | head -n 1)
-
-          # Build LD_PRELOAD list for libraries that need to be forced at runtime
-          PRELOAD_LIBS=""
-
-          if [ -n "$BUILD_LZMA" ]; then
-            echo "Found build liblzma at: $BUILD_LZMA"
-            echo "Checking symbol in $BUILD_LZMA:"
-            nm -D "$BUILD_LZMA" | grep lzma_index_uncompressed_size || echo "Symbol NOT FOUND in build lib"
-            PRELOAD_LIBS="$BUILD_LZMA"
-          else
-            echo "WARNING: build liblzma.so* not found! Verify xz_utils:shared=True"
-          fi
-
-          echo "Checking system liblzma symbol:"
-          nm -D /usr/lib/x86_64-linux-gnu/liblzma.so.5 2>/dev/null | grep lzma_index_uncompressed_size || echo "Symbol NOT FOUND in System lib"
-
-          # Preload libaio: folly (shared) uses io_submit but doesn't have libaio in DT_NEEDED
-          LIBAIO=$(find /usr/lib -name "libaio.so*" 2>/dev/null | head -n 1)
-          if [ -n "$LIBAIO" ]; then
-            echo "Found libaio at: $LIBAIO"
-            PRELOAD_LIBS="${PRELOAD_LIBS:+$PRELOAD_LIBS:}$LIBAIO"
-          else
-            echo "WARNING: libaio.so not found!"
-          fi
-
-          if [ -n "$PRELOAD_LIBS" ]; then
-            echo "LD_PRELOAD=$PRELOAD_LIBS" >> $GITHUB_ENV
-          fi
-
-          echo "Configured LD_LIBRARY_PATH and LD_PRELOAD for runtime"
-
-      - name: Install Python package
-        working-directory: ./python
-        run: make install
-
-      - name: Verify library dependencies
-        run: |
-          set -o pipefail
-
-          echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
-          echo "libmilvus-storage dependency resolution:"
-          ldd -r cpp/build/Release/libmilvus-storage.so 2>&1 | tee /tmp/libmilvus-storage.ldd
-          if grep -q "not found\\|undefined symbol" /tmp/libmilvus-storage.ldd; then
-            echo "Runtime dependency resolution failed"
-            exit 1
-          fi
-          # Check if liblzma is available
-          ldconfig -p | grep lzma || echo "liblzma not in ldconfig, checking file system..."
-          ls -la /usr/lib/x86_64-linux-gnu/liblzma* || true
-          # Check glog dependencies
-          find cpp/build/Release/libs -name "libglog.so*" -exec ldd {} \; 2>/dev/null | head -20 || true
 
       - name: Run tests
         working-directory: ./python

--- a/python/milvus_storage/transaction.py
+++ b/python/milvus_storage/transaction.py
@@ -185,44 +185,13 @@ class Transaction:
         if self._committed:
             raise ResourceError("Transaction is already committed")
 
-        # Build C structure
-        c_cg = self._ffi.new("LoonColumnGroup*")
-
-        # Columns
-        columns_c = [self._ffi.new("char[]", c.encode("utf-8")) for c in column_group.columns]
-        columns_array = self._ffi.new("char*[]", columns_c)
-        c_cg.columns = self._ffi.cast("const char**", columns_array)
-        c_cg.num_of_columns = len(column_group.columns)
-
-        # Format
-        format_c = self._ffi.new("char[]", column_group.format.encode("utf-8"))
-        c_cg.format = format_c
-
-        # Files
-        if column_group.files:
-            c_files = self._ffi.new("LoonColumnGroupFile[]", len(column_group.files))
-            path_buffers = []
-            for i, f in enumerate(column_group.files):
-                path_c = self._ffi.new("char[]", f.path.encode("utf-8"))
-                path_buffers.append(path_c)
-                c_files[i].path = path_c
-                c_files[i].start_index = f.start_index
-                c_files[i].end_index = f.end_index
-                if f.metadata:
-                    meta_c = self._ffi.new("uint8_t[]", f.metadata)
-                    c_files[i].metadata = meta_c
-                    c_files[i].metadata_size = len(f.metadata)
-                else:
-                    c_files[i].metadata = self._ffi.NULL
-                    c_files[i].metadata_size = 0
-            c_cg.files = c_files
-            c_cg.num_of_files = len(column_group.files)
-        else:
-            c_cg.files = self._ffi.NULL
-            c_cg.num_of_files = 0
-
-        result = self._lib.loon_transaction_add_column_group(self._handle, c_cg)
-        check_result(result)
+        # Reuse the canonical Python-to-C conversion so this path stays in sync
+        # with changes to LoonColumnGroupFile's properties-based ABI.
+        with ColumnGroups.from_list([column_group]) as column_groups:
+            result = self._lib.loon_transaction_add_column_group(
+                self._handle, column_groups._get_c_ptr().column_group_array
+            )
+            check_result(result)
 
     def append_files(self, column_groups: ColumnGroups) -> None:
         """

--- a/tests/integration/recovery/test_recovery.py
+++ b/tests/integration/recovery/test_recovery.py
@@ -375,6 +375,11 @@ class TestRecovery:
             rows=500,
         )
 
+        if fault_key == "FS_OPEN_INPUT_FAIL":
+            # Drop cached file-size/footer properties so the reader exercises
+            # the path-based cold-open operation guarded by this fault point.
+            cg = ColumnGroups.from_list(cg.to_list())
+
         require_fiu.enable(_get_fiu_key(fault_key), one_time=True)
 
         with pytest.raises(Exception):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,5 +5,7 @@ numpy>=1.20.0
 pyyaml>=6.0
 # vortex version must match the C++ conan dependency version
 vortex-data==0.56.0
+# substrait >=0.26.0 removed substrait.gen, which vortex-data 0.56.0 imports.
+substrait<0.26.0
 psutil>=5.9.0
 pylance==1.0.0


### PR DESCRIPTION
Run integration and stress tests on a daily schedule or manual dispatch, reusing the shared Python test environment setup.