### PR TITLE
fix: preserve Talon error diagnostics and retry classification

### DIFF
--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -7372,7 +7372,9 @@ dependencies = [
  "snafu 0.9.1",
  "sqlparser 0.55.0",
  "take_mut",
+ "talon-cache-client",
  "talon-rust-client",
+ "talon-transport",
  "tempfile",
  "tokio",
  "typetag",
@@ -8241,7 +8243,7 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 [[package]]
 name = "talon-cache-client"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=1e2482ac7a85d9a9954ffd81d89f9662f45a7803#1e2482ac7a85d9a9954ffd81d89f9662f45a7803"
 dependencies = [
  "bytes",
  "futures",
@@ -8255,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "talon-core"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=1e2482ac7a85d9a9954ffd81d89f9662f45a7803#1e2482ac7a85d9a9954ffd81d89f9662f45a7803"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8273,7 +8275,7 @@ dependencies = [
 [[package]]
 name = "talon-rust-client"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=1e2482ac7a85d9a9954ffd81d89f9662f45a7803#1e2482ac7a85d9a9954ffd81d89f9662f45a7803"
 dependencies = [
  "futures",
  "talon-cache-client",
@@ -8285,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "talon-transport"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=1e2482ac7a85d9a9954ffd81d89f9662f45a7803#1e2482ac7a85d9a9954ffd81d89f9662f45a7803"
 dependencies = [
  "anyhow",
  "bincode",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -10,10 +10,11 @@ crate-type = ["staticlib"]
 [features]
 io-trace = []
 s3-crt-async = []
-talon = ["dep:talon", "s3-crt-async"]
+talon = ["dep:talon", "dep:talon-cache-client", "s3-crt-async"]
 
 [dependencies]
-talon = { package = "talon-rust-client", git = "https://github.com/milvus-io/talon.git", rev = "9ecf024062ecdf4cbba7cc898ed500e74cc77f7d", optional = true }
+talon = { package = "talon-rust-client", git = "https://github.com/milvus-io/talon.git", rev = "1e2482ac7a85d9a9954ffd81d89f9662f45a7803", optional = true }
+talon-cache-client = { git = "https://github.com/milvus-io/talon.git", rev = "1e2482ac7a85d9a9954ffd81d89f9662f45a7803", optional = true }
 
 # common dependencies
 anyhow = "1.0.99"
@@ -98,6 +99,7 @@ sqlparser = "0.55"
 cxx = "1.0.184"
 
 [dev-dependencies]
+talon-transport = { git = "https://github.com/milvus-io/talon.git", rev = "1e2482ac7a85d9a9954ffd81d89f9662f45a7803" }
 tempfile = "3"
 # Match Paimon's OpenDAL type in snapshot error-classification tests.
 opendal-paimon = { package = "opendal-core", version = "=0.58.0" }

--- a/cpp/src/format/bridge/rust/include/talon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/talon_bridge.h
@@ -28,6 +28,14 @@
 
 namespace milvus_storage::talon {
 
+namespace internal {
+// Convert the typed Rust callback result without parsing its diagnostic text.
+arrow::Result<int64_t> ToArrowIoResult(const char* operation,
+                                       int32_t error_code,
+                                       uint64_t value,
+                                       const char* error_msg);
+}  // namespace internal
+
 /// Optional object metadata supplied by storage when opening a Talon reader.
 /// An empty version is valid for the version-independent GetRange path.
 struct TalonObjectStat {

--- a/cpp/src/format/bridge/rust/src/talon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/talon_bridge.cpp
@@ -15,14 +15,17 @@
 #include "talon_bridge.h"
 
 #include <exception>
+#include <cerrno>
 #include <limits>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include <arrow/status.h>
+#include <arrow/util/io_util.h>
 
 #include "bridge_util.h"
+#include "milvus-storage/common/extend_status.h"
 
 namespace milvus_storage::talon {
 namespace {
@@ -48,6 +51,10 @@ struct TalonIoCompletion {
   const char* const operation;
 };
 
+}  // namespace
+
+namespace internal {
+
 arrow::Result<int64_t> ToArrowIoResult(const char* operation,
                                        int32_t error_code,
                                        uint64_t value,
@@ -60,11 +67,30 @@ arrow::Result<int64_t> ToArrowIoResult(const char* operation,
   }
 
   const std::string message = error_msg == nullptr ? "unknown Talon error" : error_msg;
-  // FIXME: Map Talon's structured error kinds to Arrow errno details and
-  // ExtendStatus after Talon preserves them through the complete stat/read
-  // path. Until then, do not infer retryability from incomplete error codes.
-  return arrow::Status::IOError(operation, " (Talon error code ", error_code, "): ", message);
+  auto status = arrow::Status::IOError(operation, " (Talon error code ", error_code, "): ", message);
+  switch (static_cast<ffi::TalonErrorCode>(error_code)) {
+    case ffi::TalonErrorCode::InvalidArgument:
+      return arrow::Status::Invalid(status.message());
+    case ffi::TalonErrorCode::NotFound:
+      return status.WithDetail(arrow::internal::StatusDetailFromErrno(ENOENT));
+    case ffi::TalonErrorCode::Timeout:
+      return MakeExtendError(ExtendStatusCode::StorageTransientTimeout, status.message(), message);
+    case ffi::TalonErrorCode::Unavailable:
+      return MakeExtendError(ExtendStatusCode::StorageTransientService, status.message(), message);
+    case ffi::TalonErrorCode::RateLimited:
+      return MakeExtendError(ExtendStatusCode::StorageTransientThrottling, status.message(), message);
+    case ffi::TalonErrorCode::VersionMismatch:
+      return MakeExtendError(ExtendStatusCode::AwsErrorPreConditionFailed, status.message(), message);
+    case ffi::TalonErrorCode::NonRetryable:
+      return MakeExtendError(ExtendStatusCode::AwsErrorNonRetryable, status.message(), message);
+    default:
+      return status;
+  }
 }
+
+}  // namespace internal
+
+namespace {
 
 void MarkTalonCallbackError(arrow::Future<int64_t>& future, const char* operation, const char* message) noexcept {
   try {
@@ -82,7 +108,7 @@ void TalonIoCallbackImpl(void* context, int32_t error_code, uint64_t value, cons
   std::unique_ptr<char, decltype(&talon_free_error_string)> error(const_cast<char*>(error_msg),
                                                                   &talon_free_error_string);
   try {
-    completion->future.MarkFinished(ToArrowIoResult(completion->operation, error_code, value, error.get()));
+    completion->future.MarkFinished(internal::ToArrowIoResult(completion->operation, error_code, value, error.get()));
   } catch (const std::exception& exception) {
     MarkTalonCallbackError(completion->future, completion->operation, exception.what());
   } catch (...) {

--- a/cpp/src/format/bridge/rust/src/talon_bridge.rs
+++ b/cpp/src/format/bridge/rust/src/talon_bridge.rs
@@ -7,10 +7,23 @@ use std::{
 use anyhow::{Result, bail};
 use futures::FutureExt;
 use talon::{Client, ObjectId, ObjectStat, parse_uri};
+use talon_cache_client::{BlockReadError, CacheReadError};
 use tokio::sync::OnceCell;
 
 #[cxx::bridge(namespace = "milvus_storage::talon::ffi")]
 pub mod ffi {
+    #[repr(i32)]
+    enum TalonErrorCode {
+        InvalidArgument = 1,
+        Io = 2,
+        NotFound = 3,
+        Timeout = 4,
+        Unavailable = 5,
+        RateLimited = 6,
+        VersionMismatch = 7,
+        NonRetryable = 8,
+    }
+
     extern "Rust" {
         type TalonClient;
         type TalonObjectReader;
@@ -129,14 +142,45 @@ impl ReadBuffer {
 }
 
 fn talon_error_result(error: talon::Error) -> TalonIoResult {
-    let code = match &error {
-        talon::Error::InvalidUri(_) | talon::Error::InvalidArgument(_) => 1,
-        talon::Error::Coordinator(_) | talon::Error::Block(_) => 2,
+    // Capture the complete diagnostic before unwrapping the typed source so
+    // exhausted replicas retain both the last worker address and its failure.
+    let message = error.to_string();
+    let code = match error {
+        talon::Error::InvalidUri(_) | talon::Error::InvalidArgument(_) => {
+            ffi::TalonErrorCode::InvalidArgument
+        }
+        talon::Error::Coordinator(error) => cache_error_code(error.into()),
+        talon::Error::Block(error) => match error {
+            BlockReadError::Coordinator(error) => cache_error_code(error.into()),
+            BlockReadError::Worker(error)
+            | BlockReadError::AllReplicasFailed { source: error, .. } => {
+                cache_error_code(error.into())
+            }
+            BlockReadError::NoOwners | BlockReadError::UnresolvedOwner => {
+                ffi::TalonErrorCode::Unavailable
+            }
+        },
     };
     TalonIoResult {
-        code,
+        code: code.repr,
         value: 0,
-        message: error.to_string(),
+        message,
+    }
+}
+
+fn cache_error_code(error: CacheReadError) -> ffi::TalonErrorCode {
+    match error {
+        CacheReadError::InvalidRequest(_) => ffi::TalonErrorCode::InvalidArgument,
+        CacheReadError::NotFound(_) => ffi::TalonErrorCode::NotFound,
+        CacheReadError::Timeout(_) => ffi::TalonErrorCode::Timeout,
+        CacheReadError::Unavailable(_) => ffi::TalonErrorCode::Unavailable,
+        CacheReadError::RateLimited(_) => ffi::TalonErrorCode::RateLimited,
+        CacheReadError::VersionMismatch(_) => ffi::TalonErrorCode::VersionMismatch,
+        CacheReadError::Origin(_)
+        | CacheReadError::Protocol(_)
+        | CacheReadError::Internal(_)
+        | CacheReadError::Unknown(_)
+        | CacheReadError::CacheMiss(_) => ffi::TalonErrorCode::NonRetryable,
     }
 }
 
@@ -275,6 +319,100 @@ pub unsafe extern "C" fn talon_object_read_async(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use talon_cache_client::{CoordinatorError, WorkerError};
+    use talon_transport::{DataErrorCode, DataPlaneError};
+
+    #[test]
+    fn worker_errors_preserve_codes_and_replica_diagnostics() {
+        for (remote_code, expected) in [
+            (
+                DataErrorCode::InvalidRequest,
+                ffi::TalonErrorCode::InvalidArgument,
+            ),
+            (DataErrorCode::NotFound, ffi::TalonErrorCode::NotFound),
+            (DataErrorCode::Timeout, ffi::TalonErrorCode::Timeout),
+            (DataErrorCode::Unavailable, ffi::TalonErrorCode::Unavailable),
+            (DataErrorCode::RateLimited, ffi::TalonErrorCode::RateLimited),
+            (
+                DataErrorCode::VersionMismatch,
+                ffi::TalonErrorCode::VersionMismatch,
+            ),
+            (DataErrorCode::Origin, ffi::TalonErrorCode::NonRetryable),
+            (DataErrorCode::Internal, ffi::TalonErrorCode::NonRetryable),
+            (DataErrorCode::Unknown, ffi::TalonErrorCode::NonRetryable),
+            (DataErrorCode::CacheMiss, ffi::TalonErrorCode::NonRetryable),
+        ] {
+            for exhausted in [false, true] {
+                let source = WorkerError::Remote(DataPlaneError {
+                    code: remote_code,
+                    // Classification must use the code, never diagnostic text.
+                    message: "NotFound Timeout: original worker diagnostic".into(),
+                });
+                let error = if exhausted {
+                    BlockReadError::AllReplicasFailed {
+                        worker: "10.0.0.8:9000".into(),
+                        source,
+                    }
+                } else {
+                    BlockReadError::Worker(source)
+                };
+                let message = error.to_string();
+                let result = talon_error_result(error.into());
+                assert_eq!(result.code, expected.repr, "{message}");
+                assert_eq!(result.message, message);
+                assert_eq!(result.value, 0);
+                assert_eq!(result.message.contains("10.0.0.8:9000"), exhausted);
+                assert_eq!(result.message.contains("after refresh"), exhausted);
+            }
+        }
+    }
+
+    #[test]
+    fn transport_and_placement_errors_keep_their_classification() {
+        for (kind, expected) in [
+            (std::io::ErrorKind::TimedOut, ffi::TalonErrorCode::Timeout),
+            (
+                std::io::ErrorKind::ConnectionReset,
+                ffi::TalonErrorCode::Unavailable,
+            ),
+        ] {
+            let errors = [
+                talon::Error::Coordinator(CoordinatorError::Io(kind.into())),
+                BlockReadError::Coordinator(CoordinatorError::Io(kind.into())).into(),
+                BlockReadError::Worker(WorkerError::Io(kind.into())).into(),
+                BlockReadError::AllReplicasFailed {
+                    worker: "10.0.0.8:9000".into(),
+                    source: WorkerError::Io(kind.into()),
+                }
+                .into(),
+            ];
+            for error in errors {
+                assert_eq!(talon_error_result(error).code, expected.repr);
+            }
+        }
+        for error in [BlockReadError::NoOwners, BlockReadError::UnresolvedOwner] {
+            assert_eq!(
+                talon_error_result(error.into()).code,
+                ffi::TalonErrorCode::Unavailable.repr
+            );
+        }
+        assert_eq!(
+            talon_error_result(talon::Error::InvalidArgument("bad range".into())).code,
+            ffi::TalonErrorCode::InvalidArgument.repr
+        );
+        assert_eq!(
+            talon_error_result(parse_uri("invalid").unwrap_err()).code,
+            ffi::TalonErrorCode::InvalidArgument.repr
+        );
+        let protocol = BlockReadError::Worker(WorkerError::RangeLengthMismatch {
+            expected: 10,
+            actual: 1,
+        });
+        assert_eq!(
+            talon_error_result(protocol.into()).code,
+            ffi::TalonErrorCode::NonRetryable.repr
+        );
+    }
 
     #[test]
     fn maps_storage_providers_to_canonical_talon_uris() {

--- a/cpp/test/filesystem/talon_file_system_test.cpp
+++ b/cpp/test/filesystem/talon_file_system_test.cpp
@@ -437,6 +437,46 @@ INSTANTIATE_TEST_SUITE_P(CloudProviders,
                          TalonProviderEqualityTest,
                          ::testing::Values(kCloudProviderAWS, kCloudProviderAzure));
 
+TEST(TalonBridgeErrorTest, PreservesClassificationAndDiagnostics) {
+  const std::string message =
+      "all replicas failed after refresh; last worker 10.0.0.8:9000: worker error: Timeout: backend deadline exceeded";
+  for (const auto& [talon_code, storage_code] : {
+           std::pair{talon::ffi::TalonErrorCode::Timeout, ExtendStatusCode::StorageTransientTimeout},
+           std::pair{talon::ffi::TalonErrorCode::Unavailable, ExtendStatusCode::StorageTransientService},
+           std::pair{talon::ffi::TalonErrorCode::RateLimited, ExtendStatusCode::StorageTransientThrottling},
+           std::pair{talon::ffi::TalonErrorCode::VersionMismatch, ExtendStatusCode::AwsErrorPreConditionFailed},
+           std::pair{talon::ffi::TalonErrorCode::NonRetryable, ExtendStatusCode::AwsErrorNonRetryable},
+       }) {
+    const auto status =
+        talon::internal::ToArrowIoResult("read", static_cast<int32_t>(talon_code), 0, message.c_str()).status();
+    const auto detail = ExtendStatusDetail::UnwrapStatus(status);
+    ASSERT_NE(detail, nullptr);
+    EXPECT_EQ(detail->code(), storage_code);
+    EXPECT_EQ(detail->retryable(), talon_code == talon::ffi::TalonErrorCode::Timeout ||
+                                       talon_code == talon::ffi::TalonErrorCode::Unavailable ||
+                                       talon_code == talon::ffi::TalonErrorCode::RateLimited);
+    EXPECT_NE(status.message().find(message), std::string::npos);
+  }
+}
+
+TEST(TalonBridgeErrorTest, HandlesInvalidMissingAndUnknownErrors) {
+  EXPECT_TRUE(talon::internal::ToArrowIoResult(
+                  "read", static_cast<int32_t>(talon::ffi::TalonErrorCode::InvalidArgument), 0, "bad range")
+                  .status()
+                  .IsInvalid());
+  const auto missing = talon::internal::ToArrowIoResult(
+                           "stat", static_cast<int32_t>(talon::ffi::TalonErrorCode::NotFound), 0, "missing object")
+                           .status();
+  EXPECT_EQ(arrow::internal::ErrnoFromStatus(missing), ENOENT);
+  const auto unknown = talon::internal::ToArrowIoResult("read", 99, 0, nullptr).status();
+  EXPECT_TRUE(unknown.IsIOError());
+  EXPECT_EQ(unknown.detail(), nullptr);
+  EXPECT_NE(unknown.message().find("unknown Talon error"), std::string::npos);
+  EXPECT_EQ(talon::internal::ToArrowIoResult("read", 0, 42, nullptr).ValueOrDie(), 42);
+  EXPECT_TRUE(
+      talon::internal::ToArrowIoResult("stat", 0, std::numeric_limits<uint64_t>::max(), nullptr).status().IsIOError());
+}
+
 TEST(TalonBridgeTest, MapsClientCreationErrorAndPreservesTalonMessage) {
   const auto result = talon::TalonClient::Make("127.0.0.1:7000", 0);
 
@@ -464,7 +504,7 @@ TEST(TalonBridgeTest, MapsAsyncErrorAndPreservesTalonMessage) {
   const auto result = reader.ReadAtAsync(0, std::numeric_limits<uint64_t>::max(), nullptr).result();
 
   ASSERT_FALSE(result.ok());
-  EXPECT_TRUE(result.status().IsIOError()) << result.status().ToString();
+  EXPECT_TRUE(result.status().IsInvalid()) << result.status().ToString();
   EXPECT_NE(result.status().message().find("Failed to read Talon object"), std::string::npos);
   EXPECT_NE(result.status().message().find("Talon read length exceeds isize::MAX"), std::string::npos);
 }


### PR DESCRIPTION
Talon failures currently reach Arrow as generic I/O errors, losing the error classification callers need for retries. Keep main's Talon revision `e7f40ea` (which includes milvus-io/talon#579) and adapt `AllReplicasFailed { worker, source }` so exhausted reads retain the last worker address and original diagnostic.

Map typed errors across the Rust/C++ callback boundary: invalid requests become Arrow Invalid, missing objects carry ENOENT, timeout/unavailable/rate-limit failures carry transient storage details, and version conflicts and origin/protocol/internal/unknown failures remain non-retryable. Add regression coverage for direct and exhausted worker errors, transport and placement failures, and Arrow status conversion. The `Client::stat` and `Client::read_into` signatures are unchanged.

The merge with main `7f8e0b9` preserves the component-based bridge paths, configurable idle connection limits, and existing origin-fallback behavior. All Talon dependencies use the same revision.

Validation was rerun after the merge in the Milvus development container with the required Conan cache mounted; outputs, caches, and temporary files are backed by `/data/yuruiz/`:

- Focused Rust harness importing the production Talon bridge: 6 tests passed; static library built; Clippy passed with warnings denied.
- Focused C++ harness compiling the production bridge and generated CXX glue, linked to that Rust library: 5 tests passed.
- Complete Talon C++ test file compiled with `WITH_TALON` in syntax-check mode.
- Locked production dependency resolution, changed-file Rust/C++ formatting, error-handling ratchet, and `git diff --check` passed.

Full milvus-storage build and live Talon/MinIO E2E were not run locally.
