### PR TITLE
fix: pin lance dataset version and add dataset cache

### DIFF
--- a/cpp/include/milvus-storage/format/lance/lance_common.h
+++ b/cpp/include/milvus-storage/format/lance/lance_common.h
@@ -24,6 +24,8 @@
 
 namespace milvus_storage::lance {
 
+constexpr const char* kLanceVersionProperty = "lance_version";
+
 /// Convert ArrowFileSystemConfig to credential-free Lance read options.
 /// Authentication and credential refresh remain owned by the bound C++ filesystem.
 StorageOptions ToReaderOptions(const ArrowFileSystemConfig& config);

--- a/cpp/src/format/bridge/rust/include/lance_bridge.h
+++ b/cpp/src/format/bridge/rust/include/lance_bridge.h
@@ -91,6 +91,8 @@ class BlockingDataset {
   BlockingDataset(const BlockingDataset&) = delete;
   BlockingDataset& operator=(const BlockingDataset&) = delete;
 
+  uint64_t GetVersion() const;
+
   arrow::Result<std::vector<uint64_t>> GetAllFragmentIds() const;
 
   arrow::Result<std::vector<uint64_t>> GetFragmentDeletionPositions(uint64_t fragment_id) const;

--- a/cpp/src/format/bridge/rust/src/lance_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/lance_bridge.cpp
@@ -107,6 +107,8 @@ arrow::Status BlockingDataset::DeleteRows(const std::string& uri,
   });
 }
 
+uint64_t BlockingDataset::GetVersion() const { return impl_->version_id(); }
+
 arrow::Result<std::vector<uint64_t>> BlockingDataset::GetAllFragmentIds() const {
   return CatchRustResult<std::vector<uint64_t>>("Failed to get Lance fragment IDs", [&]() {
     auto fragment_ids = impl_->get_all_fragment_ids();

--- a/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
+++ b/cpp/src/format/bridge/rust/src/lance_bridgeimpl.rs
@@ -8,7 +8,8 @@ use futures::stream::StreamExt;
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::result::Result as RustResult;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::num::NonZeroUsize;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use tokio::runtime::Handle;
 
 use arrow_array58::Array;
@@ -47,6 +48,13 @@ use crate::lance_object_store::{
     shared_scan_scheduler,
 };
 
+static DATASET_CACHE: LazyLock<Mutex<lru::LruCache<String, Dataset>>> =
+    LazyLock::new(|| {
+        Mutex::new(lru::LruCache::new(
+            NonZeroUsize::new(5).unwrap(),
+        ))
+    });
+
 #[derive(Clone)]
 pub struct BlockingDataset {
     pub(crate) inner: Dataset,
@@ -66,6 +74,10 @@ impl BlockingDataset {
             scan_scheduler: Arc::new(OnceLock::new()),
             fragment_open_mutex: Arc::new(Mutex::new(())),
         })
+    }
+
+    pub fn version_id(&self) -> u64 {
+        self.inner.version_id()
     }
 
     fn fragment_read_config(&self, read_config: FragReadConfig) -> FragReadConfig {
@@ -323,6 +335,67 @@ pub fn open_dataset(
     }
 
     let storage_options = vec_to_hashmap(storage_options_keys, storage_options_values);
+    let version: Option<u64> = storage_options
+        .get("lance_version")
+        .and_then(|v| v.parse().ok());
+
+    // Cache path: if a pinned version is requested, check the cache first.
+    if let Some(ver) = version {
+        let cache_key = format!("{}|version:{}", uri, ver);
+
+        {
+            let mut cache = DATASET_CACHE.lock().unwrap();
+            if let Some(inner) = cache.get(&cache_key) {
+                let inner = inner.clone();
+                let dataset = BlockingDataset::new(inner)?;
+                let read_options = FFIReadOptions::parse(storage_options)?;
+                let scheduler = shared_scan_scheduler(
+                    read_options.object_store_prefix().to_string(),
+                    &dataset.object_store,
+                )?;
+                dataset
+                    .scan_scheduler
+                    .set(scheduler)
+                    .expect("a newly opened BlockingDataset has no scan scheduler");
+                return Ok(Box::new(dataset));
+            }
+        }
+
+        let read_options = FFIReadOptions::parse(storage_options)?;
+        let dataset_url = lance_io::object_store::uri_to_url(uri)?;
+        let provider = Arc::new(FFIObjectStoreProvider::new(
+            filesystem,
+            &dataset_url,
+            &read_options,
+        )?) as Arc<dyn ObjectStoreProvider>;
+        let session = build_filesystem_session(dataset_url.scheme(), provider);
+        let read_params = ReadParams {
+            index_cache_size_bytes: 0,
+            metadata_cache_size_bytes: 0,
+            store_options: Some(ObjectStoreParams::default()),
+            ..Default::default()
+        };
+        let builder = DatasetBuilder::from_uri(uri)
+            .with_version(ver)
+            .with_read_params(read_params)
+            .with_session(session);
+        let inner = TOKIO_RT.block_on(builder.load())?;
+
+        DATASET_CACHE.lock().unwrap().put(cache_key, inner.clone());
+
+        let dataset = BlockingDataset::new(inner)?;
+        let scheduler = shared_scan_scheduler(
+            read_options.object_store_prefix().to_string(),
+            &dataset.object_store,
+        )?;
+        dataset
+            .scan_scheduler
+            .set(scheduler)
+            .expect("a newly opened BlockingDataset has no scan scheduler");
+        return Ok(Box::new(dataset));
+    }
+
+    // Non-versioned path: no cache, resolve "latest"
     let read_options = FFIReadOptions::parse(storage_options)?;
     let dataset_url = lance_io::object_store::uri_to_url(uri)?;
     let provider = Arc::new(FFIObjectStoreProvider::new(

--- a/cpp/src/format/bridge/rust/src/lib.rs
+++ b/cpp/src/format/bridge/rust/src/lib.rs
@@ -140,6 +140,7 @@ pub mod lance_ffi {
             storage_options_values: Vec<String>,
         ) -> Result<()>;
 
+        pub fn version_id(self: &BlockingDataset) -> u64;
         pub fn get_all_fragment_ids(self: &BlockingDataset) -> Vec<u64>;
         pub fn get_fragment_deletion_positions(
             dataset: &BlockingDataset,

--- a/cpp/src/format/lance/lance_format.cpp
+++ b/cpp/src/format/lance/lance_format.cpp
@@ -36,17 +36,18 @@ arrow::Result<std::vector<api::ColumnGroupFile>> LanceFormat::explore(const std:
                         lance::BlockingDataset::Open(lance_base_uri, fs, lance::ToReaderOptions(fs_config)));
   ARROW_ASSIGN_OR_RAISE(auto fragment_ids, dataset->GetAllFragmentIds());
 
+  auto version = dataset->GetVersion();
+
   std::vector<api::ColumnGroupFile> files;
   for (auto frag_id : fragment_ids) {
     ARROW_ASSIGN_OR_RAISE(auto row_count, dataset->GetFragmentRowCount(frag_id));
-    // Store Milvus-format URI (scheme://address/bucket/key) so the reader
-    // can resolve the right extfs.<alias>.* by address+bucket. The reader
-    // strips address back to standard form before handing to Lance.
+    std::unordered_map<std::string, std::string> props;
+    props[lance::kLanceVersionProperty] = std::to_string(version);
     files.emplace_back(api::ColumnGroupFile{
         lance::MakeLanceUri(lance::ToMilvusLanceUri(lance_base_uri, fs_config.address), frag_id),
         0,
         static_cast<int64_t>(row_count),
-        {},
+        std::move(props),
     });
   }
 
@@ -63,8 +64,13 @@ arrow::Result<std::shared_ptr<FormatReader>> LanceFormat::create_reader(
   uint64_t fragment_id;
   ARROW_ASSIGN_OR_RAISE(std::tie(base_path, fragment_id), lance::ParseLanceUri(file.path));
   ARROW_ASSIGN_OR_RAISE(auto fs, FilesystemCache::getInstance().get(properties, base_path));
-  auto reader =
-      std::make_shared<lance::LanceTableReader>(fs, base_path, fragment_id, read_schema, properties, needed_columns);
+  auto reader_properties = properties;
+  auto version = file.Get<uint64_t>(lance::kLanceVersionProperty);
+  if (version > 0) {
+    reader_properties[lance::kLanceVersionProperty] = version;
+  }
+  auto reader = std::make_shared<lance::LanceTableReader>(fs, base_path, fragment_id, read_schema, reader_properties,
+                                                          needed_columns);
   ARROW_RETURN_NOT_OK(reader->open());
   return reader;
 }

--- a/cpp/src/format/lance/lance_table_reader.cpp
+++ b/cpp/src/format/lance/lance_table_reader.cpp
@@ -296,13 +296,12 @@ static arrow::Result<std::shared_ptr<arrow::Schema>> build_read_schema(
 std::string LanceTableReader::MetaTrait::cache_key(const milvus_storage::api::ColumnGroupFile& file) {
   auto parsed_uri = ParseLanceUri(file.path);
   if (!parsed_uri.ok()) {
-    // load_metadata() will return the detailed URI error. Keep malformed URIs
-    // distinct here so cache lookup itself remains infallible.
     LOG_STORAGE_WARNING_ << "Failed to parse Lance URI while building metadata cache key"
                          << ", path=" << file.path << ", status=" << parsed_uri.status().ToString();
     return fmt::format("lance-table|invalid-uri:{}", file.path);
   }
-  return fmt::format("lance-table|base-uri:{}", parsed_uri->first);
+  auto version = file.Get<uint64_t>(kLanceVersionProperty);
+  return fmt::format("lance-table|base-uri:{}|version:{}", parsed_uri->first, version);
 }
 
 static arrow::Result<std::shared_ptr<const LanceTableReader::MetaTrait::FragmentMetadata>> load_fragment_metadata(
@@ -370,7 +369,12 @@ arrow::Result<LanceTableReader::MetaTrait::MetadataPtr> LanceTableReader::MetaTr
   ARROW_ASSIGN_OR_RAISE(auto fs, FilesystemCache::getInstance().get(properties, base_uri));
   ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties, base_uri));
   const auto lance_uri = ToStandardLanceUri(base_uri);
-  ARROW_ASSIGN_OR_RAISE(auto dataset, BlockingDataset::Open(lance_uri, fs, ToReaderOptions(fs_config)));
+  auto reader_options = ToReaderOptions(fs_config);
+  auto version = file.Get<uint64_t>(kLanceVersionProperty);
+  if (version > 0) {
+    reader_options["lance_version"] = std::to_string(version);
+  }
+  ARROW_ASSIGN_OR_RAISE(auto dataset, BlockingDataset::Open(lance_uri, fs, reader_options));
 
   auto fragment_metadata_cache = std::make_shared<FragmentMetadataCache>();
   ARROW_ASSIGN_OR_RAISE(auto fragment_metadata, fragment_metadata_cache->get_or_load(fragment_id, [&]() {
@@ -446,13 +450,14 @@ arrow::Status LanceTableReader::open() {
   assert(!fragment_reader_);
 
   if (!dataset_) {
-    // uri_ is in Milvus format (scheme://address/bucket/key) so extfs.<alias>.*
-    // can be resolved by address+bucket. Strip the address back to standard form
-    // (scheme://bucket/key) before handing to Lance, whose object_store treats
-    // the host as the bucket.
     ARROW_ASSIGN_OR_RAISE(auto fs_config, FilesystemCache::resolve_config(properties_, uri_));
     auto lance_uri = ToStandardLanceUri(uri_);
-    ARROW_ASSIGN_OR_RAISE(dataset_, BlockingDataset::Open(lance_uri, filesystem_, ToReaderOptions(fs_config)));
+    auto reader_options = ToReaderOptions(fs_config);
+    auto version = api::GetValue<uint64_t>(properties_, kLanceVersionProperty);
+    if (version.ok() && *version > 0) {
+      reader_options["lance_version"] = std::to_string(*version);
+    }
+    ARROW_ASSIGN_OR_RAISE(dataset_, BlockingDataset::Open(lance_uri, filesystem_, reader_options));
   }
 
   // Lance 7 exposes the current dataset schema through FileFragment::schema().

--- a/cpp/test/format/lance/lance_table_test.cpp
+++ b/cpp/test/format/lance/lance_table_test.cpp
@@ -61,6 +61,7 @@
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/format_reader_cache.h"
 #include "milvus-storage/format/lance/lance_table_writer.h"
+#include "milvus-storage/format/lance/lance_format.h"
 #include "milvus-storage/format/lance/lance_table_reader.h"
 #include "milvus-storage/format/lance/lance_common.h"
 #include "milvus-storage/reader.h"
@@ -1894,6 +1895,69 @@ TEST_F(LanceBasicTest, TestStorageOptionsIntegration) {
   auto actual_id_column = std::static_pointer_cast<arrow::Int64Array>(chunk->column(0));
   for (int i = 0; i < chunk->num_rows(); i++) {
     ASSERT_EQ(actual_id_column->Value(i), expected_id_column->Value(i));
+  }
+}
+
+TEST_F(LanceBasicTest, ExploreRecordsVersionInProperties) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  LanceTableWriter writer(base_path_, schema_, properties_);
+  ASSERT_STATUS_OK(writer.Write(test_batch_));
+  ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+
+  LanceFormat format;
+  ASSERT_AND_ASSIGN(auto files, format.explore(base_path_, properties_));
+  ASSERT_FALSE(files.empty());
+
+  for (const auto& file : files) {
+    auto version = file.Get<uint64_t>(lance::kLanceVersionProperty);
+    EXPECT_GT(version, 0u) << "explore() must record a non-zero lance_version";
+  }
+
+  auto first_version = files[0].Get<uint64_t>(lance::kLanceVersionProperty);
+  for (size_t i = 1; i < files.size(); ++i) {
+    EXPECT_EQ(files[i].Get<uint64_t>(lance::kLanceVersionProperty), first_version)
+        << "All files from one explore() call must share the same version";
+  }
+}
+
+TEST_F(LanceBasicTest, VersionPinnedReaderSurvivesNewWrite) {
+  if (IsCloudEnv()) {
+    GTEST_SKIP() << "Lance fragment writer/reader not supported in cloud environment yet.";
+  }
+
+  {
+    LanceTableWriter writer(base_path_, schema_, properties_);
+    ASSERT_STATUS_OK(writer.Write(test_batch_));
+    ASSERT_AND_ASSIGN(auto cgfile, writer.Close());
+  }
+
+  LanceFormat format;
+  ASSERT_AND_ASSIGN(auto files_v1, format.explore(base_path_, properties_));
+  ASSERT_FALSE(files_v1.empty());
+  auto v1 = files_v1[0].Get<uint64_t>(lance::kLanceVersionProperty);
+  ASSERT_GT(v1, 0u);
+
+  {
+    LanceTableWriter writer2(base_path_, schema_, properties_);
+    ASSERT_STATUS_OK(writer2.Write(test_batch_));
+    ASSERT_AND_ASSIGN(auto cgfile2, writer2.Close());
+  }
+
+  ASSERT_AND_ASSIGN(auto files_v2, format.explore(base_path_, properties_));
+  ASSERT_GT(files_v2.size(), files_v1.size());
+  auto v2 = files_v2[0].Get<uint64_t>(lance::kLanceVersionProperty);
+  EXPECT_GT(v2, v1);
+
+  std::vector<std::string> needed_columns;
+  for (int i = 0; i < schema_->num_fields(); ++i) {
+    needed_columns.push_back(schema_->field(i)->name());
+  }
+  for (const auto& file : files_v1) {
+    ASSERT_AND_ASSIGN(auto reader, format.create_reader(schema_, file, properties_, needed_columns, nullptr));
+    ASSERT_NE(reader, nullptr);
   }
 }
 


### PR DESCRIPTION
See #664

Pin the dataset version during explore() and pass it through
ColumnGroupFile properties so create_reader() opens the exact
same version. This prevents fragment-not-found errors when a
writer modifies the dataset between the two phases.

Add a (uri, version)-keyed LRU dataset cache (capacity 5) in the
Rust bridge so N readers sharing the same version share one
Dataset instance via cheap Arc clone, instead of each
independently loading the full manifest.