### PR TITLE
enhance: make Talon idle connection limits configurable

### DIFF
--- a/cpp/include/milvus-storage/filesystem/fs.h
+++ b/cpp/include/milvus-storage/filesystem/fs.h
@@ -255,6 +255,8 @@ struct ArrowFileSystemConfig {
   bool talon_enabled = false;
   std::string talon_coordinator = "";
   uint32_t talon_block_size = 256U * 1024U * 1024U;
+  // Maximum idle TCP connections per peer in each Talon pool; does not cap active connections.
+  uint32_t talon_max_idle_per_addr = 256;
 
   // Alias for external filesystem identification (e.g., "prod", "backup")
   // Empty for default filesystem

--- a/cpp/include/milvus-storage/properties.h
+++ b/cpp/include/milvus-storage/properties.h
@@ -104,6 +104,7 @@ struct PropertyInfo {
 #define PROPERTY_FS_TALON_ENABLED "fs.talon.enabled"
 #define PROPERTY_FS_TALON_COORDINATOR "fs.talon.coordinator"
 #define PROPERTY_FS_TALON_BLOCK_SIZE "fs.talon.block_size"
+#define PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR "fs.talon.max_idle_per_addr"
 
 // Cross-tenant access properties
 #define PROPERTY_FS_GCP_TARGET_SERVICE_ACCOUNT "fs.gcp_target_service_account"

--- a/cpp/src/filesystem/fs.cpp
+++ b/cpp/src/filesystem/fs.cpp
@@ -97,8 +97,12 @@ std::string ArrowFileSystemConfig::GetCacheKey() const {
   hash_combine(s3_crt_async_read);
   hash_combine(load_frequency);
   hash_combine(talon_enabled);
-  hash_combine(talon_coordinator);
-  hash_combine(talon_block_size);
+  // Disabled Talon settings do not affect the origin filesystem's identity.
+  if (talon_enabled) {
+    hash_combine(talon_coordinator);
+    hash_combine(talon_block_size);
+    hash_combine(talon_max_idle_per_addr);
+  }
 
   if (IsAzureCredentialBrokerEnabled()) {
     hash_combine(access_key_id);
@@ -141,7 +145,8 @@ std::string ArrowFileSystemConfig::ToString() const {
      << ", tls_min_version=" << (tls_min_version.empty() ? "(default)" : tls_min_version)
      << ", use_crc32c_checksum=" << std::boolalpha << use_crc32c_checksum << ", s3_crt_async_read=" << std::boolalpha
      << s3_crt_async_read << ", talon_enabled=" << std::boolalpha << talon_enabled
-     << ", talon_coordinator=" << talon_coordinator << ", talon_block_size=" << talon_block_size;
+     << ", talon_coordinator=" << talon_coordinator << ", talon_block_size=" << talon_block_size
+     << ", talon_max_idle_per_addr=" << talon_max_idle_per_addr;
   if (!alias.empty()) {
     ss << ", alias=" << alias;
   }
@@ -292,6 +297,8 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
   ARROW_ASSIGN_OR_RAISE(result.talon_coordinator,
                         api::GetValue<std::string>(properties_map, PROPERTY_FS_TALON_COORDINATOR));
   ARROW_ASSIGN_OR_RAISE(result.talon_block_size, api::GetValue<uint32_t>(properties_map, PROPERTY_FS_TALON_BLOCK_SIZE));
+  ARROW_ASSIGN_OR_RAISE(result.talon_max_idle_per_addr,
+                        api::GetValue<uint32_t>(properties_map, PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR));
   ARROW_ASSIGN_OR_RAISE(result.lance_io_parallelism,
                         api::GetValue<uint32_t>(properties_map, PROPERTY_FS_LANCE_IO_PARALLELISM));
   ARROW_ASSIGN_OR_RAISE(result.iops_initial_rate,
@@ -318,6 +325,9 @@ arrow::Status ArrowFileSystemConfig::create_file_system_config(const milvus_stor
     }
     if (result.talon_block_size == 0) {
       return arrow::Status::Invalid("fs.talon.block_size must be greater than zero");
+    }
+    if (result.talon_max_idle_per_addr == 0) {
+      return arrow::Status::Invalid("fs.talon.max_idle_per_addr must be greater than zero");
     }
   }
 

--- a/cpp/src/filesystem/talon/talon_file_system.cpp
+++ b/cpp/src/filesystem/talon/talon_file_system.cpp
@@ -232,19 +232,11 @@ class TalonFileSystem final : public arrow::fs::FileSystem,
                               public UploadSizable,
                               public Observable {
   public:
-  TalonFileSystem(ArrowFileSystemPtr origin_fs,
-                  std::shared_ptr<TalonClient> client,
-                  std::string bucket,
-                  std::string cloud_provider,
-                  std::string coordinator,
-                  uint32_t block_size)
+  TalonFileSystem(ArrowFileSystemConfig config, ArrowFileSystemPtr origin_fs, std::shared_ptr<TalonClient> client)
       : arrow::fs::FileSystem(origin_fs->io_context()),
         origin_fs_(std::move(origin_fs)),
         client_(std::move(client)),
-        bucket_(std::move(bucket)),
-        cloud_provider_(std::move(cloud_provider)),
-        coordinator_(std::move(coordinator)),
-        block_size_(block_size) {}
+        config_(std::move(config)) {}
 
   std::string type_name() const override { return origin_fs_->type_name(); }
 
@@ -261,8 +253,11 @@ class TalonFileSystem final : public arrow::fs::FileSystem,
       return true;
     }
     const auto* talon = dynamic_cast<const TalonFileSystem*>(&other);
-    return talon != nullptr && bucket_ == talon->bucket_ && cloud_provider_ == talon->cloud_provider_ &&
-           coordinator_ == talon->coordinator_ && block_size_ == talon->block_size_ &&
+    return talon != nullptr && config_.bucket_name == talon->config_.bucket_name &&
+           config_.cloud_provider == talon->config_.cloud_provider &&
+           config_.talon_coordinator == talon->config_.talon_coordinator &&
+           config_.talon_block_size == talon->config_.talon_block_size &&
+           config_.talon_max_idle_per_addr == talon->config_.talon_max_idle_per_addr &&
            origin_fs_->Equals(*talon->origin_fs_);
   }
 
@@ -366,9 +361,10 @@ class TalonFileSystem final : public arrow::fs::FileSystem,
 
   private:
   arrow::Result<std::string> ObjectKey(const std::string& path) const {
-    const std::string prefix = bucket_ + "/";
+    const std::string prefix = config_.bucket_name + "/";
     if (!path.starts_with(prefix)) {
-      return arrow::Status::Invalid("Talon path does not belong to configured bucket ", bucket_, ": ", path);
+      return arrow::Status::Invalid("Talon path does not belong to configured bucket ", config_.bucket_name, ": ",
+                                    path);
     }
     const std::string key = path.substr(prefix.size());
     if (key.empty()) {
@@ -387,16 +383,14 @@ class TalonFileSystem final : public arrow::fs::FileSystem,
         known_size == arrow::fs::kNoSize
             ? std::nullopt
             : std::optional<TalonObjectStat>{TalonObjectStat{static_cast<uint64_t>(known_size), ""}};
-    ARROW_ASSIGN_OR_RAISE(auto reader, client_->OpenObject(cloud_provider_, bucket_, key, initial_stat));
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          client_->OpenObject(config_.cloud_provider, config_.bucket_name, key, initial_stat));
     return std::make_shared<TalonInputFile>(std::move(reader), origin_fs_, path, io_context().pool());
   }
 
   const ArrowFileSystemPtr origin_fs_;
   const std::shared_ptr<TalonClient> client_;
-  const std::string bucket_;
-  const std::string cloud_provider_;
-  const std::string coordinator_;
-  const uint32_t block_size_;
+  const ArrowFileSystemConfig config_;
 };
 
 }  // namespace
@@ -406,9 +400,12 @@ namespace internal {
 arrow::Result<ArrowFileSystemPtr> MakeTalonFileSystem(const ArrowFileSystemConfig& config,
                                                       ArrowFileSystemPtr origin_fs,
                                                       std::string bucket) {
-  ARROW_ASSIGN_OR_RAISE(auto client, TalonClient::Make(config.talon_coordinator, config.talon_block_size));
-  return std::make_shared<TalonFileSystem>(std::move(origin_fs), std::move(client), std::move(bucket),
-                                           config.cloud_provider, config.talon_coordinator, config.talon_block_size);
+  ARROW_ASSIGN_OR_RAISE(auto client, TalonClient::Make(config.talon_coordinator, config.talon_block_size,
+                                                       config.talon_max_idle_per_addr));
+  auto talon_config = config;
+  // Readers use the producer's normalized bucket rather than the original spelling.
+  talon_config.bucket_name = std::move(bucket);
+  return std::make_shared<TalonFileSystem>(std::move(talon_config), std::move(origin_fs), std::move(client));
 }
 
 }  // namespace internal

--- a/cpp/src/format/bridge/rust/Cargo.lock
+++ b/cpp/src/format/bridge/rust/Cargo.lock
@@ -8241,11 +8241,12 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 [[package]]
 name = "talon-cache-client"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=e7f40ea629b522cffa5549a437be0660d2bf9eeb#e7f40ea629b522cffa5549a437be0660d2bf9eeb"
 dependencies = [
  "bytes",
  "futures",
  "talon-core",
+ "talon-telemetry",
  "talon-transport",
  "thiserror 2.0.17",
  "tokio",
@@ -8255,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "talon-core"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=e7f40ea629b522cffa5549a437be0660d2bf9eeb#e7f40ea629b522cffa5549a437be0660d2bf9eeb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8273,19 +8274,31 @@ dependencies = [
 [[package]]
 name = "talon-rust-client"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=e7f40ea629b522cffa5549a437be0660d2bf9eeb#e7f40ea629b522cffa5549a437be0660d2bf9eeb"
 dependencies = [
  "futures",
  "talon-cache-client",
  "talon-core",
+ "talon-telemetry",
  "talon-transport",
  "thiserror 2.0.17",
 ]
 
 [[package]]
+name = "talon-telemetry"
+version = "0.1.0"
+source = "git+https://github.com/milvus-io/talon.git?rev=e7f40ea629b522cffa5549a437be0660d2bf9eeb#e7f40ea629b522cffa5549a437be0660d2bf9eeb"
+dependencies = [
+ "pin-project-lite",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "talon-transport"
 version = "0.1.0"
-source = "git+https://github.com/milvus-io/talon.git?rev=9ecf024062ecdf4cbba7cc898ed500e74cc77f7d#9ecf024062ecdf4cbba7cc898ed500e74cc77f7d"
+source = "git+https://github.com/milvus-io/talon.git?rev=e7f40ea629b522cffa5549a437be0660d2bf9eeb#e7f40ea629b522cffa5549a437be0660d2bf9eeb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8294,6 +8307,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "talon-core",
+ "talon-telemetry",
  "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",

--- a/cpp/src/format/bridge/rust/Cargo.toml
+++ b/cpp/src/format/bridge/rust/Cargo.toml
@@ -13,7 +13,7 @@ s3-crt-async = []
 talon = ["dep:talon", "s3-crt-async"]
 
 [dependencies]
-talon = { package = "talon-rust-client", git = "https://github.com/milvus-io/talon.git", rev = "9ecf024062ecdf4cbba7cc898ed500e74cc77f7d", optional = true }
+talon = { package = "talon-rust-client", git = "https://github.com/milvus-io/talon.git", rev = "e7f40ea629b522cffa5549a437be0660d2bf9eeb", optional = true }
 
 # common dependencies
 anyhow = "1.0.99"

--- a/cpp/src/format/bridge/rust/include/talon_bridge.h
+++ b/cpp/src/format/bridge/rust/include/talon_bridge.h
@@ -65,7 +65,9 @@ class TalonObjectReader final {
 /// Owns a Rust Talon client and converts every fallible FFI operation to Arrow errors.
 class TalonClient final {
   public:
-  static arrow::Result<std::shared_ptr<TalonClient>> Make(const std::string& coordinator, uint32_t block_size);
+  static arrow::Result<std::shared_ptr<TalonClient>> Make(const std::string& coordinator,
+                                                          uint32_t block_size,
+                                                          uint32_t max_idle_per_addr);
 
   arrow::Result<TalonObjectReader> OpenObject(const std::string& cloud_provider,
                                               const std::string& bucket,

--- a/cpp/src/format/bridge/rust/src/talon_bridge.cpp
+++ b/cpp/src/format/bridge/rust/src/talon_bridge.cpp
@@ -92,9 +92,11 @@ void TalonIoCallbackImpl(void* context, int32_t error_code, uint64_t value, cons
 
 }  // namespace
 
-arrow::Result<std::shared_ptr<TalonClient>> TalonClient::Make(const std::string& coordinator, uint32_t block_size) {
+arrow::Result<std::shared_ptr<TalonClient>> TalonClient::Make(const std::string& coordinator,
+                                                              uint32_t block_size,
+                                                              uint32_t max_idle_per_addr) {
   return CatchRustResult<std::shared_ptr<TalonClient>>("Failed to create Talon client", [&]() {
-    auto impl = ffi::new_talon_client(coordinator, block_size);
+    auto impl = ffi::new_talon_client(coordinator, block_size, max_idle_per_addr);
     return std::shared_ptr<TalonClient>(new TalonClient(std::move(impl)));
   });
 }

--- a/cpp/src/format/bridge/rust/src/talon_bridge.rs
+++ b/cpp/src/format/bridge/rust/src/talon_bridge.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Result, bail};
 use futures::FutureExt;
-use talon::{Client, ObjectId, ObjectStat, parse_uri};
+use talon::{Client, ClientBuilder, ObjectId, ObjectStat, parse_uri};
 use tokio::sync::OnceCell;
 
 #[cxx::bridge(namespace = "milvus_storage::talon::ffi")]
@@ -15,7 +15,11 @@ pub mod ffi {
         type TalonClient;
         type TalonObjectReader;
 
-        fn new_talon_client(coordinator: &str, block_size: u32) -> Result<Box<TalonClient>>;
+        fn new_talon_client(
+            coordinator: &str,
+            block_size: u32,
+            max_idle_per_addr: u32,
+        ) -> Result<Box<TalonClient>>;
         fn open_talon_object(
             client: &TalonClient,
             cloud_provider: &str,
@@ -69,9 +73,19 @@ fn talon_uri(provider: &str, bucket: &str, key: &str) -> Result<String> {
     Ok(format!("{scheme}://{bucket}/{key}"))
 }
 
-pub fn new_talon_client(coordinator: &str, block_size: u32) -> Result<Box<TalonClient>> {
+pub fn new_talon_client(
+    coordinator: &str,
+    block_size: u32,
+    max_idle_per_addr: u32,
+) -> Result<Box<TalonClient>> {
     Ok(Box::new(TalonClient {
-        inner: Arc::new(Client::new(coordinator, block_size)?),
+        inner: Arc::new(
+            ClientBuilder::default()
+                .with_coordinator(coordinator)
+                .with_block_size(block_size)
+                .with_max_idle_per_addr(max_idle_per_addr as usize)
+                .build()?,
+        ),
     }))
 }
 
@@ -293,7 +307,7 @@ mod tests {
 
     #[test]
     fn open_object_with_stat_initializes_metadata_without_resolving() {
-        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024).unwrap();
+        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024, 8).unwrap();
         let reader =
             open_talon_object(&client, "aws", "test-bucket", "path/a", true, 123, "").unwrap();
         assert_eq!(talon_object_known_size(&reader), 123);
@@ -303,7 +317,7 @@ mod tests {
 
     #[test]
     fn open_object_without_stat_leaves_metadata_unresolved() {
-        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024).unwrap();
+        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024, 8).unwrap();
         let reader =
             open_talon_object(&client, "aws", "test-bucket", "path/a", false, 0, "").unwrap();
         assert_eq!(talon_object_known_size(&reader), -1);
@@ -312,7 +326,7 @@ mod tests {
 
     #[test]
     fn resolved_stat_is_shared_by_reader_clones() {
-        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024).unwrap();
+        let client = new_talon_client("127.0.0.1:7000", 8 * 1024 * 1024, 8).unwrap();
         let reader =
             open_talon_object(&client, "aws", "test-bucket", "path/a", false, 0, "").unwrap();
         reader

--- a/cpp/src/properties.cpp
+++ b/cpp/src/properties.cpp
@@ -486,6 +486,12 @@ static std::unordered_map<std::string, PropertyInfo> property_infos = {
                       "The Talon block size in bytes.",
                       256U * 1024U * 1024U,
                       ValidatePropertyType()),
+    REGISTER_PROPERTY(PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR,
+                      PropertyType::UINT32,
+                      "Maximum idle TCP connections per peer address in each Talon coordinator/worker pool. "
+                      "Does not limit active connections.",
+                      uint32_t(256),
+                      ValidatePropertyType() + ValidatePropertyRange<uint32_t>(1, UINT32_MAX)),
     // --- Cross-tenant access properties define ---
     REGISTER_PROPERTY(PROPERTY_FS_GCP_TARGET_SERVICE_ACCOUNT,
                       PropertyType::STRING,

--- a/cpp/test/filesystem/talon_file_system_test.cpp
+++ b/cpp/test/filesystem/talon_file_system_test.cpp
@@ -248,6 +248,34 @@ TEST(TalonConfigTest, DefaultsAreDisabled) {
   EXPECT_FALSE(config.talon_enabled);
   EXPECT_TRUE(config.talon_coordinator.empty());
   EXPECT_EQ(config.talon_block_size, 256U * 1024U * 1024U);
+  EXPECT_EQ(config.talon_max_idle_per_addr, 256U);
+}
+
+TEST(TalonConfigTest, MaxIdlePerAddressProperty) {
+  constexpr auto key = PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR;
+  api::Properties properties;
+  ASSERT_AND_ASSIGN(const auto default_limit, api::GetValue<uint32_t>(properties, key));
+  EXPECT_EQ(default_limit, 256U);
+  ASSERT_EQ(api::SetValue(properties, key, "32"), std::nullopt);
+  ASSERT_AND_ASSIGN(const auto explicit_limit, api::GetValue<uint32_t>(properties, key));
+  EXPECT_EQ(explicit_limit, 32U);
+  for (const char* invalid : {"0", "-1", "4294967296", "invalid"}) {
+    EXPECT_NE(api::SetValue(properties, key, invalid), std::nullopt);
+  }
+}
+
+TEST(TalonConfigTest, ChecksTypedPoolLimitOnlyWhenEnabled) {
+  api::Properties properties;
+  properties[PROPERTY_FS_STORAGE_TYPE] = std::string("remote");
+  properties[PROPERTY_FS_TALON_COORDINATOR] = std::string("127.0.0.1:7000");
+  properties[PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR] = uint32_t{0};
+  ArrowFileSystemConfig config;
+  ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties, config));
+
+  properties[PROPERTY_FS_TALON_ENABLED] = true;
+  const auto status = ArrowFileSystemConfig::create_file_system_config(properties, config);
+  EXPECT_TRUE(status.IsInvalid()) << status;
+  EXPECT_NE(status.message().find(PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR), std::string::npos);
 }
 
 TEST(TalonConfigTest, ParsesExplicitProperties) {
@@ -256,12 +284,14 @@ TEST(TalonConfigTest, ParsesExplicitProperties) {
   ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_ENABLED, "true"), std::nullopt);
   ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_COORDINATOR, "127.0.0.1:7000"), std::nullopt);
   ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_BLOCK_SIZE, "8388608"), std::nullopt);
+  ASSERT_EQ(api::SetValue(properties, PROPERTY_FS_TALON_MAX_IDLE_PER_ADDR, "32"), std::nullopt);
 
   ArrowFileSystemConfig config;
   ASSERT_STATUS_OK(ArrowFileSystemConfig::create_file_system_config(properties, config));
   EXPECT_TRUE(config.talon_enabled);
   EXPECT_EQ(config.talon_coordinator, "127.0.0.1:7000");
   EXPECT_EQ(config.talon_block_size, 8388608U);
+  EXPECT_EQ(config.talon_max_idle_per_addr, 32U);
 }
 
 TEST(TalonConfigTest, EnabledRequiresRemoteCoordinatorAndBlockSize) {
@@ -276,6 +306,26 @@ TEST(TalonConfigTest, EnabledRequiresRemoteCoordinatorAndBlockSize) {
     ArrowFileSystemConfig config;
     EXPECT_FALSE(ArrowFileSystemConfig::create_file_system_config(properties, config).ok());
   }
+}
+
+TEST(TalonConfigTest, CacheKeyIgnoresTalonSettingsWhenDisabled) {
+  ArrowFileSystemConfig base;
+  base.storage_type = "remote";
+  base.cloud_provider = kCloudProviderAWS;
+  base.address = "127.0.0.1:9000";
+  base.bucket_name = "test-bucket";
+
+  auto other_coordinator = base;
+  other_coordinator.talon_coordinator = "127.0.0.1:7000";
+  EXPECT_EQ(base.GetCacheKey(), other_coordinator.GetCacheKey());
+
+  auto other_block_size = base;
+  other_block_size.talon_block_size = 16777216;
+  EXPECT_EQ(base.GetCacheKey(), other_block_size.GetCacheKey());
+
+  auto other_pool_size = base;
+  other_pool_size.talon_max_idle_per_addr = 32;
+  EXPECT_EQ(base.GetCacheKey(), other_pool_size.GetCacheKey());
 }
 
 TEST(TalonConfigTest, CacheKeyIncludesTalonRouting) {
@@ -298,6 +348,10 @@ TEST(TalonConfigTest, CacheKeyIncludesTalonRouting) {
   auto other_block_size = enabled;
   other_block_size.talon_block_size = 16777216;
   EXPECT_NE(enabled.GetCacheKey(), other_block_size.GetCacheKey());
+
+  auto other_pool_size = enabled;
+  other_pool_size.talon_max_idle_per_addr = 32;
+  EXPECT_NE(enabled.GetCacheKey(), other_pool_size.GetCacheKey());
 }
 
 TEST(TalonTestEnvTest, AddsTalonPropertiesWhenEnabled) {
@@ -438,7 +492,7 @@ INSTANTIATE_TEST_SUITE_P(CloudProviders,
                          ::testing::Values(kCloudProviderAWS, kCloudProviderAzure));
 
 TEST(TalonBridgeTest, MapsClientCreationErrorAndPreservesTalonMessage) {
-  const auto result = talon::TalonClient::Make("127.0.0.1:7000", 0);
+  const auto result = talon::TalonClient::Make("127.0.0.1:7000", 0, 8);
 
   ASSERT_FALSE(result.ok());
   EXPECT_TRUE(result.status().IsIOError()) << result.status().ToString();
@@ -447,7 +501,7 @@ TEST(TalonBridgeTest, MapsClientCreationErrorAndPreservesTalonMessage) {
 }
 
 TEST(TalonBridgeTest, MapsOpenErrorAndPreservesTalonMessage) {
-  ASSERT_AND_ASSIGN(auto client, talon::TalonClient::Make("127.0.0.1:7000", 8U * 1024U * 1024U));
+  ASSERT_AND_ASSIGN(auto client, talon::TalonClient::Make("127.0.0.1:7000", 8U * 1024U * 1024U, 8));
 
   const auto result = client->OpenObject("aws", "test-bucket", "", std::nullopt);
 
@@ -458,7 +512,7 @@ TEST(TalonBridgeTest, MapsOpenErrorAndPreservesTalonMessage) {
 }
 
 TEST(TalonBridgeTest, MapsAsyncErrorAndPreservesTalonMessage) {
-  ASSERT_AND_ASSIGN(auto client, talon::TalonClient::Make("127.0.0.1:7000", 8U * 1024U * 1024U));
+  ASSERT_AND_ASSIGN(auto client, talon::TalonClient::Make("127.0.0.1:7000", 8U * 1024U * 1024U, 8));
   ASSERT_AND_ASSIGN(auto reader, client->OpenObject("aws", "test-bucket", "path/a", talon::TalonObjectStat{0, ""}));
 
   const auto result = reader.ReadAtAsync(0, std::numeric_limits<uint64_t>::max(), nullptr).result();
@@ -511,6 +565,32 @@ TEST_F(TalonFileSystemServiceFreeTest, ProducerAcceptsRawProviderFilesystem) {
   ASSERT_AND_ASSIGN(auto talon_fs, TalonFileSystemProducer(config, origin).Make());
   EXPECT_EQ(talon_fs->type_name(), "recording");
   EXPECT_EQ(std::dynamic_pointer_cast<FileSystemProxy>(talon_fs), nullptr);
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, OwnsConfigWithNormalizedBucket) {
+  auto config = Config();
+  config.bucket_name = "test-bucket///";
+  auto origin = std::make_shared<RecordingFileSystem>("origin");
+  ASSERT_AND_ASSIGN(auto fs, TalonFileSystemProducer(config, origin).Make());
+
+  config.bucket_name = "different-bucket";
+  config.cloud_provider = "unsupported";
+  arrow::fs::FileInfo info("test-bucket/prefix/object", arrow::fs::FileType::File);
+  info.set_size(0);
+  ASSERT_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+  ASSERT_AND_ASSIGN(const auto size, file->GetSize());
+  EXPECT_EQ(size, 0);
+  EXPECT_EQ(origin->input_open_calls, 0);
+  ASSERT_STATUS_OK(file->Close());
+}
+
+TEST_F(TalonFileSystemServiceFreeTest, ForwardsPoolLimitAndPreservesTalonValidationError) {
+  auto config = Config();
+  config.talon_max_idle_per_addr = 0;
+  const auto result = Wrap(config, std::make_shared<RecordingFileSystem>("origin"));
+  ASSERT_FALSE(result.ok());
+  EXPECT_TRUE(result.status().IsIOError()) << result.status();
+  EXPECT_NE(result.status().message().find("max_idle_per_addr must be non-zero"), std::string::npos);
 }
 
 TEST_F(TalonFileSystemServiceFreeTest, OpenWithFileInfoRejectsNonFiles) {
@@ -613,6 +693,15 @@ TEST_F(TalonFileSystemServiceFreeTest, EqualityIncludesTalonRouting) {
   const auto block_size_talon = block_size_proxy->base_fs();
   EXPECT_FALSE(base_talon->Equals(*block_size_talon));
   EXPECT_FALSE(block_size_talon->Equals(*base_talon));
+
+  auto other_pool_size = config;
+  other_pool_size.talon_max_idle_per_addr = 32;
+  ASSERT_AND_ASSIGN(auto pool_size_fs, Wrap(other_pool_size, std::make_shared<RecordingFileSystem>("origin")));
+  const auto pool_size_proxy = std::dynamic_pointer_cast<FileSystemProxy>(pool_size_fs);
+  ASSERT_NE(pool_size_proxy, nullptr);
+  const auto pool_size_talon = pool_size_proxy->base_fs();
+  EXPECT_FALSE(base_talon->Equals(*pool_size_talon));
+  EXPECT_FALSE(pool_size_talon->Equals(*base_talon));
 }
 
 TEST_F(TalonFileSystemServiceFreeTest, ForwardsStreamingFileInfoGeneratorWithFullSelector) {


### PR DESCRIPTION
Storage currently uses Talon's default of eight idle connections per peer, so callers can't tune connection reuse for workloads that read many ranges in parallel. When reads arrive in repeated bursts, a small idle pool can end up closing connections after one burst and opening them again for the next. Make this configurable through filesystem properties so callers can choose a limit that fits their workload.

Add fs.talon.max_idle_per_addr with a storage default of 256 and pass it through ArrowFileSystemConfig and the C++/Rust bridge into Talon's ClientBuilder. Update the pinned Talon dependency to e7f40ea, which includes the configurable client API from milvus-io/talon#582. The setting controls how many idle connections each coordinator or worker pool retains per address. Connections are still created on demand, so a limit of 256 does not open 256 connections upfront or restrict the number of requests in flight.

Let TalonFileSystem own an ArrowFileSystemConfig instead of carrying a growing list of individual configuration members and constructor arguments. Store the normalized bucket in that configuration and use it consistently for object routing and filesystem equality. Keeping an owned snapshot means the filesystem does not depend on the caller keeping the original config alive, while operations outside the Talon read path continue to use the underlying provider filesystem.