### PR TITLE
fix:[3.0] reuse Lance datasets across fragments

### DIFF
--- a/cpp/include/milvus-storage/format/lance/lance_table_reader.h
+++ b/cpp/include/milvus-storage/format/lance/lance_table_reader.h
@@ -41,15 +41,17 @@ class LanceTableReader final : public FormatReader, public std::enable_shared_fr
                    const std::vector<std::string>& needed_columns = {});
 
   struct MetaTrait {
+    // One outer Metadata entry represents a Lance Dataset and is keyed by its
+    // base URI. Fragment-specific immutable metadata is cached inside Payload.
+    struct FragmentMetadata;
+    class FragmentMetadataCache;
+
     struct Payload {
       std::string base_uri;
-      uint64_t fragment_id = 0;
       std::shared_ptr<BlockingDataset> dataset;
-      uint64_t logical_row_count = 0;
-      uint64_t physical_row_count = 0;
-      uint64_t num_deletions = 0;
-      uint64_t logical_chunk_rows = 0;
-      std::shared_ptr<const std::vector<uint64_t>> column_memory_weights;
+      // BlockingFragmentReader is intentionally not cached here because it is
+      // projection-specific and stateful.
+      std::shared_ptr<FragmentMetadataCache> fragment_metadata_cache;
       milvus_storage::api::Properties properties;
     };
 

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -15,10 +15,13 @@
 #include "milvus-storage/format/lance/lance_table_reader.h"
 
 #include <algorithm>
+#include <condition_variable>
 #include <exception>
 #include <iostream>
 #include <limits>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include <arrow/chunked_array.h>  // keep this line before other arrow header
@@ -37,6 +40,139 @@
 #include "milvus-storage/format/lance/lance_common.h"
 
 namespace milvus_storage::lance {
+
+// Lance metadata follows the Dataset/fragment hierarchy:
+//
+//   FormatReaderMetadataCache (key: base URI)
+//     base URI -> Metadata -> Payload -> BlockingDataset
+//
+//   Payload::FragmentMetadataCache (key: fragment ID)
+//     fragment_id=0 -> FragmentMetadata[0]
+//     fragment_id=1 -> FragmentMetadata[1]
+//
+// Their ownership relationship is:
+//
+//   ReaderImpl
+//     `-- MetadataCache
+//           `-- FormatReaderMetadataCache<LanceTableReader>
+//                 `-- base URI -> Metadata -> Payload
+//                                      +-- BlockingDataset
+//                                      `-- FragmentMetadataCache
+//                                            +-- fragment ID 0 -> FragmentMetadata[0]
+//                                            `-- fragment ID 1 -> FragmentMetadata[1]
+//
+// The outer metadata entry therefore follows the top-level reader lifetime, so
+// different fragments share one Dataset without process-global state.
+// FragmentMetadata contains only immutable fragment-specific schema, row-group,
+// deletion, and memory-estimation data. BlockingFragmentReader remains
+// projection-specific and is created independently for every LanceTableReader.
+//
+// Opening a fragment creates a shallow Rust Dataset clone:
+//
+//   C++ BlockingDataset::inner (Rust Dataset)
+//     `-- manifest: Arc ----------------------------+
+//   FileFragment[0] -> Arc<Dataset clone>           |
+//     `-- manifest: Arc ----------------------------+--> one Manifest allocation
+//   FileFragment[1] -> Arc<Dataset clone>           |
+//     `-- manifest: Arc ----------------------------+
+//
+// The cloned Dataset structs keep fragment readers alive independently, while
+// their Arc-backed ObjectStore, Session, caches, and Manifest remain shared.
+struct LanceTableReader::MetaTrait::FragmentMetadata {
+  std::shared_ptr<arrow::Schema> file_schema;
+  std::vector<RowGroupInfo> row_group_infos;
+  uint64_t num_deletions = 0;
+  uint64_t logical_chunk_rows = 0;
+  std::shared_ptr<const std::vector<uint64_t>> column_memory_weights;
+};
+
+class LanceTableReader::MetaTrait::FragmentMetadataCache final {
+  public:
+  using FragmentMetadataPtr = std::shared_ptr<const FragmentMetadata>;
+
+  template <typename FragmentMetadataLoader>
+  arrow::Result<FragmentMetadataPtr> get_or_load(uint64_t fragment_id, FragmentMetadataLoader&& load_fn) {
+    std::shared_ptr<InFlightLoad> in_flight_load;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      auto cached = fragments_.find(fragment_id);
+      if (cached != fragments_.end()) {
+        return cached->second;
+      }
+
+      auto [it, inserted] = in_flight_loads_.try_emplace(fragment_id, std::make_shared<InFlightLoad>());
+      in_flight_load = it->second;
+      if (!inserted) {
+        in_flight_load->cv.wait(lock, [&in_flight_load]() { return in_flight_load->done; });
+        if (!in_flight_load->status.ok()) {
+          return in_flight_load->status;
+        }
+        return in_flight_load->metadata;
+      }
+    }
+
+    auto status = arrow::Status::OK();
+    FragmentMetadataPtr metadata;
+    try {
+      auto load_result = load_fn();
+      status = load_result.status();
+      if (load_result.ok()) {
+        metadata = std::move(load_result).ValueOrDie();
+        if (!metadata) {
+          status =
+              arrow::Status::Invalid("Lance fragment metadata loader returned null for fragment ID: ", fragment_id);
+        }
+      }
+    } catch (const std::exception& e) {
+      status = arrow::Status::UnknownError("Exception while loading Lance fragment metadata for fragment ID ",
+                                           fragment_id, ": ", e.what());
+    } catch (...) {
+      status = arrow::Status::UnknownError("Unknown exception while loading Lance fragment metadata for fragment ID: ",
+                                           fragment_id);
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (status.ok()) {
+        try {
+          auto [it, inserted] = fragments_.try_emplace(fragment_id, metadata);
+          if (!inserted) {
+            metadata = it->second;
+          }
+        } catch (...) {
+          // Publication is best effort. The loaded metadata must still be
+          // delivered to every waiter so the in-flight operation can finish.
+        }
+      }
+      in_flight_load->status = status;
+      in_flight_load->metadata = metadata;
+      in_flight_load->done = true;
+
+      auto in_flight_it = in_flight_loads_.find(fragment_id);
+      if (in_flight_it != in_flight_loads_.end() && in_flight_it->second == in_flight_load) {
+        in_flight_loads_.erase(in_flight_it);
+      }
+    }
+    in_flight_load->cv.notify_all();
+
+    if (!status.ok()) {
+      return status;
+    }
+    return metadata;
+  }
+
+  private:
+  struct InFlightLoad {
+    bool done = false;
+    arrow::Status status = arrow::Status::OK();
+    FragmentMetadataPtr metadata;
+    std::condition_variable cv;
+  };
+
+  std::mutex mutex_;
+  std::unordered_map<uint64_t, FragmentMetadataPtr> fragments_;
+  std::unordered_map<uint64_t, std::shared_ptr<InFlightLoad>> in_flight_loads_;
+};
 
 LanceTableReader::LanceTableReader(const std::shared_ptr<BlockingDataset>& dataset,
                                    uint64_t fragment_id,
@@ -154,36 +290,21 @@ static arrow::Result<std::shared_ptr<arrow::Schema>> build_read_schema(
 }
 
 std::string LanceTableReader::MetaTrait::cache_key(const milvus_storage::api::ColumnGroupFile& file) {
-  auto cache_key = fmt::format("lance-table|path:{}|file_size:{}|footer_size:{}", file.path,
-                               file.Get<uint64_t>(milvus_storage::api::kPropertyFileSize),
-                               file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize));
-  auto metadata_it = file.properties.find(milvus_storage::api::kPropertyMetadata);
-  if (metadata_it != file.properties.end()) {
-    cache_key += "|metadata:" + metadata_it->second;
+  auto parsed_uri = ParseLanceUri(file.path);
+  if (!parsed_uri.ok()) {
+    // load_metadata() will return the detailed URI error. Keep malformed URIs
+    // distinct here so cache lookup itself remains infallible.
+    LOG_STORAGE_WARNING_ << "Failed to parse Lance URI while building metadata cache key"
+                         << ", path=" << file.path << ", status=" << parsed_uri.status().ToString();
+    return fmt::format("lance-table|invalid-uri:{}", file.path);
   }
-  return cache_key;
+  return fmt::format("lance-table|base-uri:{}", parsed_uri->first);
 }
 
-arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTrait::load_metadata(
-    const milvus_storage::api::ColumnGroupFile& file,
+static arrow::Result<std::shared_ptr<const LanceTableReader::MetaTrait::FragmentMetadata>> load_fragment_metadata(
+    uint64_t fragment_id,
     const milvus_storage::api::Properties& properties,
-    const KeyRetriever& key_retriever) {
-  (void)key_retriever;
-
-  ARROW_ASSIGN_OR_RAISE(auto parsed_uri, ParseLanceUri(file.path));
-  auto base_uri = std::move(parsed_uri.first);
-  auto fragment_id = parsed_uri.second;
-
-  ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, base_uri));
-  auto lance_uri = ToStandardLanceUri(base_uri);
-
-  std::shared_ptr<BlockingDataset> dataset;
-  try {
-    dataset = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config));
-  } catch (const std::exception& e) {
-    return arrow::Status::IOError("Failed to open Lance dataset for metadata: ", e.what());
-  }
-
+    const std::shared_ptr<BlockingDataset>& dataset) {
   std::shared_ptr<arrow::Schema> file_schema;
   {
     ArrowSchema c_fragment_schema;
@@ -229,26 +350,56 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
       auto row_group_infos,
       create_row_group_infos(logical_rows, logical_chunk_rows, fragment_column_memory_sizes, memory_size_available));
 
+  auto fragment_metadata = std::make_shared<LanceTableReader::MetaTrait::FragmentMetadata>();
+  fragment_metadata->file_schema = std::move(file_schema);
+  fragment_metadata->row_group_infos = std::move(row_group_infos);
+  fragment_metadata->num_deletions = physical_rows - logical_rows;
+  fragment_metadata->logical_chunk_rows = logical_chunk_rows;
+  fragment_metadata->column_memory_weights =
+      memory_size_available ? std::make_shared<const std::vector<uint64_t>>(std::move(fragment_column_memory_sizes))
+                            : nullptr;
+
+  std::shared_ptr<const LanceTableReader::MetaTrait::FragmentMetadata> result = fragment_metadata;
+  return result;
+}
+
+arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTrait::load_metadata(
+    const milvus_storage::api::ColumnGroupFile& file,
+    const milvus_storage::api::Properties& properties,
+    const KeyRetriever& key_retriever) {
+  (void)key_retriever;
+
+  ARROW_ASSIGN_OR_RAISE(auto parsed_uri, ParseLanceUri(file.path));
+  auto base_uri = std::move(parsed_uri.first);
+  const auto fragment_id = parsed_uri.second;
+
+  ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, base_uri));
+  const auto lance_uri = ToStandardLanceUri(base_uri);
+
+  std::shared_ptr<BlockingDataset> dataset;
+  try {
+    dataset = BlockingDataset::Open(lance_uri, ToStorageOptions(fs_config));
+  } catch (const std::exception& e) {
+    return arrow::Status::IOError("Failed to open Lance dataset for metadata: ", e.what());
+  }
+
+  auto fragment_metadata_cache = std::make_shared<FragmentMetadataCache>();
+  ARROW_ASSIGN_OR_RAISE(auto fragment_metadata, fragment_metadata_cache->get_or_load(fragment_id, [&]() {
+    return load_fragment_metadata(fragment_id, properties, dataset);
+  }));
+
   auto metadata = std::make_shared<Metadata>();
   metadata->cache_key = cache_key(file);
-  metadata->path = file.path;
-  metadata->file_schema = std::move(file_schema);
-  metadata->row_group_infos = std::move(row_group_infos);
-  const auto column_memory_sizes_size = fragment_column_memory_sizes.size() * sizeof(uint64_t);
-  auto outer_metadata_size =
-      sizeof(Metadata) + metadata->row_group_infos.size() * sizeof(RowGroupInfo) + column_memory_sizes_size;
-  metadata->cache_size = outer_metadata_size + file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize);
+  metadata->path = base_uri;
+  // FileFragment::schema() is the current Dataset schema in Lance 7, so it is
+  // valid at the Dataset-level outer metadata. Fragment row groups live only
+  // in FragmentMetadata and are selected by create_from_metadata().
+  metadata->file_schema = fragment_metadata->file_schema;
+  metadata->cache_size = sizeof(Metadata);
   metadata->payload = Payload{
       .base_uri = std::move(base_uri),
-      .fragment_id = fragment_id,
       .dataset = std::move(dataset),
-      .logical_row_count = logical_rows,
-      .physical_row_count = physical_rows,
-      .num_deletions = physical_rows - logical_rows,
-      .logical_chunk_rows = logical_chunk_rows,
-      .column_memory_weights =
-          memory_size_available ? std::make_shared<const std::vector<uint64_t>>(std::move(fragment_column_memory_sizes))
-                                : nullptr,
+      .fragment_metadata_cache = std::move(fragment_metadata_cache),
       .properties = properties,
   };
 
@@ -262,37 +413,47 @@ arrow::Result<std::shared_ptr<LanceTableReader>> LanceTableReader::MetaTrait::cr
     const std::shared_ptr<arrow::Schema>& read_schema,
     const std::vector<std::string>& needed_columns,
     const std::string& predicate) {
-  (void)file;
   (void)predicate;
   if (!metadata) {
     return arrow::Status::Invalid("Cannot open Lance reader from null metadata");
   }
-  if (!metadata->payload.dataset) {
-    return arrow::Status::Invalid("Cannot open Lance reader from metadata with null dataset");
+  if (!metadata->payload.dataset || !metadata->payload.fragment_metadata_cache) {
+    return arrow::Status::Invalid("Cannot open Lance reader from incomplete metadata");
   }
 
-  auto reader = std::make_shared<LanceTableReader>(metadata->payload.dataset, metadata->payload.fragment_id,
-                                                   read_schema, metadata->payload.properties, needed_columns);
+  ARROW_ASSIGN_OR_RAISE(auto parsed_uri, ParseLanceUri(file.path));
+  const auto& base_uri = parsed_uri.first;
+  const auto fragment_id = parsed_uri.second;
+  if (base_uri != metadata->payload.base_uri) {
+    return arrow::Status::Invalid("Lance metadata base URI does not match file URI: ", metadata->payload.base_uri,
+                                  " != ", base_uri);
+  }
+
+  ARROW_ASSIGN_OR_RAISE(
+      auto fragment_metadata, metadata->payload.fragment_metadata_cache->get_or_load(fragment_id, [&]() {
+        return load_fragment_metadata(fragment_id, metadata->payload.properties, metadata->payload.dataset);
+      }));
+
+  auto reader = std::make_shared<LanceTableReader>(metadata->payload.dataset, fragment_id, read_schema,
+                                                   metadata->payload.properties, needed_columns);
   reader->uri_ = metadata->payload.base_uri;
-  reader->file_schema_ = metadata->file_schema;
-  reader->logical_chunk_rows_ = metadata->payload.logical_chunk_rows;
-  reader->num_deletions_ = metadata->payload.num_deletions;
-  reader->column_memory_weights_ = metadata->payload.column_memory_weights;
-  reader->row_group_infos_ = metadata->row_group_infos;
+  reader->file_schema_ = fragment_metadata->file_schema;
+  reader->logical_chunk_rows_ = fragment_metadata->logical_chunk_rows;
+  reader->num_deletions_ = fragment_metadata->num_deletions;
+  reader->column_memory_weights_ = fragment_metadata->column_memory_weights;
+  reader->row_group_infos_ = fragment_metadata->row_group_infos;
 
   ARROW_ASSIGN_OR_RAISE(auto requested_schema, build_read_schema(reader->file_schema_, read_schema, needed_columns));
   ArrowSchema c_arrow_schema;
   ARROW_RETURN_NOT_OK(arrow::ExportSchema(*requested_schema, &c_arrow_schema));
 
   try {
-    reader->fragment_reader_ =
-        BlockingFragmentReader::Open(*metadata->payload.dataset, metadata->payload.fragment_id, c_arrow_schema);
+    reader->fragment_reader_ = BlockingFragmentReader::Open(*metadata->payload.dataset, fragment_id, c_arrow_schema);
   } catch (const LanceException& e) {
     if (c_arrow_schema.release) {
       c_arrow_schema.release(&c_arrow_schema);
     }
-    return arrow::Status::IOError("Failed to open Lance fragment reader for fragment ", metadata->payload.fragment_id,
-                                  ": ", e.what());
+    return arrow::Status::IOError("Failed to open Lance fragment reader for fragment ", fragment_id, ": ", e.what());
   }
 
   return reader;

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -50,6 +50,7 @@
 #include "milvus-storage/common/lrucache.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/lance/lance_table_writer.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/lance/lance_common.h"
@@ -296,6 +297,179 @@ TEST_F(LanceBasicTest, DefaultStorageVersionIsV2_1) {
   ASSERT_AND_ASSIGN(auto storage_version, ReadLanceDataFileVersion());
   ASSERT_EQ(storage_version.major, 2);
   ASSERT_EQ(storage_version.minor, 1);
+}
+
+TEST_F(LanceBasicTest, InvalidUriCacheKeyDoesNotCollideWithBaseUri) {
+  api::ColumnGroupFile invalid_file{.path = base_path_, .start_index = 0, .end_index = 1};
+  auto valid_file = invalid_file;
+  valid_file.path = MakeLanceUri(base_path_, 0);
+
+  EXPECT_NE(LanceTableReader::MetaTrait::cache_key(invalid_file), LanceTableReader::MetaTrait::cache_key(valid_file));
+}
+
+TEST_F(LanceBasicTest, DifferentFragmentsShareDatasetMetadata) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Focused metadata-cache reproduction uses the local Lance fixture.";
+  }
+
+  LanceTableWriter first_writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(first_writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto first_file, first_writer.Close());
+
+  LanceTableWriter second_writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(second_writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto second_file, second_writer.Close());
+  ASSERT_NE(first_file.path, second_file.path);
+
+  const std::vector<api::ColumnGroupFile> files = {std::move(first_file), std::move(second_file)};
+  auto cache = FormatReaderMetadataCache<LanceTableReader>::Make();
+  size_t metadata_load_count = 0;
+  std::vector<LanceTableReader::MetaTrait::MetadataPtr> loaded_metadata;
+  std::vector<std::shared_ptr<LanceTableReader>> readers;
+  loaded_metadata.reserve(files.size());
+  readers.reserve(files.size());
+
+  ASSERT_EQ(LanceTableReader::MetaTrait::cache_key(files[0]), LanceTableReader::MetaTrait::cache_key(files[1]));
+
+  for (size_t i = 0; i < files.size(); ++i) {
+    const auto key = LanceTableReader::MetaTrait::cache_key(files[i]);
+    std::cout << "[ LANCE_METADATA_CACHE_KEY ] key=" << key << std::endl;
+    ASSERT_AND_ASSIGN(
+        auto metadata, cache->get_or_open(key, [&]() -> arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> {
+          ++metadata_load_count;
+          std::cout << "[ LANCE_METADATA_CACHE_MISS ] key=" << key << std::endl;
+          return LanceTableReader::MetaTrait::load_metadata(files[i], properties_, nullptr /* key_retriever */);
+        }));
+    ASSERT_AND_ASSIGN(auto parsed_uri, ParseLanceUri(files[i].path));
+    std::cout << "[ LANCE_DATASET ] fragment_id=" << parsed_uri.second
+              << ", dataset=" << metadata->payload.dataset.get() << std::endl;
+    ASSERT_AND_ASSIGN(auto reader, LanceTableReader::MetaTrait::create_from_metadata(metadata, files[i], schema_,
+                                                                                     std::vector<std::string>{}, ""));
+    ASSERT_AND_ASSIGN(auto row_group_infos, reader->get_row_group_infos());
+    ASSERT_FALSE(row_group_infos.empty());
+    loaded_metadata.emplace_back(metadata);
+    readers.emplace_back(std::move(reader));
+  }
+
+  ASSERT_EQ(loaded_metadata.size(), 2);
+  EXPECT_EQ(metadata_load_count, 1);
+  EXPECT_EQ(loaded_metadata[0].get(), loaded_metadata[1].get());
+  EXPECT_EQ(loaded_metadata[0]->payload.dataset.get(), loaded_metadata[1]->payload.dataset.get());
+  EXPECT_TRUE(loaded_metadata[0]->row_group_infos.empty());
+  EXPECT_NE(readers[0].get(), readers[1].get());
+
+  std::weak_ptr<BlockingDataset> weak_dataset = loaded_metadata[0]->payload.dataset;
+  readers.clear();
+  loaded_metadata.clear();
+  cache.reset();
+  EXPECT_TRUE(weak_dataset.expired());
+}
+
+TEST_F(LanceBasicTest, DifferentBaseUrisDoNotShareDataset) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Focused dataset-cache test uses the local Lance fixture.";
+  }
+
+  LanceTableWriter first_writer(base_path_ + "/first", schema_, properties_);
+  ASSERT_STATUS_OK(first_writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto first_file, first_writer.Close());
+
+  LanceTableWriter second_writer(base_path_ + "/second", schema_, properties_);
+  ASSERT_STATUS_OK(second_writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto second_file, second_writer.Close());
+
+  ASSERT_AND_ASSIGN(auto first_uri, ParseLanceUri(first_file.path));
+  ASSERT_AND_ASSIGN(auto second_uri, ParseLanceUri(second_file.path));
+  ASSERT_NE(first_uri.first, second_uri.first);
+
+  ASSERT_AND_ASSIGN(auto first_metadata,
+                    LanceTableReader::MetaTrait::load_metadata(first_file, properties_, nullptr /* key_retriever */));
+  ASSERT_AND_ASSIGN(auto second_metadata,
+                    LanceTableReader::MetaTrait::load_metadata(second_file, properties_, nullptr /* key_retriever */));
+  EXPECT_NE(first_metadata->payload.dataset.get(), second_metadata->payload.dataset.get());
+}
+
+TEST_F(LanceBasicTest, SeparateTopLevelReaderCachesDoNotShareDataset) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Focused dataset-cache test uses the local Lance fixture.";
+  }
+
+  LanceTableWriter first_writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(first_writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto first_file, first_writer.Close());
+  const auto key = LanceTableReader::MetaTrait::cache_key(first_file);
+
+  // ReaderImpl owns one MetadataCache. Independent handles here model two
+  // top-level readers with independent Dataset metadata.
+  MetadataCache first_reader_cache;
+  ASSERT_AND_ASSIGN(auto first_metadata, first_reader_cache.get<LanceTableReader>()->get_or_open(key, [&]() {
+    return LanceTableReader::MetaTrait::load_metadata(first_file, properties_, nullptr /* key_retriever */);
+  }));
+
+  LanceTableWriter second_writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(second_writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto second_file, second_writer.Close());
+  ASSERT_EQ(key, LanceTableReader::MetaTrait::cache_key(second_file));
+
+  ASSERT_AND_ASSIGN(auto first_metadata_again, first_reader_cache.get<LanceTableReader>()->get_or_open(key, [&]() {
+    return LanceTableReader::MetaTrait::load_metadata(second_file, properties_, nullptr /* key_retriever */);
+  }));
+  ASSERT_EQ(first_metadata.get(), first_metadata_again.get());
+  auto stale_fragment_result = LanceTableReader::MetaTrait::create_from_metadata(
+      first_metadata_again, second_file, schema_, std::vector<std::string>{}, "");
+  EXPECT_FALSE(stale_fragment_result.ok());
+
+  MetadataCache second_reader_cache;
+  ASSERT_AND_ASSIGN(auto second_metadata, second_reader_cache.get<LanceTableReader>()->get_or_open(key, [&]() {
+    return LanceTableReader::MetaTrait::load_metadata(second_file, properties_, nullptr /* key_retriever */);
+  }));
+  ASSERT_AND_ASSIGN(auto second_reader, LanceTableReader::MetaTrait::create_from_metadata(
+                                            second_metadata, second_file, schema_, std::vector<std::string>{}, ""));
+
+  EXPECT_NE(first_metadata->payload.dataset.get(), second_metadata->payload.dataset.get());
+}
+
+TEST_F(LanceBasicTest, SameFragmentMetadataIsReusedWithinReaderCache) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Focused metadata-cache test uses the local Lance fixture.";
+  }
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto file, writer.Close());
+
+  MetadataCache reader_cache;
+  auto cache = reader_cache.get<LanceTableReader>();
+  const auto key = LanceTableReader::MetaTrait::cache_key(file);
+  size_t metadata_load_count = 0;
+  auto load_metadata = [&]() -> arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> {
+    ++metadata_load_count;
+    return LanceTableReader::MetaTrait::load_metadata(file, properties_, nullptr /* key_retriever */);
+  };
+
+  ASSERT_AND_ASSIGN(auto first_metadata, cache->get_or_open(key, load_metadata));
+  ASSERT_AND_ASSIGN(auto second_metadata, cache->get_or_open(key, load_metadata));
+  EXPECT_EQ(metadata_load_count, 1);
+  EXPECT_EQ(first_metadata.get(), second_metadata.get());
+
+#ifdef BUILD_WITH_FIU
+  // The fragment metadata was loaded before enabling this fault. Reconstructing
+  // readers from the same metadata must hit the inner cache without estimating
+  // fragment memory again.
+  ScopedFiuFault fault(FIUKEY_MEMORY_SIZE_ESTIMATION_FAIL, /*one_time=*/false);
+  ASSERT_EQ(fault.enable_result(), 0);
+#endif
+
+  ASSERT_AND_ASSIGN(auto first_reader, LanceTableReader::MetaTrait::create_from_metadata(
+                                           first_metadata, file, schema_, std::vector<std::string>{}, ""));
+  ASSERT_AND_ASSIGN(auto second_reader, LanceTableReader::MetaTrait::create_from_metadata(
+                                            second_metadata, file, schema_, std::vector<std::string>{}, ""));
+  EXPECT_NE(first_reader.get(), second_reader.get());
+
+  ASSERT_AND_ASSIGN(auto first_memory_sizes, first_reader->get_rg_column_memsz(0));
+  ASSERT_AND_ASSIGN(auto second_memory_sizes, second_reader->get_rg_column_memsz(0));
+  EXPECT_FALSE(first_memory_sizes.empty());
+  EXPECT_EQ(first_memory_sizes, second_memory_sizes);
 }
 
 TEST_F(LanceBasicTest, TestBasic) {
@@ -615,10 +789,11 @@ TEST_F(LanceBasicTest, MemorySizeEstimationFailureDoesNotBlockOpen) {
     ASSERT_AND_ASSIGN(metadata,
                       LanceTableReader::MetaTrait::load_metadata(cgfile, properties_, nullptr /* key_retriever */));
   }
-  assert_memory_size_unavailable(metadata->row_group_infos);
 
   ASSERT_AND_ASSIGN(auto cached_reader, LanceTableReader::MetaTrait::create_from_metadata(
                                             metadata, cgfile, schema_, std::vector<std::string>{}, ""));
+  ASSERT_AND_ASSIGN(auto cached_row_group_infos, cached_reader->get_row_group_infos());
+  assert_memory_size_unavailable(cached_row_group_infos);
   EXPECT_TRUE(cached_reader->get_rg_column_memsz(0).status().IsNotImplemented());
   ASSERT_AND_ASSIGN(auto chunk, cached_reader->get_chunk(0));
   EXPECT_GT(chunk->num_rows(), 0);
@@ -723,14 +898,10 @@ TEST_F(LanceBasicTest, CachedCreateReaderReappliesProjection) {
                                         id_metadata, cgfile, nullptr /* read_schema */, {"id"}, ""));
   ASSERT_AND_ASSIGN(auto id_rgs, id_reader->get_row_group_infos());
   ASSERT_FALSE(id_rgs.empty());
-  ASSERT_EQ(id_rgs.size(), metadata->row_group_infos.size());
-  ASSERT_NE(metadata->payload.column_memory_weights, nullptr);
   for (size_t rg_idx = 0; rg_idx < id_rgs.size(); ++rg_idx) {
-    ASSERT_EQ(id_rgs[rg_idx].memory_size, metadata->row_group_infos[rg_idx].memory_size);
-    ASSERT_AND_ASSIGN(auto expected_memory_sizes, DistributeMemorySizes(metadata->row_group_infos[rg_idx].memory_size,
-                                                                        *metadata->payload.column_memory_weights));
     ASSERT_AND_ASSIGN(auto memory_sizes, id_reader->get_rg_column_memsz(rg_idx));
-    ASSERT_EQ(memory_sizes, expected_memory_sizes);
+    ASSERT_EQ(memory_sizes.size(), static_cast<size_t>(schema_->num_fields()));
+    ASSERT_EQ(std::accumulate(memory_sizes.begin(), memory_sizes.end(), uint64_t{0}), id_rgs[rg_idx].memory_size);
   }
   ASSERT_AND_ASSIGN(auto id_chunk, id_reader->get_chunk(0));
   ASSERT_EQ(id_chunk->num_columns(), 1);


### PR DESCRIPTION
pr: #658 

Format reader metadata is cached by ColumnGroupFile, and each Lance ColumnGroupFile identifies one fragment. A fragment URI key therefore only reuses repeated opens of the same fragment. Different fragments of one dataset miss independently, even though each metadata load opens the same dataset and decodes the same table manifest.

Key Lance metadata by base URI and treat the cached payload as dataset-level metadata. Keep the opened BlockingDataset in that payload and cache immutable fragment-specific schema, row groups, deletion state, and memory estimates by fragment ID. BlockingFragmentReader remains private to each reader so projection and mutable read state stay isolated.

Because FormatReaderMetadataCache is owned by the top-level MetadataCache, dataset reuse is scoped to one top-level reader. Fragments within that reader share one dataset snapshot, while independent readers open independent snapshots without process-global state.