### PR TITLE
draft:chore: add nightly C++ benchmark workflow

### DIFF
--- a/.github/actions/setup-cpp-test/action.yml
+++ b/.github/actions/setup-cpp-test/action.yml
@@ -1,0 +1,71 @@
+name: Setup C++ test environment
+description: Build the C++ library and test targets for CI
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      uses: aminya/setup-cpp@v1
+      with:
+        conan: 2.25.1
+        cmake: true
+
+    # Conan 2.x CMakeDeps doesn't propagate system_libs through shared library targets,
+    # so libaio (required by folly) must be explicitly installed and linked.
+    - name: Install system libraries
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y libaio-dev
+
+    - name: Setup Rust
+      id: rust-toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Restore rust build cache
+      id: rust-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          cpp/build/Release/cargo/build
+        key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
+        restore-keys: |
+          storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
+
+    - name: Restore conan package cache
+      id: conan-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.conan2
+        key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
+        restore-keys: |
+          conan-cpp-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: setup conan
+      shell: bash
+      run: |
+        conan profile detect --force
+        # || true: Conan 2.x errors if the remote already exists (e.g. restored from cache)
+        conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
+        conan remote list
+
+    - name: Build
+      shell: bash
+      working-directory: ./cpp
+      run: |
+        WITH_CRT=True make build
+
+    - name: Save rust build cache
+      if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      continue-on-error: true
+      with:
+        path: |
+          cpp/build/Release/cargo/build
+        key: ${{ steps.rust-cache.outputs.cache-primary-key }}
+
+    - name: Save conan package cache
+      if: github.ref == 'refs/heads/main' && steps.conan-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      continue-on-error: true
+      with:
+        path: ~/.conan2
+        key: ${{ steps.conan-cache.outputs.cache-primary-key }}

--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -1,0 +1,85 @@
+name: Setup local MinIO
+description: Start a verified local MinIO server for CI
+
+inputs:
+  cpu:
+    description: Optional CPU index reserved for the MinIO process
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install MinIO dependencies
+      shell: bash
+      run: |
+        if ! command -v s3cmd >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y s3cmd
+        fi
+
+    - name: Install MinIO server
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        minio_release=RELEASE.2025-09-07T16-13-09Z
+        minio_sha256=7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f
+        minio_url="https://dl.min.io/server/minio/release/linux-amd64/archive/minio.${minio_release}"
+
+        curl --fail --location --retry 5 --output "$RUNNER_TEMP/minio" "$minio_url"
+        printf '%s  %s\n' "$minio_sha256" "$RUNNER_TEMP/minio" | sha256sum --check --strict
+        chmod +x "$RUNNER_TEMP/minio"
+        "$RUNNER_TEMP/minio" --version
+
+        echo "MINIO_RELEASE=$minio_release" >> "$GITHUB_ENV"
+
+    - name: Start MinIO server
+      shell: bash
+      env:
+        MINIO_CPU: ${{ inputs.cpu }}
+      run: |
+        set -euo pipefail
+
+        minio_data_dir="$RUNNER_TEMP/minio-data"
+        minio_log="$RUNNER_TEMP/minio.log"
+        mkdir -p "$minio_data_dir"
+
+        minio_command=(
+          "$RUNNER_TEMP/minio" server "$minio_data_dir"
+          --address 127.0.0.1:9000
+          --console-address 127.0.0.1:9001
+        )
+        if [[ -n "$MINIO_CPU" ]]; then
+          minio_command=(taskset --cpu-list "$MINIO_CPU" "${minio_command[@]}")
+          export GOMAXPROCS=1
+        fi
+
+        MINIO_BROWSER=off \
+          MINIO_ROOT_USER=minioadmin \
+          MINIO_ROOT_PASSWORD=minioadmin \
+          "${minio_command[@]}" >"$minio_log" 2>&1 &
+        minio_pid=$!
+        printf '%s\n' "$minio_pid" > "$RUNNER_TEMP/minio.pid"
+
+        for _ in $(seq 1 30); do
+          if curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null; then
+            break
+          fi
+          if ! kill -0 "$minio_pid" 2>/dev/null; then
+            cat "$minio_log"
+            exit 1
+          fi
+          sleep 1
+        done
+        curl --fail --silent http://127.0.0.1:9000/minio/health/ready >/dev/null
+
+        s3cmd_options=(
+          --access_key=minioadmin
+          --secret_key=minioadmin
+          --host=127.0.0.1:9000
+          --host-bucket=127.0.0.1:9000
+          --region=us-east-1
+          --no-ssl
+        )
+        s3cmd "${s3cmd_options[@]}" mb s3://test-bucket

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -4,10 +4,14 @@ on:
   push:
    paths:
     - 'cpp/**'
+    - '.github/actions/setup-cpp-test/**'
+    - '.github/actions/setup-minio/**'
     - '.github/workflows/cpp-ci.yml'
   pull_request:
    paths:
     - 'cpp/**'
+    - '.github/actions/setup-cpp-test/**'
+    - '.github/actions/setup-minio/**'
     - '.github/workflows/cpp-ci.yml'
 
 concurrency:
@@ -21,68 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        uses: aminya/setup-cpp@v1
-        with:
-          conan: 2.25.1
-          cmake: true
-
-      # Conan 2.x CMakeDeps doesn't propagate system_libs through shared library targets,
-      # so libaio (required by folly) must be explicitly installed and linked.
-      - name: Install system libraries
-        run: sudo apt-get update && sudo apt-get install -y libaio-dev
-
-      - name: Setup Rust
-        id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Restore rust build cache
-        id: rust-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            cpp/build/Release/cargo/build
-          key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
-          restore-keys: |
-            storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-
-      - name: Restore conan package cache
-        id: conan-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.conan2
-          key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
-          restore-keys: |
-            conan-cpp-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: setup conan
-        run: |
-          conan profile detect --force
-          # || true: Conan 2.x errors if the remote already exists (e.g. restored from cache)
-          conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
-          conan remote list
-
-      - name: Build
-        working-directory: ./cpp
-        run: |
-          make build USE_ASAN=True BUILD_TYPE=Release
-
-      - name: Save rust build cache
-        if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: |
-            cpp/build/Release/cargo/build
-          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
-
-      - name: Save conan package cache
-        if: github.ref == 'refs/heads/main' && steps.conan-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: ~/.conan2
-          key: ${{ steps.conan-cache.outputs.cache-primary-key }}
+      - name: Setup C++ test environment
+        uses: ./.github/actions/setup-cpp-test
+        env:
+          USE_ASAN: 'True'
+          BUILD_TYPE: Release
 
       - name: Upload
         uses: actions/upload-artifact@v4
@@ -101,68 +48,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        uses: aminya/setup-cpp@v1
-        with:
-          conan: 2.25.1
-          cmake: true
-
-      # Conan 2.x CMakeDeps doesn't propagate system_libs through shared library targets,
-      # so libaio (required by folly) must be explicitly installed and linked.
-      - name: Install system libraries
-        run: sudo apt-get update && sudo apt-get install -y libaio-dev
-
-      - name: Setup Rust
-        id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Restore rust build cache
-        id: rust-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            cpp/build/Release/cargo/build
-          key: storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('cpp/src/format/bridge/rust/Cargo.lock', 'cpp/src/format/bridge/rust/Cargo.toml') }}
-          restore-keys: |
-            storage-bridge-rust-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}-
-
-      - name: Restore conan package cache
-        id: conan-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.conan2
-          key: conan-cpp-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./cpp/conanfile.py') }}
-          restore-keys: |
-            conan-cpp-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: setup conan
-        run: |
-          conan profile detect --force
-          # || true: Conan 2.x errors if the remote already exists (e.g. restored from cache)
-          conan remote add default-conan-local2 https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local2 || true
-          conan remote list
-
-      - name: Build
-        working-directory: ./cpp
-        run: |
-          make build BUILD_TYPE=Release
-
-      - name: Save rust build cache
-        if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: |
-            cpp/build/Release/cargo/build
-          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
-
-      - name: Save conan package cache
-        if: github.ref == 'refs/heads/main' && steps.conan-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        continue-on-error: true
-        with:
-          path: ~/.conan2
-          key: ${{ steps.conan-cache.outputs.cache-primary-key }}
+      - name: Setup C++ test environment
+        uses: ./.github/actions/setup-cpp-test
+        env:
+          USE_ASAN: 'True'
+          BUILD_TYPE: Release
 
       - name: check-tidy
         working-directory: ./cpp
@@ -183,7 +73,7 @@ jobs:
 
       - name: Install coverage tools
         run: |
-          sudo apt-get update && sudo apt-get install -y lcov
+          sudo apt-get update && sudo apt-get install -y lcov s3cmd
 
       - name: Change mod of binary
         working-directory: ./cpp
@@ -192,9 +82,7 @@ jobs:
           chmod +x ./build/Release/test/Test_FFI
 
       - name: Setup Minio
-        run: |
-          chmod +x ./cpp/scripts/setup_minio.sh
-          ./cpp/scripts/setup_minio.sh
+        uses: ./.github/actions/setup-minio
 
       - name: Run unittest with local filesystem
         working-directory: ./cpp

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -1,0 +1,193 @@
+name: C++ Nightly Benchmark
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+      timezone: Asia/Shanghai
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/actions/setup-cpp-test/**'
+      - '.github/actions/setup-minio/**'
+      - '.github/workflows/nightly-benchmark.yml'
+      - 'cpp/benchmark/**'
+      - 'cpp/scripts/minio_env.sh'
+      - 'cpp/test/include/test_env.h'
+      - 'cpp/test/test_env.cpp'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    env:
+      MINIO_CPU_LIST: '0'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup C++ test environment
+        uses: ./.github/actions/setup-cpp-test
+        env:
+          WITH_BENCHMARK: 'True'
+          WITH_UT: 'False'
+          WITH_FIU: 'False'
+          USE_ASAN: 'False'
+          BUILD_TYPE: Release
+
+      - name: Install benchmark dependencies
+        run: sudo apt-get install -y jq s3cmd
+
+      - name: Test nightly summary renderer
+        run: bash cpp/benchmark/nightly/test_summary.sh
+
+      - name: Setup local MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          cpu: ${{ env.MINIO_CPU_LIST }}
+
+      - name: Configure benchmark CPU affinity
+        run: |
+          set -euo pipefail
+          cpu_count=$(nproc)
+          if (( cpu_count < 2 )); then
+            echo "Nightly benchmark requires at least two CPUs"
+            exit 1
+          fi
+          benchmark_cpu_list=$(seq -s, 1 "$((cpu_count - 1))")
+          benchmark_cpu_count=$(tr ',' '\n' <<< "$benchmark_cpu_list" | wc -l)
+          NIGHTLY_CI_EXECUTOR_THREADS=$benchmark_cpu_count
+
+          if comm -12 \
+            <(tr ',' '\n' <<< "$MINIO_CPU_LIST" | sort -n) \
+            <(tr ',' '\n' <<< "$benchmark_cpu_list" | sort -n) \
+            | grep -q .; then
+            echo "MinIO and benchmark CPU lists overlap"
+            exit 1
+          fi
+          if (( NIGHTLY_CI_EXECUTOR_THREADS != benchmark_cpu_count )); then
+            echo "Nightly CI executor thread count does not match benchmark CPU count"
+            exit 1
+          fi
+
+          echo "BENCHMARK_CPU_LIST=$benchmark_cpu_list" >> "$GITHUB_ENV"
+          echo "NIGHTLY_CI_EXECUTOR_THREADS=$NIGHTLY_CI_EXECUTOR_THREADS" >> "$GITHUB_ENV"
+          echo "MINIO_CPU_LIST=$MINIO_CPU_LIST" >> "$GITHUB_ENV"
+
+      - name: Record runner information
+        run: |
+          uname -a | tee "$RUNNER_TEMP/benchmark-system-info.txt"
+          lscpu | tee -a "$RUNNER_TEMP/benchmark-system-info.txt"
+          "$RUNNER_TEMP/minio" --version | tee -a "$RUNNER_TEMP/benchmark-system-info.txt"
+          echo "minio_cpu_list=$MINIO_CPU_LIST" | tee -a "$RUNNER_TEMP/benchmark-system-info.txt"
+          echo "benchmark_cpu_list=$BENCHMARK_CPU_LIST" | tee -a "$RUNNER_TEMP/benchmark-system-info.txt"
+          echo "nightly_ci_executor_threads=$NIGHTLY_CI_EXECUTOR_THREADS" | tee -a "$RUNNER_TEMP/benchmark-system-info.txt"
+          echo "SMT physical core sharing is accepted; affinity separates logical CPUs, not physical-core isolation." \
+            | tee -a "$RUNNER_TEMP/benchmark-system-info.txt"
+
+      - name: Run nightly reader benchmarks with MinIO
+        working-directory: ./cpp
+        run: |
+          set -euo pipefail
+          source ./scripts/minio_env.sh
+          export LD_LIBRARY_PATH="$(pwd)/build/Release/libs:$(pwd)/build/Release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export NIGHTLY_CI_EXECUTOR_THREADS
+
+          bash benchmark/nightly/test_reader_alias.sh \
+            ./build/Release/benchmark/benchmark registration
+
+          target_tests=$(taskset --cpu-list "$BENCHMARK_CPU_LIST" \
+            ./build/Release/benchmark/benchmark \
+              --benchmark_filter='^NIGHTLY_CI_TARGET/' \
+              --benchmark_list_tests)
+          printf '%s\n' "$target_tests"
+          target_count=$(printf '%s\n' "$target_tests" | sed '/^[[:space:]]*$/d' | wc -l)
+          if (( target_count != 91 )); then
+            echo "Expected 91 nightly CI benchmark targets, found $target_count"
+            exit 1
+          fi
+
+          taskset --cpu-list "$BENCHMARK_CPU_LIST" \
+            ./build/Release/benchmark/benchmark \
+              --benchmark_filter='^NIGHTLY_CI_TARGET/' \
+              --benchmark_repetitions=3 \
+              --benchmark_display_aggregates_only=true \
+              --benchmark_out="$GITHUB_WORKSPACE/benchmark-results.json" \
+              --benchmark_out_format=json \
+            2>&1 | tee "$GITHUB_WORKSPACE/benchmark-results.txt"
+
+      - name: Publish benchmark summary
+        if: always()
+        run: |
+          set -euo pipefail
+
+          results_file="$GITHUB_WORKSPACE/benchmark-results.json"
+          summary_file="$GITHUB_WORKSPACE/benchmark-summary.md"
+
+          if [[ ! -s "$results_file" ]]; then
+            printf '## C++ Nightly Benchmark\n\nNo benchmark JSON was produced. Check the job logs and MinIO log artifact.\n' \
+              | tee "$summary_file" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if ! jq -e '(.benchmarks // []) | type == "array"' "$results_file" >/dev/null; then
+            printf '## C++ Nightly Benchmark\n\nThe benchmark JSON is invalid. Check the job logs and uploaded artifacts.\n' \
+              | tee "$summary_file" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          jq -r \
+            --arg command render \
+            --arg expected_count 91 \
+            --arg commit "$GITHUB_SHA" \
+            --arg trigger "$GITHUB_EVENT_NAME" \
+            --arg minio_release "$MINIO_RELEASE" \
+            --arg minio_cpu_list "$MINIO_CPU_LIST" \
+            --arg benchmark_cpu_list "$BENCHMARK_CPU_LIST" \
+            --arg executor_threads "$NIGHTLY_CI_EXECUTOR_THREADS" \
+            -f cpp/benchmark/nightly/summary.jq \
+            "$results_file" \
+            | tee "$summary_file" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+          jq -r \
+            --arg command validate \
+            --arg expected_count 91 \
+            --arg commit "$GITHUB_SHA" \
+            --arg trigger "$GITHUB_EVENT_NAME" \
+            --arg minio_release "$MINIO_RELEASE" \
+            --arg minio_cpu_list "$MINIO_CPU_LIST" \
+            --arg benchmark_cpu_list "$BENCHMARK_CPU_LIST" \
+            --arg executor_threads "$NIGHTLY_CI_EXECUTOR_THREADS" \
+            -f cpp/benchmark/nightly/summary.jq \
+            "$results_file"
+
+      - name: Stop local MinIO server
+        if: always()
+        run: |
+          if [[ -f "$RUNNER_TEMP/minio.pid" ]]; then
+            minio_pid=$(<"$RUNNER_TEMP/minio.pid")
+            kill "$minio_pid" 2>/dev/null || true
+            wait "$minio_pid" 2>/dev/null || true
+          fi
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-benchmark-${{ github.sha }}
+          path: |
+            benchmark-results.json
+            benchmark-results.txt
+            benchmark-summary.md
+            ${{ runner.temp }}/benchmark-system-info.txt
+            ${{ runner.temp }}/minio.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ make test
 make test-all
 
 # Run benchmarks
-./build/Release/benchmark/benchmark --benchmark_filter="Typical/"
+./build/Release/benchmark/benchmark --benchmark_filter="FormatReadBenchmark/ReadFullScan"
 ```
 
 ### Integration Tests (Python)

--- a/cpp/benchmark/benchmark.md
+++ b/cpp/benchmark/benchmark.md
@@ -18,13 +18,13 @@ The benchmark executable is located at `build/Release/benchmark/benchmark`.
 ./build/Release/benchmark/benchmark
 
 # Filter by regex
-./build/Release/benchmark/benchmark --benchmark_filter="Typical/"
+./build/Release/benchmark/benchmark --benchmark_filter="FormatReadBenchmark/ReadFullScan"
 
 # Multiple patterns (use | separator)
 ./build/Release/benchmark/benchmark --benchmark_filter="MilvusStorage_Read|MilvusStorage_Take"
 
-# Exclude patterns (use - prefix)
-./build/Release/benchmark/benchmark --benchmark_filter="-Typical/"
+# List matching benchmarks without running them
+./build/Release/benchmark/benchmark --benchmark_filter="FormatReadBenchmark" --benchmark_list_tests=true
 ```
 
 ## Benchmark Files
@@ -112,10 +112,60 @@ Simple read/write performance tests for quick validation:
 | `ReadFullScanSingleColumnConfig` | Single column full scan | loop_times, column_idx |
 | `WriteRead768dimVector` | 768-dim vector large file test | target_size, target_dim |
 
-## Typical Benchmarks
+## Nightly CI Reader Benchmarks
 
-Benchmarks with `Typical/` prefix are representative tests with common parameter configurations, suitable for quick validation:
+`ReaderBenchmark/` is the canonical public-Reader benchmark family.
+`NIGHTLY_CI_TARGET/` contains name-only aliases of the same configurations and
+execution bodies. Each family contains 91 registrations with identical
+semantic suffixes.
+
+Run either family locally after configuring storage, or validate their exact
+one-to-one registration contract:
 
 ```bash
-./build/Release/benchmark/benchmark --benchmark_filter="Typical/"
+./build/Release/benchmark/benchmark --benchmark_filter='^ReaderBenchmark/'
+./build/Release/benchmark/benchmark --benchmark_filter='^NIGHTLY_CI_TARGET/'
+NIGHTLY_CI_EXECUTOR_THREADS=3 ./build/Release/benchmark/benchmark \
+  --benchmark_filter='^NIGHTLY_CI_TARGET/Async/'
+bash benchmark/nightly/test_reader_alias.sh \
+  ./build/Release/benchmark/benchmark registration
 ```
+
+An unfiltered invocation executes both name families. Use an explicit prefix
+filter unless that duplication is intentional.
+
+Each family has 63 synchronous cases and 28 asynchronous cases (91 total).
+Each applicable operation/format combination runs these seven deterministic
+dataset scenarios:
+
+| Dataset | Contents |
+|---------|----------|
+| `SyntheticSmall` | 4,096 rows with scalar columns and a random 128-dimensional vector |
+| `SyntheticMedium` | 40,960 rows with scalar columns and a random 128-dimensional vector |
+| `SyntheticLarge` | 409,600 rows with scalar columns and a random 128-dimensional vector |
+| `ScalarMedium` | 40,960 scalar-only rows |
+| `RandomVector64MiB` | Random 256-dimensional vector data with a 64 MiB raw payload |
+| `LowEntropyVector256MiB` | Deterministic low-entropy 256-dimensional vector data with a 256 MiB raw payload |
+| `RandomVector2GiB` | Random 256-dimensional vector data with a 2 GiB raw payload |
+
+Synchronous cases cover record-batch reads, chunk reads, and `take` for
+Parquet, Vortex, and Lance. The asynchronous cases are genuine public async
+calls only: chunk reads and `take` for Parquet and Vortex. There is no public
+async record-batch API, and Lance has no native async override, so neither is
+reported as an async case. The `parallelism` API argument is intentionally
+omitted, retaining its default value of `1`.
+
+Async continuations run on a caller-owned `folly::CPUThreadPoolExecutor`.
+Set `NIGHTLY_CI_EXECUTOR_THREADS` to a positive integer to size that executor;
+when it is absent, the local default is `1`. This setting sizes the executor,
+not process affinity. In hosted CI, MinIO is pinned to logical CPU `0` and the
+complete benchmark process is pinned to logical CPUs `1,2,3`; the executor
+thread count is derived from the benchmark CPU set. This is logical-CPU
+separation, not physical-core isolation, and local smoke runs do not validate
+the hosted affinity configuration.
+
+The workflow writes raw Google Benchmark JSON and text output as diagnostic
+artifacts. It also renders a human-readable Markdown summary with median
+real-time, variation, throughput, and sync/async comparisons; this summary is
+printed in the job log, added to the GitHub Step Summary, and stored alongside
+the raw artifacts.

--- a/cpp/benchmark/benchmark_compression_levels.cpp
+++ b/cpp/benchmark/benchmark_compression_levels.cpp
@@ -139,7 +139,12 @@ class CompressionBench : public ::benchmark::Fixture {
     (void)_;
   }
 
-  void TearDown(::benchmark::State&) override {}
+  void TearDown(::benchmark::State& st) override {
+    const auto status = fs_->DeleteDir(base_path_);
+    if (!status.ok()) {
+      st.SkipWithError(status.ToString().c_str());
+    }
+  }
 
   protected:
   std::shared_ptr<arrow::Schema> schema_;
@@ -152,6 +157,7 @@ std::vector<std::shared_ptr<arrow::RecordBatch>> CompressionBench::batches_;
 
 }  // namespace
 
+// Measures Parquet write cost and resulting file size for each configured ZSTD compression level.
 BENCHMARK_DEFINE_F(CompressionBench, Write)(::benchmark::State& st) {
   const auto& cfg = Configs()[static_cast<size_t>(st.range(0))];
   st.SetLabel(cfg.label);
@@ -186,12 +192,20 @@ BENCHMARK_DEFINE_F(CompressionBench, Write)(::benchmark::State& st) {
       return;
     }
 
-    auto info = fs_->GetFileInfo(file_path);
+    st.PauseTiming();
+    const auto info = fs_->GetFileInfo(file_path);
+    const auto delete_status = fs_->DeleteFile(file_path);
+    st.ResumeTiming();
     if (info.ok()) {
       last_file_size = info.ValueOrDie().size();
+    } else {
+      st.SkipWithError(info.status().ToString().c_str());
+      return;
     }
-    auto del = fs_->DeleteFile(file_path);
-    (void)del;
+    if (!delete_status.ok()) {
+      st.SkipWithError(delete_status.ToString().c_str());
+      return;
+    }
   }
 
   int64_t total_rows = static_cast<int64_t>(kBatches) * kRowsPerBatch;

--- a/cpp/benchmark/benchmark_crt_reader.cpp
+++ b/cpp/benchmark/benchmark_crt_reader.cpp
@@ -20,11 +20,8 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
-#include <cstring>
-#include <limits>
 #include <memory>
 #include <mutex>
-#include <random>
 #include <string>
 #include <thread>
 #include <utility>
@@ -187,162 +184,6 @@ int64_t CalculateTableRawDataSize(const std::shared_ptr<arrow::Table>& table) {
   return bytes;
 }
 
-arrow::Result<int32_t> ResolveVectorByteWidth(size_t vector_dim) {
-  constexpr auto kFloatBytes = sizeof(float);
-  if (vector_dim > static_cast<size_t>(std::numeric_limits<int32_t>::max()) / kFloatBytes) {
-    return arrow::Status::Invalid("vector byte width exceeds fixed-size binary limit: " + std::to_string(vector_dim) +
-                                  " float32 values");
-  }
-  return static_cast<int32_t>(vector_dim * kFloatBytes);
-}
-
-arrow::Result<std::shared_ptr<arrow::Schema>> CreateCrtBenchmarkSchema(std::array<bool, 4> needed_columns,
-                                                                       size_t vector_dim) {
-  std::vector<std::shared_ptr<arrow::Field>> fields;
-  if (needed_columns[0]) {
-    fields.emplace_back(
-        arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"100"})));
-  }
-  if (needed_columns[1]) {
-    fields.emplace_back(
-        arrow::field("name", arrow::utf8(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"101"})));
-  }
-  if (needed_columns[2]) {
-    fields.emplace_back(
-        arrow::field("value", arrow::float64(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"102"})));
-  }
-  if (needed_columns[3]) {
-    ARROW_ASSIGN_OR_RAISE(auto vector_byte_width, ResolveVectorByteWidth(vector_dim));
-    fields.emplace_back(arrow::field("vector", arrow::fixed_size_binary(vector_byte_width), false,
-                                     arrow::key_value_metadata({"PARQUET:field_id"}, {"103"})));
-  }
-  if (fields.empty()) {
-    return arrow::Status::Invalid("At least one column must be needed");
-  }
-
-  return arrow::schema(std::move(fields));
-}
-
-std::string MakeBenchmarkString(size_t row, size_t string_length, bool random_data) {
-  if (!random_data) {
-    return "name_" + std::to_string(row);
-  }
-  std::string value(std::max<size_t>(1, string_length), 'a');
-  for (size_t i = 0; i < value.size(); ++i) {
-    value[i] = static_cast<char>('a' + ((row + i) % 26));
-  }
-  return value;
-}
-
-arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateCrtBenchmarkData(const std::shared_ptr<arrow::Schema>& schema,
-                                                                          int64_t start_offset,
-                                                                          const CrtDataConfig& config,
-                                                                          size_t num_rows) {
-  arrow::Int64Builder id_builder;
-  arrow::StringBuilder name_builder;
-  arrow::DoubleBuilder value_builder;
-  std::unique_ptr<arrow::FixedSizeBinaryBuilder> vector_builder;
-  std::vector<uint8_t> vector_data;
-  if (config.columns[3]) {
-    ARROW_ASSIGN_OR_RAISE(auto vector_byte_width, ResolveVectorByteWidth(config.vector_dim));
-    vector_builder = std::make_unique<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_byte_width));
-    vector_data.resize(static_cast<size_t>(vector_byte_width));
-  }
-  std::vector<std::shared_ptr<arrow::Array>> arrays;
-  std::mt19937 gen(static_cast<uint32_t>(start_offset));
-  std::uniform_real_distribution<float> float_dist(0.0f, 1000.0f);
-  std::uniform_real_distribution<double> double_dist(0.0, 1000.0);
-
-  for (size_t row = 0; row < num_rows; ++row) {
-    const auto source_row = start_offset + static_cast<int64_t>(row);
-    if (config.columns[0]) {
-      ARROW_RETURN_NOT_OK(id_builder.Append(source_row));
-    }
-    if (config.columns[1]) {
-      ARROW_RETURN_NOT_OK(name_builder.Append(
-          MakeBenchmarkString(static_cast<size_t>(source_row), config.string_length, config.random_data)));
-    }
-    if (config.columns[2]) {
-      ARROW_RETURN_NOT_OK(value_builder.Append(config.random_data ? double_dist(gen) : source_row * 1.5));
-    }
-    if (config.columns[3]) {
-      for (size_t dim = 0; dim < config.vector_dim; ++dim) {
-        const auto value = config.random_data ? float_dist(gen) : static_cast<float>(source_row * 0.1f + dim);
-        std::memcpy(vector_data.data() + dim * sizeof(float), &value, sizeof(value));
-      }
-      ARROW_RETURN_NOT_OK(vector_builder->Append(vector_data.data()));
-    }
-  }
-
-  std::shared_ptr<arrow::Array> array;
-  if (config.columns[0]) {
-    ARROW_RETURN_NOT_OK(id_builder.Finish(&array));
-    arrays.emplace_back(std::move(array));
-  }
-  if (config.columns[1]) {
-    ARROW_RETURN_NOT_OK(name_builder.Finish(&array));
-    arrays.emplace_back(std::move(array));
-  }
-  if (config.columns[2]) {
-    ARROW_RETURN_NOT_OK(value_builder.Finish(&array));
-    arrays.emplace_back(std::move(array));
-  }
-  if (config.columns[3]) {
-    ARROW_RETURN_NOT_OK(vector_builder->Finish(&array));
-    arrays.emplace_back(std::move(array));
-  }
-
-  return arrow::RecordBatch::Make(schema, static_cast<int64_t>(num_rows), std::move(arrays));
-}
-
-class CrtSyntheticBatchReader final : public arrow::RecordBatchReader {
-  public:
-  CrtSyntheticBatchReader(std::shared_ptr<arrow::Schema> schema, CrtDataConfig config)
-      : schema_(std::move(schema)), config_(std::move(config)) {}
-
-  std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
-
-  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override {
-    if (rows_read_ >= config_.num_rows) {
-      *out = nullptr;
-      return arrow::Status::OK();
-    }
-    const auto rows = std::min(config_.batch_rows, config_.num_rows - rows_read_);
-    ARROW_ASSIGN_OR_RAISE(*out, CreateCrtBenchmarkData(schema_, static_cast<int64_t>(rows_read_), config_, rows));
-    rows_read_ += rows;
-    return arrow::Status::OK();
-  }
-
-  private:
-  std::shared_ptr<arrow::Schema> schema_;
-  CrtDataConfig config_;
-  size_t rows_read_ = 0;
-};
-
-class CrtDataLoader {
-  public:
-  explicit CrtDataLoader(CrtDataConfig config) : config_(std::move(config)) {}
-
-  arrow::Status Load() {
-    ARROW_ASSIGN_OR_RAISE(schema_, CreateCrtBenchmarkSchema(config_.columns, config_.vector_dim));
-    return arrow::Status::OK();
-  }
-
-  std::shared_ptr<arrow::Schema> schema() const { return schema_; }
-  const CrtDataConfig& config() const { return config_; }
-
-  arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetRecordBatchReader() const {
-    if (!schema_) {
-      return arrow::Status::Invalid("CRT benchmark data loader is not loaded");
-    }
-    return std::make_shared<CrtSyntheticBatchReader>(schema_, config_);
-  }
-
-  private:
-  CrtDataConfig config_;
-  std::shared_ptr<arrow::Schema> schema_;
-};
-
 }  // namespace
 
 class CrtReaderBenchmark : public FormatBenchFixtureBase<false, false> {
@@ -383,17 +224,19 @@ class CrtReaderBenchmark : public FormatBenchFixtureBase<false, false> {
                             const CrtDataConfig& config,
                             const std::shared_ptr<std::vector<std::string>>& projection,
                             PreparedData* out) {
-    CrtDataLoader loader(config);
-    ARROW_RETURN_NOT_OK(loader.Load());
+    auto loader = CreateStreamingSyntheticDataLoader({config.num_rows, config.vector_dim, config.string_length,
+                                                      config.batch_rows, config.random_data, config.columns,
+                                                      VectorLayout::kFixedSizeBinary, config.label});
+    ARROW_RETURN_NOT_OK(loader->Load());
 
     auto base_path = GetUniquePath(config.path_suffix);
-    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSinglePolicy(format, loader.schema()));
-    auto writer = Writer::create(base_path, loader.schema(), std::move(policy), properties);
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSinglePolicy(format, loader->GetSchema()));
+    auto writer = Writer::create(base_path, loader->GetSchema(), std::move(policy), properties);
     if (!writer) {
       return arrow::Status::Invalid("Failed to create CRT reader benchmark writer");
     }
 
-    ARROW_ASSIGN_OR_RAISE(auto batch_reader, loader.GetRecordBatchReader());
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, loader->GetRecordBatchReader());
     std::shared_ptr<arrow::RecordBatch> batch;
     while (true) {
       ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
@@ -407,7 +250,7 @@ class CrtReaderBenchmark : public FormatBenchFixtureBase<false, false> {
       return arrow::Status::Invalid("Prepared CRT reader benchmark data has no column-group files");
     }
 
-    auto reader = Reader::create(cgs, loader.schema(), projection, properties);
+    auto reader = Reader::create(cgs, loader->GetSchema(), projection, properties);
     if (!reader) {
       return arrow::Status::Invalid("Failed to create CRT reader benchmark reader");
     }
@@ -418,7 +261,7 @@ class CrtReaderBenchmark : public FormatBenchFixtureBase<false, false> {
     }
 
     const auto& file = (*cgs)[0]->files[0];
-    out->schema = loader.schema();
+    out->schema = loader->GetSchema();
     out->column_groups = std::move(cgs);
     out->projection = projection;
     out->file_size = file.Get<uint64_t>(api::kPropertyFileSize);
@@ -997,6 +840,7 @@ class CrtReaderBenchmark : public FormatBenchFixtureBase<false, false> {
   }
 };
 
+// Measures concurrent public ChunkReader open and one-chunk reads under blocking versus async CRT S3 I/O.
 BENCHMARK_DEFINE_F(CrtReaderBenchmark, ConcurrentOpenRead)(::benchmark::State& st) {
   const auto format = GetFormatByIndex(static_cast<size_t>(st.range(0)));
   const auto mode = static_cast<CrtIoMode>(st.range(1));
@@ -1052,6 +896,7 @@ BENCHMARK_REGISTER_F(CrtReaderBenchmark, ConcurrentOpenRead)
     ->Unit(::benchmark::kMillisecond)
     ->UseManualTime();
 
+// Measures concurrent public Reader::take calls for fixed strided rows under blocking versus async CRT S3 I/O.
 BENCHMARK_DEFINE_F(CrtReaderBenchmark, ConcurrentOpenTake)(::benchmark::State& st) {
   const auto format = GetFormatByIndex(static_cast<size_t>(st.range(0)));
   const auto mode = static_cast<CrtIoMode>(st.range(1));
@@ -1113,6 +958,7 @@ BENCHMARK_REGISTER_F(CrtReaderBenchmark, ConcurrentOpenTake)
     ->Unit(::benchmark::kMillisecond)
     ->UseManualTime();
 
+// Measures concurrent reads of every chunk in a 64 MiB random-vector file under both S3 I/O modes.
 BENCHMARK_DEFINE_F(CrtReaderBenchmark, ConcurrentOpenGetAllChunks)(::benchmark::State& st) {
   const auto format = GetFormatByIndex(static_cast<size_t>(st.range(0)));
   const auto mode = static_cast<CrtIoMode>(st.range(1));
@@ -1134,6 +980,7 @@ BENCHMARK_REGISTER_F(CrtReaderBenchmark, ConcurrentOpenGetAllChunks)
     ->Unit(::benchmark::kMillisecond)
     ->UseManualTime();
 
+// Measures concurrent reads of every chunk in the streamed 2 GiB random-vector case without materializing it.
 BENCHMARK_DEFINE_F(CrtReaderBenchmark, ConcurrentOpenGetAllChunks2GiB)(::benchmark::State& st) {
   const auto format = GetFormatByIndex(static_cast<size_t>(st.range(0)));
   const auto mode = static_cast<CrtIoMode>(st.range(1));
@@ -1154,6 +1001,7 @@ BENCHMARK_REGISTER_F(CrtReaderBenchmark, ConcurrentOpenGetAllChunks2GiB)
     ->Unit(::benchmark::kMillisecond)
     ->UseManualTime();
 
+// Measures concurrent reads of every chunk in a 256 MiB low-entropy vector file to expose compression effects.
 BENCHMARK_DEFINE_F(CrtReaderBenchmark, ConcurrentOpenGetAllChunksCompressed)(::benchmark::State& st) {
   const auto format = GetFormatByIndex(static_cast<size_t>(st.range(0)));
   const auto mode = static_cast<CrtIoMode>(st.range(1));

--- a/cpp/benchmark/benchmark_data_loader.cpp
+++ b/cpp/benchmark/benchmark_data_loader.cpp
@@ -14,8 +14,12 @@
 
 #include "benchmark_data_loader.h"
 
-#include <filesystem>
+#include <algorithm>
 #include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <random>
 
 #include <arrow/io/file.h>
 #include <arrow/table.h>
@@ -24,6 +28,237 @@
 #include "test_env.h"
 
 namespace milvus_storage::benchmark {
+
+namespace {
+
+arrow::Result<std::shared_ptr<arrow::Schema>> CreateStreamingSyntheticSchema(
+    const StreamingSyntheticDataConfig& config) {
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  if (config.columns[0]) {
+    fields.emplace_back(
+        arrow::field("id", arrow::int64(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"100"})));
+  }
+  if (config.columns[1]) {
+    fields.emplace_back(
+        arrow::field("name", arrow::utf8(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"101"})));
+  }
+  if (config.columns[2]) {
+    fields.emplace_back(
+        arrow::field("value", arrow::float64(), false, arrow::key_value_metadata({"PARQUET:field_id"}, {"102"})));
+  }
+  if (config.columns[3]) {
+    if (config.vector_layout == VectorLayout::kFloatList) {
+      fields.emplace_back(arrow::field("vector", arrow::list(arrow::float32()), false,
+                                       arrow::key_value_metadata({"PARQUET:field_id"}, {"103"})));
+    } else {
+      if (config.vector_dim > static_cast<size_t>(std::numeric_limits<int32_t>::max()) / sizeof(float)) {
+        return arrow::Status::Invalid("vector byte width exceeds fixed-size binary limit");
+      }
+      fields.emplace_back(arrow::field("vector", arrow::fixed_size_binary(config.vector_dim * sizeof(float)), false,
+                                       arrow::key_value_metadata({"PARQUET:field_id"}, {"103"})));
+    }
+  }
+  if (fields.empty()) {
+    return arrow::Status::Invalid("At least one streaming data column must be selected");
+  }
+  return arrow::schema(std::move(fields));
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>> CreateStreamingSyntheticBatch(
+    const std::shared_ptr<arrow::Schema>& schema,
+    const StreamingSyntheticDataConfig& config,
+    int64_t start_offset,
+    size_t num_rows) {
+  arrow::Int64Builder id_builder;
+  arrow::StringBuilder name_builder;
+  arrow::DoubleBuilder value_builder;
+  arrow::ListBuilder list_vector_builder(arrow::default_memory_pool(), std::make_shared<arrow::FloatBuilder>());
+  std::unique_ptr<arrow::FixedSizeBinaryBuilder> binary_vector_builder;
+  std::vector<uint8_t> binary_vector_data;
+  if (config.columns[3] && config.vector_layout == VectorLayout::kFixedSizeBinary) {
+    const auto vector_byte_width = config.vector_dim * sizeof(float);
+    binary_vector_builder =
+        std::make_unique<arrow::FixedSizeBinaryBuilder>(arrow::fixed_size_binary(vector_byte_width));
+    binary_vector_data.resize(vector_byte_width);
+  }
+
+  std::mt19937 generator(static_cast<uint32_t>(start_offset));
+  std::uniform_real_distribution<float> float_distribution(0.0f, 1000.0f);
+  std::uniform_real_distribution<double> double_distribution(0.0, 1000.0);
+  auto* list_value_builder = static_cast<arrow::FloatBuilder*>(list_vector_builder.value_builder());
+
+  for (size_t row = 0; row < num_rows; ++row) {
+    const auto source_row = start_offset + static_cast<int64_t>(row);
+    if (config.columns[0]) {
+      ARROW_RETURN_NOT_OK(id_builder.Append(source_row));
+    }
+    if (config.columns[1]) {
+      std::string name;
+      if (config.random_data) {
+        name.resize(std::max<size_t>(1, config.string_length));
+        for (size_t i = 0; i < name.size(); ++i) {
+          name[i] = static_cast<char>('a' + ((source_row + static_cast<int64_t>(i)) % 26));
+        }
+      } else {
+        name = "name_" + std::to_string(source_row);
+      }
+      ARROW_RETURN_NOT_OK(name_builder.Append(name));
+    }
+    if (config.columns[2]) {
+      ARROW_RETURN_NOT_OK(value_builder.Append(config.random_data ? double_distribution(generator) : source_row * 1.5));
+    }
+    if (config.columns[3]) {
+      if (config.vector_layout == VectorLayout::kFloatList) {
+        ARROW_RETURN_NOT_OK(list_vector_builder.Append());
+      }
+      for (size_t dimension = 0; dimension < config.vector_dim; ++dimension) {
+        const auto value =
+            config.random_data ? float_distribution(generator) : static_cast<float>(source_row * 0.1f + dimension);
+        if (config.vector_layout == VectorLayout::kFloatList) {
+          ARROW_RETURN_NOT_OK(list_value_builder->Append(value));
+        } else {
+          std::memcpy(binary_vector_data.data() + dimension * sizeof(float), &value, sizeof(value));
+        }
+      }
+      if (config.vector_layout == VectorLayout::kFixedSizeBinary) {
+        ARROW_RETURN_NOT_OK(binary_vector_builder->Append(binary_vector_data.data()));
+      }
+    }
+  }
+
+  std::vector<std::shared_ptr<arrow::Array>> arrays;
+  std::shared_ptr<arrow::Array> array;
+  if (config.columns[0]) {
+    ARROW_RETURN_NOT_OK(id_builder.Finish(&array));
+    arrays.emplace_back(std::move(array));
+  }
+  if (config.columns[1]) {
+    ARROW_RETURN_NOT_OK(name_builder.Finish(&array));
+    arrays.emplace_back(std::move(array));
+  }
+  if (config.columns[2]) {
+    ARROW_RETURN_NOT_OK(value_builder.Finish(&array));
+    arrays.emplace_back(std::move(array));
+  }
+  if (config.columns[3]) {
+    if (config.vector_layout == VectorLayout::kFloatList) {
+      ARROW_RETURN_NOT_OK(list_vector_builder.Finish(&array));
+    } else {
+      ARROW_RETURN_NOT_OK(binary_vector_builder->Finish(&array));
+    }
+    arrays.emplace_back(std::move(array));
+  }
+  return arrow::RecordBatch::Make(schema, static_cast<int64_t>(num_rows), std::move(arrays));
+}
+
+class StreamingSyntheticBatchReader final : public arrow::RecordBatchReader {
+  public:
+  StreamingSyntheticBatchReader(std::shared_ptr<arrow::Schema> schema, StreamingSyntheticDataConfig config)
+      : schema_(std::move(schema)), config_(std::move(config)) {}
+
+  std::shared_ptr<arrow::Schema> schema() const override { return schema_; }
+
+  arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* out) override {
+    if (rows_read_ >= config_.num_rows) {
+      *out = nullptr;
+      return arrow::Status::OK();
+    }
+    const auto rows = std::min(config_.batch_rows, config_.num_rows - rows_read_);
+    ARROW_ASSIGN_OR_RAISE(*out,
+                          CreateStreamingSyntheticBatch(schema_, config_, static_cast<int64_t>(rows_read_), rows));
+    rows_read_ += rows;
+    return arrow::Status::OK();
+  }
+
+  private:
+  std::shared_ptr<arrow::Schema> schema_;
+  StreamingSyntheticDataConfig config_;
+  size_t rows_read_ = 0;
+};
+
+class StreamingSyntheticDataLoader final : public BenchmarkDataLoader {
+  public:
+  explicit StreamingSyntheticDataLoader(StreamingSyntheticDataConfig config) : config_(std::move(config)) {}
+
+  arrow::Status Load() override {
+    if (config_.batch_rows == 0) {
+      return arrow::Status::Invalid("Streaming batch_rows must be positive");
+    }
+    ARROW_ASSIGN_OR_RAISE(schema_, CreateStreamingSyntheticSchema(config_));
+    return arrow::Status::OK();
+  }
+
+  std::shared_ptr<arrow::Schema> GetSchema() const override { return schema_; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatchReader>> GetRecordBatchReader() const override {
+    if (!schema_) {
+      return arrow::Status::Invalid("Data not loaded");
+    }
+    return std::make_shared<StreamingSyntheticBatchReader>(schema_, config_);
+  }
+
+  std::shared_ptr<arrow::Table> GetTable() const override { return nullptr; }
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> GetRecordBatch() const override {
+    return arrow::Status::NotImplemented("Streaming benchmark data is available through GetRecordBatchReader only");
+  }
+
+  std::string GetSchemaBasePatterns() const override {
+    if (config_.columns[0] || config_.columns[1] || config_.columns[2]) {
+      return config_.columns[3] ? "id,name,value;vector" : "id,name,value";
+    }
+    return "vector";
+  }
+
+  int64_t NumRows() const override { return static_cast<int64_t>(config_.num_rows); }
+
+  int64_t GetDataSize() const override {
+    size_t bytes_per_row = 0;
+    if (config_.columns[0]) {
+      bytes_per_row += sizeof(int64_t);
+    }
+    if (config_.columns[1]) {
+      bytes_per_row += config_.string_length;
+    }
+    if (config_.columns[2]) {
+      bytes_per_row += sizeof(double);
+    }
+    if (config_.columns[3]) {
+      bytes_per_row += config_.vector_dim * sizeof(float);
+    }
+    return static_cast<int64_t>(config_.num_rows * bytes_per_row);
+  }
+
+  std::shared_ptr<std::vector<std::string>> GetScalarProjection() const override {
+    auto projection = std::make_shared<std::vector<std::string>>();
+    if (config_.columns[0]) {
+      projection->emplace_back("id");
+    }
+    if (config_.columns[1]) {
+      projection->emplace_back("name");
+    }
+    if (config_.columns[2]) {
+      projection->emplace_back("value");
+    }
+    return projection;
+  }
+
+  std::shared_ptr<std::vector<std::string>> GetVectorProjection() const override {
+    auto projection = std::make_shared<std::vector<std::string>>();
+    if (config_.columns[3]) {
+      projection->emplace_back("vector");
+    }
+    return projection;
+  }
+
+  std::string GetDescription() const override { return config_.label; }
+
+  private:
+  StreamingSyntheticDataConfig config_;
+  std::shared_ptr<arrow::Schema> schema_;
+};
+
+}  // namespace
 
 //=============================================================================
 // SyntheticDataLoader Implementation
@@ -297,6 +532,101 @@ std::unique_ptr<BenchmarkDataLoader> CreateDataLoaderFromEnv(const SyntheticData
     return std::make_unique<MilvusSegmentLoader>(segment_path);
   }
   return std::make_unique<SyntheticDataLoader>(fallback_config);
+}
+
+std::string_view ReaderBenchmarkDatasetName(ReaderBenchmarkDataset dataset) {
+  switch (dataset) {
+    case ReaderBenchmarkDataset::kSyntheticSmall:
+      return "SyntheticSmall";
+    case ReaderBenchmarkDataset::kSyntheticMedium:
+      return "SyntheticMedium";
+    case ReaderBenchmarkDataset::kSyntheticLarge:
+      return "SyntheticLarge";
+    case ReaderBenchmarkDataset::kScalarMedium:
+      return "ScalarMedium";
+    case ReaderBenchmarkDataset::kRandomVector64MiB:
+      return "RandomVector64MiB";
+    case ReaderBenchmarkDataset::kLowEntropyVector256MiB:
+      return "LowEntropyVector256MiB";
+    case ReaderBenchmarkDataset::kRandomVector2GiB:
+      return "RandomVector2GiB";
+  }
+  return "unknown";
+}
+
+std::unique_ptr<BenchmarkDataLoader> CreateStreamingSyntheticDataLoader(StreamingSyntheticDataConfig config) {
+  return std::make_unique<StreamingSyntheticDataLoader>(std::move(config));
+}
+
+arrow::Result<std::unique_ptr<BenchmarkDataLoader>> CreateReaderBenchmarkDataLoader(ReaderBenchmarkDataset dataset) {
+  constexpr size_t kVectorDimension = 256;
+  constexpr size_t kVectorBatchRows = 65536;
+  switch (dataset) {
+    case ReaderBenchmarkDataset::kSyntheticSmall:
+      return CreateStreamingSyntheticDataLoader({4096,
+                                                 128,
+                                                 128,
+                                                 4096,
+                                                 true,
+                                                 {true, true, true, true},
+                                                 VectorLayout::kFloatList,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+    case ReaderBenchmarkDataset::kSyntheticMedium:
+      return CreateStreamingSyntheticDataLoader({40960,
+                                                 128,
+                                                 128,
+                                                 40960,
+                                                 true,
+                                                 {true, true, true, true},
+                                                 VectorLayout::kFloatList,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+    case ReaderBenchmarkDataset::kSyntheticLarge:
+      return CreateStreamingSyntheticDataLoader({409600,
+                                                 128,
+                                                 128,
+                                                 65536,
+                                                 true,
+                                                 {true, true, true, true},
+                                                 VectorLayout::kFloatList,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+    case ReaderBenchmarkDataset::kScalarMedium:
+      return CreateStreamingSyntheticDataLoader({40960,
+                                                 0,
+                                                 128,
+                                                 40960,
+                                                 true,
+                                                 {true, true, true, false},
+                                                 VectorLayout::kFloatList,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+    case ReaderBenchmarkDataset::kRandomVector64MiB:
+      return CreateStreamingSyntheticDataLoader({65536,
+                                                 kVectorDimension,
+                                                 0,
+                                                 kVectorBatchRows,
+                                                 true,
+                                                 {false, false, false, true},
+                                                 VectorLayout::kFixedSizeBinary,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+    case ReaderBenchmarkDataset::kLowEntropyVector256MiB:
+      return CreateStreamingSyntheticDataLoader({262144,
+                                                 kVectorDimension,
+                                                 0,
+                                                 kVectorBatchRows,
+                                                 false,
+                                                 {false, false, false, true},
+                                                 VectorLayout::kFixedSizeBinary,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+    case ReaderBenchmarkDataset::kRandomVector2GiB:
+      return CreateStreamingSyntheticDataLoader({2097152,
+                                                 kVectorDimension,
+                                                 0,
+                                                 kVectorBatchRows,
+                                                 true,
+                                                 {false, false, false, true},
+                                                 VectorLayout::kFixedSizeBinary,
+                                                 std::string(ReaderBenchmarkDatasetName(dataset))});
+  }
+  return arrow::Status::Invalid("Unknown Reader benchmark dataset");
 }
 
 }  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_data_loader.h
+++ b/cpp/benchmark/benchmark_data_loader.h
@@ -14,8 +14,11 @@
 
 #pragma once
 
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <map>
 
@@ -92,6 +95,29 @@ struct SyntheticDataConfig {
   static SyntheticDataConfig Small() { return {4096, 128, 128, true}; }
   static SyntheticDataConfig Medium() { return {40960, 128, 128, true}; }
   static SyntheticDataConfig Large() { return {409600, 128, 128, true}; }
+};
+
+enum class VectorLayout { kFloatList, kFixedSizeBinary };
+
+struct StreamingSyntheticDataConfig {
+  size_t num_rows;
+  size_t vector_dim;
+  size_t string_length;
+  size_t batch_rows;
+  bool random_data;
+  std::array<bool, 4> columns;
+  VectorLayout vector_layout;
+  std::string label;
+};
+
+enum class ReaderBenchmarkDataset : int64_t {
+  kSyntheticSmall = 0,
+  kSyntheticMedium,
+  kSyntheticLarge,
+  kScalarMedium,
+  kRandomVector64MiB,
+  kLowEntropyVector256MiB,
+  kRandomVector2GiB,
 };
 
 class SyntheticDataLoader : public BenchmarkDataLoader {
@@ -193,6 +219,10 @@ std::unique_ptr<BenchmarkDataLoader> CreateDataLoader(
 // Otherwise, use SyntheticDataLoader with specified config
 std::unique_ptr<BenchmarkDataLoader> CreateDataLoaderFromEnv(
     const SyntheticDataConfig& fallback_config = SyntheticDataConfig::Medium());
+
+std::string_view ReaderBenchmarkDatasetName(ReaderBenchmarkDataset dataset);
+std::unique_ptr<BenchmarkDataLoader> CreateStreamingSyntheticDataLoader(StreamingSyntheticDataConfig config);
+arrow::Result<std::unique_ptr<BenchmarkDataLoader>> CreateReaderBenchmarkDataLoader(ReaderBenchmarkDataset dataset);
 
 }  // namespace benchmark
 }  // namespace milvus_storage

--- a/cpp/benchmark/benchmark_footer_size.cpp
+++ b/cpp/benchmark/benchmark_footer_size.cpp
@@ -173,15 +173,14 @@ class FooterSizeFixture : public ::benchmark::Fixture {
     GBENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_), state);
   }
 
-  void TearDown(::benchmark::State& state) override {
-    // Cleanup if needed
-  }
+  void TearDown(::benchmark::State& state) override { GBENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_), state); }
 
   api::Properties properties_;
   std::shared_ptr<arrow::fs::FileSystem> fs_;
   std::string base_path_;
 };
 
+// Measures Parquet footer size and footer-to-file ratio across row, vector, and string shapes.
 BENCHMARK_DEFINE_F(FooterSizeFixture, MeasureFooterSize)(::benchmark::State& st) {
   auto num_rows = static_cast<size_t>(st.range(0));
   auto vector_dim = static_cast<size_t>(st.range(1));

--- a/cpp/benchmark/benchmark_format_common.h
+++ b/cpp/benchmark/benchmark_format_common.h
@@ -440,9 +440,9 @@ class FormatBenchFixtureBase : public ::benchmark::Fixture {
     data_loader_.reset();
 
     // Clean up test directory
-    auto status = DeleteTestDir(fs_, base_path_);
+    const auto status = DeleteTestDir(fs_, base_path_);
     if (!status.ok()) {
-      // Log but don't fail on cleanup errors
+      st.SkipWithError(status.ToString().c_str());
     }
   }
 
@@ -534,9 +534,10 @@ class FormatBenchFixtureBase : public ::benchmark::Fixture {
     return true;
   }
 
+  public:
   // Calculate logical data size for a batch.
   // Computes size from type layout and num_rows, consistent regardless of slicing.
-  static int64_t CalculateRawDataSize(const std::shared_ptr<arrow::RecordBatch>& batch) {
+  inline static int64_t CalculateRawDataSize(const std::shared_ptr<arrow::RecordBatch>& batch) {
     int64_t size = 0;
     int64_t num_rows = batch->num_rows();
     for (int i = 0; i < batch->num_columns(); ++i) {

--- a/cpp/benchmark/benchmark_format_read.cpp
+++ b/cpp/benchmark/benchmark_format_read.cpp
@@ -15,21 +15,35 @@
 #include "benchmark_format_common.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cerrno>
+#include <charconv>
+#include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
+#include <numeric>
+#include <string_view>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #if defined(__linux__)
 #include <unistd.h>
 #endif
 
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
 #include <arrow/table.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include "iceberg_bridge.h"
+#include "milvus-storage/format/lance/lance_common.h"
 #include "milvus-storage/format/format_reader.h"
 #include "milvus-storage/format/iceberg/iceberg_common.h"
 #include "milvus-storage/format/iceberg/iceberg_format_reader.h"
@@ -44,6 +58,519 @@ namespace milvus_storage::benchmark {
 using namespace milvus_storage::api;
 
 namespace {
+
+enum class ReaderBenchmarkMode { kSync, kAsync };
+enum class ReaderBenchmarkOperation { kRecordBatchRead, kChunkRead, kTake };
+enum class ReaderBenchmarkFormat { kParquet, kVortex, kLance };
+
+struct ReaderBenchmarkConfig {
+  ReaderBenchmarkMode mode;
+  ReaderBenchmarkOperation operation;
+  ReaderBenchmarkFormat format;
+  ReaderBenchmarkDataset dataset;
+};
+
+static arrow::Result<std::string> ReaderBenchmarkSuffix(const ReaderBenchmarkConfig& config) {
+  std::string_view mode_name;
+  switch (config.mode) {
+    case ReaderBenchmarkMode::kSync:
+      mode_name = "Sync";
+      break;
+    case ReaderBenchmarkMode::kAsync:
+      mode_name = "Async";
+      break;
+    default:
+      return arrow::Status::Invalid("Unknown Reader benchmark mode");
+  }
+
+  std::string_view operation_name;
+  switch (config.operation) {
+    case ReaderBenchmarkOperation::kRecordBatchRead:
+      operation_name = "RecordBatchRead";
+      break;
+    case ReaderBenchmarkOperation::kChunkRead:
+      operation_name = "ChunkRead";
+      break;
+    case ReaderBenchmarkOperation::kTake:
+      operation_name = "Take";
+      break;
+    default:
+      return arrow::Status::Invalid("Unknown Reader benchmark operation");
+  }
+
+  std::string_view format_name;
+  switch (config.format) {
+    case ReaderBenchmarkFormat::kParquet:
+      format_name = "Parquet";
+      break;
+    case ReaderBenchmarkFormat::kVortex:
+      format_name = "Vortex";
+      break;
+    case ReaderBenchmarkFormat::kLance:
+      format_name = "Lance";
+      break;
+    default:
+      return arrow::Status::Invalid("Unknown Reader benchmark format");
+  }
+
+  return std::string(mode_name) + "/" + std::string(operation_name) + "/" + std::string(format_name) + "/" +
+         std::string(ReaderBenchmarkDatasetName(config.dataset));
+}
+
+static arrow::Result<size_t> GetReaderBenchmarkExecutorThreads() {
+  const auto* value = std::getenv("NIGHTLY_CI_EXECUTOR_THREADS");
+  if (value == nullptr) {
+    return size_t{1};
+  }
+
+  size_t threads = 0;
+  const auto* end = value + std::strlen(value);
+  const auto parse_result = std::from_chars(value, end, threads);
+  if (value == end || parse_result.ec != std::errc{} || parse_result.ptr != end || threads == 0) {
+    return arrow::Status::Invalid("NIGHTLY_CI_EXECUTOR_THREADS must be a positive integer");
+  }
+  return threads;
+}
+
+std::atomic<uint64_t> g_reader_benchmark_prefix_sequence{0};
+
+struct ReaderBenchmarkMetrics {
+  int64_t rows = 0;
+  int64_t bytes = 0;
+};
+
+static arrow::Result<ReaderBenchmarkMetrics> RunRecordBatchReadOnce(
+    Reader& reader, std::shared_ptr<arrow::RecordBatchReader>* batch_reader_out) {
+  ARROW_ASSIGN_OR_RAISE(auto batch_reader, reader.get_record_batch_reader());
+  *batch_reader_out = std::move(batch_reader);
+
+  ReaderBenchmarkMetrics metrics;
+  std::shared_ptr<arrow::RecordBatch> batch;
+  while (true) {
+    ARROW_RETURN_NOT_OK((*batch_reader_out)->ReadNext(&batch));
+    if (!batch) {
+      break;
+    }
+    metrics.rows += batch->num_rows();
+    metrics.bytes += FormatBenchFixtureBase<>::CalculateRawDataSize(batch);
+  }
+  return metrics;
+}
+
+static arrow::Result<ReaderBenchmarkMetrics> RunTakeOnce(Reader& reader,
+                                                         const std::vector<int64_t>& indices,
+                                                         std::shared_ptr<arrow::Table>* table_out) {
+  ARROW_ASSIGN_OR_RAISE(auto table, reader.take(indices));
+  *table_out = std::move(table);
+
+  ReaderBenchmarkMetrics metrics;
+  metrics.rows = (*table_out)->num_rows();
+  arrow::TableBatchReader batch_reader(**table_out);
+  std::shared_ptr<arrow::RecordBatch> batch;
+  while (true) {
+    ARROW_RETURN_NOT_OK(batch_reader.ReadNext(&batch));
+    if (!batch) {
+      break;
+    }
+    metrics.bytes += FormatBenchFixtureBase<>::CalculateRawDataSize(batch);
+  }
+  return metrics;
+}
+
+class ReaderBenchmarkCase {
+  public:
+  static arrow::Result<std::unique_ptr<ReaderBenchmarkCase>> Make(const ReaderBenchmarkConfig& config) {
+    auto benchmark_case = std::unique_ptr<ReaderBenchmarkCase>(new ReaderBenchmarkCase(config));
+    ARROW_RETURN_NOT_OK(benchmark_case->Prepare());
+    return benchmark_case;
+  }
+
+  arrow::Status Run(::benchmark::State& state) {
+    int64_t total_rows_read = 0;
+    int64_t total_bytes_read = 0;
+
+    for (auto _ : state) {
+      table_.reset();
+      batches_.clear();
+      chunk_reader_.reset();
+      batch_reader_.reset();
+      reader_.reset();
+
+      reader_ = Reader::create(column_groups_, schema_, nullptr, properties_);
+      if (!reader_) {
+        return arrow::Status::Invalid("Failed to create Reader benchmark reader");
+      }
+
+      switch (config_.operation) {
+        case ReaderBenchmarkOperation::kRecordBatchRead: {
+          ARROW_ASSIGN_OR_RAISE(auto metrics, RunRecordBatchReadOnce(*reader_, &batch_reader_));
+          total_rows_read += metrics.rows;
+          total_bytes_read += metrics.bytes;
+          break;
+        }
+        case ReaderBenchmarkOperation::kChunkRead: {
+          if (config_.mode == ReaderBenchmarkMode::kAsync) {
+            auto open_try = std::move(reader_->get_chunk_reader_async(0)).via(executor_.get()).getTry();
+            if (open_try.hasException()) {
+              return arrow::Status::IOError("Exception in Reader benchmark async ChunkRead open: ",
+                                            open_try.exception().what().toStdString());
+            }
+            ARROW_ASSIGN_OR_RAISE(chunk_reader_, std::move(open_try).value());
+          } else {
+            ARROW_ASSIGN_OR_RAISE(chunk_reader_, reader_->get_chunk_reader(0));
+          }
+          std::vector<int64_t> indices(chunk_reader_->total_number_of_chunks());
+          std::iota(indices.begin(), indices.end(), 0);
+          if (config_.mode == ReaderBenchmarkMode::kAsync) {
+            auto chunks_try = std::move(chunk_reader_->get_chunks_async(indices)).via(executor_.get()).getTry();
+            if (chunks_try.hasException()) {
+              return arrow::Status::IOError("Exception in Reader benchmark async ChunkRead chunks: ",
+                                            chunks_try.exception().what().toStdString());
+            }
+            ARROW_ASSIGN_OR_RAISE(batches_, std::move(chunks_try).value());
+          } else {
+            ARROW_ASSIGN_OR_RAISE(batches_, chunk_reader_->get_chunks(indices));
+          }
+          for (const auto& batch : batches_) {
+            if (!batch) {
+              return arrow::Status::Invalid("Reader benchmark chunk reader returned a null batch");
+            }
+            total_rows_read += batch->num_rows();
+            total_bytes_read += FormatBenchFixtureBase<>::CalculateRawDataSize(batch);
+          }
+          break;
+        }
+        case ReaderBenchmarkOperation::kTake: {
+          if (config_.mode == ReaderBenchmarkMode::kAsync) {
+            auto table_try = std::move(reader_->take_async(take_indices_)).via(executor_.get()).getTry();
+            if (table_try.hasException()) {
+              return arrow::Status::IOError("Exception in Reader benchmark async Take: ",
+                                            table_try.exception().what().toStdString());
+            }
+            ARROW_ASSIGN_OR_RAISE(table_, std::move(table_try).value());
+            total_rows_read += table_->num_rows();
+            arrow::TableBatchReader table_batch_reader(*table_);
+            std::shared_ptr<arrow::RecordBatch> batch;
+            while (true) {
+              ARROW_RETURN_NOT_OK(table_batch_reader.ReadNext(&batch));
+              if (!batch) {
+                break;
+              }
+              total_bytes_read += FormatBenchFixtureBase<>::CalculateRawDataSize(batch);
+            }
+          } else {
+            ARROW_ASSIGN_OR_RAISE(auto metrics, RunTakeOnce(*reader_, take_indices_, &table_));
+            total_rows_read += metrics.rows;
+            total_bytes_read += metrics.bytes;
+          }
+          break;
+        }
+        default:
+          return arrow::Status::Invalid("Unknown Reader benchmark operation");
+      }
+    }
+
+    ReportThroughput(state, total_bytes_read, total_rows_read);
+    if (config_.operation == ReaderBenchmarkOperation::kTake) {
+      state.counters["rows_taken"] =
+          ::benchmark::Counter(static_cast<double>(take_indices_.size()), ::benchmark::Counter::kDefaults);
+    }
+    if (config_.mode == ReaderBenchmarkMode::kAsync) {
+      state.counters["executor_threads"] =
+          ::benchmark::Counter(static_cast<double>(executor_threads_), ::benchmark::Counter::kDefaults);
+    }
+    ARROW_ASSIGN_OR_RAISE(auto suffix, ReaderBenchmarkSuffix(config_));
+    state.SetLabel(suffix);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Cleanup() {
+    table_.reset();
+    batches_.clear();
+    chunk_reader_.reset();
+    batch_reader_.reset();
+    reader_.reset();
+    column_groups_.reset();
+    schema_.reset();
+    executor_.reset();
+    loader_.reset();
+
+    if (cleaned_ || !fs_ || prefix_.empty()) {
+      cleaned_ = true;
+      return arrow::Status::OK();
+    }
+    auto status = DeleteTestDir(fs_, prefix_);
+    if (status.ok()) {
+      cleaned_ = true;
+    }
+    return status;
+  }
+
+  ~ReaderBenchmarkCase() {
+    if (!cleaned_) {
+      const auto status = Cleanup();
+      if (!status.ok()) {
+        std::cerr << "Reader benchmark cleanup failed: " << status.ToString() << '\n';
+      }
+    }
+  }
+
+  private:
+  explicit ReaderBenchmarkCase(ReaderBenchmarkConfig config) : config_(config) {}
+
+  arrow::Status Prepare() {
+    ARROW_ASSIGN_OR_RAISE(auto suffix, ReaderBenchmarkSuffix(config_));
+    std::string_view storage_format;
+    switch (config_.format) {
+      case ReaderBenchmarkFormat::kParquet:
+        storage_format = LOON_FORMAT_PARQUET;
+        break;
+      case ReaderBenchmarkFormat::kVortex:
+        storage_format = LOON_FORMAT_VORTEX;
+        break;
+      case ReaderBenchmarkFormat::kLance:
+        storage_format = LOON_FORMAT_LANCE_TABLE;
+        break;
+      default:
+        return arrow::Status::Invalid("Unknown Reader benchmark storage format");
+    }
+    if (config_.mode == ReaderBenchmarkMode::kAsync) {
+      if (config_.operation == ReaderBenchmarkOperation::kRecordBatchRead ||
+          config_.format == ReaderBenchmarkFormat::kLance) {
+        return arrow::Status::Invalid("Unsupported async Reader benchmark case");
+      }
+      ARROW_ASSIGN_OR_RAISE(executor_threads_, GetReaderBenchmarkExecutorThreads());
+      executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(executor_threads_);
+    }
+
+    ARROW_RETURN_NOT_OK(InitTestProperties(properties_));
+    api::SetValue(properties_, PROPERTY_READER_LOGICAL_CHUNK_ROWS, "32768");
+    ARROW_ASSIGN_OR_RAISE(fs_, GetFileSystem(properties_));
+    prefix_ = "format_benchmark/reader/" + suffix + "/" +
+              std::to_string(g_reader_benchmark_prefix_sequence.fetch_add(1, std::memory_order_relaxed));
+
+    ARROW_ASSIGN_OR_RAISE(loader_, CreateReaderBenchmarkDataLoader(config_.dataset));
+    ARROW_RETURN_NOT_OK(loader_->Load());
+    schema_ = loader_->GetSchema();
+    if (!schema_) {
+      return arrow::Status::Invalid("Reader benchmark data loader returned a null schema");
+    }
+    constexpr size_t kTakeRows = 1000;
+    if (loader_->NumRows() < static_cast<int64_t>(kTakeRows)) {
+      return arrow::Status::Invalid("Reader benchmark Take requires at least 1000 source rows");
+    }
+    take_indices_ = GenerateRandomIndices(1000, loader_->NumRows(), 42);
+    const bool sorted = std::is_sorted(take_indices_.begin(), take_indices_.end());
+    const bool unique = std::adjacent_find(take_indices_.begin(), take_indices_.end()) == take_indices_.end();
+    const bool in_bounds = std::all_of(take_indices_.begin(), take_indices_.end(),
+                                       [&](int64_t index) { return index >= 0 && index < loader_->NumRows(); });
+    bool non_sequential = false;
+    for (size_t i = 0; i < take_indices_.size(); ++i) {
+      if (take_indices_[i] != static_cast<int64_t>(i)) {
+        non_sequential = true;
+        break;
+      }
+    }
+    if (take_indices_.size() != kTakeRows || !sorted || !unique || !in_bounds || !non_sequential) {
+      return arrow::Status::Invalid("Reader benchmark Take indices violated the fixed-seed random selection contract");
+    }
+
+    if (config_.format == ReaderBenchmarkFormat::kLance) {
+      return PrepareLance();
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto policy, CreateSinglePolicy(std::string(storage_format), schema_));
+    auto writer = Writer::create(prefix_, schema_, std::move(policy), properties_);
+    if (!writer) {
+      return arrow::Status::Invalid("Failed to create Reader benchmark writer");
+    }
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, loader_->GetRecordBatchReader());
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader->ReadNext(&batch));
+      if (!batch) {
+        break;
+      }
+      ARROW_RETURN_NOT_OK(writer->write(batch));
+    }
+    ARROW_ASSIGN_OR_RAISE(column_groups_, writer->close());
+    if (!column_groups_ || column_groups_->empty()) {
+      return arrow::Status::Invalid("Reader benchmark writer returned no column groups");
+    }
+    return arrow::Status::OK();
+  }
+
+  arrow::Status PrepareLance() {
+    ArrowFileSystemConfig fs_config;
+    ARROW_RETURN_NOT_OK(ArrowFileSystemConfig::create_file_system_config(properties_, fs_config));
+    if (fs_config.storage_type == "remote") {
+      api::SetValue(properties_, "extfs.reader_benchmark.storage_type", "remote");
+      api::SetValue(properties_, "extfs.reader_benchmark.cloud_provider", fs_config.cloud_provider.c_str());
+      api::SetValue(properties_, "extfs.reader_benchmark.address", fs_config.address.c_str());
+      api::SetValue(properties_, "extfs.reader_benchmark.bucket_name", fs_config.bucket_name.c_str());
+      api::SetValue(properties_, "extfs.reader_benchmark.region", fs_config.region.c_str());
+      api::SetValue(properties_, "extfs.reader_benchmark.access_key_id", fs_config.access_key_id.c_str());
+      api::SetValue(properties_, "extfs.reader_benchmark.access_key_value", fs_config.access_key_value.c_str());
+      if (fs_config.use_ssl) {
+        api::SetValue(properties_, "extfs.reader_benchmark.use_ssl", "true");
+      }
+      if (fs_config.use_iam) {
+        api::SetValue(properties_, "extfs.reader_benchmark.use_iam", "true");
+      }
+    }
+    ARROW_ASSIGN_OR_RAISE(auto lance_uri, lance::BuildLanceBaseUri(fs_config, prefix_));
+    ARROW_ASSIGN_OR_RAISE(auto storage_options, lance::ToWriterOptions(fs_config));
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader, loader_->GetRecordBatchReader());
+    ArrowArrayStream stream{};
+    ARROW_RETURN_NOT_OK(arrow::ExportRecordBatchReader(batch_reader, &stream));
+    ARROW_ASSIGN_OR_RAISE(auto fragment_ids, lance::BlockingDataset::WriteDataset(lance_uri, &stream, storage_options));
+    ARROW_ASSIGN_OR_RAISE(auto dataset,
+                          lance::BlockingDataset::Open(lance_uri, fs_, lance::ToReaderOptions(fs_config)));
+    if (fragment_ids.empty()) {
+      return arrow::Status::Invalid("Lance Reader benchmark preparation returned no fragments");
+    }
+
+    auto column_group = std::make_shared<api::ColumnGroup>();
+    column_group->format = LOON_FORMAT_LANCE_TABLE;
+    column_group->columns.reserve(schema_->num_fields());
+    for (const auto& field : schema_->fields()) {
+      column_group->columns.emplace_back(field->name());
+    }
+
+    int64_t total_rows = 0;
+    const auto milvus_lance_uri = lance::ToMilvusLanceUri(lance_uri, fs_config.address);
+    for (const auto fragment_id : fragment_ids) {
+      ARROW_ASSIGN_OR_RAISE(auto row_count, dataset->GetFragmentRowCount(fragment_id));
+      if (row_count > static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - total_rows)) {
+        return arrow::Status::Invalid("Lance fragment row range exceeds int64_t");
+      }
+      // ColumnGroupFile ranges are physical offsets within each fragment;
+      // Reader handles logical concatenation across the files.
+      column_group->files.emplace_back(ColumnGroupFile{
+          .path = lance::MakeLanceUri(milvus_lance_uri, fragment_id),
+          .start_index = 0,
+          .end_index = static_cast<int64_t>(row_count),
+      });
+      total_rows += static_cast<int64_t>(row_count);
+    }
+    if (total_rows != loader_->NumRows()) {
+      return arrow::Status::Invalid("Lance fragment row count does not match Reader benchmark dataset");
+    }
+    column_groups_ = std::make_shared<ColumnGroups>();
+    column_groups_->emplace_back(std::move(column_group));
+    return arrow::Status::OK();
+  }
+
+  const ReaderBenchmarkConfig config_;
+  Properties properties_;
+  std::shared_ptr<arrow::fs::FileSystem> fs_;
+  std::unique_ptr<BenchmarkDataLoader> loader_;
+  std::shared_ptr<arrow::Schema> schema_;
+  std::shared_ptr<ColumnGroups> column_groups_;
+  std::string prefix_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  size_t executor_threads_ = 0;
+  bool cleaned_ = false;
+
+  std::unique_ptr<Reader> reader_;
+  std::shared_ptr<arrow::RecordBatchReader> batch_reader_;
+  std::unique_ptr<ChunkReader> chunk_reader_;
+  std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+  std::shared_ptr<arrow::Table> table_;
+  std::vector<int64_t> take_indices_;
+};
+
+static void RunReaderBenchmarkCase(::benchmark::State& state, ReaderBenchmarkConfig config) {
+  auto case_result = ReaderBenchmarkCase::Make(config);
+  if (!case_result.ok()) {
+    const auto message = case_result.status().ToString();
+    state.SkipWithError(message.c_str());
+    return;
+  }
+
+  auto benchmark_case = std::move(case_result).ValueOrDie();
+  const auto run_status = benchmark_case->Run(state);
+  const auto cleanup_status = benchmark_case->Cleanup();
+  if (!run_status.ok()) {
+    const auto message = run_status.ToString();
+    state.SkipWithError(message.c_str());
+  } else if (!cleanup_status.ok()) {
+    const auto message = cleanup_status.ToString();
+    state.SkipWithError(message.c_str());
+  }
+}
+
+[[maybe_unused]] const bool kReaderBenchmarksRegistered = [] {
+  constexpr std::array<std::string_view, 2> prefixes = {
+      "ReaderBenchmark/",
+      "NIGHTLY_CI_TARGET/",
+  };
+  constexpr std::array<ReaderBenchmarkDataset, 7> datasets = {
+      ReaderBenchmarkDataset::kSyntheticSmall,    ReaderBenchmarkDataset::kSyntheticMedium,
+      ReaderBenchmarkDataset::kSyntheticLarge,    ReaderBenchmarkDataset::kScalarMedium,
+      ReaderBenchmarkDataset::kRandomVector64MiB, ReaderBenchmarkDataset::kLowEntropyVector256MiB,
+      ReaderBenchmarkDataset::kRandomVector2GiB,
+  };
+  constexpr std::array<ReaderBenchmarkFormat, 3> formats = {
+      ReaderBenchmarkFormat::kParquet,
+      ReaderBenchmarkFormat::kVortex,
+      ReaderBenchmarkFormat::kLance,
+  };
+  constexpr std::array<ReaderBenchmarkOperation, 3> operations = {
+      ReaderBenchmarkOperation::kRecordBatchRead,
+      ReaderBenchmarkOperation::kChunkRead,
+      ReaderBenchmarkOperation::kTake,
+  };
+
+  for (const auto dataset : datasets) {
+    for (const auto format : formats) {
+      for (const auto operation : operations) {
+        const ReaderBenchmarkConfig config{
+            .mode = ReaderBenchmarkMode::kSync,
+            .operation = operation,
+            .format = format,
+            .dataset = dataset,
+        };
+        const auto suffix = ReaderBenchmarkSuffix(config).ValueOrDie();
+        for (const auto prefix : prefixes) {
+          ::benchmark::RegisterBenchmark(std::string(prefix) + suffix,
+                                         [config](::benchmark::State& state) { RunReaderBenchmarkCase(state, config); })
+              ->Unit(::benchmark::kMillisecond)
+              ->UseRealTime();
+        }
+      }
+    }
+  }
+
+  constexpr std::array<ReaderBenchmarkFormat, 2> async_formats = {
+      ReaderBenchmarkFormat::kParquet,
+      ReaderBenchmarkFormat::kVortex,
+  };
+  constexpr std::array<ReaderBenchmarkOperation, 2> async_operations = {
+      ReaderBenchmarkOperation::kChunkRead,
+      ReaderBenchmarkOperation::kTake,
+  };
+  for (const auto dataset : datasets) {
+    for (const auto format : async_formats) {
+      for (const auto operation : async_operations) {
+        const ReaderBenchmarkConfig config{
+            .mode = ReaderBenchmarkMode::kAsync,
+            .operation = operation,
+            .format = format,
+            .dataset = dataset,
+        };
+        const auto suffix = ReaderBenchmarkSuffix(config).ValueOrDie();
+        for (const auto prefix : prefixes) {
+          ::benchmark::RegisterBenchmark(std::string(prefix) + suffix,
+                                         [config](::benchmark::State& state) { RunReaderBenchmarkCase(state, config); })
+              ->Unit(::benchmark::kMillisecond)
+              ->UseRealTime();
+        }
+      }
+    }
+  }
+  return true;
+}();
 
 struct PreparedReaderFile {
   ColumnGroupFile file;
@@ -430,7 +957,7 @@ class FormatReadBenchmark : public FormatBenchFixtureBase<> {
 // Full Scan Benchmark
 //=============================================================================
 
-// Full scan benchmark - read all rows and all columns
+// Measures public Reader record-batch full scans; data preparation stays outside the timed loop.
 // Args: [format_idx, num_threads, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadFullScan)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
@@ -460,17 +987,10 @@ BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadFullScan)(::benchmark::State& st) {
     auto reader = Reader::create(cgs, schema_, nullptr, properties_);
     BENCH_ASSERT_NOT_NULL(reader, st);
 
-    BENCH_ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader(), st);
-
-    std::shared_ptr<arrow::RecordBatch> batch;
-    while (true) {
-      BENCH_ASSERT_STATUS_OK(batch_reader->ReadNext(&batch), st);
-      if (batch == nullptr) {
-        break;
-      }
-      total_rows_read += batch->num_rows();
-      total_bytes_read += CalculateRawDataSize(batch);
-    }
+    std::shared_ptr<arrow::RecordBatchReader> batch_reader;
+    BENCH_ASSERT_AND_ASSIGN(auto metrics, RunRecordBatchReadOnce(*reader, &batch_reader), st);
+    total_rows_read += metrics.rows;
+    total_bytes_read += metrics.bytes;
   }
 
   ReportThroughput(st, total_bytes_read, total_rows_read);
@@ -491,7 +1011,7 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
 // Column Projection Benchmark
 //=============================================================================
 
-// Column projection benchmark - read subset of columns
+// Measures public Reader record-batch scans projected to a selected number of columns.
 // Args: [format_idx, num_columns, num_threads, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadProjection)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
@@ -567,7 +1087,7 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
 // Random Access (Take) Benchmark
 //=============================================================================
 
-// Random access benchmark - read specific rows by indices
+// Measures public Reader::take for sequential, random, or clustered row-index distributions.
 // Args: [format_idx, take_count, distribution, num_threads, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadTake)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
@@ -602,19 +1122,10 @@ BENCHMARK_DEFINE_F(FormatReadBenchmark, ReadTake)(::benchmark::State& st) {
     auto reader = Reader::create(cgs, schema_, nullptr, properties_);
     BENCH_ASSERT_NOT_NULL(reader, st);
 
-    BENCH_ASSERT_AND_ASSIGN(auto table, reader->take(indices), st);
-
-    total_rows_read += table->num_rows();
-    // Estimate bytes read
-    arrow::TableBatchReader batch_reader(*table);
-    std::shared_ptr<arrow::RecordBatch> batch;
-    while (true) {
-      BENCH_ASSERT_STATUS_OK(batch_reader.ReadNext(&batch), st);
-      if (batch == nullptr) {
-        break;
-      }
-      total_bytes_read += CalculateRawDataSize(batch);
-    }
+    std::shared_ptr<arrow::Table> table;
+    BENCH_ASSERT_AND_ASSIGN(auto metrics, RunTakeOnce(*reader, indices, &table), st);
+    total_rows_read += metrics.rows;
+    total_bytes_read += metrics.bytes;
   }
 
   ReportThroughput(st, total_bytes_read, total_rows_read);
@@ -642,6 +1153,7 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
 
 // Open many live FormatReaders from one shared metadata payload and report RSS.
 // Args: [format_idx, reader_count]
+// Measures metadata and resident-memory cost while opening many readers for one prepared file.
 BENCHMARK_DEFINE_F(FormatReadBenchmark, OpenManyFormatReadersRSS)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
   auto reader_count = static_cast<size_t>(st.range(1));
@@ -702,47 +1214,6 @@ BENCHMARK_REGISTER_F(FormatReadBenchmark, OpenManyFormatReadersRSS)
         {100, 10000},  // live FormatReader count
     })
     ->Iterations(1)
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-//=============================================================================
-// Typical Benchmarks
-// Run with: --benchmark_filter="Typical/"
-//=============================================================================
-
-BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
-    ->Name("Typical/ReadFullScan_Parquet")
-    ->Args({0, 8, 1})  // Parquet + 8 threads + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadFullScan)
-    ->Name("Typical/ReadFullScan_Vortex")
-    ->Args({1, 8, 1})  // Vortex + 8 threads + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
-    ->Name("Typical/ReadProjection_Parquet")
-    ->Args({0, 1, 8, 1})  // Parquet + 1 col + 8 threads + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadProjection)
-    ->Name("Typical/ReadProjection_Vortex")
-    ->Args({1, 1, 8, 1})  // Vortex + 1 col + 8 threads + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
-    ->Name("Typical/ReadTake_Parquet")
-    ->Args({0, 1000, 1, 8, 1})  // Parquet + 1000 rows + Random + 8 threads + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatReadBenchmark, ReadTake)
-    ->Name("Typical/ReadTake_Vortex")
-    ->Args({1, 1000, 1, 8, 1})  // Vortex + 1000 rows + Random + 8 threads + Default
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 

--- a/cpp/benchmark/benchmark_format_write.cpp
+++ b/cpp/benchmark/benchmark_format_write.cpp
@@ -71,7 +71,7 @@ class FormatWriteBenchmark : public FormatBenchFixtureBase<> {
   int64_t total_rows_ = 0;
 };
 
-// Write comparison benchmark across formats
+// Measures end-to-end public Writer write-and-close throughput for the selected format and loaded dataset.
 // Args: [format_idx, data_config_idx, memory_config_idx]
 BENCHMARK_DEFINE_F(FormatWriteBenchmark, WriteComparison)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
@@ -182,6 +182,7 @@ static double BytesToMiB(int64_t bytes) { return static_cast<double>(bytes) / 10
 // Split the same loaded data into many record batches and time writer->write()
 // separately from writer->close(). This mirrors Milvus sort compaction's
 // storage.Sort(...)->rw.Write(record) phase and the later srw.Close() phase.
+// Measures the write and close stages separately, including their throughput and output file counts.
 BENCHMARK_DEFINE_F(FormatWriteBenchmark, StageBreakdown)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
   auto writer_buffer_mib = static_cast<int64_t>(st.range(1));
@@ -311,8 +312,7 @@ static arrow::Result<int64_t> CalculateFileSize(const std::shared_ptr<arrow::fs:
   return total_size;
 }
 
-// This benchmark measures file size and compression ratio
-// The compression ratio is calculated by comparing file size against raw data size from loader
+// Measures encoded file size and compression ratio against the loader's raw logical data size.
 // Args: [format_idx, data_config_idx]
 BENCHMARK_DEFINE_F(FormatWriteBenchmark, CompressionAnalysis)(::benchmark::State& st) {
   auto format_idx = static_cast<size_t>(st.range(0));
@@ -378,36 +378,5 @@ BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime()
     ->Iterations(3);  // Few iterations since we're measuring file size
-
-//=============================================================================
-// Typical Benchmarks
-// Run with: --benchmark_filter="Typical/"
-//=============================================================================
-
-BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
-    ->Name("Typical/FormatWrite_Parquet")
-    ->Args({0, 1, 1})  // Parquet + Medium + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatWriteBenchmark, WriteComparison)
-    ->Name("Typical/FormatWrite_Vortex")
-    ->Args({1, 1, 1})  // Vortex + Medium + Default
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
-    ->Name("Typical/Compression_Parquet")
-    ->Args({0, 1})  // Parquet + Medium
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime()
-    ->Iterations(3);
-
-BENCHMARK_REGISTER_F(FormatWriteBenchmark, CompressionAnalysis)
-    ->Name("Typical/Compression_Vortex")
-    ->Args({1, 1})  // Vortex + Medium
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime()
-    ->Iterations(3);
 
 }  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_predicate.cpp
+++ b/cpp/benchmark/benchmark_predicate.cpp
@@ -153,6 +153,7 @@ class PredicateBenchmark : public FormatBenchFixtureBase<> {
 };
 
 // Args: [sorted, selectivity_pct, predicate_col]
+// Measures Vortex predicate pushdown for sorted or unsorted data and reports result and filesystem I/O selectivity.
 BENCHMARK_DEFINE_F(PredicateBenchmark, ReadWithPredicate)(::benchmark::State& st) {
   bool sorted = st.range(0) != 0;
   int selectivity_pct = static_cast<int>(st.range(1));

--- a/cpp/benchmark/benchmark_storage_layer.cpp
+++ b/cpp/benchmark/benchmark_storage_layer.cpp
@@ -332,6 +332,7 @@ class StorageLayerFixture : public FormatBenchFixtureBase<> {
 //=============================================================================
 
 // Args: [format_type]
+// Measures public Milvus Storage Writer throughput including the transaction commit path.
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_WriteCommit)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
 
@@ -367,6 +368,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
 //=============================================================================
 
 // Args: [format_type]
+// Measures public Milvus Storage Writer throughput without the transaction commit layer.
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_WriteOnly)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
 
@@ -403,6 +405,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteOnly)
 //=============================================================================
 
 // Args: [format_type, num_threads]
+// Measures committed Milvus Storage data opening and full public Reader scans at each thread-pool size.
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_OpenRead)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
   int num_threads = static_cast<int>(st.range(1));
@@ -448,6 +451,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
 //=============================================================================
 
 // Args: [format_type, take_count, num_threads]
+// Measures public Reader random-row take performance over committed Milvus Storage data.
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_Take)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
   auto take_count = static_cast<size_t>(st.range(1));
@@ -498,6 +502,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
 // Lance Native Benchmarks
 //=============================================================================
 
+// Measures native Lance WriteDataset throughput without routing the measured operation through Milvus Reader APIs.
 BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_WriteCommit)(::benchmark::State& st) {
   ConfigureThreadPool(1);
 
@@ -526,6 +531,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_WriteCommit)->Unit(::bench
 //=============================================================================
 
 // Args: [num_threads]
+// Measures native Lance dataset open, scan, and stream-drain performance at each runtime thread count.
 BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_OpenRead)(::benchmark::State& st) {
   int num_threads = static_cast<int>(st.range(0));
 
@@ -598,6 +604,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_OpenRead)
 //=============================================================================
 
 // Args: [take_count, num_threads]
+// Measures native Lance random-row Take performance at each requested row count and runtime size.
 BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_Take)(::benchmark::State& st) {
   auto take_count = static_cast<size_t>(st.range(0));
   int num_threads = static_cast<int>(st.range(1));
@@ -669,29 +676,12 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_Take)
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 
-// Typical: Lance benchmarks
-BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_WriteCommit)
-    ->Name("Typical/Lance_Write")
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_OpenRead)
-    ->Name("Typical/Lance_Read")
-    ->Args({8})  // 8 threads
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_Take)
-    ->Name("Typical/Lance_Take")
-    ->Args({1000, 8})  // 1000 rows + 8 threads
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
 //=============================================================================
 // Lance Multi-Reader Concurrency Benchmark
 //=============================================================================
 
 // Args: [num_readers, thread_pool_size]
+// Measures many concurrent native Lance opens and full scans while reporting throughput and peak threads.
 BENCHMARK_DEFINE_F(StorageLayerFixture, LanceNative_MultiReader)(::benchmark::State& st) {
   int num_readers = static_cast<int>(st.range(0));
   int thread_pool_size = static_cast<int>(st.range(1));
@@ -793,6 +783,7 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, LanceNative_MultiReader)
 //=============================================================================
 
 // Args: [format_type, num_readers, thread_pool_size]
+// Measures concurrent transaction opens and public Reader full scans while reporting throughput and peak threads.
 BENCHMARK_DEFINE_F(StorageLayerFixture, MilvusStorage_MultiReader)(::benchmark::State& st) {
   auto format_type = static_cast<StorageFormatType>(st.range(0));
   int num_readers = static_cast<int>(st.range(1));
@@ -886,73 +877,6 @@ BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_MultiReader)
         {1, 16, 64, 256},  // NumReaders: 1, 16, 64, 256
         {1, 8, 16, 32}     // ThreadPoolSize: 1, 8, 16, 32
     })
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-//=============================================================================
-// Typical Benchmarks (Quick validation with representative parameters)
-// Run with: --benchmark_filter="Typical/"
-//=============================================================================
-
-// Typical: MilvusStorage Parquet
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
-    ->Name("Typical/MilvusStorage_Write_Parquet")
-    ->Args({0})  // Parquet
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
-    ->Name("Typical/MilvusStorage_Read_Parquet_1T")
-    ->Args({0, 1})  // Parquet + 1 thread
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
-    ->Name("Typical/MilvusStorage_Read_Parquet_8T")
-    ->Args({0, 8})  // Parquet + 8 threads
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
-    ->Name("Typical/MilvusStorage_Take_Parquet_1T")
-    ->Args({0, 1000, 1})  // Parquet + 1000 rows + 1 thread
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
-    ->Name("Typical/MilvusStorage_Take_Parquet")
-    ->Args({0, 1000, 8})  // Parquet + 1000 rows + 8 threads
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-// Typical: MilvusStorage Vortex
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_WriteCommit)
-    ->Name("Typical/MilvusStorage_Write_Vortex")
-    ->Args({1})  // Vortex
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
-    ->Name("Typical/MilvusStorage_Read_Vortex_1T")
-    ->Args({1, 1})  // Vortex + 1 thread
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_OpenRead)
-    ->Name("Typical/MilvusStorage_Read_Vortex_8T")
-    ->Args({1, 8})  // Vortex + 8 threads
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
-    ->Name("Typical/MilvusStorage_Take_Vortex_1T")
-    ->Args({1, 1000, 1})  // Vortex + 1000 rows + 1 thread
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(StorageLayerFixture, MilvusStorage_Take)
-    ->Name("Typical/MilvusStorage_Take_Vortex_8T")
-    ->Args({1, 1000, 8})  // Vortex + 1000 rows + 8 threads
     ->Unit(::benchmark::kMillisecond)
     ->UseRealTime();
 

--- a/cpp/benchmark/benchmark_v2_v3.cpp
+++ b/cpp/benchmark/benchmark_v2_v3.cpp
@@ -146,6 +146,7 @@ class V2V3BenchFixture : public FormatBenchFixtureBase<> {
 // V2: PackedRecordBatchReader Benchmark (Low-level)
 //=============================================================================
 
+// Measures low-level V2 PackedRecordBatchReader full-scan throughput over a prepared packed file.
 BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchReader)(::benchmark::State& st) {
   // Write data using packed writer
   std::string path;
@@ -181,6 +182,7 @@ BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchReader)->Unit(::bench
 // V3: Reader::get_record_batch_reader Benchmark (Top-level)
 //=============================================================================
 
+// Measures top-level V3 public Reader record-batch full-scan throughput over Writer-produced data.
 BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_RecordBatchReader)(::benchmark::State& st) {
   // Write data using Writer API
   std::shared_ptr<ColumnGroups> cgs;
@@ -217,6 +219,7 @@ BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_RecordBatchReader)->Unit(::benchmark::
 //=============================================================================
 
 // Args: [config_idx]
+// Measures top-level V3 public ChunkReader by opening and reading every logical chunk individually.
 BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_ChunkReader)(::benchmark::State& st) {
   // Write data using Writer API
   std::shared_ptr<ColumnGroups> cgs;
@@ -249,6 +252,7 @@ BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_ChunkReader)->Unit(::benchmark::kMilli
 // V2: PackedRecordBatchWriter Benchmark (Low-level)
 //=============================================================================
 
+// Measures low-level V2 PackedRecordBatchWriter throughput while writing all preloaded batches.
 BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)(::benchmark::State& st) {
   std::string base_path = GetUniquePath("v2_write_bench");
 
@@ -277,9 +281,13 @@ BENCHMARK_DEFINE_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)(::benchmark::St
     }
     auto result = writer->Close();
 
-    // Cleanup for next iteration
-    BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path), st);
-    BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path), st);
+    // Keep the per-iteration path reset out of the measured write time.
+    st.PauseTiming();
+    const auto delete_status = DeleteTestDir(fs_, base_path);
+    const auto create_status = CreateTestDir(fs_, base_path);
+    st.ResumeTiming();
+    BENCH_ASSERT_STATUS_OK(delete_status, st);
+    BENCH_ASSERT_STATUS_OK(create_status, st);
   }
 
   int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
@@ -294,6 +302,7 @@ BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)->Unit(::bench
 // V3: Writer API Benchmark (Top-level)
 //=============================================================================
 
+// Measures top-level V3 public Writer write-and-close throughput over the same preloaded batches.
 BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_Writer)(::benchmark::State& st) {
   std::string base_path = GetUniquePath("v3_write_bench");
 
@@ -310,9 +319,13 @@ BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_Writer)(::benchmark::State& st) {
     }
     BENCH_ASSERT_AND_ASSIGN(auto cgs, writer->close(), st);
 
-    // Cleanup for next iteration
-    BENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path), st);
-    BENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path), st);
+    // Keep the per-iteration path reset out of the measured write time.
+    st.PauseTiming();
+    const auto delete_status = DeleteTestDir(fs_, base_path);
+    const auto create_status = CreateTestDir(fs_, base_path);
+    st.ResumeTiming();
+    BENCH_ASSERT_STATUS_OK(delete_status, st);
+    BENCH_ASSERT_STATUS_OK(create_status, st);
   }
 
   int64_t total_bytes = total_bytes_ * static_cast<int64_t>(st.iterations());
@@ -322,30 +335,5 @@ BENCHMARK_DEFINE_F(V2V3BenchFixture, V3_Writer)(::benchmark::State& st) {
 }
 
 BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_Writer)->Unit(::benchmark::kMillisecond)->UseRealTime();
-
-//=============================================================================
-// Typical Benchmarks
-// Run with: --benchmark_filter="Typical/"
-//=============================================================================
-
-BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchReader)
-    ->Name("Typical/V2_Reader")
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_RecordBatchReader)
-    ->Name("Typical/V3_Reader")
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(V2V3BenchFixture, V2_PackedRecordBatchWriter)
-    ->Name("Typical/V2_Writer")
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK_REGISTER_F(V2V3BenchFixture, V3_Writer)
-    ->Name("Typical/V3_Writer")
-    ->Unit(::benchmark::kMillisecond)
-    ->UseRealTime();
 
 }  // namespace milvus_storage::benchmark

--- a/cpp/benchmark/benchmark_wr.cpp
+++ b/cpp/benchmark/benchmark_wr.cpp
@@ -75,9 +75,7 @@ class StorageFixture : public benchmark::Fixture {
     GBENCH_ASSERT_STATUS_OK(CreateTestDir(fs_, base_path_), state);
   }
 
-  void TearDown(::benchmark::State& state) override {
-    // GBENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_), state);
-  }
+  void TearDown(::benchmark::State& state) override { GBENCH_ASSERT_STATUS_OK(DeleteTestDir(fs_, base_path_), state); }
 
   api::Properties properties_;
   std::shared_ptr<arrow::fs::FileSystem> fs_;
@@ -208,6 +206,7 @@ static void APIWriteLargeBenchmark(benchmark::State& st,
   }
 }
 
+// Measures public Writer throughput for a 4K-row dataset containing all scalar and vector columns.
 BENCHMARK_DEFINE_F(StorageFixture, WriteDefaultConfig)(benchmark::State& st) {
   size_t loop_times = st.range(0);
   APIWriteBenchmark(st, fs_, base_path_, properties_, loop_times,
@@ -218,6 +217,7 @@ BENCHMARK_DEFINE_F(StorageFixture, WriteDefaultConfig)(benchmark::State& st) {
                                     .needed_columns = {true, true, true, true}});
 }
 
+// Measures public Writer throughput when the input schema contains only one selected column.
 BENCHMARK_DEFINE_F(StorageFixture, WriteSingleColumnConfig)(benchmark::State& st) {
   size_t loop_times = st.range(0);
   int column_idx = st.range(1);
@@ -232,6 +232,7 @@ BENCHMARK_DEFINE_F(StorageFixture, WriteSingleColumnConfig)(benchmark::State& st
                                     .needed_columns = needed_columns});
 }
 
+// Measures a public Reader full scan of all columns after preparing the default 4K-row dataset.
 BENCHMARK_DEFINE_F(StorageFixture, ReadFullScanDefaultConfig)(benchmark::State& st) {
   size_t loop_times = st.range(0);
 
@@ -246,6 +247,7 @@ BENCHMARK_DEFINE_F(StorageFixture, ReadFullScanDefaultConfig)(benchmark::State& 
                        });
 }
 
+// Measures a public Reader full scan projected to one selected column of the prepared dataset.
 BENCHMARK_DEFINE_F(StorageFixture, ReadFullScanSingleColumnConfig)(benchmark::State& st) {
   size_t loop_times = st.range(0);
   int column_idx = st.range(1);
@@ -265,6 +267,7 @@ BENCHMARK_DEFINE_F(StorageFixture, ReadFullScanSingleColumnConfig)(benchmark::St
                        });
 }
 
+// Measures vector-only public Writer/Reader processing for a target-sized 768-dimensional dataset.
 BENCHMARK_DEFINE_F(StorageFixture, WriteRead768dimVector)(benchmark::State& st) {
   uint64_t target_size = st.range(0);
   uint32_t target_dim = st.range(1);

--- a/cpp/benchmark/nightly/summary.jq
+++ b/cpp/benchmark/nightly/summary.jq
@@ -1,0 +1,301 @@
+def target_parts:
+  ((.run_name // .name // "") | tostring | split("/")) as $parts
+  | if ($parts | length) < 5 or $parts[0] != "NIGHTLY_CI_TARGET"
+    then {valid: false, raw_name: (.run_name // .name // "")}
+    else {
+      valid: true,
+      mode: $parts[1],
+      operation: $parts[2],
+      format: $parts[3],
+      dataset: $parts[4]
+    }
+    end;
+
+def to_ms:
+  if (.real_time | type) != "number" then null
+  elif .time_unit == "ns" then .real_time / 1000000
+  elif .time_unit == "us" then .real_time / 1000
+  elif .time_unit == "ms" then .real_time
+  elif .time_unit == "s" then .real_time * 1000
+  else null
+  end;
+
+def markdown_escape:
+  tostring | gsub("\\r?\\n"; "<br>") | gsub("\\|"; "\\|");
+
+def fixed($digits):
+  . as $number
+  | pow(10; $digits) as $scale
+  | (($number * $scale) | round) as $scaled
+  | (if $scaled < 0 then "-" else "" end) as $sign
+  | ($scaled | fabs) as $absolute
+  | (($absolute / $scale) | floor | tostring) as $whole
+  | (($absolute % $scale) | floor | tostring) as $fraction
+  | $sign + $whole + "." + (("000000000000" + $fraction) | .[(-$digits):]);
+
+def benchmark_entries:
+  if (.benchmarks? | type) == "array" then .benchmarks else [] end;
+
+def median_cv_shaped_entries:
+  [benchmark_entries[] | select(.aggregate_name? == "median" or .aggregate_name? == "cv")];
+
+def aggregate_entries:
+  [median_cv_shaped_entries[] | select(.run_type? == "aggregate")];
+
+def target_key:
+  "\(.mode)/\(.operation)/\(.format)/\(.dataset)";
+
+def analyzed_records:
+  [aggregate_entries[]
+   | . as $record
+   | ($record | target_parts) as $target
+   | ($record | to_ms) as $normalized_ms
+   | $record + {
+       target: $target,
+       normalized_ms: $normalized_ms,
+       raw_name: (($record.run_name // $record.name // "") | tostring),
+       semantic_key: (if $target.valid then ($target | target_key) else null end)
+     }];
+
+def raw_cases:
+  analyzed_records
+  | sort_by(.raw_name)
+  | group_by(.raw_name)
+  | map(
+      . as $records
+      | [$records[] | select(.aggregate_name == "median")] as $medians
+      | [$records[] | select(.aggregate_name == "cv")] as $cvs
+      | {
+          raw_name: $records[0].raw_name,
+          target: $records[0].target,
+          semantic_key: $records[0].semantic_key,
+          medians: $medians,
+          cvs: $cvs,
+          median: ($medians[0] // null),
+          cv: ($cvs[0] // null)
+        }
+    );
+
+def cases:
+  [raw_cases[] | select(.target.valid)]
+  | sort_by(.semantic_key)
+  | group_by(.semantic_key)
+  | map(. as $raw_runs | $raw_runs[0] + {raw_cases: $raw_runs});
+
+def approved_target:
+  . as $target
+  | $target.valid
+    and (
+      if $target.mode == "Sync"
+      then (["RecordBatchRead", "ChunkRead", "Take"] | index($target.operation) != null)
+           and (["Parquet", "Vortex", "Lance"] | index($target.format) != null)
+      elif $target.mode == "Async"
+      then (["ChunkRead", "Take"] | index($target.operation) != null)
+           and (["Parquet", "Vortex"] | index($target.format) != null)
+      else false
+      end
+    )
+    and ([
+      "SyntheticSmall", "SyntheticMedium", "SyntheticLarge", "ScalarMedium",
+      "RandomVector64MiB", "LowEntropyVector256MiB", "RandomVector2GiB"
+    ] | index($target.dataset) != null);
+
+def benchmark_errors:
+  [benchmark_entries[]
+   | select(.error_occurred? == true)
+   | {
+       name: (.run_name // .name // "<unknown>"),
+       message: (.error_message // "benchmark reported an error")
+     }];
+
+def completed_cases:
+  cases as $cases
+  | benchmark_errors as $benchmark_errors
+  | [$cases[]
+     | . as $case
+     | select(
+         ($case.target | approved_target)
+         and ($case.raw_cases | length) == 1
+         and ($case.medians | length) == 1
+         and ($case.cvs | length) == 1
+         and $case.median.normalized_ms != null
+         and $case.cv.normalized_ms != null
+         and ([$benchmark_errors[]
+               | ({run_name: .name} | target_parts) as $error_target
+               | select($error_target.valid
+                        and ($error_target | target_key) == $case.semantic_key)]
+              | length) == 0
+       )];
+
+def expected_count_value:
+  if ($expected_count | test("^[0-9]+$"))
+  then ($expected_count | tonumber)
+  else null
+  end;
+
+def validation_issues:
+  analyzed_records as $records
+  | median_cv_shaped_entries as $median_cv_records
+  | raw_cases as $raw_cases
+  | cases as $cases
+  | benchmark_errors as $benchmark_errors
+  | expected_count_value as $expected
+  | [
+      if (.benchmarks? | type) != "array" then "missing benchmarks array" else empty end,
+      if $expected == null then "expected_count is not a number" else empty end,
+      ($median_cv_records[]
+       | select(.run_type? != "aggregate")
+       | "median/CV-shaped record must use run_type aggregate for \((.run_name // .name // "<unknown>") | markdown_escape), found \((.run_type // "<missing>") | tostring | markdown_escape)"),
+      ($records[]
+       | select(.target.valid | not)
+       | "malformed target name: \((.target.raw_name // "<unknown>") | markdown_escape)"),
+      ($raw_cases[]
+       | select(.target.valid == true and (.target | approved_target | not))
+       | "unapproved semantic target: \(.semantic_key | markdown_escape)"),
+      ($records[]
+       | select(.normalized_ms == null)
+       | "unsupported or missing time unit for \((.run_name // .name // "<unknown>") | markdown_escape)"),
+      ($raw_cases[]
+       | select((.medians | length) != 1)
+       | "expected exactly one median for raw run \(.raw_name | markdown_escape), found \(.medians | length)"),
+      ($raw_cases[]
+       | select((.cvs | length) != 1)
+       | "expected exactly one real-time CV for raw run \(.raw_name | markdown_escape), found \(.cvs | length)"),
+      ($cases[]
+       | select((.raw_cases | length) != 1)
+       | "multiple raw runs map to semantic target \(.semantic_key | markdown_escape): \(.raw_cases | map(.raw_name | markdown_escape) | join(", "))"),
+      ($benchmark_errors[]
+       | "benchmark error for \(.name | markdown_escape): \(.message | markdown_escape)"),
+      if $expected != null and ($cases | length) != $expected
+      then "expected \($expected) unique semantic targets, found \($cases | length)"
+      else empty
+      end
+    ];
+
+def median_ms:
+  if .median == null then null else .median.normalized_ms end;
+
+def cv_percent:
+  if .cv == null or (.cv.real_time | type) != "number" then null else .cv.real_time * 100 end;
+
+def throughput_text:
+  if .median == null then "—"
+  else [
+    .median
+    | to_entries[]
+    | select(.key == "bytes_per_second" or .key == "rows/s" or (.key | startswith("throughput(")))
+    | "\(.key): \(.value)"
+  ] | if length == 0 then "—" else join("<br>") end
+  end;
+
+def parquet_median($all_cases):
+  . as $case
+  | [$all_cases[]
+     | select(
+         .target.mode == $case.target.mode
+         and .target.operation == $case.target.operation
+         and .target.dataset == $case.target.dataset
+         and .target.format == "Parquet"
+       )
+     | median_ms]
+  | .[0] // null;
+
+def speedup_text($all_cases):
+  median_ms as $median
+  | parquet_median($all_cases) as $parquet
+  | if $median == null or $parquet == null or $median == 0
+    then "—"
+    else "\(($parquet / $median) | fixed(3))x"
+    end;
+
+def time_text:
+  median_ms as $value
+  | if $value == null then "—" else "\($value | fixed(3)) ms" end;
+
+def cv_text:
+  cv_percent as $value
+  | if $value == null then "—"
+    elif $value > 10 then "WARN \($value | fixed(2))%"
+    else "\($value | fixed(2))%"
+    end;
+
+def format_cell($format; $all_cases):
+  ([.[] | select(.target.format == $format)] | .[0] // null) as $case
+  | if $case == null then "—"
+    else "\($case | time_text) (\($case | speedup_text($all_cases)))"
+    end;
+
+def comparison_table($mode; $all_cases):
+  [$all_cases[] | select(.target.mode == $mode)]
+  | sort_by([.target.dataset, .target.operation])
+  | group_by([.target.dataset, .target.operation])
+  | if $mode == "Async"
+    then ["| Dataset | Operation | Parquet | Vortex |",
+          "| --- | --- | ---: | ---: |"]
+         + map(
+             . as $group
+             | "| \($group[0].target.dataset | markdown_escape) | \($group[0].target.operation | markdown_escape) | \($group | format_cell("Parquet"; $all_cases) | markdown_escape) | \($group | format_cell("Vortex"; $all_cases) | markdown_escape) |"
+           )
+    else ["| Dataset | Operation | Parquet | Vortex | Lance |",
+          "| --- | --- | ---: | ---: | ---: |"]
+         + map(
+             . as $group
+             | "| \($group[0].target.dataset | markdown_escape) | \($group[0].target.operation | markdown_escape) | \($group | format_cell("Parquet"; $all_cases) | markdown_escape) | \($group | format_cell("Vortex"; $all_cases) | markdown_escape) | \($group | format_cell("Lance"; $all_cases) | markdown_escape) |"
+           )
+    end
+  | join("\n");
+
+def render_markdown:
+  cases as $cases
+  | completed_cases as $completed_cases
+  | validation_issues as $issues
+  | expected_count_value as $expected
+  | [ $cases[] | cv_percent | select(. != null) ] as $cvs
+  | [
+      "## C++ Nightly Reader Benchmark",
+      "",
+      "Commit: `\($commit | markdown_escape)`  ",
+      "Trigger: `\($trigger | markdown_escape)`  ",
+      "MinIO release: `\($minio_release | markdown_escape)`",
+      "",
+      "Cases: \($completed_cases | length) completed / \(if $expected == null then "invalid" else $expected end) expected  ",
+      "Errors: \($issues | length)  ",
+      "Max real-time CV: \(if ($cvs | length) == 0 then "—" else (($cvs | max) as $max | (if $max > 10 then "WARN " else "" end) + ($max | fixed(2)) + "%") end)  ",
+      "MinIO CPUs: `\($minio_cpu_list | markdown_escape)`  ",
+      "Benchmark CPUs: `\($benchmark_cpu_list | markdown_escape)`  ",
+      "Executor threads: `\($executor_threads | markdown_escape)`",
+      "",
+      "### Sync comparison",
+      "",
+      comparison_table("Sync"; $cases),
+      "",
+      "### Async comparison",
+      "",
+      comparison_table("Async"; $cases),
+      "",
+      "### Case details",
+      "",
+      "| Mode | Operation | Format | Dataset | Median real time | Real-time CV | Throughput | Parquet speedup |",
+      "| --- | --- | --- | --- | ---: | ---: | --- | ---: |"
+    ]
+    + ($cases | sort_by([.target.mode, .target.dataset, .target.operation, .target.format]) | map(
+        "| \(.target.mode | markdown_escape) | \(.target.operation | markdown_escape) | \(.target.format | markdown_escape) | \(.target.dataset | markdown_escape) | \(time_text | markdown_escape) | \(cv_text | markdown_escape) | \(throughput_text | markdown_escape) | \(speedup_text($cases) | markdown_escape) |"
+      ))
+    + (if ($issues | length) == 0 then [] else [
+        "",
+        "### Benchmark errors",
+        "",
+        ($issues | map("- " + .) | join("\n"))
+      ] end)
+  | join("\n");
+
+def validate_results:
+  validation_issues as $issues
+  | if ($issues | length) == 0 then "nightly summary validation passed"
+    else error("nightly summary validation failed: \($issues | join("; "))")
+    end;
+
+if $command == "render" then render_markdown
+elif $command == "validate" then validate_results
+else error("unknown nightly summary command")
+end

--- a/cpp/benchmark/nightly/test_reader_alias.sh
+++ b/cpp/benchmark/nightly/test_reader_alias.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# < 1 || $# > 2 )); then
+  printf 'usage: %s <benchmark-binary> [registration|smoke]\n' "$0" >&2
+  exit 2
+fi
+
+binary=$1
+mode=${2:-registration}
+if [[ ! -x $binary ]]; then
+  printf 'benchmark binary is not executable: %s\n' "$binary" >&2
+  exit 1
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/reader-benchmark-alias.XXXXXX")
+trap 'rm -rf "$temp_dir"' EXIT
+
+all_tests="$temp_dir/all-tests.txt"
+expected_file="$temp_dir/expected.txt"
+canonical_file="$temp_dir/canonical.txt"
+alias_file="$temp_dir/aliases.txt"
+
+"$binary" --benchmark_list_tests=true >"$all_tests"
+
+datasets=(
+  SyntheticSmall
+  SyntheticMedium
+  SyntheticLarge
+  ScalarMedium
+  RandomVector64MiB
+  LowEntropyVector256MiB
+  RandomVector2GiB
+)
+sync_formats=(Parquet Vortex Lance)
+sync_operations=(RecordBatchRead ChunkRead Take)
+async_formats=(Parquet Vortex)
+async_operations=(ChunkRead Take)
+
+if [[ $mode == smoke ]]; then
+  canonical_json="$temp_dir/canonical.json"
+  canonical_log="$temp_dir/canonical.log"
+  alias_json="$temp_dir/aliases.json"
+  alias_log="$temp_dir/aliases.log"
+
+  if ! "$binary" \
+    --benchmark_filter='^ReaderBenchmark/(Sync|Async)/.*/.*/SyntheticSmall' \
+    --benchmark_repetitions=1 \
+    --benchmark_min_time=0.01s \
+    --benchmark_out="$canonical_json" \
+    --benchmark_out_format=json >"$canonical_log" 2>&1; then
+    sed -n '1,240p' "$canonical_log" >&2
+    exit 1
+  fi
+  if ! "$binary" \
+    --benchmark_filter='^NIGHTLY_CI_TARGET/(Sync|Async)/.*/.*/SyntheticSmall' \
+    --benchmark_repetitions=1 \
+    --benchmark_min_time=0.01s \
+    --benchmark_out="$alias_json" \
+    --benchmark_out_format=json >"$alias_log" 2>&1; then
+    sed -n '1,240p' "$alias_log" >&2
+    exit 1
+  fi
+
+  jq -s -e --arg executor_threads "${NIGHTLY_CI_EXECUTOR_THREADS:-1}" '
+    def normalized($document; $prefix):
+      [$document.benchmarks[]
+       | select((.run_type // "iteration") == "iteration")
+       | {
+           suffix: ((.run_name // .name)
+                    | sub("/real_time$"; "")
+                    | sub("^" + $prefix; "")),
+           label: (.label // ""),
+           error_occurred: (.error_occurred // false),
+           error_message: (.error_message // ""),
+           # Throughput units depend on the Google Benchmark adaptive iteration
+           # count, so compare the counter kind rather than its rendered unit.
+           counter_keys: ([keys[]
+                           | select(. == "rows/s"
+                                    or . == "rows_taken"
+                                    or . == "executor_threads"
+                                    or startswith("throughput("))
+                           | if startswith("throughput(") then "throughput" else . end]
+                          | unique
+                          | sort),
+           rows_taken: (.rows_taken // null),
+           executor_threads: (.executor_threads // null)
+         }]
+      | sort_by(.suffix);
+
+    normalized(.[0]; "ReaderBenchmark/") as $canonical
+    | normalized(.[1]; "NIGHTLY_CI_TARGET/") as $aliases
+    | {
+        canonical_count: ($canonical | length),
+        alias_count: ($aliases | length),
+        identical_stable_results: ($canonical == $aliases),
+        take_count: ([$canonical[] | select(.rows_taken == 1000)] | length),
+        async_count: ([$canonical[]
+                       | select(.executor_threads == ($executor_threads | tonumber))]
+                      | length),
+        error_count: ([$canonical[], $aliases[]
+                       | select(.error_occurred == true
+                                or (.error_message | test("cleanup"; "i")))]
+                      | length)
+      }
+    | select(.canonical_count == 13
+             and .alias_count == 13
+             and .identical_stable_results
+             and .take_count == 5
+             and .async_count == 4
+             and .error_count == 0)
+  ' "$canonical_json" "$alias_json"
+
+  if grep -qi 'Reader benchmark cleanup failed' "$canonical_log" "$alias_log"; then
+    printf 'Reader benchmark cleanup failed during alias smoke\n' >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+if [[ $mode != registration ]]; then
+  printf 'unknown mode: %s\n' "$mode" >&2
+  exit 2
+fi
+
+for dataset in "${datasets[@]}"; do
+  for format in "${sync_formats[@]}"; do
+    for operation in "${sync_operations[@]}"; do
+      printf 'Sync/%s/%s/%s\n' "$operation" "$format" "$dataset"
+    done
+  done
+  for format in "${async_formats[@]}"; do
+    for operation in "${async_operations[@]}"; do
+      printf 'Async/%s/%s/%s\n' "$operation" "$format" "$dataset"
+    done
+  done
+done | sort >"$expected_file"
+
+awk '/^ReaderBenchmark\// {
+  sub(/^ReaderBenchmark\//, "")
+  sub(/\/real_time$/, "")
+  print
+}' "$all_tests" | sort >"$canonical_file"
+
+awk '/^NIGHTLY_CI_TARGET\// {
+  sub(/^NIGHTLY_CI_TARGET\//, "")
+  sub(/\/real_time$/, "")
+  print
+}' "$all_tests" | sort >"$alias_file"
+
+assert_exact_matrix() {
+  local label=$1 file=$2 count unique_count
+  count=$(awk 'END {print NR + 0}' "$file")
+  unique_count=$(sort -u "$file" | awk 'END {print NR + 0}')
+  if (( count != 91 || unique_count != 91 )); then
+    printf '%s registrations: expected 91 unique entries, found %s entries/%s unique\n' \
+      "$label" "$count" "$unique_count" >&2
+    return 1
+  fi
+  if grep -q 'Iceberg' "$file"; then
+    printf '%s registrations unexpectedly contain Iceberg\n' "$label" >&2
+    return 1
+  fi
+  diff -u "$expected_file" "$file"
+}
+
+assert_exact_matrix canonical "$canonical_file"
+assert_exact_matrix alias "$alias_file"
+diff -u "$canonical_file" "$alias_file"
+
+if grep -q '^Typical/' "$all_tests"; then
+  printf 'removed Typical registrations are still present\n' >&2
+  exit 1
+fi
+
+printf 'reader benchmark registration contract passed: canonical=91 aliases=91\n'

--- a/cpp/benchmark/nightly/test_summary.sh
+++ b/cpp/benchmark/nightly/test_summary.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+renderer="$script_dir/summary.jq"
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/nightly-summary.XXXXXX")"
+trap 'rm -rf "$temp_dir"' EXIT
+
+render() {
+  local expected_count=${2:-5}
+  jq -r \
+    --arg command render \
+    --arg expected_count "$expected_count" \
+    --arg commit 'test-sha' \
+    --arg trigger 'test' \
+    --arg minio_release 'test-minio' \
+    --arg minio_cpu_list '0' \
+    --arg benchmark_cpu_list '1,2,3' \
+    --arg executor_threads '3' \
+    -f "$renderer" "$1"
+}
+
+validate() {
+  jq -e \
+    --arg command validate \
+    --arg expected_count "$2" \
+    --arg commit 'test-sha' \
+    --arg trigger 'test' \
+    --arg minio_release 'test-minio' \
+    --arg minio_cpu_list '0' \
+    --arg benchmark_cpu_list '1,2,3' \
+    --arg executor_threads '3' \
+    -f "$renderer" "$1" >/dev/null
+}
+
+assert_contains() {
+  local haystack=$1 needle=$2
+  [[ $haystack == *"$needle"* ]] || {
+    printf 'expected output to contain %s\n%s\n' "$needle" "$haystack" >&2
+    exit 1
+  }
+}
+
+assert_validate_fails() {
+  local fixture=$1 expected_count=$2 diagnostic=$3 stderr
+  if stderr="$(validate "$fixture" "$expected_count" 2>&1)"; then
+    printf 'expected validation failure for %s\n' "$fixture" >&2
+    exit 1
+  fi
+  assert_contains "$stderr" "$diagnostic"
+}
+
+write_fixture() {
+  local path=$1 records=$2
+  printf '{"benchmarks":%s}\n' "$records" >"$path"
+}
+
+median() {
+  local name=$1 time=$2 unit=$3 throughput=$4
+  printf '{"run_name":"%s","run_type":"aggregate","aggregate_name":"median","real_time":%s,"time_unit":"%s","throughput(MB/s)":%s}' \
+    "$name" "$time" "$unit" "$throughput"
+}
+
+cv() {
+  local name=$1 value=$2
+  printf '{"run_name":"%s","run_type":"aggregate","aggregate_name":"cv","real_time":%s,"time_unit":"ms"}' \
+    "$name" "$value"
+}
+
+sync_parquet='NIGHTLY_CI_TARGET/Sync/RecordBatchRead/Parquet/SyntheticSmall'
+sync_vortex='NIGHTLY_CI_TARGET/Sync/RecordBatchRead/Vortex/SyntheticSmall/repeats:4'
+sync_lance='NIGHTLY_CI_TARGET/Sync/RecordBatchRead/Lance/SyntheticSmall'
+async_parquet='NIGHTLY_CI_TARGET/Async/ChunkRead/Parquet/SyntheticSmall'
+async_vortex='NIGHTLY_CI_TARGET/Async/ChunkRead/Vortex/SyntheticSmall'
+
+success_records="[$(median "$sync_parquet" 1000000 ns 100),$(cv "$sync_parquet" 0.02),$(median "$sync_vortex" 500 us 200),$(cv "$sync_vortex" 0.11),$(median "$sync_lance" 2 ms 50),$(cv "$sync_lance" 0.01),$(median "$async_parquet" 1 s 10),$(cv "$async_parquet" 0.03),$(median "$async_vortex" 250 ms 40),$(cv "$async_vortex" 0.04)]"
+success_fixture="$temp_dir/success.json"
+write_fixture "$success_fixture" "$success_records"
+
+# A missing renderer must make this real invocation fail, proving RED before implementation.
+if [[ ! -e $renderer ]]; then
+  if render "$success_fixture"; then
+    printf 'missing renderer unexpectedly rendered output\n' >&2
+    exit 1
+  fi
+  exit 1
+fi
+
+output="$(render "$success_fixture")"
+assert_contains "$output" '## C++ Nightly Reader Benchmark'
+assert_contains "$output" 'Cases: 5 completed / 5 expected'
+assert_contains "$output" '### Sync comparison'
+assert_contains "$output" '### Async comparison'
+assert_contains "$output" '### Case details'
+assert_contains "$output" 'Executor threads: `3`'
+assert_contains "$output" '2.000x'
+assert_contains "$output" 'WARN'
+sync_section=${output#*'### Sync comparison'}
+sync_section=${sync_section%%'### Async comparison'*}
+assert_contains "$sync_section" '| Dataset | Operation | Parquet | Vortex | Lance |'
+async_section=${output#*'### Async comparison'}
+async_section=${async_section%%'### Case details'*}
+assert_contains "$async_section" '| Dataset | Operation | Parquet | Vortex |'
+[[ $async_section != *'Lance'* ]] || {
+  printf 'Async comparison must not contain a Lance column\n%s\n' "$async_section" >&2
+  exit 1
+}
+validate "$success_fixture" 5
+
+malformed_fixture="$temp_dir/malformed.json"
+write_fixture "$malformed_fixture" "[$(median 'not/a/nightly/target' 1 ms 1),$(cv 'not/a/nightly/target' 0.01)]"
+
+missing_median_fixture="$temp_dir/missing-median.json"
+write_fixture "$missing_median_fixture" "[$(cv "$sync_parquet" 0.01)]"
+
+duplicate_median_fixture="$temp_dir/duplicate-median.json"
+write_fixture "$duplicate_median_fixture" "[$(median "$sync_parquet" 1 ms 1),$(median "$sync_parquet" 2 ms 1),$(cv "$sync_parquet" 0.01)]"
+
+error_fixture="$temp_dir/error.json"
+write_fixture "$error_fixture" "[$(median "$sync_parquet" 1 ms 1),$(cv "$sync_parquet" 0.01),{\"run_name\":\"$sync_parquet\",\"error_occurred\":true,\"error_message\":\"read failed|retry\"}]"
+
+missing_field_fixture="$temp_dir/missing-field.json"
+write_fixture "$missing_field_fixture" "[{\"run_name\":\"$sync_parquet\",\"run_type\":\"aggregate\",\"aggregate_name\":\"median\",\"time_unit\":\"ns\"},$(cv "$sync_parquet" 0.01)]"
+
+async_recordbatch_fixture="$temp_dir/async-recordbatch.json"
+async_recordbatch='NIGHTLY_CI_TARGET/Async/RecordBatchRead/Parquet/SyntheticSmall'
+write_fixture "$async_recordbatch_fixture" "[$(median "$async_recordbatch" 1 ms 1),$(cv "$async_recordbatch" 0.01)]"
+
+async_lance_fixture="$temp_dir/async-lance.json"
+async_lance='NIGHTLY_CI_TARGET/Async/ChunkRead/Lance/SyntheticSmall'
+write_fixture "$async_lance_fixture" "[$(median "$async_lance" 1 ms 1),$(cv "$async_lance" 0.01)]"
+
+split_raw_suffix_fixture="$temp_dir/split-raw-suffix.json"
+split_median='NIGHTLY_CI_TARGET/Sync/RecordBatchRead/Parquet/SyntheticSmall/repeats:4'
+split_cv='NIGHTLY_CI_TARGET/Sync/RecordBatchRead/Parquet/SyntheticSmall/repeats:5'
+write_fixture "$split_raw_suffix_fixture" "[$(median "$split_median" 1 ms 1),$(cv "$split_cv" 0.01)]"
+
+duplicate_raw_suffix_fixture="$temp_dir/duplicate-raw-suffix.json"
+write_fixture "$duplicate_raw_suffix_fixture" "[$(median "$split_median" 1 ms 1),$(cv "$split_median" 0.01),$(median "$split_cv" 2 ms 1),$(cv "$split_cv" 0.02)]"
+
+wrong_run_type_fixture="$temp_dir/wrong-run-type.json"
+write_fixture "$wrong_run_type_fixture" "[{\"run_name\":\"$sync_parquet\",\"run_type\":\"iteration\",\"aggregate_name\":\"median\",\"real_time\":1,\"time_unit\":\"ms\"},{\"run_name\":\"$sync_parquet\",\"run_type\":\"iteration\",\"aggregate_name\":\"cv\",\"real_time\":0.01,\"time_unit\":\"ms\"}]"
+
+for fixture in "$malformed_fixture" "$missing_median_fixture" "$duplicate_median_fixture" "$error_fixture" "$missing_field_fixture" "$async_recordbatch_fixture" "$async_lance_fixture" "$split_raw_suffix_fixture" "$duplicate_raw_suffix_fixture" "$wrong_run_type_fixture"; do
+  assert_contains "$(render "$fixture")" '### Benchmark errors'
+done
+
+error_output="$(render "$error_fixture")"
+assert_contains "$error_output" 'read failed\|retry'
+[[ $error_output != *'read failed\\|retry'* ]] || {
+  printf 'Markdown pipe escape must use one backslash\n' >&2
+  exit 1
+}
+
+assert_contains "$(render "$missing_median_fixture" 1)" 'Cases: 0 completed / 1 expected'
+assert_contains "$(render "$error_fixture" 1)" 'Cases: 0 completed / 1 expected'
+
+assert_validate_fails "$success_fixture" invalid 'expected_count is not a number'
+assert_validate_fails "$malformed_fixture" 0 'malformed target name'
+assert_validate_fails "$missing_median_fixture" 1 'expected exactly one median'
+assert_validate_fails "$duplicate_median_fixture" 1 'expected exactly one median'
+assert_validate_fails "$error_fixture" 1 'benchmark error'
+assert_validate_fails "$missing_field_fixture" 1 'unsupported or missing time unit'
+assert_validate_fails "$async_recordbatch_fixture" 1 'unapproved semantic target: Async/RecordBatchRead/Parquet/SyntheticSmall'
+assert_validate_fails "$async_lance_fixture" 1 'unapproved semantic target: Async/ChunkRead/Lance/SyntheticSmall'
+assert_validate_fails "$split_raw_suffix_fixture" 1 "expected exactly one real-time CV for raw run $split_median"
+assert_validate_fails "$duplicate_raw_suffix_fixture" 1 'multiple raw runs map to semantic target Sync/RecordBatchRead/Parquet/SyntheticSmall'
+assert_validate_fails "$wrong_run_type_fixture" 0 'median/CV-shaped record must use run_type aggregate'
+assert_validate_fails "$success_fixture" 4 'expected 4 unique semantic targets, found 5'
+
+printf 'nightly summary renderer tests passed\n'

--- a/cpp/scripts/minio_env.sh
+++ b/cpp/scripts/minio_env.sh
@@ -1,6 +1,6 @@
 export TEST_ENV_STORAGE_TYPE="remote"
 export TEST_ENV_CLOUD_PROVIDER="aws"
-export TEST_ENV_ADDRESS="http://localhost:9000"
+export TEST_ENV_ADDRESS="http://127.0.0.1:9000"
 export TEST_ENV_BUCKET_NAME="test-bucket"
 export TEST_ENV_ACCESS_KEY="minioadmin"
 export TEST_ENV_SECRET_KEY="minioadmin"

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -16,7 +16,14 @@ file(GLOB_RECURSE BUSTUB_TEST_SOURCES "${PROJECT_SOURCE_DIR}/test/*.cpp")
 
 add_executable(milvus_test ${BUSTUB_TEST_SOURCES})
 
-target_include_directories(milvus_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_sources(milvus_test PRIVATE
+  ${PROJECT_SOURCE_DIR}/benchmark/benchmark_data_loader.cpp
+)
+
+target_include_directories(milvus_test PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/benchmark
+)
 
 set_target_properties(milvus_test PROPERTIES
   CXX_STANDARD 20

--- a/cpp/test/benchmark_data_loader_test.cpp
+++ b/cpp/test/benchmark_data_loader_test.cpp
@@ -1,0 +1,126 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark_data_loader.h"
+#include "test_env.h"
+
+#include <gtest/gtest.h>
+
+namespace milvus_storage::benchmark {
+
+TEST(ReaderBenchmarkDataLoaderTest, DefinesApprovedDatasetMatrix) {
+  struct Expected {
+    ReaderBenchmarkDataset dataset;
+    int64_t rows;
+    std::vector<std::string> fields;
+    std::string_view name;
+  };
+  const std::vector<Expected> expected = {
+      {ReaderBenchmarkDataset::kSyntheticSmall, 4096, {"id", "name", "value", "vector"}, "SyntheticSmall"},
+      {ReaderBenchmarkDataset::kSyntheticMedium, 40960, {"id", "name", "value", "vector"}, "SyntheticMedium"},
+      {ReaderBenchmarkDataset::kSyntheticLarge, 409600, {"id", "name", "value", "vector"}, "SyntheticLarge"},
+      {ReaderBenchmarkDataset::kScalarMedium, 40960, {"id", "name", "value"}, "ScalarMedium"},
+      {ReaderBenchmarkDataset::kRandomVector64MiB, 65536, {"vector"}, "RandomVector64MiB"},
+      {ReaderBenchmarkDataset::kLowEntropyVector256MiB, 262144, {"vector"}, "LowEntropyVector256MiB"},
+      {ReaderBenchmarkDataset::kRandomVector2GiB, 2097152, {"vector"}, "RandomVector2GiB"},
+  };
+  for (const auto& item : expected) {
+    ASSERT_AND_ASSIGN(auto loader, CreateReaderBenchmarkDataLoader(item.dataset));
+    ASSERT_STATUS_OK(loader->Load());
+    EXPECT_EQ(loader->NumRows(), item.rows);
+    ASSERT_EQ(loader->GetSchema()->num_fields(), static_cast<int>(item.fields.size()));
+    for (int i = 0; i < loader->GetSchema()->num_fields(); ++i) {
+      EXPECT_EQ(loader->GetSchema()->field(i)->name(), item.fields[i]);
+    }
+    EXPECT_EQ(ReaderBenchmarkDatasetName(item.dataset), item.name);
+  }
+}
+
+TEST(ReaderBenchmarkDataLoaderTest, StreamsTwoGiBInBoundedBatches) {
+  ASSERT_AND_ASSIGN(auto loader, CreateReaderBenchmarkDataLoader(ReaderBenchmarkDataset::kRandomVector2GiB));
+  ASSERT_STATUS_OK(loader->Load());
+  EXPECT_EQ(loader->GetTable(), nullptr);
+  ASSERT_AND_ASSIGN(auto reader, loader->GetRecordBatchReader());
+  std::shared_ptr<arrow::RecordBatch> first;
+  ASSERT_STATUS_OK(reader->ReadNext(&first));
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(first->column(0)->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+  EXPECT_LT(first->num_rows(), loader->NumRows());
+  EXPECT_LE(first->num_rows() * 256 * static_cast<int64_t>(sizeof(float)), 64LL * 1024 * 1024);
+}
+
+TEST(ReaderBenchmarkDataLoaderTest, FreshReadersRepeatMultipleBoundedBatches) {
+  auto loader = CreateStreamingSyntheticDataLoader(
+      {10, 8, 0, 4, true, {false, false, false, true}, VectorLayout::kFixedSizeBinary, "multi-batch"});
+  ASSERT_STATUS_OK(loader->Load());
+  EXPECT_EQ(loader->GetTable(), nullptr);
+  ASSERT_AND_ASSIGN(auto left_reader, loader->GetRecordBatchReader());
+  ASSERT_AND_ASSIGN(auto right_reader, loader->GetRecordBatchReader());
+
+  std::shared_ptr<arrow::RecordBatch> previous_left_batch;
+  for (int batch_index = 0; batch_index < 2; ++batch_index) {
+    std::shared_ptr<arrow::RecordBatch> left_batch;
+    std::shared_ptr<arrow::RecordBatch> right_batch;
+    ASSERT_STATUS_OK(left_reader->ReadNext(&left_batch));
+    ASSERT_STATUS_OK(right_reader->ReadNext(&right_batch));
+    ASSERT_NE(left_batch, nullptr);
+    ASSERT_NE(right_batch, nullptr);
+    EXPECT_EQ(left_batch->num_rows(), 4);
+    EXPECT_LE(left_batch->num_rows() * 8 * static_cast<int64_t>(sizeof(float)),
+              4 * 8 * static_cast<int64_t>(sizeof(float)));
+    EXPECT_TRUE(left_batch->Equals(*right_batch));
+    if (previous_left_batch) {
+      EXPECT_FALSE(left_batch->Equals(*previous_left_batch));
+    }
+    previous_left_batch = std::move(left_batch);
+  }
+}
+
+TEST(ReaderBenchmarkDataLoaderTest, PreservesCrtStringPayloads) {
+  auto random_loader = CreateStreamingSyntheticDataLoader({40960,
+                                                           128,
+                                                           128,
+                                                           40960,
+                                                           true,
+                                                           {true, true, true, true},
+                                                           VectorLayout::kFixedSizeBinary,
+                                                           "synthetic/40960rows/128dim"});
+  ASSERT_STATUS_OK(random_loader->Load());
+  ASSERT_AND_ASSIGN(auto random_reader, random_loader->GetRecordBatchReader());
+  std::shared_ptr<arrow::RecordBatch> random_batch;
+  ASSERT_STATUS_OK(random_reader->ReadNext(&random_batch));
+  ASSERT_NE(random_batch, nullptr);
+  const auto random_names = std::static_pointer_cast<arrow::StringArray>(random_batch->GetColumnByName("name"));
+  ASSERT_NE(random_names, nullptr);
+  EXPECT_EQ(random_names->GetString(0),
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+            "abcdefghijklmnopqrstuvwx");
+  EXPECT_EQ(random_names->GetString(1),
+            "bcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+            "abcdefghijklmnopqrstuvwxy");
+
+  auto sequential_loader = CreateStreamingSyntheticDataLoader(
+      {2, 0, 128, 2, false, {false, true, false, false}, VectorLayout::kFixedSizeBinary, "sequential"});
+  ASSERT_STATUS_OK(sequential_loader->Load());
+  ASSERT_AND_ASSIGN(auto sequential_reader, sequential_loader->GetRecordBatchReader());
+  std::shared_ptr<arrow::RecordBatch> sequential_batch;
+  ASSERT_STATUS_OK(sequential_reader->ReadNext(&sequential_batch));
+  ASSERT_NE(sequential_batch, nullptr);
+  const auto sequential_names = std::static_pointer_cast<arrow::StringArray>(sequential_batch->GetColumnByName("name"));
+  ASSERT_NE(sequential_names, nullptr);
+  EXPECT_EQ(sequential_names->GetString(0), "name_0");
+  EXPECT_EQ(sequential_names->GetString(1), "name_1");
+}
+
+}  // namespace milvus_storage::benchmark

--- a/cpp/test/format/iceberg/iceberg_bridge_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_bridge_test.cpp
@@ -196,7 +196,7 @@ class AsyncReaderLifecycleState {
 };
 
 class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
-                                             public milvus_storage::NonBlockingReadAtFile {
+                                             public milvus_storage::NonBlockingRandomAccessFile {
   public:
   CallbackThreadRandomAccessFile(std::shared_ptr<arrow::io::RandomAccessFile> file,
                                  std::shared_ptr<AsyncReaderLifecycleState> state)
@@ -228,6 +228,7 @@ class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
   }
   arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
   arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
+  arrow::Future<int64_t> GetSizeAsync() override { return arrow::Future<int64_t>::MakeFinished(file_->GetSize()); }
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     return file_->ReadAt(position, nbytes, out);
   }

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -294,7 +294,7 @@ class AsyncReaderLifecycleState {
 };
 
 class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
-                                             public milvus_storage::NonBlockingReadAtFile {
+                                             public milvus_storage::NonBlockingRandomAccessFile {
   public:
   CallbackThreadRandomAccessFile(std::shared_ptr<arrow::io::RandomAccessFile> file,
                                  std::shared_ptr<AsyncReaderLifecycleState> state)
@@ -326,6 +326,7 @@ class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
   }
   arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
   arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
+  arrow::Future<int64_t> GetSizeAsync() override { return arrow::Future<int64_t>::MakeFinished(file_->GetSize()); }
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     return file_->ReadAt(position, nbytes, out);
   }


### PR DESCRIPTION
Run representative C++ benchmarks against a local MinIO server on a daily schedule or manual dispatch, reusing shared C++ test and MinIO setup actions and publishing a summary table.