### PR TITLE
enhance:[3.0] preserve file properties in column group FFI creation (#672)

### DIFF
--- a/cpp/include/milvus-storage/ffi_c.h
+++ b/cpp/include/milvus-storage/ffi_c.h
@@ -352,13 +352,15 @@ FFI_EXPORT char* loon_manifest_debug_string(const LoonManifest* manifest);
  * @param paths Array of file paths
  * @param start_indices Array of start indices
  * @param end_indices Array of end indices
+ * @param file_properties Optional array of file_lens entries. Null, or count == 0, means no properties.
  * @param file_lens Number of files
  * @param out_column_groups Output parameter for generated LoonColumnGroups (function allocates and returns pointer)
  *                          Caller must call `loon_column_groups_destroy` to free allocated memory
  * @return 0 on success, others is error code
  *
- * Notice that: The current method may no longer be used.
- * Please construct LoonColumnGroups directly using the C Struct.
+ * All inputs are borrowed only for this call; the result owns a deep copy.
+ * File properties are opaque strings, not reader/filesystem configuration.
+ * On failure, out_column_groups is set to null when supplied.
  */
 FFI_EXPORT LoonFFIResult loon_column_groups_create(const char** columns,
                                                    size_t col_lens,
@@ -366,6 +368,7 @@ FFI_EXPORT LoonFFIResult loon_column_groups_create(const char** columns,
                                                    char** paths,
                                                    int64_t* start_indices,
                                                    int64_t* end_indices,
+                                                   const LoonProperties* file_properties,
                                                    size_t file_lens,
                                                    LoonColumnGroups** out_column_groups);
 

--- a/cpp/src/ffi/column_groups_c.cpp
+++ b/cpp/src/ffi/column_groups_c.cpp
@@ -28,8 +28,12 @@ LoonFFIResult loon_column_groups_create(const char** columns,
                                         char** paths,
                                         int64_t* start_indices,
                                         int64_t* end_indices,
+                                        const LoonProperties* file_properties,
                                         size_t file_lens,
                                         LoonColumnGroups** out_column_groups) {
+  if (out_column_groups) {
+    *out_column_groups = nullptr;
+  }
   if (!columns || !col_lens || !paths || !format || !file_lens || !out_column_groups || !start_indices ||
       !end_indices) {
     RETURN_ERROR(LOON_INVALID_ARGS, "Invalid arguments");
@@ -55,6 +59,21 @@ LoonFFIResult loon_column_groups_create(const char** columns,
           .start_index = start_indices[file_idx],
           .end_index = end_indices[file_idx],
       });
+      if (file_properties) {
+        const auto& properties = file_properties[file_idx];
+        if (properties.count > 0 && !properties.properties) {
+          RETURN_ERROR(LOON_INVALID_ARGS, "File properties are null [index=", file_idx, "]");
+        }
+        for (size_t property_idx = 0; property_idx < properties.count; ++property_idx) {
+          const auto& property = properties.properties[property_idx];
+          if (!property.key || !property.value) {
+            RETURN_ERROR(LOON_INVALID_ARGS, "File property key/value is null [file=", file_idx,
+                         ", property=", property_idx, "]");
+          }
+          // File properties are opaque metadata; do not parse them as reader configuration.
+          cg->files.back().properties[property.key] = property.value;
+        }
+      }
     }
     cg->format = format;
     cgs.push_back(cg);

--- a/cpp/test/ffi/bridge_test.cpp
+++ b/cpp/test/ffi/bridge_test.cpp
@@ -15,7 +15,9 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <sstream>
+#include <unordered_map>
 #include <random>
 
 #include "milvus-storage/column_groups.h"
@@ -29,6 +31,85 @@ namespace milvus_storage::test {
 using namespace milvus_storage::api;
 
 class BridgeTest : public ::testing::Test {};
+
+TEST_F(BridgeTest, CreateColumnGroupsCopiesFileProperties) {
+  const char* columns[] = {"id", "value"};
+  char path[] = "table/data.parquet";
+  char* paths[] = {path, path, path};
+  int64_t starts[] = {0, 10, 20};
+  int64_t ends[] = {10, 20, 25};
+  char version[] = "42";
+  char metadata[] = R"({"delete_files":["deletes.parquet"]})";
+  LoonProperty first[] = {{const_cast<char*>("dataset_version"), version}};
+  LoonProperty second[] = {{const_cast<char*>("metadata"), metadata},
+                           {const_cast<char*>("empty"), const_cast<char*>("")}};
+  LoonProperties properties[] = {{first, 1}, {second, 2}, {nullptr, 0}};
+  LoonColumnGroups* groups = nullptr;
+  auto result = loon_column_groups_create(columns, 2, const_cast<char*>("iceberg-table"), paths, starts, ends,
+                                          properties, 3, &groups);
+  ASSERT_EQ(result.err_code, loon_errcode_success) << result.message;
+  std::unique_ptr<LoonColumnGroups, decltype(&loon_column_groups_destroy)> owned(groups, loon_column_groups_destroy);
+  // The result must survive reuse of every caller-owned input buffer.
+  path[0] = 'X';
+  version[0] = '9';
+  metadata[0] = 'X';
+  ColumnGroups imported;
+  ASSERT_STATUS_OK(column_groups_import(groups, &imported));
+  ASSERT_EQ(imported.size(), 1);
+  const auto& group = *imported[0];
+  EXPECT_EQ(group.columns, (std::vector<std::string>{"id", "value"}));
+  EXPECT_EQ(group.format, "iceberg-table");
+  ASSERT_EQ(group.files.size(), 3);
+  for (size_t i = 0; i < group.files.size(); ++i) {
+    EXPECT_EQ(group.files[i].path, "table/data.parquet");
+    EXPECT_EQ(group.files[i].start_index, starts[i]);
+    EXPECT_EQ(group.files[i].end_index, ends[i]);
+  }
+  EXPECT_EQ(group.files[0].properties, (std::unordered_map<std::string, std::string>{{"dataset_version", "42"}}));
+  EXPECT_EQ(group.files[1].properties, (std::unordered_map<std::string, std::string>{
+                                           {"metadata", R"({"delete_files":["deletes.parquet"]})"}, {"empty", ""}}));
+  EXPECT_TRUE(group.files[2].properties.empty());
+}
+
+TEST_F(BridgeTest, CreateColumnGroupsWithoutFileProperties) {
+  const char* columns[] = {"id"};
+  char* paths[] = {const_cast<char*>("file.parquet")};
+  int64_t starts[] = {3};
+  int64_t ends[] = {9};
+  const LoonProperties empty_properties{nullptr, 0};
+  for (const auto* properties : {static_cast<const LoonProperties*>(nullptr), &empty_properties}) {
+    LoonColumnGroups* groups = nullptr;
+    auto result = loon_column_groups_create(columns, 1, const_cast<char*>("parquet"), paths, starts, ends, properties,
+                                            1, &groups);
+    ASSERT_EQ(result.err_code, loon_errcode_success) << result.message;
+    std::unique_ptr<LoonColumnGroups, decltype(&loon_column_groups_destroy)> owned(groups, loon_column_groups_destroy);
+    ColumnGroups imported;
+    ASSERT_STATUS_OK(column_groups_import(groups, &imported));
+    ASSERT_EQ(imported.size(), 1);
+    ASSERT_EQ(imported[0]->files.size(), 1);
+    EXPECT_EQ(imported[0]->files[0].start_index, 3);
+    EXPECT_EQ(imported[0]->files[0].end_index, 9);
+    EXPECT_TRUE(imported[0]->files[0].properties.empty());
+  }
+}
+
+TEST_F(BridgeTest, CreateColumnGroupsRejectsInvalidFileProperties) {
+  const char* columns[] = {"id"};
+  char* paths[] = {const_cast<char*>("file.parquet")};
+  int64_t starts[] = {0};
+  int64_t ends[] = {10};
+  LoonProperty no_key{nullptr, const_cast<char*>("value")};
+  LoonProperty no_value{const_cast<char*>("key"), nullptr};
+  for (const auto properties : {LoonProperties{nullptr, 1}, LoonProperties{&no_key, 1}, LoonProperties{&no_value, 1}}) {
+    LoonColumnGroups* groups = nullptr;
+    auto result = loon_column_groups_create(columns, 1, const_cast<char*>("parquet"), paths, starts, ends, &properties,
+                                            1, &groups);
+    EXPECT_EQ(result.err_code, loon_errcode_invalid_args);
+    EXPECT_EQ(groups, nullptr);
+    loon_ffi_free_result(&result);
+    loon_column_groups_destroy(groups);
+  }
+}
 
 TEST_F(BridgeTest, ExportImportColumnGroups) {
   // create column groups

--- a/cpp/test/ffi/ffi_external_test.c
+++ b/cpp/test/ffi/ffi_external_test.c
@@ -442,7 +442,7 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0};
     int64_t end_indices[] = {file1_row_count};
 
-    rc = loon_column_groups_create((const char**)columns, 3, "parquet", paths, start_indices, end_indices, 1,
+    rc = loon_column_groups_create((const char**)columns, 3, "parquet", paths, start_indices, end_indices, NULL, 1,
                                    &column_groups);
 
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
@@ -459,7 +459,7 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0, 0};
     int64_t end_indices[] = {file1_row_count, file2_row_count};
 
-    rc = loon_column_groups_create((const char**)columns, 2, "parquet", paths, start_indices, end_indices, 2,
+    rc = loon_column_groups_create((const char**)columns, 2, "parquet", paths, start_indices, end_indices, NULL, 2,
                                    &column_groups);
 
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
@@ -475,7 +475,7 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0, 0};
     int64_t end_indices[] = {50, 25};
 
-    rc = loon_column_groups_create((const char**)columns, 3, "parquet", paths, start_indices, end_indices, 2,
+    rc = loon_column_groups_create((const char**)columns, 3, "parquet", paths, start_indices, end_indices, NULL, 2,
                                    &column_groups);
 
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
@@ -490,7 +490,7 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0};
     int64_t end_indices[] = {file1_row_count};
 
-    rc = loon_column_groups_create(NULL, 1, "parquet", paths, start_indices, end_indices, 1, &column_groups);
+    rc = loon_column_groups_create(NULL, 1, "parquet", paths, start_indices, end_indices, NULL, 1, &column_groups);
 
     ck_assert(!loon_ffi_is_success(&rc));
     ck_assert_int_eq(rc.err_code, loon_errcode_invalid_args);
@@ -504,7 +504,7 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0};
     int64_t end_indices[] = {file1_row_count};
 
-    rc = loon_column_groups_create((const char**)columns, 1, "parquet", NULL, start_indices, end_indices, 1,
+    rc = loon_column_groups_create((const char**)columns, 1, "parquet", NULL, start_indices, end_indices, NULL, 1,
                                    &column_groups);
 
     ck_assert(!loon_ffi_is_success(&rc));
@@ -520,8 +520,8 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0};
     int64_t end_indices[] = {file1_row_count};
 
-    rc =
-        loon_column_groups_create((const char**)columns, 1, NULL, paths, start_indices, end_indices, 1, &column_groups);
+    rc = loon_column_groups_create((const char**)columns, 1, NULL, paths, start_indices, end_indices, NULL, 1,
+                                   &column_groups);
 
     ck_assert(!loon_ffi_is_success(&rc));
     ck_assert_int_eq(rc.err_code, loon_errcode_invalid_args);
@@ -536,7 +536,7 @@ static void test_column_groups_create(void) {
     int64_t start_indices[] = {0};
     int64_t end_indices[] = {file1_row_count};
 
-    rc = loon_column_groups_create((const char**)columns, 0, "parquet", paths, start_indices, end_indices, 1,
+    rc = loon_column_groups_create((const char**)columns, 0, "parquet", paths, start_indices, end_indices, NULL, 1,
                                    &column_groups);
 
     ck_assert(!loon_ffi_is_success(&rc));
@@ -588,7 +588,7 @@ static void test_column_groups_create_then_read(void) {
     ck_assert_int_eq(length_of_paths, sizeof(end_indices) / sizeof(end_indices[0]));
 
     rc = loon_column_groups_create((const char**)columns, length_of_columns, "parquet", paths, start_indices,
-                                   end_indices, length_of_paths, &column_groups);
+                                   end_indices, NULL, length_of_paths, &column_groups);
 
     ck_assert_msg(loon_ffi_is_success(&rc), "%s", loon_ffi_get_errmsg(&rc));
 


### PR DESCRIPTION
pr: #672

loon_column_groups_create previously accepted only file paths and row ranges, forcing callers that needed file properties to construct and manage nested C structures themselves.

Accept an optional LoonProperties array indexed by file and copy its opaque key/value pairs into each ColumnGroupFile. The returned groups own their strings and use loon_column_groups_destroy for cleanup, so callers can release their input buffers after creation.

Callers without file properties pass NULL for the new argument. The updated FFI signature requires matching headers and library binaries.