### PR TITLE
feat: add optional Talon-backed remote filesystem

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build
         working-directory: ./cpp
         run: |
-          make build USE_ASAN=True BUILD_TYPE=Release
+          make build USE_ASAN=True BUILD_TYPE=Release WITH_TALON=True
 
       - name: Save rust build cache
         if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
@@ -145,7 +145,7 @@ jobs:
       - name: Build
         working-directory: ./cpp
         run: |
-          make build BUILD_TYPE=Release
+          make build BUILD_TYPE=Release WITH_TALON=True
 
       - name: Save rust build cache
         if: github.ref == 'refs/heads/main' && steps.rust-cache.outputs.cache-hit != 'true'
@@ -248,3 +248,147 @@ jobs:
           fail_ci_if_error: true
           disable_safe_directory: true
           verbose: true
+
+  talon-integration:
+    runs-on: ubuntu-22.04
+    needs: build
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve Talon revision
+        id: talon_revision
+        run: |
+          # Keep the Talon services on the same revision as the Rust client dependency.
+          revision="$(sed -nE '/^talon = /s/.*rev = "([0-9a-f]{40})".*/\1/p' cpp/src/format/bridge/rust/Cargo.toml)"
+          if [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Failed to resolve the pinned Talon revision from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "revision=$revision" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Talon
+        uses: actions/checkout@v4
+        with:
+          repository: milvus-io/talon
+          ref: ${{ steps.talon_revision.outputs.revision }}
+          path: talon
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Talon build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: talon -> target
+
+      - name: Install Talon build dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Build Talon services
+        working-directory: ./talon
+        run: |
+          cargo build --release --locked \
+            -p talon-coordinator --bin talon-coordinator \
+            -p talon-worker --bin talon-worker
+
+      - name: Download test binary
+        uses: actions/download-artifact@v4
+        with:
+          name: gtest-binary
+          path: ./cpp/build/Release
+
+      - name: Setup Minio
+        run: |
+          chmod +x ./cpp/scripts/setup_minio.sh
+          ./cpp/scripts/setup_minio.sh
+
+      - name: Start Talon services
+        env:
+          TALON_WORKER_BACKEND: s3
+          TALON_WORKER_BLOCK_SIZE: "8388608"
+          TALON_WORKER_CACHE_DIRS: ${{ runner.temp }}/talon-cache
+          TALON_WORKER_CAPACITY_BYTES: "1073741824"
+          TALON_WORKER_S3_REGION: us-east-1
+          TALON_WORKER_S3_ENDPOINT: http://127.0.0.1:9000
+          TALON_WORKER_S3_ACCESS_KEY_ID: minioadmin
+          TALON_WORKER_S3_SECRET_ACCESS_KEY: minioadmin
+          TALON_WORKER_S3_PATH_STYLE: "true"
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/talon-cache" "$RUNNER_TEMP/talon-logs"
+
+          ./talon/target/release/talon-coordinator \
+            --listen 127.0.0.1:7000 \
+            --admin-listen 127.0.0.1:8000 \
+            >"$RUNNER_TEMP/talon-logs/coordinator.log" 2>&1 &
+          echo "TALON_COORDINATOR_PID=$!" >> "$GITHUB_ENV"
+
+          coordinator_ready=false
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/readyz >/dev/null; then
+              coordinator_ready=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$coordinator_ready" != "true" ]; then
+            cat "$RUNNER_TEMP/talon-logs/coordinator.log"
+            echo "Talon coordinator did not become ready" >&2
+            exit 1
+          fi
+
+          ./talon/target/release/talon-worker \
+            --listen 127.0.0.1:7001 \
+            --advertise-addr 127.0.0.1:7001 \
+            --admin-listen 127.0.0.1:8001 \
+            --coordinator 127.0.0.1:7000 \
+            --block-size 8388608 \
+            >"$RUNNER_TEMP/talon-logs/worker.log" 2>&1 &
+          echo "TALON_WORKER_PID=$!" >> "$GITHUB_ENV"
+
+          worker_ready=false
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8001/readyz >/dev/null; then
+              worker_ready=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$worker_ready" != "true" ]; then
+            cat "$RUNNER_TEMP/talon-logs/worker.log"
+            echo "Talon worker did not become ready" >&2
+            exit 1
+          fi
+
+      - name: Run Talon integration tests
+        working-directory: ./cpp
+        env:
+          AWS_EC2_METADATA_DISABLED: "true"
+          TEST_ENV_TALON_ENABLED: "true"
+          TEST_ENV_TALON_COORDINATOR: 127.0.0.1:7000
+          TEST_ENV_TALON_BLOCK_SIZE: "8388608"
+        run: |
+          set -euo pipefail
+          chmod +x ./build/Release/test/milvus_test
+          export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$(pwd)/build/Release:$(pwd)/build/Release/libs"
+          source ./scripts/minio_env.sh
+          ./build/Release/test/milvus_test --gtest_filter='TalonIntegrationTest.*'
+
+      - name: Stop Talon services
+        if: always()
+        run: |
+          for pid in "${TALON_WORKER_PID:-}" "${TALON_COORDINATOR_PID:-}"; do
+            if [ -n "$pid" ]; then
+              kill "$pid" 2>/dev/null || true
+            fi
+          done
+          docker logs minio >"$RUNNER_TEMP/talon-logs/minio.log" 2>&1 || true
+
+      - name: Upload Talon logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talon-integration-logs
+          path: ${{ runner.temp }}/talon-logs
+          if-no-files-found: warn

--- a/.github/workflows/cpp-mac-ci.yml
+++ b/.github/workflows/cpp-mac-ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build
         working-directory: ./cpp
         run: |
-          make build USE_ASAN=False libcxx_setting="-s:h compiler.libcxx=libc++ -s:h compiler.cppstd=20 -s:h arrow/*:compiler.cppstd=17 -s:b compiler.libcxx=libc++ -s:b compiler.cppstd=20"
+          make build WITH_TALON=True USE_ASAN=False libcxx_setting="-s:h compiler.libcxx=libc++ -s:h compiler.cppstd=20 -s:h arrow/*:compiler.cppstd=17 -s:b compiler.libcxx=libc++ -s:b compiler.cppstd=20"
 
       - name: Upload mac gtest binary
         uses: actions/upload-artifact@v4

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,10 +13,15 @@ option(WITH_JNI "Build with JNI library." OFF)
 option(WITH_PYTHON_BINDING "Build for Python bindings with hidden symbols." OFF)
 option(WITH_FIU "Build with fault injection support (libfiu)." OFF)
 option(WITH_CRT "Build with AWS S3 CRT support." OFF)
+option(WITH_TALON "Build with Talon filesystem support." OFF)
 option(ARROW_WITH_JEMALLOC "Build with jemalloc." OFF)
 
 if (WITH_CRT)
   add_compile_definitions(WITH_CRT)
+endif()
+
+if (WITH_TALON)
+  add_compile_definitions(WITH_TALON)
 endif()
 
 include(GNUInstallDirs)
@@ -63,6 +68,9 @@ set(CORROSION_FEATURES "")
 if (WITH_CRT)
   list(APPEND CORROSION_FEATURES s3-crt-async)
 endif()
+if (WITH_TALON)
+  list(APPEND CORROSION_FEATURES talon)
+endif()
 add_subdirectory(${RUST_BRIDGE_PATH})
 
 list(APPEND LINK_LIBS prsbridge)
@@ -85,6 +93,9 @@ file(GLOB_RECURSE ALL_SRC_FILES
 )
 list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/format/bridge/.*\\.(cpp|cc)$")
 list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/jni/.*\\.cpp$")
+if (NOT WITH_TALON)
+  list(FILTER ALL_SRC_FILES EXCLUDE REGEX ".*/src/filesystem/talon/.*\\.cpp$")
+endif()
 
 add_library(milvus-storage SHARED ${ALL_SRC_FILES})
 
@@ -275,7 +286,7 @@ if (WITH_JNI)
   endif()
 endif()
 
-if (WITH_ASAN STREQUAL "True")
+if (WITH_ASAN)
   set(CMAKE_CXX_FLAGS
     "-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -g -fsanitize=address ${CMAKE_CXX_FLAGS}"
   )

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -14,6 +14,7 @@ use_asan := $(or $(USE_ASAN),True)
 with_ut := $(or $(WITH_UT),True)
 with_fiu := $(or $(WITH_FIU),True)
 with_crt := $(or $(WITH_CRT),False)
+with_talon := $(or $(WITH_TALON),False)
 with_benchmark := $(or $(WITH_BENCHMARK),True)
 build_type := $(or $(BUILD_TYPE),Release)
 use_jni := $(or $(USE_JNI),False)
@@ -43,16 +44,17 @@ build:
 	@echo "use_python_binding: ${use_python_binding}"
 	@echo "with_fiu: ${with_fiu}"
 	@echo "with_crt: ${with_crt}"
+	@echo "with_talon: ${with_talon}"
 
 	mkdir -p build && cd build && \
 	${CONAN_BASE} \
 	-o "&:with_ut=${with_ut}" -o "&:with_benchmark=${with_benchmark}" -o "&:with_asan=${use_asan}" \
 	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" \
-	-o "&:with_crt=${with_crt}" && \
+	-o "&:with_crt=${with_crt}" -o "&:with_talon=${with_talon}" && \
 	conan build .. ${CONAN_SETTINGS} \
 	-o "&:with_ut=${with_ut}" -o "&:with_benchmark=${with_benchmark}" -o "&:with_asan=${use_asan}" \
 	-o "&:with_jni=${use_jni}" -o "&:with_python_binding=${use_python_binding}" -o "&:with_fiu=${with_fiu}" \
-	-o "&:with_crt=${with_crt}"
+	-o "&:with_crt=${with_crt}" -o "&:with_talon=${with_talon}"
 
 package: build
 	mkdir -p build && cd build && \
@@ -99,7 +101,7 @@ test-all: build
 	./scripts/setup_azurite.sh
 	(source ./scripts/azurite_env.sh && ./build/${build_type}/test/milvus_test)
 	(source ./scripts/azurite_env.sh && ./build/${build_type}/test/Test_FFI)
-	
+
 # Test cloud storage with all providers or a specific one
 # Usage: make test-cloud-storage     # Test all cloud providers
 #        make test-cloud-storage aws  # Test AWS only

--- a/cpp/benchmark/CMakeLists.txt
+++ b/cpp/benchmark/CMakeLists.txt
@@ -30,6 +30,12 @@ list(APPEND BENCHMARK_SOURCES
 # Include test helper implementation used by benchmarks
 list(APPEND BENCHMARK_SOURCES "${PROJECT_SOURCE_DIR}/test/test_env.cpp")
 
+if (WITH_TALON)
+  list(APPEND BENCHMARK_SOURCES
+    ${PROJECT_SOURCE_DIR}/benchmark/benchmark_talon_reader.cpp
+  )
+endif()
+
 add_executable(
   benchmark
   ${BENCHMARK_SOURCES}

--- a/cpp/benchmark/benchmark_talon_reader.cpp
+++ b/cpp/benchmark/benchmark_talon_reader.cpp
@@ -1,0 +1,271 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/util/future.h>
+
+#include "milvus-storage/filesystem/async_random_access_file.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "test_env.h"
+
+namespace milvus_storage {
+
+class TalonReaderBenchmark : public ::benchmark::Fixture {
+  protected:
+  void SetUp(::benchmark::State& state) override {
+    if (!IsTalonEnv()) {
+      state.SkipWithError("Talon benchmark environment is not configured");
+      return;
+    }
+
+    const auto properties_status = InitTestProperties(properties_);
+    if (!properties_status.ok()) {
+      state.SkipWithError(("Failed to initialize Talon benchmark properties: " + properties_status.ToString()).c_str());
+      return;
+    }
+
+    FilesystemCache::getInstance().clean();
+    auto fs_result = GetFileSystem(properties_);
+    if (!fs_result.ok()) {
+      state.SkipWithError(("Failed to create Talon benchmark filesystem: " + fs_result.status().ToString()).c_str());
+      return;
+    }
+    fs_ = std::move(fs_result).ValueOrDie();
+
+    const auto unique_suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    path_ = "talon-benchmark/reader-" + std::to_string(getpid()) + "-" + std::to_string(unique_suffix);
+    expected_.resize(kObjectSize);
+    for (size_t i = 0; i < expected_.size(); ++i) {
+      expected_[i] = static_cast<uint8_t>(i % 251);
+    }
+
+    auto output_result = fs_->OpenOutputStream(path_);
+    if (!output_result.ok()) {
+      state.SkipWithError(("Failed to open Talon benchmark object: " + output_result.status().ToString()).c_str());
+      return;
+    }
+    auto output = std::move(output_result).ValueOrDie();
+    const auto write_status = output->Write(expected_.data(), static_cast<int64_t>(expected_.size()));
+    if (!write_status.ok()) {
+      (void)output->Close();
+      state.SkipWithError(("Failed to write Talon benchmark object: " + write_status.ToString()).c_str());
+      return;
+    }
+    const auto close_status = output->Close();
+    if (!close_status.ok()) {
+      state.SkipWithError(("Failed to close Talon benchmark object: " + close_status.ToString()).c_str());
+      return;
+    }
+
+    auto info_result = fs_->GetFileInfo(path_);
+    if (!info_result.ok()) {
+      state.SkipWithError(("Failed to stat Talon benchmark object: " + info_result.status().ToString()).c_str());
+      return;
+    }
+    const auto info = std::move(info_result).ValueOrDie();
+    if (info.type() != arrow::fs::FileType::File || info.size() != static_cast<int64_t>(expected_.size())) {
+      state.SkipWithError("Talon benchmark object has an unexpected type or size");
+      return;
+    }
+
+    auto file_result = fs_->OpenInputFile(info);
+    if (!file_result.ok()) {
+      state.SkipWithError(("Failed to open Talon benchmark reader: " + file_result.status().ToString()).c_str());
+      return;
+    }
+    file_ = std::move(file_result).ValueOrDie();
+
+    auto warm_result = file_->ReadAt(0, static_cast<int64_t>(expected_.size()));
+    if (!warm_result.ok()) {
+      state.SkipWithError(("Failed to warm Talon benchmark object: " + warm_result.status().ToString()).c_str());
+      return;
+    }
+    const auto warm = std::move(warm_result).ValueOrDie();
+    if (warm->size() != static_cast<int64_t>(expected_.size()) ||
+        std::memcmp(warm->data(), expected_.data(), expected_.size()) != 0) {
+      state.SkipWithError("Talon benchmark warm read returned unexpected data");
+      return;
+    }
+
+    scratch_.resize(expected_.size());
+    small_io_offsets_.resize(kObjectSize / kSmallIoSize);
+    for (size_t i = 0; i < small_io_offsets_.size(); ++i) {
+      // 4051 is odd, so multiplication permutes every 4 KiB page in the
+      // power-of-two-sized object instead of benchmarking one hot region.
+      const size_t page = (i * 4051U) % small_io_offsets_.size();
+      small_io_offsets_[i] = static_cast<int64_t>(page * kSmallIoSize);
+    }
+  }
+
+  void TearDown(::benchmark::State& state) override {
+    if (file_ != nullptr) {
+      const auto close_status = file_->Close();
+      if (!close_status.ok()) {
+        state.SkipWithError(("Failed to close Talon benchmark reader: " + close_status.ToString()).c_str());
+      }
+      file_.reset();
+    }
+    if (fs_ != nullptr && !path_.empty()) {
+      const auto delete_status = fs_->DeleteFile(path_);
+      if (!delete_status.ok()) {
+        state.SkipWithError(("Failed to delete Talon benchmark object: " + delete_status.ToString()).c_str());
+      }
+      fs_.reset();
+    }
+    FilesystemCache::getInstance().clean();
+  }
+
+  static constexpr size_t kObjectSize = 64U * 1024U * 1024U;
+  static constexpr size_t kRangeSize = 4U * 1024U * 1024U;
+  static constexpr size_t kSmallIoSize = 4U * 1024U;
+  static constexpr size_t kIopsBatchSize = 64U;
+
+  api::Properties properties_;
+  ArrowFileSystemPtr fs_;
+  std::shared_ptr<arrow::io::RandomAccessFile> file_;
+  std::string path_;
+  std::vector<uint8_t> expected_;
+  std::vector<uint8_t> scratch_;
+  std::vector<int64_t> small_io_offsets_;
+};
+
+BENCHMARK_DEFINE_F(TalonReaderBenchmark, FullObjectReadAt)(::benchmark::State& state) {
+  if (file_ == nullptr) {
+    return;
+  }
+
+  for (auto _ : state) {
+    auto read_result = file_->ReadAt(0, static_cast<int64_t>(expected_.size()));
+    if (!read_result.ok()) {
+      state.SkipWithError(("Talon full-object read failed: " + read_result.status().ToString()).c_str());
+      break;
+    }
+    const auto buffer = std::move(read_result).ValueOrDie();
+    if (buffer->size() != static_cast<int64_t>(expected_.size())) {
+      state.SkipWithError("Talon full-object read returned an unexpected length");
+      break;
+    }
+    ::benchmark::DoNotOptimize(buffer->data());
+  }
+
+  state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(expected_.size()));
+}
+
+BENCHMARK_DEFINE_F(TalonReaderBenchmark, ConcurrentAsyncRanges)(::benchmark::State& state) {
+  if (file_ == nullptr) {
+    return;
+  }
+  auto* const async_file = dynamic_cast<NonBlockingRandomAccessFile*>(file_.get());
+  if (async_file == nullptr) {
+    state.SkipWithError("Talon reader does not implement NonBlockingRandomAccessFile");
+    return;
+  }
+
+  const size_t range_count = expected_.size() / kRangeSize;
+  std::vector<arrow::Future<int64_t>> futures;
+  futures.reserve(range_count);
+  for (auto _ : state) {
+    futures.clear();
+    for (size_t i = 0; i < range_count; ++i) {
+      futures.emplace_back(async_file->ReadAtAsyncInto(
+          static_cast<int64_t>(i * kRangeSize), static_cast<int64_t>(kRangeSize), scratch_.data() + i * kRangeSize));
+    }
+
+    std::string iteration_error;
+    for (auto& future : futures) {
+      auto read_result = future.result();
+      if (!read_result.ok()) {
+        if (iteration_error.empty()) {
+          iteration_error = "Talon async range read failed: " + read_result.status().ToString();
+        }
+      } else if (read_result.ValueOrDie() != static_cast<int64_t>(kRangeSize) && iteration_error.empty()) {
+        iteration_error = "Talon async range read returned an unexpected length";
+      }
+    }
+    if (!iteration_error.empty()) {
+      state.SkipWithError(iteration_error.c_str());
+      break;
+    }
+    ::benchmark::ClobberMemory();
+  }
+
+  state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(expected_.size()));
+}
+
+BENCHMARK_DEFINE_F(TalonReaderBenchmark, Concurrent4KiBReadIOPS)(::benchmark::State& state) {
+  if (file_ == nullptr) {
+    return;
+  }
+  auto* const async_file = dynamic_cast<NonBlockingRandomAccessFile*>(file_.get());
+  if (async_file == nullptr) {
+    state.SkipWithError("Talon reader does not implement NonBlockingRandomAccessFile");
+    return;
+  }
+
+  std::vector<arrow::Future<int64_t>> futures;
+  futures.reserve(kIopsBatchSize);
+  size_t offset_index = 0;
+  int64_t completed_operations = 0;
+  for (auto _ : state) {
+    futures.clear();
+    for (size_t i = 0; i < kIopsBatchSize; ++i) {
+      futures.emplace_back(async_file->ReadAtAsyncInto(
+          small_io_offsets_[offset_index + i], static_cast<int64_t>(kSmallIoSize), scratch_.data() + i * kSmallIoSize));
+    }
+    offset_index += kIopsBatchSize;
+    if (offset_index == small_io_offsets_.size()) {
+      offset_index = 0;
+    }
+
+    std::string iteration_error;
+    for (auto& future : futures) {
+      auto read_result = future.result();
+      if (!read_result.ok()) {
+        if (iteration_error.empty()) {
+          iteration_error = "Talon 4 KiB read failed: " + read_result.status().ToString();
+        }
+      } else if (read_result.ValueOrDie() != static_cast<int64_t>(kSmallIoSize) && iteration_error.empty()) {
+        iteration_error = "Talon 4 KiB read returned an unexpected length";
+      }
+    }
+    if (!iteration_error.empty()) {
+      state.SkipWithError(iteration_error.c_str());
+      break;
+    }
+    completed_operations += static_cast<int64_t>(kIopsBatchSize);
+    ::benchmark::ClobberMemory();
+  }
+
+  // One completed item is one 4 KiB I/O, so items_per_second is the IOPS rate.
+  state.SetItemsProcessed(completed_operations);
+  state.SetBytesProcessed(completed_operations * static_cast<int64_t>(kSmallIoSize));
+}
+
+BENCHMARK_REGISTER_F(TalonReaderBenchmark, FullObjectReadAt)->UseRealTime();
+BENCHMARK_REGISTER_F(TalonReaderBenchmark, ConcurrentAsyncRanges)->UseRealTime();
+BENCHMARK_REGISTER_F(TalonReaderBenchmark, Concurrent4KiBReadIOPS)->UseRealTime();
+
+}  // namespace milvus_storage

--- a/cpp/conanfile.py
+++ b/cpp/conanfile.py
@@ -32,6 +32,7 @@ class StorageConan(ConanFile):
         "with_python_binding": [True, False],
         "with_fiu": [True, False],
         "with_crt": [True, False],
+        "with_talon": [True, False],
     }
     default_options = {
         "shared": True,
@@ -45,6 +46,7 @@ class StorageConan(ConanFile):
         "with_python_binding": False,
         "with_fiu": False,
         "with_crt": False,
+        "with_talon": False,
         "folly/*:shared": True,
         "glog/*:with_gflags": True,
         "glog/*:shared": True,
@@ -164,7 +166,7 @@ class StorageConan(ConanFile):
         self.requires("zlib/1.3.1#8045430172a5f8d56ba001b14561b4ea")
         self.requires("libcurl/8.10.1#a3113369c86086b0e84231844e7ed0a9", force=True, override=True)
         self.requires("folly/2026.04.20.00@milvus/dev#06852bea5b6449f0c4eb0df002b5779c")
-        self.requires("libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d")
+        self.requires("libavrocpp/1.12.1.1@milvus/dev#b4854183542196740ec9a004fdfff7ec")
         self.requires("google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43")
         self.requires("opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720")
         self.requires("milvus-common/1.0.0-60a563c@milvus/dev#a7448f82ed17d10934eacb6d1b152fd8")
@@ -234,15 +236,18 @@ class StorageConan(ConanFile):
             tc.variables["MSVC_LANGUAGE_VERSION"] = cxx_std_value
             tc.variables["MSVC_ENABLE_ALL_WARNINGS"] = False
             tc.variables["MSVC_USE_STATIC_RUNTIME"] = "MT" in msvc_runtime_flag(self)
-        tc.variables["WITH_ASAN"] = self.options.with_asan
+        # These options are switched in a reused build directory, so they must
+        # override values cached by a prior configure.
+        tc.cache_variables["WITH_ASAN"] = self.options.with_asan
         tc.variables["WITH_PROFILER"] = self.options.with_profiler
-        tc.variables["WITH_UT"] = self.options.with_ut
-        tc.variables["WITH_BENCHMARK"] = self.options.with_benchmark
+        tc.cache_variables["WITH_UT"] = self.options.with_ut
+        tc.cache_variables["WITH_BENCHMARK"] = self.options.with_benchmark
         tc.variables["ARROW_WITH_JEMALLOC"] = self.options.with_jemalloc
         tc.variables["WITH_JNI"] = self.options.with_jni
         tc.variables["WITH_PYTHON_BINDING"] = self.options.with_python_binding
         tc.variables["WITH_FIU"] = self.options.with_fiu
-        tc.variables["WITH_CRT"] = self.options.with_crt
+        tc.cache_variables["WITH_CRT"] = self.options.with_crt
+        tc.cache_variables["WITH_TALON"] = self.options.with_talon
 
         # Set JAVA_HOME for JNI compilation
         if self.options.with_jni:

--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -251,6 +251,11 @@ struct ArrowFileSystemConfig {
   uint32_t iops_initial_rate = 2000;
   uint32_t iops_max_rate = 5000;
 
+  // Whether remote filesystem reads should use Talon block routing.
+  bool talon_enabled = false;
+  std::string talon_coordinator = "";
+  uint32_t talon_block_size = 256U * 1024U * 1024U;
+
   // Alias for external filesystem identification (e.g., "prod", "backup")
   // Empty for default filesystem
   std::string alias = "";
@@ -370,8 +375,10 @@ class FilesystemCache {
    *
    * Local format: `file://{root_path}#{cache_key}`.
    * Remote format: `{address}/{bucket_name}#{cache_key}`. An empty remote
-   * address is rendered as `<null>`. `cache_key` is the existing internal LRU
-   * key returned by ArrowFileSystemConfig::GetCacheKey().
+   * address is rendered as `<null>`.
+   * Talon format: `{address}/{bucket_name}?talon={coordinator}#{cache_key}`.
+   * `cache_key` is the existing internal LRU key returned by
+   * ArrowFileSystemConfig::GetCacheKey().
    */
   [[nodiscard]] static std::string MakeDisplayKey(const ArrowFileSystemConfig& config, const std::string& cache_key);
 

--- a/cpp/include/milvus-storage/filesystem/talon/talon_file_system.h
+++ b/cpp/include/milvus-storage/filesystem/talon/talon_file_system.h
@@ -1,0 +1,41 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <arrow/result.h>
+
+namespace arrow::fs {
+class FileSystem;
+}
+
+namespace milvus_storage {
+struct ArrowFileSystemConfig;
+}
+
+namespace milvus_storage::talon::internal {
+
+/// Creates a Talon read decorator around `origin_fs`.
+///
+/// No concrete filesystem type is required. `bucket` is the normalized,
+/// non-empty bucket name used with the cloud provider and object key to
+/// construct Talon's ObjectId. Reads use Talon; all other operations delegate
+/// to `origin_fs`.
+arrow::Result<std::shared_ptr<arrow::fs::FileSystem>> MakeTalonFileSystem(
+    const ArrowFileSystemConfig& config, std::shared_ptr<arrow::fs::FileSystem> origin_fs, std::string bucket);
+
+}  // namespace milvus_storage::talon::internal

--- a/cpp/include/milvus-storage/filesystem/talon/talon_file_system_producer.h
+++ b/cpp/include/milvus-storage/filesystem/talon/talon_file_system_producer.h
@@ -1,0 +1,40 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <utility>
+
+#include "milvus-storage/filesystem/fs.h"
+
+namespace milvus_storage {
+
+/// Builds a Talon read decorator around an Arrow filesystem.
+///
+/// The wrapped filesystem is used only as a delegation target. No concrete
+/// provider or wrapper type is required.
+class TalonFileSystemProducer final : public FileSystemProducer {
+  public:
+  TalonFileSystemProducer(const ArrowFileSystemConfig& config, ArrowFileSystemPtr origin_fs)
+      : config_(config), origin_fs_(std::move(origin_fs)) {}
+
+  /// Returns a Talon filesystem that delegates non-read operations to `origin_fs_`.
+  arrow::Result<ArrowFileSystemPtr> Make() override;
+
+  private:
+  const ArrowFileSystemConfig config_;
+  const ArrowFileSystemPtr origin_fs_;
+};
+
+}  // namespace milvus_storage

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -100,6 +100,11 @@ struct PropertyInfo {
 #define PROPERTY_FS_IOPS_INITIAL_RATE "fs.iops_initial_rate"
 #define PROPERTY_FS_IOPS_MAX_RATE "fs.iops_max_rate"
 
+// talon properties
+#define PROPERTY_FS_TALON_ENABLED "fs.talon.enabled"
+#define PROPERTY_FS_TALON_COORDINATOR "fs.talon.coordinator"
+#define PROPERTY_FS_TALON_BLOCK_SIZE "fs.talon.block_size"
+
 // Cross-tenant access properties
 #define PROPERTY_FS_GCP_TARGET_SERVICE_ACCOUNT "fs.gcp_target_service_account"
 #define PROPERTY_FS_AZURE_CLIENT_ID "fs.azure_client_id"

--- a/cpp/src/filesystem/azure/azure_fs_producer.cpp
+++ b/cpp/src/filesystem/azure/azure_fs_producer.cpp
@@ -90,8 +90,7 @@ arrow::Result<ArrowFileSystemPtr> AzureFileSystemProducer::Make() {
     ARROW_RETURN_NOT_OK(options.ConfigureAccountKeyCredential(config_.access_key_value));
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto fs, milvus_storage::fs::AzureFileSystem::Make(options));
-  return std::make_shared<FileSystemProxy>(config_.bucket_name, fs);
+  return milvus_storage::fs::AzureFileSystem::Make(options);
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/azure/azurefs.cc
+++ b/cpp/src/filesystem/azure/azurefs.cc
@@ -45,7 +45,6 @@
 #include <arrow/filesystem/path_util.h>
 
 #include <arrow/result.h>
-#include <arrow/util/checked_cast.h>
 #include <arrow/util/formatting.h>
 #include <arrow/util/future.h>
 #include <arrow/util/key_value_metadata.h>
@@ -3555,8 +3554,9 @@ bool AzureFileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   }
-  const auto& azure_fs = ::arrow::internal::checked_cast<const AzureFileSystem&>(other);
-  return options().Equals(azure_fs.options());
+  // Decorators such as Talon can preserve the provider name without sharing its type.
+  const auto* azure_fs = dynamic_cast<const AzureFileSystem*>(&other);
+  return azure_fs != nullptr && options().Equals(azure_fs->options());
 }
 
 Result<FileInfo> AzureFileSystem::GetFileInfo(const std::string& path) {

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -28,6 +28,9 @@
 #include "milvus-storage/common/lrucache.h"
 
 #include "milvus-storage/filesystem/azure/azure_fs_producer.h"
+#ifdef WITH_TALON
+#include "milvus-storage/filesystem/talon/talon_file_system_producer.h"
+#endif
 
 namespace milvus_storage {
 
@@ -93,6 +96,9 @@ std::string ArrowFileSystemConfig::GetCacheKey() const {
   hash_combine(use_crc32c_checksum);
   hash_combine(s3_crt_async_read);
   hash_combine(load_frequency);
+  hash_combine(talon_enabled);
+  hash_combine(talon_coordinator);
+  hash_combine(talon_block_size);
 
   if (IsAzureCredentialBrokerEnabled()) {
     hash_combine(access_key_id);
@@ -134,7 +140,8 @@ std::string ArrowFileSystemConfig::ToString() const {
      << ", request_timeout_ms=" << request_timeout_ms << ", max_connections=" << max_connections
      << ", tls_min_version=" << (tls_min_version.empty() ? "(default)" : tls_min_version)
      << ", use_crc32c_checksum=" << std::boolalpha << use_crc32c_checksum << ", s3_crt_async_read=" << std::boolalpha
-     << s3_crt_async_read;
+     << s3_crt_async_read << ", talon_enabled=" << std::boolalpha << talon_enabled
+     << ", talon_coordinator=" << talon_coordinator << ", talon_block_size=" << talon_block_size;
   if (!alias.empty()) {
     ss << ", alias=" << alias;
   }
@@ -144,30 +151,55 @@ std::string ArrowFileSystemConfig::ToString() const {
 }
 
 arrow::Result<ArrowFileSystemPtr> CreateArrowFileSystem(const ArrowFileSystemConfig& config) {
+  if (config.talon_enabled) {
+    if (config.storage_type != "remote") {
+      return arrow::Status::Invalid("Talon requires remote storage");
+    }
+#ifndef WITH_TALON
+    return arrow::Status::Invalid("Talon support is not enabled in this build");
+#endif
+  }
+
   auto storage_type = StorageType_Map[config.storage_type];
   switch (storage_type) {
     case StorageType::Local: {
       return LocalFileSystemProducer(config).Make();
     }
     case StorageType::Remote: {
+      // Create the raw provider filesystem first. Remote producers must not
+      // apply bucket path rooting so decorators can be inserted below it.
+      ArrowFileSystemPtr raw_fs;
       auto cloud_provider = CloudProviderType_Map[config.cloud_provider];
       switch (cloud_provider) {
         case CloudProviderType::AZURE: {
-          return AzureFileSystemProducer(config).Make();
+          ARROW_ASSIGN_OR_RAISE(raw_fs, AzureFileSystemProducer(config).Make());
+          break;
         }
         case CloudProviderType::GCP: {
-          return GcpFileSystemProducer(config).Make();
+          ARROW_ASSIGN_OR_RAISE(raw_fs, GcpFileSystemProducer(config).Make());
+          break;
         }
         case CloudProviderType::AWS:
         case CloudProviderType::ALIYUN:
         case CloudProviderType::TENCENTCLOUD:
         case CloudProviderType::HUAWEICLOUD: {
-          return S3FileSystemProducer(config).Make();
+          ARROW_ASSIGN_OR_RAISE(raw_fs, S3FileSystemProducer(config).Make());
+          break;
         }
         default: {
           return arrow::Status::Invalid("Unsupported cloud provider: " + config.cloud_provider);
         }
       }
+
+#ifdef WITH_TALON
+      // Talon decorates reads without depending on the concrete provider type
+      // or taking ownership of bucket path rooting.
+      if (config.talon_enabled) {
+        ARROW_ASSIGN_OR_RAISE(raw_fs, TalonFileSystemProducer(config, std::move(raw_fs)).Make());
+      }
+#endif
+      // Apply the bucket subtree exactly once, after all optional decorators.
+      return std::make_shared<FileSystemProxy>(config.bucket_name, std::move(raw_fs));
     }
     default: {
       return arrow::Status::Invalid("Unsupported storage type: " + config.storage_type);
@@ -211,7 +243,11 @@ std::string FilesystemCache::MakeDisplayKey(const ArrowFileSystemConfig& config,
   if (config.storage_type == "local") {
     return "file://" + config.root_path + "#" + cache_key;
   }
-  return (config.address.empty() ? "<null>" : config.address) + "/" + config.bucket_name + "#" + cache_key;
+  const std::string remote_path = (config.address.empty() ? "<null>" : config.address) + "/" + config.bucket_name;
+  if (config.talon_enabled) {
+    return remote_path + "?talon=" + config.talon_coordinator + "#" + cache_key;
+  }
+  return remote_path + "#" + cache_key;
 }
 
 arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_storage::api::Properties& properties_map,
@@ -252,6 +288,10 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
   ARROW_ASSIGN_OR_RAISE(result.use_crc32c_checksum,
                         api::GetValue<bool>(properties_map, PROPERTY_FS_USE_CRC32C_CHECKSUM));
   ARROW_ASSIGN_OR_RAISE(result.s3_crt_async_read, api::GetValue<bool>(properties_map, PROPERTY_FS_S3_CRT_ASYNC_READ));
+  ARROW_ASSIGN_OR_RAISE(result.talon_enabled, api::GetValue<bool>(properties_map, PROPERTY_FS_TALON_ENABLED));
+  ARROW_ASSIGN_OR_RAISE(result.talon_coordinator,
+                        api::GetValue<std::string>(properties_map, PROPERTY_FS_TALON_COORDINATOR));
+  ARROW_ASSIGN_OR_RAISE(result.talon_block_size, api::GetValue<uint32_t>(properties_map, PROPERTY_FS_TALON_BLOCK_SIZE));
   ARROW_ASSIGN_OR_RAISE(result.lance_io_parallelism,
                         api::GetValue<uint32_t>(properties_map, PROPERTY_FS_LANCE_IO_PARALLELISM));
   ARROW_ASSIGN_OR_RAISE(result.iops_initial_rate,
@@ -268,6 +308,18 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
                         api::GetValue<std::string>(properties_map, PROPERTY_FS_AZURE_TENANT_ID));
   ARROW_ASSIGN_OR_RAISE(result.azure_credential_endpoint,
                         api::GetValue<std::string>(properties_map, PROPERTY_FS_AZURE_CREDENTIAL_ENDPOINT));
+
+  if (result.talon_enabled) {
+    if (result.storage_type != "remote") {
+      return arrow::Status::Invalid("Talon requires fs.storage_type=remote");
+    }
+    if (result.talon_coordinator.empty()) {
+      return arrow::Status::Invalid("fs.talon.enabled=true requires fs.talon.coordinator");
+    }
+    if (result.talon_block_size == 0) {
+      return arrow::Status::Invalid("fs.talon.block_size must be greater than zero");
+    }
+  }
 
   if (result.cloud_provider == kCloudProviderAzure && result.IsAzureCredentialBrokerEnabled()) {
     if (result.azure_client_id.empty() || result.azure_tenant_id.empty() || result.azure_credential_endpoint.empty() ||

--- a/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
+++ b/cpp/src/filesystem/gcp/gcp_filesystem_producer.cpp
@@ -260,8 +260,7 @@ arrow::Result<ArrowFileSystemPtr> GcpFileSystemProducer::Make() {
   ARROW_RETURN_NOT_OK(RegisterIdentity(config_));
 
   ARROW_ASSIGN_OR_RAISE(auto s3_options, CreateS3Options());
-  ARROW_ASSIGN_OR_RAISE(auto fs, S3FileSystem::Make(s3_options));
-  return std::make_shared<FileSystemProxy>(config_.bucket_name, fs);
+  return S3FileSystem::Make(s3_options);
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/s3/s3_filesystem.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem.cpp
@@ -2629,8 +2629,9 @@ bool S3FileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   }
-  const auto& s3fs = ::arrow::fs::internal::checked_cast<const S3FileSystem&>(other);
-  return options().Equals(s3fs.options());
+  // Decorators such as Talon can preserve the provider name without sharing its type.
+  const auto* s3fs = dynamic_cast<const S3FileSystem*>(&other);
+  return s3fs != nullptr && options().Equals(s3fs->options());
 }
 
 arrow::Result<std::string> S3FileSystem::PathFromUri(const std::string& uri_string) const {

--- a/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
+++ b/cpp/src/filesystem/s3/s3_filesystem_producer.cpp
@@ -308,8 +308,7 @@ arrow::Result<ArrowFileSystemPtr> S3FileSystemProducer::Make() {
   ARROW_RETURN_NOT_OK(InitS3());
 
   ARROW_ASSIGN_OR_RAISE(auto s3_options, CreateS3Options());
-  ARROW_ASSIGN_OR_RAISE(auto fs, S3FileSystem::Make(s3_options));
-  return std::make_shared<FileSystemProxy>(config_.bucket_name, fs);
+  return S3FileSystem::Make(s3_options);
 }
 
 }  // namespace milvus_storage

--- a/cpp/src/filesystem/talon/talon_file_system.cpp
+++ b/cpp/src/filesystem/talon/talon_file_system.cpp
@@ -1,0 +1,416 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/talon/talon_file_system.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <arrow/buffer.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/memory_pool.h>
+#include <arrow/status.h>
+#include <arrow/util/future.h>
+
+#include "milvus-storage/filesystem/async_random_access_file.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/filesystem/util_internal.h"
+#include "talon_bridge.h"
+
+namespace milvus_storage::talon {
+namespace {
+
+class TalonInputFile final : public arrow::io::RandomAccessFile, public NonBlockingRandomAccessFile {
+  public:
+  TalonInputFile(TalonObjectReader reader,
+                 ArrowFileSystemPtr origin_fs,
+                 std::string path,
+                 arrow::MemoryPool* const pool)
+      : reader_(std::move(reader)), origin_fs_(std::move(origin_fs)), path_(std::move(path)), pool_(pool) {}
+
+  arrow::Result<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadata() override {
+    ARROW_ASSIGN_OR_RAISE(auto file, GetOrOpenOriginFile());
+    return file->ReadMetadata();
+  }
+
+  arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadataAsync(
+      const arrow::io::IOContext& io_context) override {
+    auto file = GetOrOpenOriginFile();
+    if (!file.ok()) {
+      return arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>>::MakeFinished(file.status());
+    }
+    return file.ValueOrDie()->ReadMetadataAsync(io_context);
+  }
+
+  arrow::Result<int64_t> GetSize() override { return GetSizeAsync().result(); }
+
+  arrow::Future<int64_t> GetSizeAsync() override {
+    if (closed_) {
+      return arrow::Future<int64_t>::MakeFinished(
+          arrow::Result<int64_t>(arrow::Status::Invalid("Operation on closed Talon input file")));
+    }
+    const int64_t known_size = reader_->KnownSize();
+    if (known_size >= 0) {
+      return arrow::Future<int64_t>::MakeFinished(known_size);
+    }
+
+    return reader_->StatAsync();
+  }
+
+  arrow::Future<int64_t> ReadAtAsyncInto(int64_t position, int64_t nbytes, uint8_t* out) override {
+    auto read_size = GetReadSize(position, nbytes);
+    if (!read_size.ok()) {
+      return arrow::Future<int64_t>::MakeFinished(read_size.status());
+    }
+    nbytes = read_size.ValueOrDie();
+    if (nbytes > 0 && out == nullptr) {
+      return arrow::Future<int64_t>::MakeFinished(
+          arrow::Result<int64_t>(arrow::Status::Invalid("Talon read destination is null")));
+    }
+
+    if (nbytes == 0) {
+      return arrow::Future<int64_t>::MakeFinished(0);
+    }
+
+    return reader_->ReadAtAsync(static_cast<uint64_t>(position), static_cast<uint64_t>(nbytes), out);
+  }
+
+  arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    return ReadAtAsyncInto(position, nbytes, reinterpret_cast<uint8_t*>(out)).result();
+  }
+
+  arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
+    ARROW_ASSIGN_OR_RAISE(nbytes, GetReadSize(position, nbytes));
+    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, pool_));
+    ARROW_ASSIGN_OR_RAISE(const int64_t bytes_read, ReadAt(position, nbytes, buffer->mutable_data()));
+    ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read));
+    return std::shared_ptr<arrow::Buffer>(std::move(buffer));
+  }
+
+  arrow::Future<std::shared_ptr<arrow::Buffer>> ReadAsync(const arrow::io::IOContext& io_context,
+                                                          int64_t position,
+                                                          int64_t nbytes) override {
+    auto read_size = GetReadSize(position, nbytes);
+    if (!read_size.ok()) {
+      return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(read_size.status());
+    }
+    nbytes = read_size.ValueOrDie();
+    auto maybe_buffer = arrow::AllocateResizableBuffer(nbytes, io_context.pool());
+    if (!maybe_buffer.ok()) {
+      return arrow::Future<std::shared_ptr<arrow::Buffer>>::MakeFinished(
+          arrow::Result<std::shared_ptr<arrow::Buffer>>(maybe_buffer.status()));
+    }
+    auto buffer = std::move(maybe_buffer).ValueOrDie();
+    auto* const out = buffer->mutable_data();
+    return ReadAtAsyncInto(position, nbytes, out)
+        .Then([buffer = std::move(buffer),
+               nbytes](const int64_t bytes_read) mutable -> arrow::Result<std::shared_ptr<arrow::Buffer>> {
+          if (bytes_read > nbytes) {
+            return arrow::Status::IOError("Talon returned more bytes than requested");
+          }
+          ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read));
+          return std::shared_ptr<arrow::Buffer>(std::move(buffer));
+        });
+  }
+
+  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
+    ARROW_ASSIGN_OR_RAISE(const int64_t bytes_read, ReadAt(pos_, nbytes, out));
+    pos_ += bytes_read;
+    return bytes_read;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, ReadAt(pos_, nbytes));
+    pos_ += buffer->size();
+    return buffer;
+  }
+
+  arrow::Status Seek(int64_t position) override {
+    if (position < 0) {
+      return arrow::Status::Invalid("Cannot seek to negative position");
+    }
+    if (closed_) {
+      return arrow::Status::Invalid("Operation on closed Talon input file");
+    }
+    const int64_t known_size = reader_->KnownSize();
+    if (known_size >= 0 && position > known_size) {
+      return arrow::Status::IOError("Cannot seek past end of Talon input file");
+    }
+    pos_ = position;
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    if (closed_) {
+      return arrow::Status::Invalid("Operation on closed Talon input file");
+    }
+    return pos_;
+  }
+
+  // Matches the lifecycle contract used by Arrow's S3 and Azure input files:
+  // Close() is not safe to call concurrently with another operation on this
+  // file. Reads whose submission completed before Close() was called own a
+  // Rust reader clone and may complete after the C++ handle is released here.
+  arrow::Status Close() override {
+    if (origin_file_ != nullptr) {
+      ARROW_RETURN_NOT_OK(origin_file_->Close());
+      origin_file_.reset();
+    }
+    origin_fs_.reset();
+    reader_.reset();
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+
+  bool closed() const override { return closed_; }
+
+  private:
+  arrow::Result<int64_t> GetReadSize(const int64_t position, const int64_t nbytes) const {
+    if (closed_) {
+      return arrow::Status::Invalid("Operation on closed Talon input file");
+    }
+    if (position < 0) {
+      return arrow::Status::Invalid("Cannot read from negative position");
+    }
+    if (nbytes < 0) {
+      return arrow::Status::Invalid("Cannot read a negative number of bytes");
+    }
+    // Match S3's EOF handling before allocating a buffer. Only consult cached
+    // metadata so an unknown size never introduces a blocking stat here.
+    const int64_t known_size = reader_->KnownSize();
+    if (known_size >= 0) {
+      if (position > known_size) {
+        return arrow::Status::IOError("Cannot read past end of file");
+      }
+      return std::min(nbytes, known_size - position);
+    }
+    return nbytes;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> GetOrOpenOriginFile() {
+    if (closed_) {
+      return arrow::Status::Invalid("Operation on closed Talon input file");
+    }
+    // Share the provider client and open a file only when metadata is requested.
+    // Keep the successfully opened file until Close(), preserving the provider's
+    // metadata cache without adding origin opens or HEADs to ordinary Talon reads.
+    const std::lock_guard<std::mutex> lock(origin_file_mutex_);
+    if (origin_file_ == nullptr) {
+      ARROW_ASSIGN_OR_RAISE(origin_file_, origin_fs_->OpenInputFile(path_));
+    }
+    return origin_file_;
+  }
+
+  std::optional<TalonObjectReader> reader_;
+  ArrowFileSystemPtr origin_fs_;
+  const std::string path_;
+  std::mutex origin_file_mutex_;
+  std::shared_ptr<arrow::io::RandomAccessFile> origin_file_;
+  arrow::MemoryPool* const pool_;
+  int64_t pos_ = 0;
+  bool closed_ = false;
+};
+
+class TalonFileSystem final : public arrow::fs::FileSystem,
+                              public UploadConditional,
+                              public UploadSizable,
+                              public Observable {
+  public:
+  TalonFileSystem(ArrowFileSystemPtr origin_fs,
+                  std::shared_ptr<TalonClient> client,
+                  std::string bucket,
+                  std::string cloud_provider,
+                  std::string coordinator,
+                  uint32_t block_size)
+      : arrow::fs::FileSystem(origin_fs->io_context()),
+        origin_fs_(std::move(origin_fs)),
+        client_(std::move(client)),
+        bucket_(std::move(bucket)),
+        cloud_provider_(std::move(cloud_provider)),
+        coordinator_(std::move(coordinator)),
+        block_size_(block_size) {}
+
+  std::string type_name() const override { return origin_fs_->type_name(); }
+
+  arrow::Result<std::string> NormalizePath(std::string path) override {
+    return origin_fs_->NormalizePath(std::move(path));
+  }
+
+  arrow::Result<std::string> PathFromUri(const std::string& uri) const override { return origin_fs_->PathFromUri(uri); }
+
+  arrow::Result<std::string> MakeUri(std::string path) const override { return origin_fs_->MakeUri(std::move(path)); }
+
+  bool Equals(const arrow::fs::FileSystem& other) const override {
+    if (this == &other) {
+      return true;
+    }
+    const auto* talon = dynamic_cast<const TalonFileSystem*>(&other);
+    return talon != nullptr && bucket_ == talon->bucket_ && cloud_provider_ == talon->cloud_provider_ &&
+           coordinator_ == talon->coordinator_ && block_size_ == talon->block_size_ &&
+           origin_fs_->Equals(*talon->origin_fs_);
+  }
+
+  arrow::Result<arrow::fs::FileInfo> GetFileInfo(const std::string& path) override {
+    return origin_fs_->GetFileInfo(path);
+  }
+
+  arrow::Result<arrow::fs::FileInfoVector> GetFileInfo(const arrow::fs::FileSelector& selector) override {
+    return origin_fs_->GetFileInfo(selector);
+  }
+
+  arrow::fs::FileInfoGenerator GetFileInfoGenerator(const arrow::fs::FileSelector& selector) override {
+    return origin_fs_->GetFileInfoGenerator(selector);
+  }
+
+  arrow::Status CreateDir(const std::string& path, bool recursive) override {
+    return origin_fs_->CreateDir(path, recursive);
+  }
+
+  arrow::Status DeleteDir(const std::string& path) override { return origin_fs_->DeleteDir(path); }
+
+  arrow::Status DeleteDirContents(const std::string& path, bool missing_dir_ok) override {
+    return origin_fs_->DeleteDirContents(path, missing_dir_ok);
+  }
+
+  arrow::Status DeleteRootDirContents() override { return origin_fs_->DeleteRootDirContents(); }
+
+  arrow::Status DeleteFile(const std::string& path) override { return origin_fs_->DeleteFile(path); }
+
+  arrow::Status Move(const std::string& src, const std::string& dest) override { return origin_fs_->Move(src, dest); }
+
+  arrow::Status CopyFile(const std::string& src, const std::string& dest) override {
+    return origin_fs_->CopyFile(src, dest);
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const std::string& path) override {
+    ARROW_ASSIGN_OR_RAISE(auto file, OpenTalon(path, arrow::fs::kNoSize));
+    return std::static_pointer_cast<arrow::io::InputStream>(std::move(file));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::InputStream>> OpenInputStream(const arrow::fs::FileInfo& info) override {
+    ARROW_ASSIGN_OR_RAISE(auto file, OpenInputFile(info));
+    return std::static_pointer_cast<arrow::io::InputStream>(std::move(file));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override {
+    return OpenTalon(path, arrow::fs::kNoSize);
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const arrow::fs::FileInfo& info) override {
+    // Honor the caller's known type without issuing another metadata request.
+    if (info.type() == arrow::fs::FileType::NotFound) {
+      return arrow::fs::internal::PathNotFound(info.path());
+    }
+    if (info.type() != arrow::fs::FileType::File && info.type() != arrow::fs::FileType::Unknown) {
+      return arrow::fs::internal::NotAFile(info.path());
+    }
+    return OpenTalon(info.path(), info.size());
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
+    return origin_fs_->OpenOutputStream(path, metadata);
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenAppendStream(
+      const std::string& path, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) override {
+    return origin_fs_->OpenAppendStream(path, metadata);
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenConditionalOutputStream(
+      const std::string& path, std::shared_ptr<arrow::KeyValueMetadata> metadata) override {
+    const auto conditional = std::dynamic_pointer_cast<UploadConditional>(origin_fs_);
+    if (conditional == nullptr) {
+      return arrow::Status::NotImplemented("Talon cannot forward conditional output stream for path '", path,
+                                           "': origin filesystem type '", origin_fs_->type_name(),
+                                           "' does not implement UploadConditional");
+    }
+    return conditional->OpenConditionalOutputStream(path, std::move(metadata));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::OutputStream>> OpenOutputStreamWithUploadSize(
+      const std::string& path,
+      const std::shared_ptr<const arrow::KeyValueMetadata>& metadata,
+      int64_t part_size) override {
+    const auto sizable = std::dynamic_pointer_cast<UploadSizable>(origin_fs_);
+    if (sizable == nullptr) {
+      return arrow::Status::NotImplemented("Talon cannot forward sized output stream for path '", path,
+                                           "' with part size ", part_size, ": origin filesystem type '",
+                                           origin_fs_->type_name(), "' does not implement UploadSizable");
+    }
+    return sizable->OpenOutputStreamWithUploadSize(path, metadata, part_size);
+  }
+
+  std::shared_ptr<FilesystemMetrics> GetMetrics() const override {
+    // TODO(jiaqizho): Add dedicated Talon metrics to distinguish accesses through Talon from
+    // direct cloud-provider accesses, keeping them separate from these origin metrics.
+    const auto observable = std::dynamic_pointer_cast<Observable>(origin_fs_);
+    return observable == nullptr ? nullptr : observable->GetMetrics();
+  }
+
+  private:
+  arrow::Result<std::string> ObjectKey(const std::string& path) const {
+    const std::string prefix = bucket_ + "/";
+    if (!path.starts_with(prefix)) {
+      return arrow::Status::Invalid("Talon path does not belong to configured bucket ", bucket_, ": ", path);
+    }
+    const std::string key = path.substr(prefix.size());
+    if (key.empty()) {
+      return arrow::Status::Invalid("Talon object key must be non-empty");
+    }
+    return key;
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenTalon(const std::string& path,
+                                                                        int64_t known_size) const {
+    ARROW_ASSIGN_OR_RAISE(auto key, ObjectKey(path));
+    if (known_size < arrow::fs::kNoSize) {
+      return arrow::Status::Invalid("Invalid known Talon object size: ", known_size);
+    }
+    const auto initial_stat =
+        known_size == arrow::fs::kNoSize
+            ? std::nullopt
+            : std::optional<TalonObjectStat>{TalonObjectStat{static_cast<uint64_t>(known_size), ""}};
+    ARROW_ASSIGN_OR_RAISE(auto reader, client_->OpenObject(cloud_provider_, bucket_, key, initial_stat));
+    return std::make_shared<TalonInputFile>(std::move(reader), origin_fs_, path, io_context().pool());
+  }
+
+  const ArrowFileSystemPtr origin_fs_;
+  const std::shared_ptr<TalonClient> client_;
+  const std::string bucket_;
+  const std::string cloud_provider_;
+  const std::string coordinator_;
+  const uint32_t block_size_;
+};
+
+}  // namespace
+
+namespace internal {
+
+arrow::Result<ArrowFileSystemPtr> MakeTalonFileSystem(const ArrowFileSystemConfig& config,
+                                                      ArrowFileSystemPtr origin_fs,
+                                                      std::string bucket) {
+  ARROW_ASSIGN_OR_RAISE(auto client, TalonClient::Make(config.talon_coordinator, config.talon_block_size));
+  return std::make_shared<TalonFileSystem>(std::move(origin_fs), std::move(client), std::move(bucket),
+                                           config.cloud_provider, config.talon_coordinator, config.talon_block_size);
+}
+
+}  // namespace internal
+
+}  // namespace milvus_storage::talon

--- a/cpp/src/filesystem/talon/talon_file_system_producer.cpp
+++ b/cpp/src/filesystem/talon/talon_file_system_producer.cpp
@@ -1,0 +1,40 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "milvus-storage/filesystem/talon/talon_file_system_producer.h"
+
+#include <string>
+#include <utility>
+
+#include "milvus-storage/filesystem/talon/talon_file_system.h"
+
+namespace milvus_storage {
+
+arrow::Result<ArrowFileSystemPtr> TalonFileSystemProducer::Make() {
+  if (origin_fs_ == nullptr) {
+    return arrow::Status::Invalid("Talon requires a remote provider filesystem");
+  }
+
+  std::string bucket = config_.bucket_name;
+  while (!bucket.empty() && bucket.back() == '/') {
+    bucket.pop_back();
+  }
+  if (bucket.empty()) {
+    return arrow::Status::Invalid("Talon requires a non-empty remote bucket");
+  }
+
+  return talon::internal::MakeTalonFileSystem(config_, origin_fs_, std::move(bucket));
+}
+
+}  // namespace milvus_storage

--- a/cpp/src/format/bridge/rust/CMakeLists.txt
+++ b/cpp/src/format/bridge/rust/CMakeLists.txt
@@ -20,9 +20,13 @@ corrosion_set_env_vars(rust_bridge
 
 # corrosion_add_cxxbridge can only import a single static library; 
 # otherwise, `rlib` will conflict.
+set(CXX_BRIDGE_FILES lib.rs)
+if (WITH_TALON)
+    list(APPEND CXX_BRIDGE_FILES talon_bridge.rs)
+endif()
 corrosion_add_cxxbridge(rust-bridge
     CRATE rust_bridge
-    FILES lib.rs)
+    FILES ${CXX_BRIDGE_FILES})
 
 target_include_directories(rust-bridge PUBLIC ${Arrow_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}/corrosion_generated/cxxbridge/rust-bridge/include
@@ -33,6 +37,9 @@ target_include_directories(rust-bridge PUBLIC ${Arrow_INCLUDE_DIRS}
 file(GLOB_RECURSE CPP_SOURCE_FILE CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
 )
+if (NOT WITH_TALON)
+    list(FILTER CPP_SOURCE_FILE EXCLUDE REGEX ".*/talon_bridge\\.cpp$")
+endif()
 
 add_library(prsbridge STATIC ${CPP_SOURCE_FILE})
 

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -960,6 +960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-const-array"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd73835ad7deb4bd2b389e6f10333b143f025d607c55ca04c66a0bcc6bb2fc6d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1382,15 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bindgen"
@@ -2841,8 +2861,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3180,6 +3213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flatbuffers"
 version = "25.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3237,18 @@ dependencies = [
  "crc32fast",
  "libz-rs-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3382,6 +3433,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3748,7 +3808,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4016,6 +4076,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -4579,7 +4649,7 @@ dependencies = [
  "deepsize",
  "futures",
  "http 1.4.0",
- "io-uring",
+ "io-uring 0.7.13",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
@@ -5040,6 +5110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5073,6 +5152,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
@@ -5101,6 +5192,40 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "monoio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd0f8bcde87b1949f95338b547543fcab187bc7e7a5024247e359a5e828ba6a"
+dependencies = [
+ "auto-const-array",
+ "bytes",
+ "flume",
+ "fxhash",
+ "io-uring 0.6.4",
+ "libc",
+ "memchr",
+ "mio 0.8.11",
+ "monoio-macros",
+ "nix",
+ "once_cell",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "threadpool",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "monoio-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176a5f5e69613d9e88337cf2a65e11135332b4efbcc628404a7c555e4452084c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5143,6 +5268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5179,6 +5313,19 @@ name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
 
 [[package]]
 name = "nom"
@@ -6589,7 +6736,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6627,7 +6774,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -7225,6 +7372,7 @@ dependencies = [
  "snafu 0.9.1",
  "sqlparser 0.55.0",
  "take_mut",
+ "talon-rust-client",
  "tempfile",
  "tokio",
  "typetag",
@@ -7289,6 +7437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -7581,6 +7730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7839,6 +7997,16 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -7852,6 +8020,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -8068,6 +8239,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "talon-cache-client"
+version = "0.1.0"
+source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+dependencies = [
+ "bytes",
+ "futures",
+ "talon-core",
+ "talon-transport",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "talon-core"
+version = "0.1.0"
+source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "talon-rust-client"
+version = "0.1.0"
+source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+dependencies = [
+ "futures",
+ "talon-cache-client",
+ "talon-core",
+ "talon-transport",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "talon-transport"
+version = "0.1.0"
+source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "monoio",
+ "rustls",
+ "rustls-webpki",
+ "serde",
+ "talon-core",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "x509-cert",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8160,6 +8394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8236,6 +8479,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8243,11 +8507,11 @@ checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8308,6 +8572,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -9990,11 +10295,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10003,7 +10317,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10017,19 +10331,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -10039,9 +10374,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10057,9 +10404,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10069,15 +10428,36 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -10098,6 +10478,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -10197,6 +10589,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -10,8 +10,11 @@ crate-type = ["staticlib"]
 [features]
 io-trace = []
 s3-crt-async = []
+talon = ["dep:talon", "s3-crt-async"]
 
 [dependencies]
+talon = { package = "talon-rust-client", git = "https://github.com/milvus-io/talon.git", rev = "9ecf024062ecdf4cbba7cc898ed500e74cc77f7d", optional = true }
+
 # common dependencies
 anyhow = "1.0.99"
 futures = "0.3.31"

--- a/cpp/src/format/bridge/rust/include/talon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/talon_bridge.h
@@ -1,0 +1,81 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <arrow/result.h>
+#include <arrow/util/future.h>
+
+#include "rust/cxx.h"
+#include "rust-bridge/talon_bridge.h"
+
+namespace milvus_storage::talon {
+
+/// Optional object metadata supplied by storage when opening a Talon reader.
+/// An empty version is valid for the version-independent GetRange path.
+struct TalonObjectStat {
+  uint64_t size;
+  std::string version;
+};
+
+/// Owns a Rust Talon object reader and exposes only Arrow-native results to C++ callers.
+class TalonObjectReader final {
+  public:
+  TalonObjectReader(TalonObjectReader&&) noexcept = default;
+  TalonObjectReader& operator=(TalonObjectReader&&) noexcept = default;
+
+  TalonObjectReader(const TalonObjectReader&) = delete;
+  TalonObjectReader& operator=(const TalonObjectReader&) = delete;
+
+  /// Returns the cached or caller-provided object size, or -1 when unknown.
+  int64_t KnownSize() const;
+
+  /// Resolves object metadata on Talon's shared Tokio runtime.
+  arrow::Future<int64_t> StatAsync() const;
+
+  /// Reads into caller-owned memory on Talon's shared Tokio runtime.
+  /// `dst` must remain valid until the returned future completes.
+  arrow::Future<int64_t> ReadAtAsync(uint64_t offset, uint64_t length, uint8_t* dst) const;
+
+  private:
+  friend class TalonClient;
+
+  explicit TalonObjectReader(rust::Box<ffi::TalonObjectReader> impl) : impl_(std::move(impl)) {}
+
+  rust::Box<ffi::TalonObjectReader> impl_;
+};
+
+/// Owns a Rust Talon client and converts every fallible FFI operation to Arrow errors.
+class TalonClient final {
+  public:
+  static arrow::Result<std::shared_ptr<TalonClient>> Make(const std::string& coordinator, uint32_t block_size);
+
+  arrow::Result<TalonObjectReader> OpenObject(const std::string& cloud_provider,
+                                              const std::string& bucket,
+                                              const std::string& key,
+                                              const std::optional<TalonObjectStat>& initial_stat) const;
+
+  private:
+  explicit TalonClient(rust::Box<ffi::TalonClient> impl) : impl_(std::move(impl)) {}
+
+  rust::Box<ffi::TalonClient> impl_;
+};
+
+}  // namespace milvus_storage::talon

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -24,6 +24,8 @@ mod paimon_split_serde;
 mod paimon_testutil;
 mod predicate_parser;
 mod rust_runtime;
+#[cfg(feature = "talon")]
+mod talon_bridge;
 mod vortex_bridgeimpl;
 mod vortex_layout_strategy_v2;
 

--- a/cpp/src/format/bridge/rust/src/talon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/talon_bridge.cpp
@@ -1,0 +1,134 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "talon_bridge.h"
+
+#include <exception>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <arrow/status.h>
+
+#include "bridge_util.h"
+
+namespace milvus_storage::talon {
+namespace {
+
+using TalonIoCallback = void (*)(void* context, int32_t error_code, uint64_t value, const char* error_msg);
+
+extern "C" {
+
+void talon_object_stat_async(const void* reader, TalonIoCallback callback, void* context);
+
+void talon_object_read_async(
+    const void* reader, uint64_t offset, uint64_t length, uint8_t* dst, TalonIoCallback callback, void* context);
+
+void talon_free_error_string(char* ptr);
+
+}  // extern "C"
+
+struct TalonIoCompletion {
+  TalonIoCompletion(arrow::Future<int64_t> future, const char* operation)
+      : future(std::move(future)), operation(operation) {}
+
+  arrow::Future<int64_t> future;
+  const char* const operation;
+};
+
+arrow::Result<int64_t> ToArrowIoResult(const char* operation,
+                                       int32_t error_code,
+                                       uint64_t value,
+                                       const char* error_msg) {
+  if (error_code == 0) {
+    if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      return arrow::Status::IOError(operation, ": Talon returned a value larger than INT64_MAX");
+    }
+    return static_cast<int64_t>(value);
+  }
+
+  const std::string message = error_msg == nullptr ? "unknown Talon error" : error_msg;
+  // FIXME: Map Talon's structured error kinds to Arrow errno details and
+  // ExtendStatus after Talon preserves them through the complete stat/read
+  // path. Until then, do not infer retryability from incomplete error codes.
+  return arrow::Status::IOError(operation, " (Talon error code ", error_code, "): ", message);
+}
+
+void MarkTalonCallbackError(arrow::Future<int64_t>& future, const char* operation, const char* message) noexcept {
+  try {
+    future.MarkFinished(
+        arrow::Result<int64_t>(arrow::Status::IOError(operation, ": failed to complete callback: ", message)));
+  } catch (...) {
+    // No further error reporting is safe from a callback crossing the C ABI.
+  }
+}
+
+void TalonIoCallbackImpl(void* context, int32_t error_code, uint64_t value, const char* error_msg) noexcept {
+  // Rust invokes the callback exactly once, so this callback reclaims both the
+  // completion context and any owned Rust error string.
+  std::unique_ptr<TalonIoCompletion> completion(static_cast<TalonIoCompletion*>(context));
+  std::unique_ptr<char, decltype(&talon_free_error_string)> error(const_cast<char*>(error_msg),
+                                                                  &talon_free_error_string);
+  try {
+    completion->future.MarkFinished(ToArrowIoResult(completion->operation, error_code, value, error.get()));
+  } catch (const std::exception& exception) {
+    MarkTalonCallbackError(completion->future, completion->operation, exception.what());
+  } catch (...) {
+    MarkTalonCallbackError(completion->future, completion->operation, "unknown exception");
+  }
+}
+
+}  // namespace
+
+arrow::Result<std::shared_ptr<TalonClient>> TalonClient::Make(const std::string& coordinator, uint32_t block_size) {
+  return CatchRustResult<std::shared_ptr<TalonClient>>("Failed to create Talon client", [&]() {
+    auto impl = ffi::new_talon_client(coordinator, block_size);
+    return std::shared_ptr<TalonClient>(new TalonClient(std::move(impl)));
+  });
+}
+
+arrow::Result<TalonObjectReader> TalonClient::OpenObject(const std::string& cloud_provider,
+                                                         const std::string& bucket,
+                                                         const std::string& key,
+                                                         const std::optional<TalonObjectStat>& initial_stat) const {
+  return CatchRustResult<TalonObjectReader>("Failed to open Talon object", [&]() {
+    const bool has_initial_stat = initial_stat.has_value();
+    const std::string empty_version;
+    return TalonObjectReader(ffi::open_talon_object(*impl_, cloud_provider, bucket, key, has_initial_stat,
+                                                    has_initial_stat ? initial_stat->size : 0,
+                                                    has_initial_stat ? initial_stat->version : empty_version));
+  });
+}
+
+int64_t TalonObjectReader::KnownSize() const { return ffi::talon_object_known_size(*impl_); }
+
+arrow::Future<int64_t> TalonObjectReader::StatAsync() const {
+  auto future = arrow::Future<int64_t>::Make();
+  auto completion = std::make_unique<TalonIoCompletion>(future, "Failed to stat Talon object");
+  auto* const raw_completion = completion.release();
+  talon_object_stat_async(static_cast<const void*>(&*impl_), TalonIoCallbackImpl, static_cast<void*>(raw_completion));
+  return future;
+}
+
+arrow::Future<int64_t> TalonObjectReader::ReadAtAsync(uint64_t offset, uint64_t length, uint8_t* dst) const {
+  auto future = arrow::Future<int64_t>::Make();
+  auto completion = std::make_unique<TalonIoCompletion>(future, "Failed to read Talon object");
+  auto* const raw_completion = completion.release();
+  talon_object_read_async(static_cast<const void*>(&*impl_), offset, length, dst, TalonIoCallbackImpl,
+                          static_cast<void*>(raw_completion));
+  return future;
+}
+
+}  // namespace milvus_storage::talon

--- a/cpp/src/format/bridge/rust/src/talon_bridge.rs
+++ b/cpp/src/format/bridge/rust/src/talon_bridge.rs
@@ -1,0 +1,330 @@
+use std::{
+    ffi::{CString, c_char, c_void},
+    panic::AssertUnwindSafe,
+    sync::Arc,
+};
+
+use anyhow::{Result, bail};
+use futures::FutureExt;
+use talon::{Client, ObjectId, ObjectStat, parse_uri};
+use tokio::sync::OnceCell;
+
+#[cxx::bridge(namespace = "milvus_storage::talon::ffi")]
+pub mod ffi {
+    extern "Rust" {
+        type TalonClient;
+        type TalonObjectReader;
+
+        fn new_talon_client(coordinator: &str, block_size: u32) -> Result<Box<TalonClient>>;
+        fn open_talon_object(
+            client: &TalonClient,
+            cloud_provider: &str,
+            bucket: &str,
+            key: &str,
+            has_initial_stat: bool,
+            initial_size: u64,
+            initial_version: &str,
+        ) -> Result<Box<TalonObjectReader>>;
+        fn talon_object_known_size(reader: &TalonObjectReader) -> i64;
+    }
+}
+
+type TalonIoCallback = unsafe extern "C" fn(
+    context: *mut c_void,
+    error_code: i32,
+    value: u64,
+    error_msg: *const c_char,
+);
+
+struct TalonIoResult {
+    code: i32,
+    value: u64,
+    message: String,
+}
+
+pub struct TalonClient {
+    inner: Arc<Client>,
+}
+
+#[derive(Clone)]
+pub struct TalonObjectReader {
+    client: Arc<Client>,
+    object: ObjectId,
+    stat: Arc<OnceCell<ObjectStat>>,
+}
+
+// A Talon deployment serves one origin credential domain. The coordinator
+// selects that deployment, so its endpoint, account, and credentials are
+// deployment configuration rather than part of ObjectId. Within the selected
+// origin, ObjectId deliberately consists only of backend, bucket/container,
+// and key; a different origin must use a different Talon deployment.
+fn talon_uri(provider: &str, bucket: &str, key: &str) -> Result<String> {
+    let scheme = match provider {
+        // Milvus accesses these providers through their S3-compatible APIs, so
+        // the corresponding Talon deployment must use its S3 backend as well.
+        "aws" | "aliyun" | "tencent" | "huawei" | "gcp" => "s3",
+        "azure" => "az",
+        value => bail!("Talon does not support cloud provider {value:?}"),
+    };
+    Ok(format!("{scheme}://{bucket}/{key}"))
+}
+
+pub fn new_talon_client(coordinator: &str, block_size: u32) -> Result<Box<TalonClient>> {
+    Ok(Box::new(TalonClient {
+        inner: Arc::new(Client::new(coordinator, block_size)?),
+    }))
+}
+
+pub fn open_talon_object(
+    client: &TalonClient,
+    cloud_provider: &str,
+    bucket: &str,
+    key: &str,
+    has_initial_stat: bool,
+    initial_size: u64,
+    initial_version: &str,
+) -> Result<Box<TalonObjectReader>> {
+    if bucket.is_empty() || key.is_empty() {
+        bail!("Talon bucket and object key must be non-empty");
+    }
+    let initial_stat = has_initial_stat.then(|| ObjectStat {
+        size: initial_size,
+        version: initial_version.into(),
+    });
+    Ok(Box::new(TalonObjectReader {
+        client: Arc::clone(&client.inner),
+        object: parse_uri(&talon_uri(cloud_provider, bucket, key)?)?,
+        stat: Arc::new(OnceCell::new_with(initial_stat)),
+    }))
+}
+
+pub fn talon_object_known_size(reader: &TalonObjectReader) -> i64 {
+    reader
+        .stat
+        .get()
+        .map(|stat| stat.size)
+        .and_then(|size| i64::try_from(size).ok())
+        .unwrap_or(-1)
+}
+
+impl TalonObjectReader {
+    async fn resolved_stat(&self) -> Result<&ObjectStat, talon::Error> {
+        self.stat
+            .get_or_try_init(|| async { self.client.stat(&self.object).await })
+            .await
+    }
+}
+
+struct ReadBuffer {
+    ptr: *mut u8,
+    len: usize,
+}
+
+unsafe impl Send for ReadBuffer {}
+
+impl ReadBuffer {
+    unsafe fn into_mut_slice(self) -> &'static mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+
+fn talon_error_result(error: talon::Error) -> TalonIoResult {
+    let code = match &error {
+        talon::Error::InvalidUri(_) | talon::Error::InvalidArgument(_) => 1,
+        talon::Error::Coordinator(_) | talon::Error::Block(_) => 2,
+    };
+    TalonIoResult {
+        code,
+        value: 0,
+        message: error.to_string(),
+    }
+}
+
+fn complete_talon_io(callback: TalonIoCallback, context: *mut c_void, result: TalonIoResult) {
+    let error_msg = if result.code == 0 {
+        std::ptr::null()
+    } else {
+        CString::new(result.message)
+            .unwrap_or_else(|_| {
+                CString::new("Talon IO error contains an interior NUL byte").unwrap()
+            })
+            .into_raw()
+    };
+    unsafe { callback(context, result.code, result.value, error_msg) };
+}
+
+fn complete_talon_error(
+    callback: TalonIoCallback,
+    context: *mut c_void,
+    code: i32,
+    message: impl ToString,
+) {
+    complete_talon_io(
+        callback,
+        context,
+        TalonIoResult {
+            code,
+            value: 0,
+            message: message.to_string(),
+        },
+    );
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn talon_free_error_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe {
+            drop(CString::from_raw(ptr));
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn talon_object_stat_async(
+    reader: *const c_void,
+    callback: TalonIoCallback,
+    context: *mut c_void,
+) {
+    let Some(reader) = (unsafe { (reader as *const TalonObjectReader).as_ref() }) else {
+        complete_talon_error(callback, context, 1, "Talon stat received a null reader");
+        return;
+    };
+    let reader = reader.clone();
+    let context_addr = context as usize;
+    crate::TOKIO_RT.spawn(async move {
+        let result = match AssertUnwindSafe(reader.resolved_stat())
+            .catch_unwind()
+            .await
+        {
+            Ok(Ok(stat)) => TalonIoResult {
+                code: 0,
+                value: stat.size,
+                message: String::new(),
+            },
+            Ok(Err(error)) => talon_error_result(error),
+            Err(_) => TalonIoResult {
+                code: 2,
+                value: 0,
+                message: "Talon stat task panicked".to_string(),
+            },
+        };
+        complete_talon_io(callback, context_addr as *mut c_void, result);
+    });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn talon_object_read_async(
+    reader: *const c_void,
+    offset: u64,
+    length: u64,
+    dst: *mut u8,
+    callback: TalonIoCallback,
+    context: *mut c_void,
+) {
+    if length > isize::MAX as u64 {
+        complete_talon_error(callback, context, 1, "Talon read length exceeds isize::MAX");
+        return;
+    }
+    if length > 0 && dst.is_null() {
+        complete_talon_error(callback, context, 1, "Talon read destination is null");
+        return;
+    }
+    let Some(reader) = (unsafe { (reader as *const TalonObjectReader).as_ref() }) else {
+        complete_talon_error(callback, context, 1, "Talon read received a null reader");
+        return;
+    };
+
+    let reader = reader.clone();
+    let buffer = ReadBuffer {
+        ptr: dst,
+        len: length as usize,
+    };
+    let context_addr = context as usize;
+    crate::TOKIO_RT.spawn(async move {
+        let read_result = AssertUnwindSafe(async {
+            if buffer.len == 0 {
+                return Ok(0usize);
+            }
+            let stat = reader.resolved_stat().await?;
+            let dst = unsafe { buffer.into_mut_slice() };
+            reader
+                .client
+                .read_into(&reader.object, offset, dst, Some(stat))
+                .await
+        })
+        .catch_unwind()
+        .await;
+
+        let result = match read_result {
+            Ok(Ok(bytes_written)) => TalonIoResult {
+                code: 0,
+                value: bytes_written as u64,
+                message: String::new(),
+            },
+            Ok(Err(error)) => talon_error_result(error),
+            Err(_) => TalonIoResult {
+                code: 2,
+                value: 0,
+                message: "Talon read task panicked".to_string(),
+            },
+        };
+        complete_talon_io(callback, context_addr as *mut c_void, result);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_storage_providers_to_canonical_talon_uris() {
+        for provider in ["aws", "aliyun", "tencent", "huawei", "gcp"] {
+            assert_eq!(
+                talon_uri(provider, "bucket", "path/a").unwrap(),
+                "s3://bucket/path/a"
+            );
+        }
+        assert_eq!(
+            talon_uri("azure", "container", "path/a").unwrap(),
+            "az://container/path/a"
+        );
+        assert!(talon_uri("local", "bucket", "path/a").is_err());
+    }
+
+    #[test]
+    fn open_object_with_stat_initializes_metadata_without_resolving() {
+        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024).unwrap();
+        let reader =
+            open_talon_object(&client, "aws", "test-bucket", "path/a", true, 123, "").unwrap();
+        assert_eq!(talon_object_known_size(&reader), 123);
+        assert_eq!(reader.stat.get().unwrap().size, 123);
+        assert!(reader.stat.get().unwrap().version.is_empty());
+    }
+
+    #[test]
+    fn open_object_without_stat_leaves_metadata_unresolved() {
+        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024).unwrap();
+        let reader =
+            open_talon_object(&client, "aws", "test-bucket", "path/a", false, 0, "").unwrap();
+        assert_eq!(talon_object_known_size(&reader), -1);
+        assert!(reader.stat.get().is_none());
+    }
+
+    #[test]
+    fn resolved_stat_is_shared_by_reader_clones() {
+        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024).unwrap();
+        let reader =
+            open_talon_object(&client, "aws", "test-bucket", "path/a", false, 0, "").unwrap();
+        reader
+            .stat
+            .set(ObjectStat {
+                size: 7,
+                version: "v1".into(),
+            })
+            .unwrap();
+        let clone = reader.clone();
+        assert_eq!(clone.stat.get().unwrap().size, 7);
+        assert_eq!(clone.stat.get().unwrap().version, "v1");
+        assert_eq!(talon_object_known_size(&clone), 7);
+    }
+}

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -469,6 +469,23 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "The default is 5000, matching Lance's default. Set to 0 to disable the AIMD rate ceiling.",
                       uint32_t(5000),
                       ValidatePropertyType() + ValidatePropertyRange<uint32_t>(0, UINT32_MAX)),
+
+    // --- talon properties ---
+    REGISTER_PROPERTY(PROPERTY_FS_TALON_ENABLED,
+                      PropertyType::BOOL,
+                      "Whether remote filesystem reads should use Talon block routing.",
+                      false,
+                      ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_TALON_COORDINATOR,
+                      PropertyType::STRING,
+                      "The Talon coordinator address used for block routing.",
+                      "",
+                      ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_TALON_BLOCK_SIZE,
+                      PropertyType::UINT32,
+                      "The Talon block size in bytes.",
+                      256U * 1024U * 1024U,
+                      ValidatePropertyType()),
     // --- Cross-tenant access properties define ---
     REGISTER_PROPERTY(PROPERTY_FS_GCP_TARGET_SERVICE_ACCOUNT,
                       PropertyType::STRING,

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 find_package(GTest REQUIRED)
 
-if (WITH_ASAN STREQUAL "True")
+if (WITH_ASAN)
   set(CMAKE_CXX_FLAGS
     "-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -g -fsanitize=address ${CMAKE_CXX_FLAGS}"
   )

--- a/cpp/test/filesystem/talon_file_system_test.cpp
+++ b/cpp/test/filesystem/talon_file_system_test.cpp
@@ -1,0 +1,929 @@
+// Copyright 2026 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <unistd.h>
+
+#ifdef WITH_TALON
+#include <arrow/api.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/io/memory.h>
+#include <arrow/util/async_generator.h>
+#include <arrow/util/io_util.h>
+#endif
+
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/common/extend_status.h"
+#include "milvus-storage/filesystem/async_random_access_file.h"
+#include "milvus-storage/filesystem/fs.h"
+#ifdef WITH_TALON
+#include "milvus-storage/filesystem/talon/talon_file_system_producer.h"
+#include "talon_bridge.h"
+#endif
+#include "milvus-storage/properties.h"
+#include "milvus-storage/reader.h"
+#include "milvus-storage/writer.h"
+#include "test_env.h"
+
+namespace milvus_storage::test {
+
+namespace {
+
+class ScopedEnv final {
+  public:
+  ScopedEnv(const char* name, const char* value) : name_(name) {
+    if (const char* old = std::getenv(name); old != nullptr) {
+      old_value_ = old;
+    }
+    if (value != nullptr) {
+      setenv(name, value, 1);
+    } else {
+      unsetenv(name);
+    }
+  }
+
+  ~ScopedEnv() {
+    if (old_value_.has_value()) {
+      setenv(name_.c_str(), old_value_->c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  private:
+  const std::string name_;
+  std::optional<std::string> old_value_;
+};
+
+}  // namespace
+
+#ifdef WITH_TALON
+namespace {
+
+class MetadataInputFile final : public arrow::io::BufferReader {
+  public:
+  MetadataInputFile() : arrow::io::BufferReader(arrow::Buffer::FromString("payload")) {}
+
+  arrow::Result<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadata() override { return metadata_result; }
+
+  arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>> ReadMetadataAsync(
+      const arrow::io::IOContext& io_context) override {
+    async_pool = io_context.pool();
+    return async_result.is_valid()
+               ? async_result
+               : arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>>::MakeFinished(metadata_result);
+  }
+
+  arrow::Result<std::shared_ptr<const arrow::KeyValueMetadata>> metadata_result{
+      std::shared_ptr<const arrow::KeyValueMetadata>(
+          arrow::key_value_metadata({"ETag", "Content-Length", "owner"}, {"\"origin-etag\"", "7", "test-owner"}))};
+  arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>> async_result;
+  arrow::MemoryPool* async_pool = nullptr;
+};
+
+class RejectingMemoryPool final : public arrow::ProxyMemoryPool {
+  public:
+  RejectingMemoryPool() : arrow::ProxyMemoryPool(arrow::default_memory_pool()) {}
+
+  arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
+    last_requested_size = size;
+    if (size == 0) {
+      return arrow::ProxyMemoryPool::Allocate(size, alignment, out);
+    }
+    // Stop before network I/O so tests can inspect the allocation request itself.
+    return arrow::Status::OutOfMemory("Rejected test allocation");
+  }
+
+  int64_t last_requested_size = -1;
+};
+
+class RecordingFileSystem final : public arrow::fs::LocalFileSystem {
+  public:
+  explicit RecordingFileSystem(std::string identity,
+                               const arrow::io::IOContext& io_context = arrow::io::default_io_context())
+      : arrow::fs::LocalFileSystem(io_context), identity_(std::move(identity)) {}
+
+  std::string type_name() const override { return "recording"; }
+
+  bool Equals(const arrow::fs::FileSystem& other) const override {
+    ++equals_calls_;
+    if (this == &other) {
+      return true;
+    }
+    const auto* recording = dynamic_cast<const RecordingFileSystem*>(&other);
+    return recording != nullptr && identity_ == recording->identity_;
+  }
+
+  arrow::Result<arrow::fs::FileInfoVector> GetFileInfo(const arrow::fs::FileSelector& selector) override {
+    ++synchronous_listing_calls_;
+    return arrow::fs::FileInfoVector{
+        arrow::fs::FileInfo(selector.base_dir + "/synchronous", arrow::fs::FileType::File)};
+  }
+
+  arrow::fs::FileInfoGenerator GetFileInfoGenerator(const arrow::fs::FileSelector& selector) override {
+    ++generator_calls_;
+    last_generator_selector_ = selector;
+    std::vector<arrow::fs::FileInfoVector> batches;
+    batches.push_back({arrow::fs::FileInfo(selector.base_dir + "/first", arrow::fs::FileType::File)});
+    batches.push_back({arrow::fs::FileInfo(selector.base_dir + "/second", arrow::fs::FileType::File)});
+    return arrow::MakeVectorGenerator(std::move(batches));
+  }
+
+  arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> OpenInputFile(const std::string& path) override {
+    ++input_open_calls;
+    last_input_path = path;
+    ARROW_RETURN_NOT_OK(input_open_status);
+    return input_file;
+  }
+
+  std::shared_ptr<MetadataInputFile> input_file = std::make_shared<MetadataInputFile>();
+  arrow::Status input_open_status;
+  int input_open_calls = 0;
+  std::string last_input_path;
+
+  int synchronous_listing_calls() const { return synchronous_listing_calls_; }
+  int generator_calls() const { return generator_calls_; }
+  int equals_calls() const { return equals_calls_; }
+  const arrow::fs::FileSelector& last_generator_selector() const { return last_generator_selector_; }
+
+  private:
+  const std::string identity_;
+  mutable int equals_calls_ = 0;
+  int synchronous_listing_calls_ = 0;
+  int generator_calls_ = 0;
+  arrow::fs::FileSelector last_generator_selector_;
+};
+
+class TalonFileSystemServiceFreeTest : public ::testing::Test {
+  protected:
+  static ArrowFileSystemConfig Config() {
+    ArrowFileSystemConfig config;
+    config.storage_type = "remote";
+    config.cloud_provider = kCloudProviderAWS;
+    config.bucket_name = "test-bucket";
+    config.talon_enabled = true;
+    config.talon_coordinator = "127.0.0.1:7000";
+    config.talon_block_size = 8388608;
+    return config;
+  }
+
+  static arrow::Result<ArrowFileSystemPtr> Wrap(const ArrowFileSystemConfig& config,
+                                                std::shared_ptr<RecordingFileSystem> origin) {
+    ARROW_ASSIGN_OR_RAISE(auto talon_fs, TalonFileSystemProducer(config, std::move(origin)).Make());
+    return std::make_shared<FileSystemProxy>(config.bucket_name, std::move(talon_fs));
+  }
+};
+
+class TalonIntegrationTest : public ::testing::Test {
+  protected:
+  void SetUp() override {
+    if (!IsTalonEnv()) {
+      GTEST_SKIP() << "Talon integration environment is not configured";
+    }
+
+    ASSERT_STATUS_OK(InitTestProperties(properties_));
+    FilesystemCache::getInstance().clean();
+    ASSERT_AND_ASSIGN(fs_, GetFileSystem(properties_));
+
+    path_ = "talon-integration/" + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + "-" +
+            std::to_string(getpid());
+    parquet_path_ = path_ + "-parquet";
+    expected_.resize(1024 * 1024);
+    for (size_t i = 0; i < expected_.size(); ++i) {
+      expected_[i] = static_cast<uint8_t>(i % 251);
+    }
+
+    ASSERT_AND_ASSIGN(auto output, fs_->OpenOutputStream(path_));
+    ASSERT_STATUS_OK(output->Write(expected_.data(), static_cast<int64_t>(expected_.size())));
+    ASSERT_STATUS_OK(output->Close());
+  }
+
+  void TearDown() override {
+    if (fs_ != nullptr) {
+      (void)fs_->DeleteFile(path_);
+      (void)fs_->DeleteDir(parquet_path_);
+      FilesystemCache::getInstance().clean();
+    }
+  }
+
+  api::Properties properties_;
+  ArrowFileSystemPtr fs_;
+  std::string path_;
+  std::string parquet_path_;
+  std::vector<uint8_t> expected_;
+};
+
+}  // namespace
+#endif
+
+TEST(TalonConfigTest, DefaultsAreDisabled) {
+  api::Properties properties;
+  ArrowFileSystemConfig config;
+  ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties, config));
+  EXPECT_FALSE(config.talon_enabled);
+  EXPECT_TRUE(config.talon_coordinator.empty());
+  EXPECT_EQ(config.talon_block_size, 256U * 1024U * 1024U);
+}
+
+TEST(TalonConfigTest, ParsesExplicitProperties) {
+  api::Properties properties;
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_STORAGE_TYPE, "remote"), std::nullopt);
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_ENABLED, "true"), std::nullopt);
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_COORDINATOR, "127.0.0.1:7000"), std::nullopt);
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_BLOCK_SIZE, "8388608"), std::nullopt);
+
+  ArrowFileSystemConfig config;
+  ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties, config));
+  EXPECT_TRUE(config.talon_enabled);
+  EXPECT_EQ(config.talon_coordinator, "127.0.0.1:7000");
+  EXPECT_EQ(config.talon_block_size, 8388608U);
+}
+
+TEST(TalonConfigTest, EnabledRequiresRemoteCoordinatorAndBlockSize) {
+  for (const auto& [storage_type, coordinator, block_size] :
+       std::vector<std::tuple<std::string, std::string, std::string>>{
+           {"local", "127.0.0.1:7000", "8388608"}, {"remote", "", "8388608"}, {"remote", "127.0.0.1:7000", "0"}}) {
+    api::Properties properties;
+    ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_STORAGE_TYPE, storage_type.c_str()), std::nullopt);
+    ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_ENABLED, "true"), std::nullopt);
+    ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_COORDINATOR, coordinator.c_str()), std::nullopt);
+    ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_BLOCK_SIZE, block_size.c_str()), std::nullopt);
+    ArrowFileSystemConfig config;
+    EXPECT_FALSE(ArrowFileSystemConfig::create_file_system_config(properties, config).ok());
+  }
+}
+
+TEST(TalonConfigTest, CacheKeyIncludesTalonRouting) {
+  ArrowFileSystemConfig base;
+  base.storage_type = "remote";
+  base.cloud_provider = kCloudProviderAWS;
+  base.address = "127.0.0.1:9000";
+  base.bucket_name = "test-bucket";
+
+  auto enabled = base;
+  enabled.talon_enabled = true;
+  enabled.talon_coordinator = "127.0.0.1:7000";
+  enabled.talon_block_size = 8388608;
+  EXPECT_NE(base.GetCacheKey(), enabled.GetCacheKey());
+
+  auto other_coordinator = enabled;
+  other_coordinator.talon_coordinator = "127.0.0.1:7001";
+  EXPECT_NE(enabled.GetCacheKey(), other_coordinator.GetCacheKey());
+
+  auto other_block_size = enabled;
+  other_block_size.talon_block_size = 16777216;
+  EXPECT_NE(enabled.GetCacheKey(), other_block_size.GetCacheKey());
+}
+
+TEST(TalonTestEnvTest, AddsTalonPropertiesWhenEnabled) {
+  ScopedEnv storage_type(ENV_VAR_STORAGE_TYPE, "remote");
+  ScopedEnv enabled(ENV_VAR_TALON_ENABLED, "true");
+  ScopedEnv coordinator(ENV_VAR_TALON_COORDINATOR, "127.0.0.1:7000");
+  ScopedEnv block_size(ENV_VAR_TALON_BLOCK_SIZE, "8388608");
+
+  api::Properties properties;
+  ASSERT_STATUS_OK(InitTestProperties(properties));
+  EXPECT_TRUE(IsTalonEnv());
+  EXPECT_TRUE(api::GetValue<bool>(properties, PROPERTY_FS_TALON_ENABLED).ValueOrDie());
+  EXPECT_EQ(api::GetValue<std::string>(properties, PROPERTY_FS_TALON_COORDINATOR).ValueOrDie(), "127.0.0.1:7000");
+  EXPECT_EQ(api::GetValue<uint32_t>(properties, PROPERTY_FS_TALON_BLOCK_SIZE).ValueOrDie(), 8388608U);
+}
+
+TEST(TalonTestEnvTest, AcceptsOneAndUsesDefaultBlockSize) {
+  ScopedEnv storage_type(ENV_VAR_STORAGE_TYPE, "remote");
+  ScopedEnv enabled(ENV_VAR_TALON_ENABLED, "1");
+  ScopedEnv coordinator(ENV_VAR_TALON_COORDINATOR, "127.0.0.1:7000");
+  ScopedEnv block_size(ENV_VAR_TALON_BLOCK_SIZE, nullptr);
+
+  api::Properties properties;
+  ASSERT_STATUS_OK(InitTestProperties(properties));
+  EXPECT_TRUE(IsTalonEnv());
+  EXPECT_EQ(api::GetValue<uint32_t>(properties, PROPERTY_FS_TALON_BLOCK_SIZE).ValueOrDie(), 268435456U);
+}
+
+TEST(TalonTestEnvTest, DoesNotAddTalonPropertiesWhenDisabled) {
+  ScopedEnv storage_type(ENV_VAR_STORAGE_TYPE, "remote");
+  ScopedEnv enabled(ENV_VAR_TALON_ENABLED, "false");
+  ScopedEnv coordinator(ENV_VAR_TALON_COORDINATOR, "127.0.0.1:7000");
+  ScopedEnv block_size(ENV_VAR_TALON_BLOCK_SIZE, "8388608");
+
+  api::Properties properties;
+  ASSERT_STATUS_OK(InitTestProperties(properties));
+  EXPECT_FALSE(IsTalonEnv());
+  EXPECT_FALSE(properties.contains(PROPERTY_FS_TALON_ENABLED));
+  EXPECT_FALSE(properties.contains(PROPERTY_FS_TALON_COORDINATOR));
+  EXPECT_FALSE(properties.contains(PROPERTY_FS_TALON_BLOCK_SIZE));
+}
+
+TEST(TalonTestEnvTest, RejectsEnabledTalonOutsideRemoteStorage) {
+  ScopedEnv storage_type(ENV_VAR_STORAGE_TYPE, "local");
+  ScopedEnv enabled(ENV_VAR_TALON_ENABLED, "true");
+  ScopedEnv coordinator(ENV_VAR_TALON_COORDINATOR, "127.0.0.1:7000");
+
+  api::Properties properties;
+  const auto status = InitTestProperties(properties);
+  EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+}
+
+TEST(TalonTestEnvTest, RequiresCoordinatorWhenEnabled) {
+  ScopedEnv storage_type(ENV_VAR_STORAGE_TYPE, "remote");
+  ScopedEnv enabled(ENV_VAR_TALON_ENABLED, "true");
+  ScopedEnv coordinator(ENV_VAR_TALON_COORDINATOR, nullptr);
+
+  api::Properties properties;
+  const auto status = InitTestProperties(properties);
+  EXPECT_TRUE(status.IsInvalid()) << status.ToString();
+}
+
+TEST(TalonFileSystemTest, S3CompatibleProviderIdentityIsPartOfEquality) {
+  ArrowFileSystemConfig aws;
+  aws.storage_type = "remote";
+  aws.cloud_provider = kCloudProviderAWS;
+  aws.address = "127.0.0.1:9000";
+  aws.bucket_name = "test-bucket";
+  aws.access_key_id = "access-key";
+  aws.access_key_value = "secret-key";
+  aws.region = "us-east-1";
+  aws.use_ssl = false;
+
+  auto aliyun = aws;
+  aliyun.cloud_provider = kCloudProviderAliyun;
+
+  ASSERT_AND_ASSIGN(auto aws_fs, CreateArrowFileSystem(aws));
+  ASSERT_AND_ASSIGN(auto aliyun_fs, CreateArrowFileSystem(aliyun));
+  const auto aws_proxy = std::dynamic_pointer_cast<FileSystemProxy>(aws_fs);
+  const auto aliyun_proxy = std::dynamic_pointer_cast<FileSystemProxy>(aliyun_fs);
+  ASSERT_NE(aws_proxy, nullptr);
+  ASSERT_NE(aliyun_proxy, nullptr);
+  EXPECT_EQ(aws_proxy->base_path(), "test-bucket/");
+  EXPECT_EQ(aliyun_proxy->base_path(), "test-bucket/");
+  EXPECT_EQ(std::dynamic_pointer_cast<FileSystemProxy>(aws_proxy->base_fs()), nullptr);
+  EXPECT_EQ(std::dynamic_pointer_cast<FileSystemProxy>(aliyun_proxy->base_fs()), nullptr);
+  EXPECT_FALSE(aws_fs->Equals(*aliyun_fs));
+  EXPECT_FALSE(aliyun_fs->Equals(*aws_fs));
+}
+
+#ifdef WITH_TALON
+class TalonProviderEqualityTest : public ::testing::TestWithParam<const char*> {};
+
+TEST_P(TalonProviderEqualityTest, ComparesRealProviderAndTalonSymmetrically) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "remote";
+  config.cloud_provider = GetParam();
+  config.address = config.cloud_provider == kCloudProviderAzure ? "core.windows.net" : "127.0.0.1:9000";
+  config.bucket_name = "test-bucket";
+  config.access_key_id = "testaccount";
+  config.access_key_value = "c2VjcmV0";
+  config.region = "us-east-1";
+
+  ASSERT_AND_ASSIGN(auto disabled, CreateArrowFileSystem(config));
+  ASSERT_AND_ASSIGN(auto same_disabled, CreateArrowFileSystem(config));
+  EXPECT_TRUE(disabled->Equals(*same_disabled));
+  EXPECT_TRUE(same_disabled->Equals(*disabled));
+
+  config.talon_enabled = true;
+  config.talon_coordinator = "127.0.0.1:7000";
+  ASSERT_AND_ASSIGN(auto enabled, CreateArrowFileSystem(config));
+  ASSERT_EQ(disabled->type_name(), enabled->type_name());
+  EXPECT_FALSE(enabled->Equals(*disabled));
+  EXPECT_FALSE(disabled->Equals(*enabled));
+
+  const auto disabled_proxy = std::dynamic_pointer_cast<FileSystemProxy>(disabled);
+  const auto enabled_proxy = std::dynamic_pointer_cast<FileSystemProxy>(enabled);
+  ASSERT_NE(disabled_proxy, nullptr);
+  ASSERT_NE(enabled_proxy, nullptr);
+  EXPECT_FALSE(enabled_proxy->base_fs()->Equals(*disabled_proxy->base_fs()));
+  EXPECT_FALSE(disabled_proxy->base_fs()->Equals(*enabled_proxy->base_fs()));
+  // A raw provider must also reject its bucket-rooted wrapper despite the matching type name.
+  EXPECT_FALSE(disabled_proxy->base_fs()->Equals(*disabled));
+
+  ASSERT_AND_ASSIGN(auto same_enabled, CreateArrowFileSystem(config));
+  EXPECT_TRUE(enabled->Equals(*same_enabled));
+  EXPECT_TRUE(same_enabled->Equals(*enabled));
+
+  config.talon_enabled = false;
+  config.access_key_id = "differentaccount";
+  ASSERT_AND_ASSIGN(auto different_account, CreateArrowFileSystem(config));
+  EXPECT_FALSE(disabled->Equals(*different_account));
+  EXPECT_FALSE(different_account->Equals(*disabled));
+}
+
+INSTANTIATE_TEST_SUITE_P(CloudProviders,
+                         TalonProviderEqualityTest,
+                         ::testing::Values(kCloudProviderAWS, kCloudProviderAzure));
+
+TEST(TalonBridgeTest, MapsClientCreationErrorAndPreservesTalonMessage) {
+  const auto result = talon::TalonClient::Make("127.0.0.1:7000", 0);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsIOError()) << result.status().ToString();
+  EXPECT_NE(result.status().message().find("Failed to create Talon client"), std::string::npos);
+  EXPECT_NE(result.status().message().find("block_size must be non-zero"), std::string::npos);
+}
+
+TEST(TalonBridgeTest, MapsOpenErrorAndPreservesTalonMessage) {
+  ASSERT_AND_ASSIGN(auto client, talon::TalonClient::Make("127.0.0.1:7000", 8U * 1024U * 1024U));
+
+  const auto result = client->OpenObject("aws", "test-bucket", "", std::nullopt);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsIOError()) << result.status().ToString();
+  EXPECT_NE(result.status().message().find("Failed to open Talon object"), std::string::npos);
+  EXPECT_NE(result.status().message().find("bucket and object key must be non-empty"), std::string::npos);
+}
+
+TEST(TalonBridgeTest, MapsAsyncErrorAndPreservesTalonMessage) {
+  ASSERT_AND_ASSIGN(auto client, talon::TalonClient::Make("127.0.0.1:7000", 8U * 1024U * 1024U));
+  ASSERT_AND_ASSIGN(auto reader, client->OpenObject("aws", "test-bucket", "path/a", talon::TalonObjectStat{0, ""}));
+
+  const auto result = reader.ReadAtAsync(0, std::numeric_limits<uint64_t>::max(), nullptr).result();
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsIOError()) << result.status().ToString();
+  EXPECT_NE(result.status().message().find("Failed to read Talon object"), std::string::npos);
+  EXPECT_NE(result.status().message().find("Talon read length exceeds isize::MAX"), std::string::npos);
+}
+
+TEST(TalonFileSystemTest, PreservesOuterSubtreeAndKnownSize) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "remote";
+  config.cloud_provider = kCloudProviderAWS;
+  config.address = "http://127.0.0.1:9000";
+  config.bucket_name = "test-bucket";
+  config.access_key_id = "minioadmin";
+  config.access_key_value = "minioadmin";
+  config.region = "us-east-1";
+  config.s3_crt_async_read = false;
+  config.talon_enabled = true;
+  config.talon_coordinator = "127.0.0.1:7000";
+  config.talon_block_size = 8388608;
+
+  ASSERT_AND_ASSIGN(auto fs, CreateArrowFileSystem(config));
+  auto proxy = std::dynamic_pointer_cast<FileSystemProxy>(fs);
+  ASSERT_NE(proxy, nullptr);
+  EXPECT_EQ(proxy->base_path(), "test-bucket/");
+  EXPECT_EQ(std::dynamic_pointer_cast<FileSystemProxy>(proxy->base_fs()), nullptr);
+  EXPECT_NE(std::dynamic_pointer_cast<UploadConditional>(fs), nullptr);
+  EXPECT_NE(std::dynamic_pointer_cast<UploadSizable>(fs), nullptr);
+  EXPECT_NE(std::dynamic_pointer_cast<Observable>(fs), nullptr);
+
+  arrow::fs::FileInfo info("known-empty", arrow::fs::FileType::File);
+  info.set_size(0);
+  ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+  ASSERT_AND_ASSIGN(auto size, file->GetSize());
+  EXPECT_EQ(size, 0);
+  auto* const async_file = dynamic_cast<NonBlockingRandomAccessFile*>(file.get());
+  ASSERT_NE(async_file, nullptr);
+  ASSERT_AND_ASSIGN(const auto async_size, async_file->GetSizeAsync().result());
+  EXPECT_EQ(async_size, 0);
+  ASSERT_STATUS_OK(file->Close());
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, ProducerAcceptsRawProviderFilesystem) {
+  const auto config = Config();
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+
+  ASSERT_AND_ASSIGN(auto talon_fs, TalonFileSystemProducer(config, origin).Make());
+  EXPECT_EQ(talon_fs->type_name(), "recording");
+  EXPECT_EQ(std::dynamic_pointer_cast<FileSystemProxy>(talon_fs), nullptr);
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, OpenWithFileInfoRejectsNonFiles) {
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+  for (const auto type : {arrow::fs::FileType::NotFound, arrow::fs::FileType::Directory}) {
+    SCOPED_TRACE(static_cast<int>(type));
+    const arrow::fs::FileInfo info("prefix/object", type);
+    const auto file = fs->OpenInputFile(info);
+    const auto stream = fs->OpenInputStream(info);
+    for (const auto& status : {file.status(), stream.status()}) {
+      EXPECT_TRUE(status.IsIOError()) << status;
+      EXPECT_NE(status.message().find("test-bucket/prefix/object"), std::string::npos);
+      if (type == arrow::fs::FileType::NotFound) {
+        EXPECT_EQ(arrow::internal::ErrnoFromStatus(status), ENOENT);
+      } else {
+        EXPECT_NE(status.message().find("Not a regular file"), std::string::npos);
+      }
+    }
+  }
+  EXPECT_EQ(origin->input_open_calls, 0);
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, OpenWithFileInfoAcceptsFileAndUnknown) {
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+  for (const auto type : {arrow::fs::FileType::File, arrow::fs::FileType::Unknown}) {
+    for (const int64_t size : {-1, 0, 7}) {
+      SCOPED_TRACE(::testing::Message() << "type=" << static_cast<int>(type) << ", size=" << size);
+      arrow::fs::FileInfo info("prefix/object", type);
+      info.set_size(size);
+      ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+      ASSERT_AND_ASSIGN(auto stream, fs->OpenInputStream(info));
+      if (size >= 0) {
+        ASSERT_AND_ASSIGN(const auto known_size, file->GetSize());
+        EXPECT_EQ(known_size, size);
+      }
+      ASSERT_STATUS_OK(file->Close());
+      ASSERT_STATUS_OK(stream->Close());
+    }
+  }
+  EXPECT_EQ(origin->input_open_calls, 0);
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, EquivalentTalonFilesystemsCompareEqualSymmetrically) {
+  const auto config = Config();
+  ASSERT_AND_ASSIGN(auto left, Wrap(config, std::make_shared<RecordingFileSystem>("origin")));
+  ASSERT_AND_ASSIGN(auto right, Wrap(config, std::make_shared<RecordingFileSystem>("origin")));
+  const auto left_proxy = std::dynamic_pointer_cast<FileSystemProxy>(left);
+  const auto right_proxy = std::dynamic_pointer_cast<FileSystemProxy>(right);
+  ASSERT_NE(left_proxy, nullptr);
+  ASSERT_NE(right_proxy, nullptr);
+  const auto left_talon = left_proxy->base_fs();
+  const auto right_talon = right_proxy->base_fs();
+
+  EXPECT_TRUE(left_talon->Equals(*right_talon));
+  EXPECT_TRUE(right_talon->Equals(*left_talon));
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, PreservesProviderTypeName) {
+  const auto config = Config();
+  ASSERT_AND_ASSIGN(auto fs, Wrap(config, std::make_shared<RecordingFileSystem>("origin")));
+
+  EXPECT_EQ(fs->type_name(), "recording");
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, TalonFilesystemComparesUnequalToUndecoratedOrigin) {
+  const auto config = Config();
+  ASSERT_AND_ASSIGN(auto talon_fs, Wrap(config, std::make_shared<RecordingFileSystem>("origin")));
+  auto raw_origin = std::make_shared<RecordingFileSystem>("origin");
+
+  const auto talon_proxy = std::dynamic_pointer_cast<FileSystemProxy>(talon_fs);
+  ASSERT_NE(talon_proxy, nullptr);
+  const auto talon_base = talon_proxy->base_fs();
+  EXPECT_FALSE(talon_base->Equals(*raw_origin));
+  EXPECT_FALSE(raw_origin->Equals(*talon_base));
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, EqualityIncludesTalonRouting) {
+  const auto config = Config();
+  ASSERT_AND_ASSIGN(auto base, Wrap(config, std::make_shared<RecordingFileSystem>("origin")));
+  const auto base_proxy = std::dynamic_pointer_cast<FileSystemProxy>(base);
+  ASSERT_NE(base_proxy, nullptr);
+  const auto base_talon = base_proxy->base_fs();
+
+  auto other_coordinator = config;
+  other_coordinator.talon_coordinator = "127.0.0.1:7001";
+  ASSERT_AND_ASSIGN(auto coordinator_fs, Wrap(other_coordinator, std::make_shared<RecordingFileSystem>("origin")));
+  const auto coordinator_proxy = std::dynamic_pointer_cast<FileSystemProxy>(coordinator_fs);
+  ASSERT_NE(coordinator_proxy, nullptr);
+  const auto coordinator_talon = coordinator_proxy->base_fs();
+  EXPECT_FALSE(base_talon->Equals(*coordinator_talon));
+  EXPECT_FALSE(coordinator_talon->Equals(*base_talon));
+
+  auto other_block_size = config;
+  other_block_size.talon_block_size *= 2;
+  ASSERT_AND_ASSIGN(auto block_size_fs, Wrap(other_block_size, std::make_shared<RecordingFileSystem>("origin")));
+  const auto block_size_proxy = std::dynamic_pointer_cast<FileSystemProxy>(block_size_fs);
+  ASSERT_NE(block_size_proxy, nullptr);
+  const auto block_size_talon = block_size_proxy->base_fs();
+  EXPECT_FALSE(base_talon->Equals(*block_size_talon));
+  EXPECT_FALSE(block_size_talon->Equals(*base_talon));
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, ForwardsStreamingFileInfoGeneratorWithFullSelector) {
+  const auto config = Config();
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, Wrap(config, origin));
+
+  arrow::fs::FileSelector selector;
+  selector.base_dir = "prefix";
+  selector.allow_not_found = true;
+  selector.recursive = true;
+  selector.max_recursion = 3;
+  auto generator = fs->GetFileInfoGenerator(selector);
+
+  EXPECT_EQ(origin->synchronous_listing_calls(), 0);
+  EXPECT_EQ(origin->generator_calls(), 1);
+  EXPECT_EQ(origin->last_generator_selector().base_dir, "test-bucket/prefix");
+  EXPECT_TRUE(origin->last_generator_selector().allow_not_found);
+  EXPECT_TRUE(origin->last_generator_selector().recursive);
+  EXPECT_EQ(origin->last_generator_selector().max_recursion, 3);
+
+  ASSERT_AND_ASSIGN(auto first, generator().result());
+  ASSERT_EQ(first.size(), 1);
+  EXPECT_EQ(first[0].path(), "prefix/first");
+
+  ASSERT_AND_ASSIGN(auto second, generator().result());
+  ASSERT_EQ(second.size(), 1);
+  EXPECT_EQ(second[0].path(), "prefix/second");
+
+  ASSERT_AND_ASSIGN(auto end, generator().result());
+  EXPECT_TRUE(end.empty());
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, ReadMetadataLazilyPreservesOriginMetadata) {
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+  arrow::fs::FileInfo info("prefix/object", arrow::fs::FileType::File);
+  info.set_size(7);
+  ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+  ASSERT_AND_ASSIGN(const auto size, file->GetSize());
+  EXPECT_EQ(size, 7);
+  EXPECT_EQ(origin->input_open_calls, 0);
+
+  ASSERT_AND_ASSIGN(auto metadata, file->ReadMetadata());
+  ASSERT_NE(metadata, nullptr);
+  ASSERT_AND_ASSIGN(const auto etag, metadata->Get("ETag"));
+  ASSERT_AND_ASSIGN(const auto content_length, metadata->Get("Content-Length"));
+  ASSERT_AND_ASSIGN(const auto owner, metadata->Get("owner"));
+  EXPECT_EQ(etag, "\"origin-etag\"");
+  EXPECT_EQ(content_length, "7");
+  EXPECT_EQ(owner, "test-owner");
+  EXPECT_EQ(origin->last_input_path, "test-bucket/prefix/object");
+  ASSERT_AND_ASSIGN(auto repeated, file->ReadMetadata());
+  EXPECT_EQ(repeated, metadata);
+  ASSERT_AND_ASSIGN(auto async_metadata, file->ReadMetadataAsync().result());
+  EXPECT_EQ(async_metadata, metadata);
+  EXPECT_EQ(origin->input_open_calls, 1);
+
+  ASSERT_STATUS_OK(file->Close());
+  EXPECT_TRUE(origin->input_file->closed());
+  EXPECT_TRUE(file->ReadMetadata().status().IsInvalid());
+  EXPECT_TRUE(file->ReadMetadataAsync().result().status().IsInvalid());
+  ASSERT_STATUS_OK(file->Close());
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, ReadMetadataAsyncForwardsProviderFutureAndContext) {
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+  ASSERT_AND_ASSIGN(auto file, fs->OpenInputStream("prefix/object"));
+  arrow::ProxyMemoryPool pool(arrow::default_memory_pool());
+  origin->input_file->async_result = arrow::Future<std::shared_ptr<const arrow::KeyValueMetadata>>::Make();
+
+  auto future = file->ReadMetadataAsync(arrow::io::IOContext(&pool));
+  EXPECT_FALSE(future.is_finished());
+  EXPECT_EQ(origin->input_file->async_pool, &pool);
+  EXPECT_EQ(origin->last_input_path, "test-bucket/prefix/object");
+  origin->input_file->async_result.MarkFinished(origin->input_file->metadata_result);
+  ASSERT_AND_ASSIGN(auto metadata, future.result());
+  ASSERT_NE(metadata, nullptr);
+  ASSERT_AND_ASSIGN(const auto etag, metadata->Get("ETag"));
+  EXPECT_EQ(etag, "\"origin-etag\"");
+  ASSERT_STATUS_OK(file->Close());
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, ReadMetadataPreservesOriginErrorsAndNullMetadata) {
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+  ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile("prefix/object"));
+  const auto error =
+      MakeExtendError(ExtendStatusCode::AwsErrorAccessDenied, "origin metadata denied", "provider detail");
+  origin->input_open_status = error;
+  EXPECT_EQ(file->ReadMetadata().status(), error);
+  EXPECT_EQ(file->ReadMetadataAsync().result().status(), error);
+
+  origin->input_open_status = arrow::Status::OK();
+  origin->input_file->metadata_result = error;
+  EXPECT_EQ(file->ReadMetadata().status(), error);
+  EXPECT_EQ(file->ReadMetadataAsync().result().status(), error);
+
+  origin->input_file->metadata_result = std::shared_ptr<const arrow::KeyValueMetadata>{};
+  ASSERT_AND_ASSIGN(auto metadata, file->ReadMetadata());
+  EXPECT_EQ(metadata, nullptr);
+  ASSERT_AND_ASSIGN(auto async_metadata, file->ReadMetadataAsync().result());
+  EXPECT_EQ(async_metadata, nullptr);
+  ASSERT_STATUS_OK(file->Close());
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, AllocatingReadsClampKnownSizeBeforeAllocation) {
+  for (const bool async : {false, true}) {
+    SCOPED_TRACE(async);
+    RejectingMemoryPool pool;
+    const arrow::io::IOContext io_context(&pool);
+    auto origin = std::make_shared<RecordingFileSystem>("origin", io_context);
+    ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+    arrow::fs::FileInfo info("prefix/object", arrow::fs::FileType::File);
+    info.set_size(8192);
+    ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+
+    const auto result =
+        async ? file->ReadAsync(io_context, 4096, 64 * 1024 * 1024).result() : file->ReadAt(4096, 64 * 1024 * 1024);
+    EXPECT_TRUE(result.status().IsOutOfMemory()) << result.status();
+    EXPECT_EQ(pool.last_requested_size, 4096);
+    ASSERT_STATUS_OK(file->Close());
+  }
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, AllocatingReadsAtKnownEofDoNotAllocatePayload) {
+  for (const bool async : {false, true}) {
+    for (const int64_t size : {0, 8192}) {
+      SCOPED_TRACE(::testing::Message() << "async=" << async << ", size=" << size);
+      arrow::ProxyMemoryPool pool(arrow::default_memory_pool());
+      const arrow::io::IOContext io_context(&pool);
+      auto origin = std::make_shared<RecordingFileSystem>("origin", io_context);
+      ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+      arrow::fs::FileInfo info("prefix/object", arrow::fs::FileType::File);
+      info.set_size(size);
+      ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+
+      ASSERT_AND_ASSIGN(auto buffer, async ? file->ReadAsync(io_context, size, 64 * 1024 * 1024).result()
+                                           : file->ReadAt(size, 64 * 1024 * 1024));
+      EXPECT_EQ(buffer->size(), 0);
+      EXPECT_EQ(pool.max_memory(), 0);
+      ASSERT_STATUS_OK(file->Close());
+    }
+  }
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, AllocatingReadsValidateBeforeAllocation) {
+  for (const bool async : {false, true}) {
+    SCOPED_TRACE(async);
+    RejectingMemoryPool pool;
+    const arrow::io::IOContext io_context(&pool);
+    auto origin = std::make_shared<RecordingFileSystem>("origin", io_context);
+    ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+    arrow::fs::FileInfo info("prefix/object", arrow::fs::FileType::File);
+    info.set_size(8192);
+    ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+
+    const std::vector<std::tuple<int64_t, int64_t, arrow::StatusCode>> cases{
+        {-1, 64 * 1024 * 1024, arrow::StatusCode::Invalid},
+        {0, -1, arrow::StatusCode::Invalid},
+        {8193, 64 * 1024 * 1024, arrow::StatusCode::IOError}};
+    for (const auto& [position, nbytes, expected_code] : cases) {
+      const auto result =
+          async ? file->ReadAsync(io_context, position, nbytes).result() : file->ReadAt(position, nbytes);
+      EXPECT_EQ(result.status().code(), expected_code);
+    }
+    ASSERT_STATUS_OK(file->Close());
+    const auto closed =
+        async ? file->ReadAsync(io_context, 0, 64 * 1024 * 1024).result() : file->ReadAt(0, 64 * 1024 * 1024);
+    EXPECT_TRUE(closed.status().IsInvalid());
+    EXPECT_EQ(pool.last_requested_size, -1);
+  }
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, AllocatingReadsWithUnknownSizeDoNotPreflightStat) {
+  for (const bool async : {false, true}) {
+    SCOPED_TRACE(async);
+    RejectingMemoryPool pool;
+    const arrow::io::IOContext io_context(&pool);
+    auto origin = std::make_shared<RecordingFileSystem>("origin", io_context);
+    ASSERT_AND_ASSIGN(auto fs, Wrap(Config(), origin));
+    ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile("prefix/object"));
+
+    const auto result =
+        async ? file->ReadAsync(io_context, 4096, 64 * 1024 * 1024).result() : file->ReadAt(4096, 64 * 1024 * 1024);
+    EXPECT_TRUE(result.status().IsOutOfMemory()) << result.status();
+    EXPECT_EQ(pool.last_requested_size, 64 * 1024 * 1024);
+    ASSERT_STATUS_OK(file->Close());
+  }
+}
+
+TEST_F(TalonIntegrationTest, WriteOriginReadThroughTalon) {
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path_));
+  ASSERT_AND_ASSIGN(auto buffer, file->ReadAt(0, static_cast<int64_t>(expected_.size())));
+  ASSERT_EQ(buffer->size(), static_cast<int64_t>(expected_.size()));
+  EXPECT_EQ(std::memcmp(buffer->data(), expected_.data(), expected_.size()), 0);
+}
+
+TEST_F(TalonIntegrationTest, OpenWithKnownSize) {
+  ASSERT_AND_ASSIGN(const auto info, fs_->GetFileInfo(path_));
+  ASSERT_EQ(info.type(), arrow::fs::FileType::File);
+  ASSERT_EQ(info.size(), static_cast<int64_t>(expected_.size()));
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(info));
+  ASSERT_AND_ASSIGN(const auto size, file->GetSize());
+  EXPECT_EQ(size, static_cast<int64_t>(expected_.size()));
+  ASSERT_AND_ASSIGN(auto buffer, file->ReadAt(0, static_cast<int64_t>(expected_.size())));
+  ASSERT_EQ(buffer->size(), static_cast<int64_t>(expected_.size()));
+  EXPECT_EQ(std::memcmp(buffer->data(), expected_.data(), expected_.size()), 0);
+}
+
+TEST_F(TalonIntegrationTest, OpenWithoutKnownSize) {
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path_));
+  ASSERT_AND_ASSIGN(const auto size, file->GetSize());
+  ASSERT_EQ(size, static_cast<int64_t>(expected_.size()));
+
+  constexpr int64_t kOffset = 4096;
+  constexpr int64_t kLength = 4096;
+  ASSERT_AND_ASSIGN(auto buffer, file->ReadAt(kOffset, kLength));
+  ASSERT_EQ(buffer->size(), kLength);
+  EXPECT_EQ(std::memcmp(buffer->data(), expected_.data() + kOffset, kLength), 0);
+}
+
+TEST_F(TalonIntegrationTest, AsyncReadAtIntoCallerBuffer) {
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path_));
+  auto* const async_file = dynamic_cast<NonBlockingRandomAccessFile*>(file.get());
+  ASSERT_NE(async_file, nullptr);
+
+  constexpr int64_t kOffset = 1024;
+  std::vector<uint8_t> output(4096);
+  auto future = async_file->ReadAtAsyncInto(kOffset, static_cast<int64_t>(output.size()), output.data());
+  ASSERT_AND_ASSIGN(const auto bytes_read, future.result());
+  ASSERT_EQ(bytes_read, static_cast<int64_t>(output.size()));
+  EXPECT_TRUE(std::equal(output.begin(), output.end(), expected_.begin() + kOffset));
+}
+
+TEST_F(TalonIntegrationTest, ConcurrentAsyncRanges) {
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path_));
+  auto* const async_file = dynamic_cast<NonBlockingRandomAccessFile*>(file.get());
+  ASSERT_NE(async_file, nullptr);
+
+  constexpr size_t kRangeCount = 16;
+  constexpr size_t kRangeSize = 64 * 1024;
+  std::vector<std::vector<uint8_t>> outputs(kRangeCount, std::vector<uint8_t>(kRangeSize));
+  std::vector<arrow::Future<int64_t>> futures;
+  futures.reserve(kRangeCount);
+  for (size_t i = 0; i < kRangeCount; ++i) {
+    futures.push_back(async_file->ReadAtAsyncInto(static_cast<int64_t>(i * kRangeSize),
+                                                  static_cast<int64_t>(kRangeSize), outputs[i].data()));
+  }
+
+  // Drain all reads before a fatal assertion can release buffers still used by Rust.
+  // Each future retains its result for the assertions below, including failures.
+  for (const auto& future : futures) {
+    future.Wait();
+  }
+
+  for (size_t i = 0; i < kRangeCount; ++i) {
+    ASSERT_AND_ASSIGN(const auto bytes_read, futures[i].result());
+    ASSERT_EQ(bytes_read, static_cast<int64_t>(kRangeSize));
+    EXPECT_TRUE(std::equal(outputs[i].begin(), outputs[i].end(), expected_.begin() + i * kRangeSize));
+  }
+}
+
+TEST_F(TalonIntegrationTest, EofAndClosedFileSemantics) {
+  ASSERT_AND_ASSIGN(auto file, fs_->OpenInputFile(path_));
+  std::vector<uint8_t> output(4096);
+  ASSERT_AND_ASSIGN(const auto bytes_read, file->ReadAt(static_cast<int64_t>(expected_.size()),
+                                                        static_cast<int64_t>(output.size()), output.data()));
+  EXPECT_EQ(bytes_read, 0);
+
+  ASSERT_STATUS_OK(file->Close());
+  const auto closed_read = file->ReadAt(0, static_cast<int64_t>(output.size()), output.data());
+  ASSERT_FALSE(closed_read.ok());
+  EXPECT_TRUE(closed_read.status().IsInvalid()) << closed_read.status().ToString();
+}
+
+TEST_F(TalonIntegrationTest, ParquetReadThroughNormalStorageApi) {
+  ASSERT_STATUS_OK(CreateTestDir(fs_, parquet_path_));
+  ASSERT_AND_ASSIGN(auto schema, CreateTestSchema());
+  ASSERT_AND_ASSIGN(auto batch, CreateTestData(schema));
+  ASSERT_AND_ASSIGN(auto policy, CreateSinglePolicy(LOON_FORMAT_PARQUET, schema));
+
+  auto writer = api::Writer::create(parquet_path_, schema, std::move(policy), properties_);
+  ASSERT_NE(writer, nullptr);
+  ASSERT_STATUS_OK(writer->write(batch));
+  ASSERT_AND_ASSIGN(auto column_groups, writer->close());
+
+  auto reader = api::Reader::create(column_groups, schema, nullptr, properties_);
+  ASSERT_NE(reader, nullptr);
+  ASSERT_AND_ASSIGN(auto batch_reader, reader->get_record_batch_reader());
+  std::shared_ptr<arrow::RecordBatch> result;
+  ASSERT_STATUS_OK(batch_reader->ReadNext(&result));
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->num_rows(), batch->num_rows());
+  ASSERT_STATUS_OK(ValidateRowAlignment(result));
+  ASSERT_STATUS_OK(batch_reader->ReadNext(&result));
+  EXPECT_EQ(result, nullptr);
+}
+#endif
+
+#ifndef WITH_TALON
+TEST(TalonFileSystemTest, EnabledWithoutBuildSupportIsRejected) {
+  ArrowFileSystemConfig config;
+  config.storage_type = "remote";
+  config.talon_enabled = true;
+  config.talon_coordinator = "127.0.0.1:7000";
+  auto result = CreateArrowFileSystem(config);
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsInvalid());
+}
+#endif
+
+}  // namespace milvus_storage::test

--- a/cpp/test/format/fs_cache_test.cpp
+++ b/cpp/test/format/fs_cache_test.cpp
@@ -182,6 +182,30 @@ TEST_F(FileSystemCacheTest, ListReturnsRemoteDisplayKey) {
   EXPECT_EQ(entries[0].second, fs);
 }
 
+#ifdef WITH_TALON
+TEST_F(FileSystemCacheTest, ListReturnsTalonDisplayKey) {
+  api::Properties props;
+  props[PROPERTY_FS_STORAGE_TYPE] = std::string("remote");
+  props[PROPERTY_FS_CLOUD_PROVIDER] = std::string(kCloudProviderAWS);
+  props[PROPERTY_FS_ADDRESS] = std::string("minio.example.com:9000");
+  props[PROPERTY_FS_BUCKET_NAME] = std::string("display-bucket");
+  props[PROPERTY_FS_ACCESS_KEY_ID] = std::string("ak");
+  props[PROPERTY_FS_ACCESS_KEY_VALUE] = std::string("sk");
+  props[PROPERTY_FS_TALON_ENABLED] = true;
+  props[PROPERTY_FS_TALON_COORDINATOR] = std::string("127.0.0.1:7000");
+  props[PROPERTY_FS_TALON_BLOCK_SIZE] = uint32_t{8U * 1024U * 1024U};
+
+  auto& cache = FilesystemCache::getInstance();
+  ASSERT_AND_ASSIGN(auto config, cache.resolve_config(props));
+  ASSERT_AND_ASSIGN(auto fs, cache.get(props));
+
+  auto entries = cache.list();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].first, "minio.example.com:9000/display-bucket?talon=127.0.0.1:7000#" + config.GetCacheKey());
+  EXPECT_EQ(entries[0].second, fs);
+}
+#endif
+
 TEST_F(FileSystemCacheTest, ListUsesNullForEmptyRemoteAddress) {
   api::Properties props;
   props[PROPERTY_FS_STORAGE_TYPE] = std::string("remote");

--- a/cpp/test/format/iceberg/iceberg_bridge_test.cpp
+++ b/cpp/test/format/iceberg/iceberg_bridge_test.cpp
@@ -196,7 +196,7 @@ class AsyncReaderLifecycleState {
 };
 
 class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
-                                             public milvus_storage::NonBlockingReadAtFile {
+                                             public milvus_storage::NonBlockingRandomAccessFile {
   public:
   CallbackThreadRandomAccessFile(std::shared_ptr<arrow::io::RandomAccessFile> file,
                                  std::shared_ptr<AsyncReaderLifecycleState> state)
@@ -228,6 +228,7 @@ class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
   }
   arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
   arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
+  arrow::Future<int64_t> GetSizeAsync() override { return arrow::Future<int64_t>::MakeFinished(file_->GetSize()); }
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     return file_->ReadAt(position, nbytes, out);
   }

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -294,7 +294,7 @@ class AsyncReaderLifecycleState {
 };
 
 class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
-                                             public milvus_storage::NonBlockingReadAtFile {
+                                             public milvus_storage::NonBlockingRandomAccessFile {
   public:
   CallbackThreadRandomAccessFile(std::shared_ptr<arrow::io::RandomAccessFile> file,
                                  std::shared_ptr<AsyncReaderLifecycleState> state)
@@ -326,6 +326,7 @@ class CallbackThreadRandomAccessFile final : public arrow::io::RandomAccessFile,
   }
   arrow::Status Seek(int64_t position) override { return file_->Seek(position); }
   arrow::Result<int64_t> GetSize() override { return file_->GetSize(); }
+  arrow::Future<int64_t> GetSizeAsync() override { return arrow::Future<int64_t>::MakeFinished(file_->GetSize()); }
   arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     return file_->ReadAt(position, nbytes, out);
   }

--- a/cpp/test/include/test_env.h
+++ b/cpp/test/include/test_env.h
@@ -39,6 +39,9 @@
 #define ENV_VAR_REGION "TEST_ENV_REGION"
 #define ENV_VAR_USE_IAM "TEST_ENV_USE_IAM"
 #define ENV_VAR_USE_SSL "TEST_ENV_USE_SSL"
+#define ENV_VAR_TALON_ENABLED "TEST_ENV_TALON_ENABLED"
+#define ENV_VAR_TALON_COORDINATOR "TEST_ENV_TALON_COORDINATOR"
+#define ENV_VAR_TALON_BLOCK_SIZE "TEST_ENV_TALON_BLOCK_SIZE"
 
 // only used in local storage
 #define ENV_VAR_ROOT_PATH "ROOT_PATH"
@@ -61,7 +64,22 @@
 #define ASSERT_AND_ASSIGN(lhs, rexpr) ASSERT_AND_ASSIGN_IMPL(CONCAT(_tmp_value, __COUNTER__), lhs, rexpr);
 
 namespace milvus_storage {
+/// Returns whether integration tests are configured to use remote storage.
+///
+/// Only TEST_ENV_STORAGE_TYPE="remote" is treated as a cloud environment.
 bool IsCloudEnv();
+
+/// Returns whether Talon integration tests are explicitly enabled.
+///
+/// Only TEST_ENV_TALON_ENABLED values "true" and "1" enable Talon. This
+/// function does not validate the remaining environment; InitTestProperties()
+/// performs that validation while building the filesystem properties.
+bool IsTalonEnv();
+
+/// Populates filesystem properties from the TEST_ENV_* environment variables.
+///
+/// When Talon is enabled, remote storage and TEST_ENV_TALON_COORDINATOR are
+/// required. TEST_ENV_TALON_BLOCK_SIZE is optional and defaults to 256 MiB.
 arrow::Status InitTestProperties(api::Properties& properties);
 std::string GetTestBasePath(const std::string& dir);
 arrow::Status MoveTestBasePath(const milvus_storage::ArrowFileSystemPtr& fs,

--- a/cpp/test/test_env.cpp
+++ b/cpp/test/test_env.cpp
@@ -41,8 +41,18 @@ bool IsCloudEnv() {
   return storage_type == "remote";
 }
 
+bool IsTalonEnv() {
+  const auto enabled = GetEnvVar(ENV_VAR_TALON_ENABLED).ValueOr("");
+  return enabled == "true" || enabled == "1";
+}
+
 arrow::Status InitTestProperties(api::Properties& properties) {
-  auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
+  const auto storage_type = GetEnvVar(ENV_VAR_STORAGE_TYPE).ValueOr("");
+  const bool talon_enabled = IsTalonEnv();
+
+  if (talon_enabled && storage_type != "remote") {
+    return arrow::Status::Invalid("Talon test environment requires TEST_ENV_STORAGE_TYPE=remote");
+  }
 
   if (storage_type == "local" || storage_type.empty()) {
     api::SetValue(properties, PROPERTY_FS_ROOT_PATH, "/tmp/milvus-storage-test");
@@ -68,6 +78,25 @@ arrow::Status InitTestProperties(api::Properties& properties) {
                     GetEnvVar(ENV_VAR_ACCESS_KEY_ID).ValueOr("minioadmin").c_str());
       api::SetValue(properties, PROPERTY_FS_ACCESS_KEY_VALUE,
                     GetEnvVar(ENV_VAR_ACCESS_KEY_VALUE).ValueOr("minioadmin").c_str());
+    }
+
+    if (talon_enabled) {
+      const auto coordinator = GetEnvVar(ENV_VAR_TALON_COORDINATOR).ValueOr("");
+      if (coordinator.empty()) {
+        return arrow::Status::Invalid("Talon test environment requires TEST_ENV_TALON_COORDINATOR");
+      }
+      const auto block_size = GetEnvVar(ENV_VAR_TALON_BLOCK_SIZE).ValueOr("268435456");
+      if (const auto error = api::SetValue(properties, PROPERTY_FS_TALON_ENABLED, "true"); error.has_value()) {
+        return arrow::Status::Invalid(*error);
+      }
+      if (const auto error = api::SetValue(properties, PROPERTY_FS_TALON_COORDINATOR, coordinator.c_str());
+          error.has_value()) {
+        return arrow::Status::Invalid(*error);
+      }
+      if (const auto error = api::SetValue(properties, PROPERTY_FS_TALON_BLOCK_SIZE, block_size.c_str());
+          error.has_value()) {
+        return arrow::Status::Invalid(*error);
+      }
     }
   } else {
     return arrow::Status::Invalid("Unknown STORAGE_TYPE: " + storage_type);


### PR DESCRIPTION
Remote filesystem reads currently go straight to cloud providers even when a Talon deployment is available. This change adds an opt-in Talon read layer so callers can keep using the existing storage API and provider credentials while routing object reads through Talon's coordinator and cache workers. Remote filesystem creation now builds the raw cloud provider first, optionally decorates it with Talon, and finally applies one outer FileSystemProxy for bucket rooting. This keeps the bucket available when constructing Talon object IDs, avoids applying subtree behavior twice, and continues forwarding listings, mutations, uploads, metrics, and provider-specific capabilities to the original filesystem.

A dedicated C++ and Rust bridge wraps the Talon Rust client and keeps the raw callback ABI inside the bridge. Each filesystem reuses one Talon client while opened files use lightweight object readers. The reader accepts known size hints, shares resolved size and version metadata across concurrent operations, and exposes non-blocking size and range reads through Arrow futures while preserving the original Talon error messages.

The integration maps configured cloud providers to Talon's backend schemes and identifies objects by backend, bucket or container, and relative key. Talon settings are exposed through filesystem properties, validated when enabled, and included in filesystem cache and display identities so different coordinator or block-size configurations are not accidentally shared.

Talon support is gated behind WITH_TALON and an optional Rust feature, leaving the default build unchanged. The benchmark suite also includes full-object throughput, concurrent range reads, and batched 4 KiB IOPS workloads for measuring both bandwidth-oriented and small-read behavior.